### PR TITLE
MR5 (#592): missionary unit + preach action

### DIFF
--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -13,6 +13,7 @@ Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 |------|--------|-----------|
 | settler | ✅ sprite | civilian |
 | worker | ✅ sprite | civilian |
+| missionary | ⚠️ placeholder (reuses WorkerSprite) | civilian |
 | scout | ✅ sprite | civilian |
 | scout_hound | ✅ sprite | hound |
 | war_hound | ✅ sprite | hound |

--- a/docs/superpowers/plans/2026-07-18-missionary-preach.md
+++ b/docs/superpowers/plans/2026-07-18-missionary-preach.md
@@ -1,0 +1,1187 @@
+# Missionary Unit + Preach Action (Issue #592, MR5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do NOT use subagent-driven-development or dispatch any subagents/parallel Agent calls for this plan — this project's CLAUDE.md forbids it explicitly. Execute every task inline in the current session.**
+
+**Goal:** Add a trainable `missionary` civilian unit and a `preach` action that lets players/AI actively push faith conversion, completing `missionary-zeal`'s tech promise ("Missionaries spread religion to conquered cities faster").
+
+**Architecture:** Extend MR4's religion system (`religion-system.ts`, `religion-definitions.ts`, `CityFaith`) with an active-conversion path that sits alongside passive spread. The key structural change: `CityFaith.conversionProgress` moves from a single `{toReligionId, points}` slot to a per-religion `Record<religionId, points>` map, so a missionary's deliberate investment toward religion A is never silently discarded by an unrelated turn tick where ambient pressure points toward religion B — the two are now independent ledger entries that both accumulate against the same `CONVERSION_THRESHOLD`, and conversion resolves to whichever bucket crosses it. A new `conversionCooldownUntilTurn` field on `CityFaith` prevents rapid flip-flopping between *rival* faiths, while explicitly exempting the original owner's own faith so "re-convert a flipped city" keeps working. Missionary charges are baked in at unit-creation time (not read reactively) by teaching the one production-completion call site (`turn-manager.ts:353`) to check `civ.techState.completed` before calling `createUnit`, then overwriting the returned unit's `chargesRemaining`. Trainability threads a `followsOwnFaith: boolean` flag into `getTrainableUnitsForCity`, computed by each of its 7 call sites from data they already have in scope (mirroring how the function already computes `coastal` internally).
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D (sprite pipeline unaffected — placeholder only this MR).
+
+## Global Constraints
+
+- `UNIT_CLASS_BY_TYPE.missionary = ['civilian']` — never fights, excluded from `general-mobilization`'s 0.85x military discount automatically via `isMilitaryUnitType`'s `!classes.includes('civilian')` check (verified at `src/systems/unit-modifier-definitions.ts:97`) — no extra wiring needed for that exclusion.
+- Production cost **16**, movement **2**, no combat stats (strength 0).
+- Charges: base 2, or 3 if owner completed `missionary-zeal` **at the moment the unit is created** — never recomputed later.
+- `PREACH_POINTS = 50` (two charges converts a fresh city exactly, matching `CONVERSION_THRESHOLD = 100`).
+- Occupied-city doubling: `missionary-zeal` owner + target city has `city.occupation != null` → Preach grants **100** instead of 50 (converts a conquered city in one call).
+- `OCCUPATION_ACCRUAL = 5`/turn already exists in `religion-definitions.ts`, unused until this MR — wire into `processReligionTurn`.
+- Preach is uncapped in volume (no per-turn empire-wide limit) but each **missionary** gets a personal cooldown after acting, and each **city** gets an anti-flip-flop cooldown after converting (scoped to block rival-religion conversions only — the original owner's own faith is always exempt, per the "re-convert a flipped city" use case).
+- New constants (this MR, `religion-definitions.ts`): `MISSIONARY_COST = 16`, `MISSIONARY_BASE_CHARGES = 2`, `MISSIONARY_ZEAL_CHARGES = 3`, `PREACH_POINTS = 50`, `PREACH_OCCUPIED_DOUBLE = 100`, `MISSIONARY_ACTION_COOLDOWN_TURNS = 3` (unit can't preach again for 3 turns after preaching — reflects the "action + rest" framing), `CITY_CONVERSION_COOLDOWN_TURNS = 7` (city can't flip to a *different* rival religion for 7 turns after converting; owner's own faith is always exempt from this cooldown).
+- No difficulty-mode (explorer/standard/veteran) scaling anywhere in this MR — matches MR4 precedent.
+- Copy register: plain language, ages 7-43, no jargon — match MR4's boon-modal tone ("cannot be changed later" style, not "cooldown expires at tick N").
+- `PRODUCTION_ICONS['missionary']` entry required or `tests/systems/city-system.test.ts` → `PRODUCTION_ICONS coverage` fails.
+- Every new `Tech`/`Building`/`UNIT_DESCRIPTIONS` string touched must stay honest per `.claude/rules/content-description-honesty.md` — no claims beyond what's implemented.
+- PR body must never contain `close[sd]?\s+#\d+|fix(e[sd])?\s+#\d+|resolve[sd]?\s+#\d+` (case-insensitive) — grep it before `gh pr create`. Reference #592/#587 only, never "closes #524".
+
+---
+
+## File Map (created/modified)
+
+| File | Change |
+|---|---|
+| `src/core/types.ts` | Add `'missionary'` to `UnitType`; add `Unit.missionaryCooldownUntilTurn?: number`; change `CityFaith.conversionProgress` shape; add `CityFaith.conversionCooldownUntilTurn?: number` + `conversionCooldownExemptCivId?: string` |
+| `src/systems/unit-modifier-definitions.ts` | `UNIT_CLASS_BY_TYPE.missionary = ['civilian']` |
+| `src/systems/unit-system.ts` | `UNIT_DEFINITIONS.missionary`, `UNIT_DESCRIPTIONS.missionary` |
+| `src/systems/city-system.ts` | `TRAINABLE_UNITS` entry, `PRODUCTION_ICONS.missionary`, `getTrainableUnitsForCity` signature (+`followsOwnFaith`), all internal call sites |
+| `src/ai/ai-resource-marketplace.ts`, `src/ai/ai-production.ts` (x2), `src/systems/quest-objective-system.ts`, `src/systems/minor-civ-economy-system.ts`, `src/ui/city-panel.ts` (x2) | Update call sites of `getTrainableUnitsForCity` to compute+pass `followsOwnFaith` |
+| `src/systems/religion-definitions.ts` | New constants listed above |
+| `src/systems/religion-system.ts` | Restructure `conversionProgress` handling in `processReligionTurn`; add `getCityConversionPoints`/`applyCityConversionPoints` helpers; add `preach()`; add occupation accrual |
+| `src/core/turn-manager.ts` | Bake missionary charges at creation (~:353) |
+| `src/ui/selected-unit-info.ts` | Preach button + help text |
+| `src/ui/unit-delete-confirmation-panel.ts` | Add optional `title` override |
+| `src/ai/ai-production.ts` | Missionary production scoring (Fervor-weighted) |
+| `src/ai/ai-unit-roles.ts` or a new `src/ai/ai-missionary-dispatch.ts` | Dispatch logic: own unconverted cities first, then friendly minors |
+| `src/renderer/sprites/sprite-catalog.ts`, `docs/sprite-design-system.md` | Placeholder registration |
+| `src/systems/tech-definitions-eras5-7.ts` | `missionary-zeal` `unlocks` text (~:266) |
+| Tests: `tests/systems/religion-system.test.ts`, `tests/systems/religion-spread.test.ts` (rewrite existing assertions for new shape), `tests/systems/city-system.test.ts`, `tests/systems/unit-modifier-system.test.ts` (auto-covered by completeness), `tests/ai/ai-production.test.ts` or equivalent, `tests/ui/selected-unit-info.test.ts` | New + updated coverage |
+
+---
+
+### Task 1: Data model — `UnitType`, `Unit` cooldown field, `CityFaith` restructure
+
+**Files:**
+- Modify: `src/core/types.ts:340-342` (UnitType union), `:421` (Unit interface), `:1603-1608` (CityFaith interface)
+- Test: `tests/systems/religion-system.test.ts` (new file section, or existing describe block)
+
+**Interfaces:**
+- Produces: `UnitType` now includes `'missionary'`. `Unit.missionaryCooldownUntilTurn?: number`. `CityFaith.conversionProgress?: Record<string, number>` (was `{toReligionId, points}`). `CityFaith.conversionCooldownUntilTurn?: number`. `CityFaith.conversionCooldownExemptCivId?: string` (the civ whose faith is always exempt from this city's cooldown — set to the city owner's civ id at the moment the cooldown starts).
+
+- [ ] **Step 1: Add `'missionary'` to `UnitType` union**
+
+Edit `src/core/types.ts:340-342`, insert `missionary` into the civilian cluster:
+
+```typescript
+export type UnitType =
+  | 'settler' | 'worker' | 'scout' | 'warrior' | 'archer' | 'missionary'
+  | 'swordsman' | 'pikeman' | 'musketeer' | 'galley' | 'trireme'
+```
+
+- [ ] **Step 2: Add cooldown field to `Unit`**
+
+Edit `src/core/types.ts` near `:421` (right after the existing `chargesRemaining` line):
+
+```typescript
+  chargesRemaining?: number; // workers default to 2; omitted on legacy saves
+  missionaryCooldownUntilTurn?: number; // set after preach(); missionary can't preach again until state.turn >= this
+```
+
+- [ ] **Step 3: Restructure `CityFaith.conversionProgress` and add cooldown fields**
+
+Edit `src/core/types.ts:1603-1608`:
+
+```typescript
+export interface CityFaith {
+  religionId: string;
+  isHolyCity?: true;      // founding city — permanently immune to conversion, under ANY owner
+  // Per-religion progress ledger (MR5, #592): keyed by candidate religionId, NOT a single
+  // slot. This lets ambient passive pressure toward religion A accumulate independently of
+  // missionary-driven preach progress toward religion B in the same city — previously a
+  // single {toReligionId, points} slot meant a preach investment could be silently wiped
+  // out the moment ambient pressure pointed elsewhere. Conversion fires for whichever
+  // religionId's bucket first reaches CONVERSION_THRESHOLD.
+  conversionProgress?: Record<string, number>;
+  // MR5 anti-flip-flop guard: once set, no religionId OTHER than conversionCooldownExemptCivId's
+  // faith may convert this city until state.turn >= conversionCooldownUntilTurn. The exempt
+  // civ (the city's owner at the moment of the LAST conversion) can always re-convert its own
+  // city immediately — this preserves "preach a flipped city back" as an owner privilege while
+  // still stopping rival faiths from ping-ponging a border city turn after turn.
+  conversionCooldownUntilTurn?: number;
+  conversionCooldownExemptCivId?: string;
+  // loyaltyProgress added by MR6 (#593)
+}
+```
+
+- [ ] **Step 4: Run typecheck to confirm nothing else references the old `conversionProgress` shape yet (expected: religion-system.ts and religion-spread.test.ts will show as broken — that's Task 5/9's job to fix, just confirm scope here)**
+
+Run: `bash scripts/run-with-mise.sh yarn build 2>&1 | grep -A2 "conversionProgress\|toReligionId" | head -60`
+Expected: TypeScript errors in `src/systems/religion-system.ts` and possibly `src/ui/city-panel.ts` referencing `.toReligionId`/`.points` on the old shape — confirms the blast radius is exactly those two files (plus test files, which don't block `yarn build`). Do not fix yet; this step is a scope-confirmation checkpoint before Task 5 tackles it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/types.ts
+git commit -m "feat(religion): add missionary UnitType and restructure CityFaith conversion tracking"
+```
+
+---
+
+### Task 2: Missionary unit definitions, classification, sprite placeholder
+
+**Files:**
+- Modify: `src/systems/unit-modifier-definitions.ts:9-40` (UNIT_CLASS_BY_TYPE)
+- Modify: `src/systems/unit-system.ts:40-...` (UNIT_DEFINITIONS), `:641-...` (UNIT_DESCRIPTIONS)
+- Modify: `src/renderer/sprites/sprite-catalog.ts:207-...` (UNIT_SPRITE_CATALOG) — reuse an existing civilian sprite component as placeholder (matches how other placeholder units are handled — verify pattern first)
+- Modify: `docs/sprite-design-system.md` (Units table, `civilian` data-kind row group)
+- Test: `tests/systems/unit-modifier-system.test.ts` (completeness test already covers this generically — no new test file needed, just confirm it passes)
+
+**Interfaces:**
+- Consumes: `UnitClass` type from `unit-modifier-definitions.ts` (Task 1 unaffected).
+- Produces: `UNIT_DEFINITIONS.missionary: UnitDefinition`, `UNIT_DESCRIPTIONS.missionary: string`, `UNIT_CLASS_BY_TYPE.missionary: UnitClass[]`.
+
+- [ ] **Step 1: Check how an existing placeholder unit's sprite entry is written (e.g. `observation_balloon`, marked `⚠️ placeholder` in the doc) to match the exact code pattern**
+
+Run: `grep -n "observation_balloon" src/renderer/sprites/sprite-catalog.ts`
+Expected: shows whether placeholders reuse an existing sprite component (e.g. `withMotion('observation_balloon', SomeFallbackSprite)`) or a dedicated placeholder function — copy that exact pattern for `missionary`.
+
+- [ ] **Step 2: Add `UNIT_CLASS_BY_TYPE.missionary`**
+
+Edit `src/systems/unit-modifier-definitions.ts`, add alongside `worker: ['civilian'],`:
+
+```typescript
+  missionary: ['civilian'],
+```
+
+- [ ] **Step 3: Add `UNIT_DEFINITIONS.missionary`**
+
+Edit `src/systems/unit-system.ts`, add alongside the `worker` entry:
+
+```typescript
+  missionary: {
+    type: 'missionary', name: 'Missionary', movementPoints: 2,
+    visionRange: 2, strength: 0, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 16,
+  },
+```
+
+- [ ] **Step 4: Add `UNIT_DESCRIPTIONS.missionary`**
+
+Edit `src/systems/unit-system.ts`, add alongside the `worker` description:
+
+```typescript
+  missionary: 'Civilian unit that spreads your faith. Preach in a city to push it toward your religion — preaching a city your own faith already lost brings it back fastest. Missionaries start with 2 charges (3 once Missionary Zeal is researched) and are used up after the last charge.',
+```
+
+- [ ] **Step 5: Register sprite placeholder using the pattern found in Step 1**
+
+Edit `src/renderer/sprites/sprite-catalog.ts` — add the `missionary:` line to `UNIT_SPRITE_CATALOG` using whatever placeholder pattern Step 1 revealed (e.g. reusing `WorkerSprite` component with a distinct `data-kind` tag, since missionary is civilian and bespoke art ships in MR7/#594).
+
+- [ ] **Step 6: Add doc table row**
+
+Edit `docs/sprite-design-system.md`, in the Units table, add:
+
+```
+| missionary | ⚠️ placeholder | civilian |
+```
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: no new errors from this task's changes (existing conversionProgress errors from Task 1 still present — that's expected until Task 5).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/unit-modifier-definitions.ts src/systems/unit-system.ts src/renderer/sprites/sprite-catalog.ts docs/sprite-design-system.md
+git commit -m "feat(religion): missionary unit definition, classification, sprite placeholder"
+```
+
+---
+
+### Task 3: Trainability gate — thread `followsOwnFaith` through `getTrainableUnitsForCity`
+
+**Files:**
+- Modify: `src/systems/city-system.ts:1683-1694` (`getTrainableUnitsForCity`), `TRAINABLE_UNITS` array (~:1093-1104 area), `PRODUCTION_ICONS` (~:1381+)
+- Modify (call sites, add `followsOwnFaith` computation before calling): `src/ui/city-panel.ts:540,569`, `src/ai/ai-resource-marketplace.ts:44`, `src/ai/ai-production.ts:74,270`, `src/systems/quest-objective-system.ts:105`, `src/systems/minor-civ-economy-system.ts:289`
+- Test: `tests/systems/city-system.test.ts` (new describe block `missionary trainability`)
+
+**Interfaces:**
+- Consumes: `state.cityFaith`, `state.religions` (Task 1's types), `city.owner`, `state.civilizations[owner]`.
+- Produces: `getTrainableUnitsForCity(city, completedTechs, map, civType?, availableResources?, followsOwnFaith?: boolean): TrainableUnitEntry[]` — new optional 6th param, defaults to `false` if omitted (fail-closed: missionary simply won't show as trainable rather than silently becoming available, matching the game-balance.md caution about missed call sites). Also exports a new helper `cityFollowsOwnFaith(state: GameState, city: City): boolean` that every call site should use to compute the flag consistently.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/systems/city-system.test.ts`:
+
+```typescript
+describe('missionary trainability (#592)', () => {
+  function setupReligionCiv(state: GameState, civId: string, cityId: string) {
+    const religionId = `religion-${civId}`;
+    return {
+      ...state,
+      religions: { ...(state.religions ?? {}), [religionId]: { id: religionId, name: 'Test Faith', ownerCivId: civId, foundedTurn: 1 } },
+      cityFaith: { ...(state.cityFaith ?? {}), [cityId]: { religionId } },
+    };
+  }
+
+  it('is NOT trainable without a founded religion', () => {
+    const state = makeTestState(); // existing test helper in this file
+    const city = state.cities['city-1'];
+    city.buildings = ['temple'];
+    const trainable = getTrainableUnitsForCity(city, [], state.map, undefined, undefined, false);
+    expect(trainable.find(u => u.type === 'missionary')).toBeUndefined();
+  });
+
+  it('is NOT trainable without a Temple, even with religion + own faith', () => {
+    let state = makeTestState();
+    const civId = state.cities['city-1'].owner;
+    state = setupReligionCiv(state, civId, 'city-1');
+    const city = { ...state.cities['city-1'], buildings: [] };
+    const trainable = getTrainableUnitsForCity(city, [], state.map, undefined, undefined, true);
+    expect(trainable.find(u => u.type === 'missionary')).toBeUndefined();
+  });
+
+  it('is NOT trainable when the city follows a foreign faith', () => {
+    let state = makeTestState();
+    const civId = state.cities['city-1'].owner;
+    state = setupReligionCiv(state, civId, 'city-1');
+    const city = { ...state.cities['city-1'], buildings: ['temple'] };
+    // followsOwnFaith computed as false by caller because cityFaith.religionId belongs to a different civ
+    const trainable = getTrainableUnitsForCity(city, [], state.map, undefined, undefined, false);
+    expect(trainable.find(u => u.type === 'missionary')).toBeUndefined();
+  });
+
+  it('IS trainable when religion founded + own faith + Temple all hold', () => {
+    let state = makeTestState();
+    const civId = state.cities['city-1'].owner;
+    state = setupReligionCiv(state, civId, 'city-1');
+    const city = { ...state.cities['city-1'], buildings: ['temple'] };
+    const trainable = getTrainableUnitsForCity(city, [], state.map, undefined, undefined, true);
+    expect(trainable.find(u => u.type === 'missionary')).toBeDefined();
+  });
+});
+```
+
+(Adjust `makeTestState()`/city-id literals to match whatever test helper this file already uses — grep `tests/systems/city-system.test.ts` for its existing state-builder helper name before writing this; do not invent a new one.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- city-system.test.ts -t "missionary trainability"`
+Expected: FAIL — `missionary` not in `TRAINABLE_UNITS`, and `getTrainableUnitsForCity` doesn't accept a 6th param yet.
+
+- [ ] **Step 3: Add `TRAINABLE_UNITS` entry and `PRODUCTION_ICONS` entry**
+
+Edit `src/systems/city-system.ts`, add alongside the `worker`/`settler` entries:
+
+```typescript
+  { type: 'missionary', name: 'Missionary', cost: 16, trainedFromBuilding: 'temple' },
+```
+
+Edit `PRODUCTION_ICONS` (~:1381+):
+
+```typescript
+  missionary: '🙏',
+```
+
+- [ ] **Step 4: Update `getTrainableUnitsForCity` signature and add `cityFollowsOwnFaith` helper**
+
+Edit `src/systems/city-system.ts:1683-1694`:
+
+```typescript
+export function cityFollowsOwnFaith(state: GameState, city: City): boolean {
+  const faith = state.cityFaith?.[city.id];
+  if (!faith) return false;
+  const religion = state.religions?.[faith.religionId];
+  return !!religion && religion.ownerCivId === city.owner;
+}
+
+export function getTrainableUnitsForCity(
+  city: City,
+  completedTechs: string[],
+  map: GameMap,
+  civType?: string,
+  availableResources?: Set<ResourceType>,
+  followsOwnFaith: boolean = false,
+): TrainableUnitEntry[] {
+  const coastal = isCityCoastal(city, map);
+  return getTrainableUnitsForCiv(completedTechs, civType, availableResources)
+    .filter(unit => !unit.coastalRequired || coastal)
+    .filter(unit => !unit.trainedFromBuilding || (city.buildings ?? []).includes(unit.trainedFromBuilding))
+    .filter(unit => unit.type !== 'missionary' || followsOwnFaith);
+}
+```
+
+Note: `trainedFromBuilding: 'temple'` already handles the Temple-gate via the existing filter — `followsOwnFaith` only needs to gate the religion+own-faith conjunction, since "no religion at all" and "foreign faith" both simply fail `cityFollowsOwnFaith`'s check (no religion → no `faith` entry → `false`; foreign faith → `religion.ownerCivId !== city.owner` → `false`).
+
+- [ ] **Step 5: Update all 7 call sites to compute and pass `followsOwnFaith`**
+
+For each call site, insert `cityFollowsOwnFaith(state, city)` (or the local equivalent — some sites may only have `civId`/`cityId` in scope, in which case pass `cityFollowsOwnFaith(state, city)` after resolving `city` from `state.cities[cityId]`):
+
+`src/ui/city-panel.ts:540`:
+```typescript
+const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, playerResources, cityFollowsOwnFaith(state, city));
+```
+
+`src/ui/city-panel.ts:569`:
+```typescript
+const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined, cityFollowsOwnFaith(state, city));
+```
+
+`src/ai/ai-resource-marketplace.ts:44` and `src/ai/ai-production.ts:74,270`: same pattern — add `cityFollowsOwnFaith(state, city)` as the trailing argument, importing `cityFollowsOwnFaith` from `@/systems/city-system` in each file that doesn't already import it.
+
+`src/systems/quest-objective-system.ts:105`: same pattern.
+
+`src/systems/minor-civ-economy-system.ts:289`: minor civs never found religions (verify with a quick grep: `grep -n "minorCiv.*religion\|religion.*minorCiv" src/systems/*.ts` — expect no hits), so pass `false` explicitly with a one-line comment (`// minor civs never found a religion — missionary never trainable here`) rather than importing the full helper.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- city-system.test.ts -t "missionary trainability"`
+Expected: PASS (all 4 cases).
+
+- [ ] **Step 7: Run full build to catch any missed call site**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: no TypeScript errors about `getTrainableUnitsForCity` arity (the 6th param is optional, so a missed site won't error — cross-check by grepping again: `grep -rn "getTrainableUnitsForCity(" src/ | wc -l` should still be 7 call sites, all touched).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/city-system.ts src/ui/city-panel.ts src/ai/ai-resource-marketplace.ts src/ai/ai-production.ts src/systems/quest-objective-system.ts src/systems/minor-civ-economy-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(religion): missionary trainability gate (religion + own faith + Temple)"
+```
+
+---
+
+### Task 4: Charges baked in at unit creation (turn-manager.ts)
+
+**Files:**
+- Modify: `src/core/turn-manager.ts:353` (unit-creation call site)
+- Test: `tests/systems/turn-manager.test.ts` or wherever production-completion is already tested — grep first: `grep -rln "createUnit(result.completedUnit" tests/` to find the right test file.
+
+**Interfaces:**
+- Consumes: `createUnit(type, owner, position, counters, bonusEffect?): Unit` (unchanged signature, Task unaffected).
+- Produces: after this task, a missionary `Unit` created via production completion has `chargesRemaining` set to 3 if `civ.techState.completed.includes('missionary-zeal')` at that exact moment, else 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing test file covering `city:unit-trained` / production completion (from the grep above) and add:
+
+```typescript
+it('missionary gets 3 charges if missionary-zeal is completed at build time, else 2', () => {
+  let state = /* existing test-state builder used in this file, with a city queued to produce 'missionary' */;
+  // civ WITHOUT missionary-zeal
+  let result = processTurn(state, bus); // or whatever this file's existing turn-advance helper is named
+  const missionaryNoTech = Object.values(result.units).find(u => u.type === 'missionary');
+  expect(missionaryNoTech?.chargesRemaining).toBe(2);
+
+  // civ WITH missionary-zeal completed before the same production completes
+  state = { ...state, civilizations: { ...state.civilizations, [civId]: { ...state.civilizations[civId], techState: { ...state.civilizations[civId].techState, completed: [...state.civilizations[civId].techState.completed, 'missionary-zeal'] } } } };
+  result = processTurn(state, bus);
+  const missionaryWithTech = Object.values(result.units).find(u => u.type === 'missionary');
+  expect(missionaryWithTech?.chargesRemaining).toBe(3);
+});
+```
+
+(Adjust to match this file's actual state-setup and turn-advance helper names — grep the file first, do not guess names.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- turn-manager -t "missionary gets 3 charges"`
+Expected: FAIL — charges default to `undefined` (createUnit's default: `type === 'worker' ? 2 : undefined`) for missionary today.
+
+- [ ] **Step 3: Bake charges in at the call site**
+
+Edit `src/core/turn-manager.ts` at the block around line 353:
+
+```typescript
+      if (result.completedUnit) {
+        bus.emit('city:unit-trained', { cityId, unitType: result.completedUnit });
+        const newUnit = createUnit(result.completedUnit, civId, city.position, newState.idCounters, civDef?.bonusEffect);
+        if (result.completedUnit === 'missionary') {
+          newUnit.chargesRemaining = civ.techState.completed.includes('missionary-zeal')
+            ? MISSIONARY_ZEAL_CHARGES
+            : MISSIONARY_BASE_CHARGES;
+        }
+        const unitDef = UNIT_DEFINITIONS[result.completedUnit];
+```
+
+Add the import at the top of `turn-manager.ts`:
+
+```typescript
+import { MISSIONARY_BASE_CHARGES, MISSIONARY_ZEAL_CHARGES } from './religion-definitions';
+```
+
+- [ ] **Step 4: Add the two charge constants to `religion-definitions.ts`** (defined here, in this task, before Step 3's import is used — Task 5 adds the remaining preach/cooldown constants separately and does not redefine these two)
+
+Edit `src/systems/religion-definitions.ts`, add near `OCCUPATION_ACCRUAL`:
+
+```typescript
+export const MISSIONARY_COST = 16;
+export const MISSIONARY_BASE_CHARGES = 2;
+export const MISSIONARY_ZEAL_CHARGES = 3;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- turn-manager -t "missionary gets 3 charges"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/turn-manager.ts src/systems/religion-definitions.ts tests/systems/turn-manager.test.ts
+git commit -m "feat(religion): bake missionary charges in at creation from build-time tech state"
+```
+
+---
+
+### Task 5: `religion-definitions.ts` — remaining constants (preach points, cooldowns)
+
+**Files:**
+- Modify: `src/systems/religion-definitions.ts`
+
+**Interfaces:**
+- Produces: `PREACH_POINTS = 50`, `PREACH_OCCUPIED_DOUBLE = 100`, `MISSIONARY_ACTION_COOLDOWN_TURNS = 3`, `CITY_CONVERSION_COOLDOWN_TURNS = 7`.
+
+- [ ] **Step 1: Add constants**
+
+Edit `src/systems/religion-definitions.ts`, add near `OCCUPATION_ACCRUAL`:
+
+```typescript
+// #592 MR5: active conversion via missionary preach.
+export const PREACH_POINTS = 50;
+export const PREACH_OCCUPIED_DOUBLE = 100;
+// A missionary that just preached needs to "rest" before preaching again — reflects the
+// action itself plus recovery, same framing as a worker's multi-turn improvement build.
+export const MISSIONARY_ACTION_COOLDOWN_TURNS = 3;
+// Anti-flip-flop guard: once a city converts, it can't flip to a DIFFERENT rival religion
+// again for this many turns. The city's own owner (at the moment of conversion) is always
+// exempt, so preaching a just-flipped city back to its owner's faith is never blocked by
+// this cooldown — see CityFaith.conversionCooldownExemptCivId.
+export const CITY_CONVERSION_COOLDOWN_TURNS = 7;
+```
+
+- [ ] **Step 2: No test needed for bare constants — proceed directly to typecheck**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: clean (constants unused so far is fine — Task 4 and Task 6 consume them next).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/systems/religion-definitions.ts
+git commit -m "feat(religion): add preach and cooldown constants"
+```
+
+---
+
+### Task 6: Restructure `processReligionTurn` for per-religion progress map + occupation accrual
+
+**Files:**
+- Modify: `src/systems/religion-system.ts:143-183` (`processReligionTurn`)
+- Modify: `tests/systems/religion-spread.test.ts` (rewrite 5 existing assertions that use the old `{toReligionId, points}` shape — lines ~103, 114, 131, 144, 168 per the drift-check grep)
+
+**Interfaces:**
+- Consumes: `CityFaith.conversionProgress?: Record<string, number>` (Task 1).
+- Produces: `getCityConversionPoints(faith: CityFaith | undefined, religionId: string): number` (reads a bucket, 0 if absent) and `applyCityConversionPoints(cityFaith: CityFaith | undefined, religionId: string, delta: number): { cityFaith: CityFaith; converted: boolean }` (adds points to one bucket, returns whether it crossed `CONVERSION_THRESHOLD`) — both exported from `religion-system.ts`, reused by `preach()` in Task 7 so accrual and preach share one code path.
+
+- [ ] **Step 1: Write the failing test — rewrite the 5 existing assertions for the new shape**
+
+Edit `tests/systems/religion-spread.test.ts`. Example rewrite for the assertion at line ~103:
+
+```typescript
+// OLD: expect(next.cityFaith!['own-neighbor'].conversionProgress).toEqual({ toReligionId: `religion-${civId}`, points: 15 });
+// NEW:
+expect(next.cityFaith!['own-neighbor'].conversionProgress).toEqual({ [`religion-${civId}`]: 15 });
+```
+
+Apply the same transform to the other 4 assertions (~114, 131, 144, 168), and the seed states at ~114/131 that construct `conversionProgress: { toReligionId: ..., points: ... }` — change those to `conversionProgress: { [religionId]: points }` object literals.
+
+Add one NEW test proving the actual bug fix — independent buckets surviving an ambient-target switch:
+
+```typescript
+it('preach-style progress toward religion A survives a later tick where ambient pressure points to religion B (#592)', () => {
+  let state = /* seed: city with existing conversionProgress = { [religionA]: 40 }, and ambient geography now favors religionB */;
+  const next = processReligionTurn(state, bus);
+  // religionA's bucket must still show 40 — untouched by this tick's religionB accrual
+  expect(next.cityFaith!['city-x'].conversionProgress?.[religionAId]).toBe(40);
+  // religionB's bucket accrues independently
+  expect(next.cityFaith!['city-x'].conversionProgress?.[religionBId]).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- religion-spread.test.ts`
+Expected: FAIL on the old-shape assertions (still asserting old code) and the new test (feature not yet implemented).
+
+- [ ] **Step 3: Add `getCityConversionPoints` / `applyCityConversionPoints` helpers and rewrite `processReligionTurn`**
+
+Edit `src/systems/religion-system.ts`, replace the whole function body (lines 143-183) and add the two new exported helpers above it:
+
+```typescript
+export function getCityConversionPoints(faith: CityFaith | undefined, religionId: string): number {
+  return faith?.conversionProgress?.[religionId] ?? 0;
+}
+
+// Adds `delta` points to religionId's own bucket in cityFaith.conversionProgress, independent
+// of any other religion's bucket. Returns the updated CityFaith and whether this delta pushed
+// that bucket to/over CONVERSION_THRESHOLD (caller decides whether/how to apply the actual flip).
+export function applyCityConversionPoints(
+  faith: CityFaith | undefined,
+  religionId: string,
+  delta: number,
+): { cityFaith: CityFaith; converted: boolean } {
+  const currentPoints = getCityConversionPoints(faith, religionId);
+  const nextPoints = currentPoints + delta;
+  const converted = nextPoints >= CONVERSION_THRESHOLD;
+  const nextProgress = { ...(faith?.conversionProgress ?? {}), [religionId]: nextPoints };
+  return {
+    cityFaith: { ...(faith ?? { religionId: faith?.religionId ?? religionId }), conversionProgress: nextProgress },
+    converted,
+  };
+}
+
+// Passive faith spread + conversion (#591 MR4, restructured #592 MR5 for independent
+// per-religion progress buckets — see CityFaith.conversionProgress doc comment in types.ts).
+// Holy cities never accrue. Cities under an active conversionCooldownUntilTurn only accrue
+// toward conversionCooldownExemptCivId's religion (or their current religion, if it's not
+// the exempt civ's) — rival religions' passive pressure is paused, not reset, during cooldown.
+export function processReligionTurn(state: GameState, bus: EventBus): GameState {
+  const cityFaithMap = state.cityFaith ?? {};
+  let cityFaith = { ...cityFaithMap };
+  let changed = false;
+
+  for (const cityId of Object.keys(state.cities).sort()) {
+    const faith = cityFaith[cityId];
+    if (faith?.isHolyCity) continue;
+
+    const pressure = getStrongestPressure(state, cityId);
+    if (!pressure) continue;
+    if (faith?.religionId === pressure.religionId && !getCityConversionPoints(faith, pressure.religionId)) continue;
+
+    const cooldownActive = (faith?.conversionCooldownUntilTurn ?? 0) > state.turn;
+    const exemptCivId = faith?.conversionCooldownExemptCivId;
+    const pressureReligion = state.religions?.[pressure.religionId];
+    const pressureIsExempt = !!exemptCivId && pressureReligion?.ownerCivId === exemptCivId;
+    if (cooldownActive && !pressureIsExempt) continue; // rival religion's passive pressure is paused during cooldown
+
+    const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, pressure.religionId, pressure.accrual);
+
+    if (converted) {
+      const fromReligionId = faith?.religionId;
+      const cityOwner = state.cities[cityId]?.owner;
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: {
+          religionId: pressure.religionId,
+          conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+          conversionCooldownExemptCivId: cityOwner,
+        },
+      };
+      changed = true;
+      bus.emit('religion:city-converted', { cityId, toReligionId: pressure.religionId, fromReligionId });
+    } else {
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? pressure.religionId },
+      };
+      changed = true;
+    }
+  }
+
+  return processOccupationAccrual(changed ? { ...state, cityFaith } : state, bus);
+}
+
+// #592 MR5: cities under occupation accrue toward the OCCUPYING civ's faith every turn,
+// independent of geography/trade pressure — this is what makes missionary-zeal's doubled
+// preach on occupied cities land on top of a baseline that's already moving.
+function processOccupationAccrual(state: GameState, bus: EventBus): GameState {
+  let cityFaith = { ...(state.cityFaith ?? {}) };
+  let changed = false;
+
+  for (const [cityId, city] of Object.entries(state.cities)) {
+    if (!city.occupation) continue;
+    const occupierReligion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === city.owner);
+    if (!occupierReligion) continue;
+    const faith = cityFaith[cityId];
+    if (faith?.isHolyCity) continue;
+
+    const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, occupierReligion.id, OCCUPATION_ACCRUAL);
+    if (converted) {
+      const fromReligionId = faith?.religionId;
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: {
+          religionId: occupierReligion.id,
+          conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+          conversionCooldownExemptCivId: city.owner,
+        },
+      };
+      bus.emit('religion:city-converted', { cityId, toReligionId: occupierReligion.id, fromReligionId });
+    } else {
+      cityFaith = { ...cityFaith, [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? occupierReligion.id } };
+    }
+    changed = true;
+  }
+
+  return changed ? { ...state, cityFaith } : state;
+}
+```
+
+Add the two new constant imports at the top of `religion-system.ts`:
+
+```typescript
+import {
+  NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, CONVERSION_THRESHOLD,
+  OWN_CITY_ACCRUAL, FOREIGN_ADJACENT_ACCRUAL, FOREIGN_ADJACENT_CAP,
+  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER, TITHES_CAP, OCCUPATION_ACCRUAL,
+  CITY_CONVERSION_COOLDOWN_TURNS,
+} from './religion-definitions';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- religion-spread.test.ts religion-system.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add occupation-accrual-specific test**
+
+Add to `tests/systems/religion-system.test.ts`:
+
+```typescript
+it('occupied city accrues OCCUPATION_ACCRUAL/turn toward the occupier faith (#592)', () => {
+  let state = /* seed: civA owns civB's former capital under occupation, civA has founded a religion */;
+  const before = getCityConversionPoints(state.cityFaith?.['occupied-city'], `religion-${civAId}`);
+  const next = processReligionTurn(state, bus);
+  const after = getCityConversionPoints(next.cityFaith?.['occupied-city'], `religion-${civAId}`);
+  expect(after - before).toBe(OCCUPATION_ACCRUAL);
+});
+
+it('occupation accrual stops once occupation ends', () => {
+  let state = /* same seed as above, then occupation cleared (city.occupation = undefined) */;
+  const before = getCityConversionPoints(state.cityFaith?.['occupied-city'], `religion-${civAId}`);
+  const next = processReligionTurn(state, bus);
+  const after = getCityConversionPoints(next.cityFaith?.['occupied-city'], `religion-${civAId}`);
+  expect(after).toBe(before); // no growth — occupation.turnsRemaining hit 0 elsewhere clears city.occupation
+});
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- religion-system.test.ts -t "occupied city accrues"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/religion-system.ts tests/systems/religion-spread.test.ts tests/systems/religion-system.test.ts
+git commit -m "feat(religion): per-religion conversion progress buckets + occupation passive pressure"
+```
+
+---
+
+### Task 7: `preach()` action
+
+**Files:**
+- Modify: `src/systems/religion-system.ts` (add `preach()`)
+- Test: `tests/systems/religion-system.test.ts`
+
+**Interfaces:**
+- Consumes: `applyCityConversionPoints`, `getCityConversionPoints` (Task 6), `Unit.missionaryCooldownUntilTurn` (Task 1), `Unit.chargesRemaining` (existing generic field).
+- Produces: `preach(state: GameState, unitId: string, cityId: string, bus: EventBus): { state: GameState; ok: true; converted: boolean; unitConsumed: boolean } | { state: GameState; ok: false; reason: 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' }`.
+
+- [ ] **Step 1: Write the failing tests — full matrix from the issue**
+
+Add to `tests/systems/religion-system.test.ts`:
+
+```typescript
+describe('preach() (#592)', () => {
+  // Shared fixture builder — adjust to this file's existing state-seed helper.
+  function seedMissionaryScenario(overrides: Partial<{ atWar: boolean; holyCity: boolean; occupied: boolean; zeal: boolean; discovered: boolean }> = {}) { /* ... build state with owner civ, a missionary unit with 2 charges, a target city ... */ }
+
+  it('grants PREACH_POINTS (50) toward a freshly-founded target city, not doubled', () => {
+    const { state, bus, unitId, cityId, civId } = seedMissionaryScenario();
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(true);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('grants PREACH_OCCUPIED_DOUBLE (100) and converts outright when target is occupied AND owner has missionary-zeal', () => {
+    const { state, bus, unitId, cityId, civId } = seedMissionaryScenario({ occupied: true, zeal: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok && result.converted).toBe(true);
+    expect(result.state.cityFaith?.[cityId].religionId).toBe(`religion-${civId}`);
+  });
+
+  it('grants only PREACH_POINTS (50, not doubled) when occupied but owner lacks missionary-zeal', () => {
+    const { state, bus, unitId, cityId, civId } = seedMissionaryScenario({ occupied: true, zeal: false });
+    const result = preach(state, unitId, cityId, bus);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('grants only PREACH_POINTS (50) when owner has missionary-zeal but target is NOT occupied', () => {
+    const { state, bus, unitId, cityId, civId } = seedMissionaryScenario({ occupied: false, zeal: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('refuses to preach a holy city', () => {
+    const { state, bus, unitId, cityId } = seedMissionaryScenario({ holyCity: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('holy-city');
+  });
+
+  it('refuses to preach a city owned by a civ the missionary owner is at war with', () => {
+    const { state, bus, unitId, cityId } = seedMissionaryScenario({ atWar: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('at-war');
+  });
+
+  it('refuses to preach an undiscovered city', () => {
+    const { state, bus, unitId, cityId } = seedMissionaryScenario({ discovered: false });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('undiscovered');
+  });
+
+  it('consumes one charge per preach and marks the unit for consumption at 0', () => {
+    const { state, bus, unitId, cityId } = seedMissionaryScenario(); // starts at 2 charges
+    const afterFirst = preach(state, unitId, cityId, bus);
+    expect(afterFirst.ok && afterFirst.state.units[unitId]?.chargesRemaining).toBe(1);
+    expect(afterFirst.ok && afterFirst.unitConsumed).toBe(false);
+    // second preach must wait out MISSIONARY_ACTION_COOLDOWN_TURNS — advance state.turn manually for the test
+    const cooledDownState = { ...afterFirst.state, turn: afterFirst.state.turn + MISSIONARY_ACTION_COOLDOWN_TURNS };
+    const afterSecond = preach(cooledDownState, unitId, cityId, bus);
+    expect(afterSecond.ok && afterSecond.state.units[unitId]).toBeUndefined(); // consumed at 0 charges
+    expect(afterSecond.ok && afterSecond.unitConsumed).toBe(true);
+  });
+
+  it('refuses to preach again before the personal cooldown elapses', () => {
+    const { state, bus, unitId, cityId } = seedMissionaryScenario();
+    const first = preach(state, unitId, cityId, bus);
+    const second = preach(first.state, unitId, cityId, bus); // same turn, cooldown active
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toBe('on-cooldown');
+  });
+
+  it('own cities are a valid preach target (re-convert a flipped city)', () => {
+    const { state, bus, unitId, cityId, civId } = seedMissionaryScenario(); // city already owned by civId but flipped to a rival faith
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- religion-system.test.ts -t "preach"`
+Expected: FAIL — `preach` not exported yet.
+
+- [ ] **Step 3: Implement `preach()`**
+
+Add to `src/systems/religion-system.ts`:
+
+```typescript
+export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered';
+
+export type PreachResult =
+  | { ok: true; state: GameState; converted: boolean; unitConsumed: boolean }
+  | { ok: false; state: GameState; reason: PreachFailureReason };
+
+export function preach(state: GameState, unitId: string, cityId: string, bus: EventBus): PreachResult {
+  const unit = state.units[unitId];
+  const city = state.cities[cityId];
+  if (!unit || unit.type !== 'missionary' || !city) {
+    return { ok: false, state, reason: 'not-missionary' };
+  }
+  if ((unit.chargesRemaining ?? 0) <= 0) return { ok: false, state, reason: 'no-charges' };
+  if ((unit.missionaryCooldownUntilTurn ?? 0) > state.turn) return { ok: false, state, reason: 'on-cooldown' };
+
+  const faith = state.cityFaith?.[cityId];
+  if (faith?.isHolyCity) return { ok: false, state, reason: 'holy-city' };
+
+  const owner = state.civilizations[unit.owner];
+  if (!owner) return { ok: false, state, reason: 'not-missionary' };
+
+  const atWar = (owner.diplomacy.atWarWith ?? []).includes(city.owner);
+  if (atWar) return { ok: false, state, reason: 'at-war' };
+
+  const isDiscovered = owner.discoveredCivIds?.includes(city.owner) || city.owner === unit.owner || owner.discoveredCities?.includes(cityId);
+  // NOTE: verify the exact discovery-tracking field name against this codebase before
+  // finalizing — grep `discoveredCiv|discoveredCit` in types.ts/civ-system.ts; MR4 used a
+  // similar discovery gate for Sacred Council founding notifications (commit 97360d1f),
+  // reuse that exact helper/field rather than inventing a new one here.
+  if (!isDiscovered) return { ok: false, state, reason: 'undiscovered' };
+
+  const religion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === unit.owner);
+  if (!religion) return { ok: false, state, reason: 'not-missionary' };
+
+  const hasZeal = owner.techState.completed.includes('missionary-zeal');
+  const isDoubled = hasZeal && !!city.occupation;
+  const pointsGranted = isDoubled ? PREACH_OCCUPIED_DOUBLE : PREACH_POINTS;
+
+  const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, religion.id, pointsGranted);
+
+  let cityFaith = { ...(state.cityFaith ?? {}) };
+  if (converted) {
+    cityFaith = {
+      ...cityFaith,
+      [cityId]: {
+        religionId: religion.id,
+        conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+        conversionCooldownExemptCivId: city.owner,
+      },
+    };
+    bus.emit('religion:city-converted', { cityId, toReligionId: religion.id, fromReligionId: faith?.religionId });
+  } else {
+    cityFaith = { ...cityFaith, [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? religion.id } };
+  }
+
+  const chargesRemaining = (unit.chargesRemaining ?? 0) - 1;
+  const unitConsumed = chargesRemaining <= 0;
+
+  let units = state.units;
+  if (unitConsumed) {
+    const { [unitId]: _removed, ...rest } = state.units;
+    units = rest;
+  } else {
+    units = {
+      ...state.units,
+      [unitId]: { ...unit, chargesRemaining, missionaryCooldownUntilTurn: state.turn + MISSIONARY_ACTION_COOLDOWN_TURNS },
+    };
+  }
+
+  let civilizations = state.civilizations;
+  if (unitConsumed) {
+    civilizations = {
+      ...state.civilizations,
+      [unit.owner]: { ...owner, units: owner.units.filter(id => id !== unitId) },
+    };
+  }
+
+  bus.emit('religion:preached', { cityId, unitId, civId: unit.owner, points: pointsGranted, unitConsumed });
+
+  return {
+    ok: true,
+    state: { ...state, cityFaith, units, civilizations },
+    converted,
+    unitConsumed,
+  };
+}
+```
+
+Add the constant imports (`PREACH_POINTS`, `PREACH_OCCUPIED_DOUBLE`, `MISSIONARY_ACTION_COOLDOWN_TURNS`) to the existing import block from `religion-definitions`.
+
+**Before finalizing this step**, grep the exact discovery-check helper MR4 used for Sacred Council's founding notification gate (per the drift-check note in the issue: "add missing religion:city-converted notification" commit `97360d1f`) and replace the placeholder `isDiscovered` line with that exact helper/field — do not invent new discovery-tracking state.
+
+Also add `'religion:preached'` to the `GameEvents` type map in `src/core/types.ts` if it doesn't already exist — grep first: `grep -n "'religion:" src/core/types.ts`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- religion-system.test.ts -t "preach"`
+Expected: PASS (all cases in the matrix).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/religion-system.ts src/core/types.ts tests/systems/religion-system.test.ts
+git commit -m "feat(religion): preach() action with exact-point matrix, charge consumption, cooldowns"
+```
+
+---
+
+### Task 8: UI — Preach button, confirmation-panel title override
+
+**Files:**
+- Modify: `src/ui/unit-delete-confirmation-panel.ts` (optional `title` field)
+- Modify: `src/ui/selected-unit-info.ts` (Preach button, charges display, help text)
+- Test: `tests/ui/selected-unit-info.test.ts` (grep for exact filename first)
+
+**Interfaces:**
+- Consumes: `preach()` from Task 7, `createGameButton` from `src/ui/ui-kit.ts` (per `.claude/skills/button-styling.md` — **invoke that skill before writing the button code in this task**), `createUnitDeleteConfirmationPanel`.
+- Produces: `SelectedUnitInfoCallbacks.onPreach?: (unitId: string, cityId: string) => void`.
+
+- [ ] **Step 1: Invoke the button-styling skill** (do this before writing any button code)
+
+- [ ] **Step 2: Add optional `title` to `UnitDeleteConfirmationConfig`**
+
+Edit `src/ui/unit-delete-confirmation-panel.ts`:
+
+```typescript
+export interface UnitDeleteConfirmationConfig {
+  unitName: string;
+  title?: string;
+  bodyText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+```
+
+And change the title line:
+
+```typescript
+  title.textContent = config.title ?? `Delete ${config.unitName}?`;
+```
+
+- [ ] **Step 3: Write the failing test for the button + confirmation copy**
+
+Add to `tests/ui/selected-unit-info.test.ts` (grep the file's existing pattern for worker action buttons first, mirror it exactly):
+
+```typescript
+it('shows a Preach button with help text for a missionary adjacent to an eligible city, and calls onPreach on click', () => {
+  const { container, state, unit } = /* existing render helper in this file, seeded with a missionary unit adjacent to an eligible city */;
+  const onPreach = vi.fn();
+  renderSelectedUnitInfo(container, state, unit.id, { onPreach /* ...other required callbacks */ });
+  const button = container.querySelector('button[data-action="preach"]');
+  expect(button?.textContent).toContain('Preach');
+  expect(button?.title || button?.getAttribute('aria-label')).toBeTruthy(); // help text present
+  button!.dispatchEvent(new Event('click'));
+  expect(onPreach).toHaveBeenCalledWith(unit.id, expect.any(String));
+});
+
+it('does not show a Preach button when the missionary has 0 charges', () => {
+  const { container, state, unit } = /* same seed, unit.chargesRemaining = 0 */;
+  renderSelectedUnitInfo(container, state, unit.id, { onPreach: vi.fn() });
+  expect(container.querySelector('button[data-action="preach"]')).toBeNull();
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- selected-unit-info -t "Preach"`
+Expected: FAIL — no such button yet.
+
+- [ ] **Step 5: Add `onPreach` callback type and render the button**
+
+Edit `src/ui/selected-unit-info.ts`, add to `SelectedUnitInfoCallbacks` (near `onWorkerAction`):
+
+```typescript
+  onPreach?: (unitId: string, cityId: string) => void;
+```
+
+Add rendering logic in the unit-actions block (mirroring the `canBuildImprovements` worker-charges block, adjacent to it), using `createGameButton` per the button-styling skill's API (exact call shape depends on that skill's guidance fetched in Step 1):
+
+```typescript
+  if (unit.type === 'missionary') {
+    const charges = unit.chargesRemaining ?? 0;
+    const chargeDiv = document.createElement('div');
+    chargeDiv.style.cssText = 'font-size:10px;opacity:0.75;margin-top:6px;';
+    chargeDiv.textContent = `Missionary Charges: ${charges}`;
+    wrapper.appendChild(chargeDiv);
+
+    const eligibleCityId = findEligiblePreachTargetCityId(state, unit); // helper added below
+    if (charges > 0 && eligibleCityId && callbacks.onPreach) {
+      const btn = createGameButton('Preach', 'primary');
+      btn.dataset.action = 'preach';
+      btn.title = 'Push this city toward your faith. Uses one charge — the missionary is used up after its last charge.';
+      btn.addEventListener('click', () => callbacks.onPreach!(unit.id, eligibleCityId));
+      actionsDiv.appendChild(btn);
+    }
+  }
+```
+
+Add the helper function (near the top-level helpers in this file or imported from `religion-system.ts` if the eligibility logic belongs there — prefer importing a shared eligibility check from `religion-system.ts` so UI and the actual `preach()` gate never drift apart; add a `canPreachTarget(state, unit, cityId): boolean` export to `religion-system.ts` in this same task, reusing the same refusal conditions as `preach()` without mutating state):
+
+```typescript
+function findEligiblePreachTargetCityId(state: GameState, unit: Unit): string | null {
+  const candidates = Object.values(state.cities).filter(city => {
+    if (mapDistance(state.map, unit.position, city.position) > 1) return false;
+    return canPreachTarget(state, unit, city.id);
+  });
+  return candidates[0]?.id ?? null;
+}
+```
+
+- [ ] **Step 6: Wire panel rerender after preach (per ui-panels.md: "panel action mutates state the panel renders → must refresh immediately")**
+
+Find wherever `onWorkerAction` is wired up in the main UI wiring file (grep: `grep -rn "onWorkerAction:" src/main.ts src/ui/*.ts`) and add an analogous `onPreach` wiring that calls `preach()`, then re-renders `selected-unit-info` (and the city panel's Faith row, if that city panel happens to be open) from the returned state — mirror the exact rerender pattern used for `onWorkerAction`.
+
+If `preach()` results in `unitConsumed: true`, show `createUnitDeleteConfirmationPanel` with `title: 'Missionary Used Up'` (not the default "Delete ...?" framing, since this is a successful action, not a destructive one) before finalizing the state update, per the gates checklist's explicit note about this.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- selected-unit-info -t "Preach"`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/selected-unit-info.ts src/ui/unit-delete-confirmation-panel.ts src/systems/religion-system.ts src/main.ts tests/ui/selected-unit-info.test.ts
+git commit -m "feat(religion): Preach button, non-destructive consumption confirmation, panel rerender"
+```
+
+---
+
+### Task 9: Tech text honesty update
+
+**Files:**
+- Modify: `src/systems/tech-definitions-eras5-7.ts:266-268`
+- Test: `tests/systems/description-honesty.test.ts` (just confirm it still passes — no new denylist entries needed since this is honest new text, not a repeat of a removed phrase)
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Update the `unlocks` text**
+
+Edit `src/systems/tech-definitions-eras5-7.ts:266-268`:
+
+```typescript
+  { id: 'missionary-zeal', name: 'Missionary Zeal', track: 'spirituality', cost: 120,
+    prerequisites: ['monastic-orders'],
+    unlocks: ['Preaching in cities conquered from other civilizations is twice as effective; missionaries carry 3 charges instead of 2'], era: 6 },
+```
+
+- [ ] **Step 2: Run the honesty and tech-consistency suites**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- description-honesty tech-unlocks-consistency`
+Expected: PASS (new text names no building/unit by exact name, so `tech-unlocks-consistency.test.ts`'s "unlocks must not exactly match an entity name" check is unaffected; it's effect-only text).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/systems/tech-definitions-eras5-7.ts
+git commit -m "fix(religion): missionary-zeal unlocks text states both real effects"
+```
+
+---
+
+### Task 10: AI production scoring + dispatch
+
+**Files:**
+- Modify: `src/ai/ai-production.ts` (scoring — find the unit candidate-scoring loop, distinct from the building loop at `:337+`)
+- Create or modify: dispatch logic — grep `src/ai/ai-unit-roles.ts` and `src/ai/basic-ai.ts` for the existing worker/auto-explore dispatch pattern first, then add a missionary-dispatch function following that same file's convention (do not add a new file if an existing per-turn AI unit-order pass already exists to extend)
+- Test: `tests/ai/ai-production.test.ts` (or wherever AI unit scoring is tested — grep first)
+
+**Interfaces:**
+- Consumes: `preach()`, `canPreachTarget()` (Task 8/7), `cityFollowsOwnFaith()` (Task 3), `chooseAiBoon`'s existing `fervor` boon detection.
+- Produces: a scoring contribution for `missionary` in the AI's unit-candidate list, and a per-turn dispatch pass that orders idle missionaries to preach.
+
+- [ ] **Step 1: Locate the exact unit-scoring loop**
+
+Run: `grep -n "personalityScore\|roleDemandScore" src/ai/ai-production.ts | head -20` — confirm the unit candidate loop's exact structure before writing scoring code (per spec-fidelity.md: verify current code, don't assume).
+
+- [ ] **Step 2: Write the failing test — deterministic scoring + dispatch**
+
+Add to the AI test file found above:
+
+```typescript
+it('scores missionary higher for a civ with the Fervor boon than one without, all else equal', () => {
+  const stateWithFervor = /* seed: civ with founded religion + fervor boon, city with Temple, follows own faith */;
+  const stateWithoutFervor = /* same seed, boon = 'tithes' or undefined */;
+  const candidatesWithFervor = getAIProductionCandidates(stateWithFervor, cityId); // exact function name TBD from Step 1's grep
+  const candidatesWithoutFervor = getAIProductionCandidates(stateWithoutFervor, cityId);
+  const fervorScore = candidatesWithFervor.find(c => c.itemId === 'missionary')?.personalityScore ?? 0;
+  const baseScore = candidatesWithoutFervor.find(c => c.itemId === 'missionary')?.personalityScore ?? 0;
+  expect(fervorScore).toBeGreaterThan(baseScore);
+});
+
+it('AI dispatches an idle missionary to preach its own unconverted city before a friendly minor-civ city', () => {
+  const state = /* seed: AI civ with one idle missionary, one own city not yet following own faith, one friendly minor-civ city also eligible */;
+  const next = runAiMissionaryDispatch(state, bus); // exact function name TBD from Step 4
+  // assert the missionary's charges decreased (it acted) and the OWN city's conversionProgress grew, not the minor civ's
+});
+
+it('AI missionary dispatch is deterministic given the same seed/state', () => {
+  const state = /* same seed as above */;
+  const runA = runAiMissionaryDispatch(state, bus);
+  const runB = runAiMissionaryDispatch(state, bus);
+  expect(runA.state.cityFaith).toEqual(runB.state.cityFaith);
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- ai-production -t "missionary"`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement scoring**
+
+In `src/ai/ai-production.ts`, in the unit-candidate loop found in Step 1, add a `missionary`-specific contribution to `personalityScore` gated by: civ has founded a religion (reuse the same lookup `preach()` uses), city satisfies `getTrainableUnitsForCity`'s new gate (religion + own faith + Temple — i.e. only score it where it's actually trainable), and boost when `religion.boon === 'fervor'`. Follow this file's existing convention for how other unit types contribute to `personalityScore` (copy the exact numeric-weighting style already used for a comparable civilian/utility unit rather than inventing a new scale).
+
+- [ ] **Step 5: Implement dispatch**
+
+Add a `runAiMissionaryDispatch(state, bus)` function (in `ai-production.ts` if a per-turn AI unit-order pass already lives there, else in `ai-unit-roles.ts` — match whichever file already owns worker/auto-explore dispatch, found via the grep in the task header): for each civ with a founded religion, for each idle missionary (charges > 0, not on cooldown, `hasActed` false), find the highest-priority eligible target by iterating `Object.values(state.cities).sort by id)` (deterministic order) filtered to: own cities failing `cityFollowsOwnFaith` first, then friendly (non-hostile, per existing diplomacy helper) minor-civ cities eligible per `canPreachTarget`; call `preach()` on the first match found; if no match, leave the unit idle. Move the missionary adjacent to its target first if not already in range, using the existing shared movement helper (grep `moveUnitTo` or equivalent — do not write ad hoc pathing).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- ai-production -t "missionary"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai/ai-production.ts src/ai/ai-unit-roles.ts tests/ai/ai-production.test.ts
+git commit -m "feat(religion): AI missionary production scoring (Fervor-weighted) and dispatch"
+```
+
+---
+
+### Task 11: Verify city panel's Faith row needs no changes (regression only)
+
+**Files:**
+- Test only: `tests/ui/city-panel.test.ts` (grep exact filename)
+
+**Interfaces:** none new — this task is verification, not implementation.
+
+- [ ] **Step 1: Write a regression test proving the existing Faith row renders preach-driven progress correctly with the new per-religion map shape**
+
+Add to the city-panel test file:
+
+```typescript
+it('Faith row shows conversion progress correctly after a preach() call (per-religion map shape, #592)', () => {
+  let state = /* seed: city with cityFaith.conversionProgress = { [religionId]: 50 } via the NEW map shape */;
+  const html = renderCityPanel(state, cityId, /* ...existing required args */);
+  expect(html).toContain(/* whatever percentage/points string city-panel.ts:441-456 currently derives from conversionProgress */);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- city-panel -t "Faith row"`
+Expected: Read `src/ui/city-panel.ts:435-456` first — if it destructures `conversionProgress.points`/`.toReligionId` directly (old shape), this test FAILS and city-panel.ts needs a small fix to read `conversionProgress[cityFaithEntry.religionId]` (or the target religion, whichever the panel is meant to show) from the new map instead. Apply that fix if the test fails; if the panel already computed progress generically enough to not care about shape, this is a pure regression-proving no-op per the gates checklist ("verify, don't rebuild").
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "test(religion): confirm Faith row renders per-religion conversion progress correctly"
+```
+
+(If Step 2 required no source fix, commit only the test file with message `test(religion): regression-cover Faith row against per-religion progress shape`.)
+
+---
+
+### Task 12: Full verification, inline multi-dimensional review, PR
+
+**Files:** none (process task).
+
+- [ ] **Step 1: Rebase on latest `origin/main`**
+
+Run: `git fetch origin main && git rebase origin/main`
+
+- [ ] **Step 2: Full build + test**
+
+Run: `bash scripts/run-with-mise.sh yarn build` (expect exit 0)
+Run: `bash scripts/run-with-mise.sh yarn test` (expect exit 0)
+
+- [ ] **Step 3: Pacing gate sanity check**
+
+Run: `bash scripts/run-with-mise.sh yarn test -- pacing-audit pacing-reference-economy`
+Expected: PASS with no snapshot changes — missionary/preach introduce no yields or tech-cost levers, only a one-time state-mutating side effect (conversion), so the reference-economy fixture should be untouched. If it DOES show a diff, stop and investigate before proceeding — that would mean something in this change unexpectedly touched an economy lever.
+
+- [ ] **Step 4: Inline multi-dimensional review** (no subagents) — actually re-read the changed files for each dimension, do not restate intentions:
+  - Balancing/gameplay/fun: re-read `PREACH_POINTS`, cooldown constants, and the doubling condition against `.claude/rules/game-balance.md`'s spirit (this MR adds no yields, so the yield-ceiling rules don't apply, but sanity-check the cooldown numbers feel right at a table-top level).
+  - Player ages 7-43: re-read all new UI copy (button help text, confirmation panel body text) for plain language.
+  - Difficulty modes: confirm no explorer/standard/veteran branching was added anywhere touched.
+  - AI: re-read the Task 10 scoring/dispatch code for a determinism regression (same-seed reproducibility) and confirm it doesn't crash on a civ with zero cities or zero religion.
+  - UI/UX: click through Preach in a running dev server if browser preview is available; confirm the confirmation panel's copy reads as a success message, not a warning.
+  - Architecture/extensibility: confirm `NP_PRODUCTION_DISCOUNTS`-style "table not branch" conventions weren't violated (missionary scoring should not require per-unit-ID branches elsewhere).
+  - Data/saves: confirm a legacy save with no `missionaryCooldownUntilTurn`/no per-religion `conversionProgress` map loads without crashing (all new fields are optional; add one load-old-save-shape test if none exists).
+  - SFX: confirm silent-for-now is intentional and noted in the PR body (per the issue's stale "reuse unit-action sound" claim — no such generic hook exists per drift-check).
+  - Solo + hot-seat regressions: confirm `state.currentPlayer` is used correctly anywhere the Preach button reads "whose turn is it" (it shouldn't need to — missionary ownership already gates the button, but verify no `'player'` literal was hardcoded per `.claude/rules/game-systems.md`).
+  - Fix anything found, re-run `yarn build && yarn test`.
+
+- [ ] **Step 5: Draft PR body, grep for the closes-keyword bug**
+
+Draft body including: summary, save/migration note (additive `UnitType` + optional `chargesRemaining`/`missionaryCooldownUntilTurn`/`conversionCooldownUntilTurn`/`conversionCooldownExemptCivId` fields — no migration needed, all optional and absent-safe), SFX note (silent this MR, bespoke chime is MR7/#594), architecture note (per-religion `conversionProgress` map is a data-shape change from MR4 — call this out explicitly as an intentional deviation improving on the original design, per spec-fidelity.md's "note the deviation" guidance), reference `#592`/`#587` — never "closes #524".
+
+Run: `echo "$PR_BODY" | grep -iE 'close[sd]?\s+#[0-9]+|fix(e[sd])?\s+#[0-9]+|resolve[sd]?\s+#[0-9]+'`
+Expected: no output. If it matches, rewrite that sentence before proceeding.
+
+- [ ] **Step 6: Open the PR (do not merge)**
+
+Run (timeout 120000ms): `gh pr create --title "MR5 (#592): missionary unit + preach action" --body "$(cat pr-body.md)"`
+
+Report the PR URL back to the user. Stop here — do not merge.

--- a/src/ai/ai-personality.ts
+++ b/src/ai/ai-personality.ts
@@ -82,6 +82,9 @@ export function weightProductionRoles(
   if (roles.includes('espionage')) {
     score += personality.diplomacyFocus * 4;
   }
+  if (roles.includes('missionary')) {
+    score += personality.diplomacyFocus * 6;
+  }
   return score;
 }
 

--- a/src/ai/ai-production.ts
+++ b/src/ai/ai-production.ts
@@ -9,6 +9,7 @@ import {
   getAvailableBuildings,
   getProductionCostForItem,
   getTrainableUnitsForCity,
+  cityFollowsOwnFaith,
 } from '@/systems/city-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import {
@@ -78,6 +79,7 @@ function validQueuedUnitRoles(
         state.map,
         civ.civType,
         resources,
+        cityFollowsOwnFaith(state, city),
       ).map(unit => unit.type),
     );
     return city.productionQueue.flatMap(itemId =>
@@ -275,6 +277,7 @@ function generateWithResidual(
     state.map,
     civ.civType,
     resources,
+    cityFollowsOwnFaith(state, city),
   )) {
     if (UNIT_DEFINITIONS[unit.type].airOperation
       && !canCompleteAirUnitProduction(state, cityId, unit.type).ok) continue;

--- a/src/ai/ai-production.ts
+++ b/src/ai/ai-production.ts
@@ -350,6 +350,59 @@ function generateWithResidual(
     });
   }
 
+  // #592 MR5: missionary production scoring. Bypasses the demand-gated military loop
+  // above — spreading faith isn't a combat force-composition role, so there's no
+  // AIForceDemand entry for it to match against. Only scored when the unit is actually
+  // trainable (religion founded + city follows own faith + Temple), mirroring the real
+  // trainability gate rather than a duplicated check.
+  const civReligion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === civId);
+  if (civReligion) {
+    const missionaryTrainable = getTrainableUnitsForCity(
+      city,
+      civ.techState.completed,
+      state.map,
+      civ.civType,
+      resources,
+      cityFollowsOwnFaith(state, city),
+    ).some(candidate => candidate.type === 'missionary');
+    if (missionaryTrainable) {
+      const maintenanceImpact = projectedUnitMaintenanceImpact(state, civId, cityId, 'missionary');
+      if (reserveAllows(state, civId, maintenanceImpact, false, 1)) {
+        const cost = getProductionCostForItem('missionary', {
+          city,
+          bonusEffect: civDefinition?.bonusEffect,
+          era: state.era,
+          completedTechs: civ.techState.completed,
+          activeNationalProjects,
+          availableResources: resources,
+        });
+        const productionTurns = Math.max(1, Math.ceil(cost / productionPerTurn));
+        const personalityScore = weightProductionRoles(personality, ['missionary']);
+        // Fervor-boon civs weight missionaries higher — their faith already spreads/
+        // converts faster, so each additional missionary compounds more value.
+        const fervorWeight = civReligion.boon === 'fervor' ? 2 : 1;
+        const score = 6 * fervorWeight
+          + personalityScore
+          - productionTurns * 1.5
+          - maintenanceImpact * 3;
+        candidates.push({
+          itemId: 'missionary',
+          kind: 'unit',
+          roles: ['missionary'],
+          productionTurns,
+          maintenanceImpact,
+          roleDemandScore: 0,
+          economyScore: 0,
+          personalityScore,
+          emergencyDefenseScore: 0,
+          citySpecializationScore: 0,
+          maintenanceRisk: maintenanceImpact,
+          score,
+        });
+      }
+    }
+  }
+
   for (const building of getAvailableBuildings(
     city,
     civ.techState.completed,

--- a/src/ai/ai-resource-marketplace.ts
+++ b/src/ai/ai-resource-marketplace.ts
@@ -4,6 +4,7 @@ import {
   getAvailableBuildings,
   getProductionCostForItem,
   getTrainableUnitsForCity,
+  cityFollowsOwnFaith,
   TRAINABLE_UNITS,
 } from '@/systems/city-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
@@ -48,6 +49,7 @@ function getResourcePurchaseCandidates(state: GameState, civId: string, cityId: 
       state.map,
       civ.civType,
       undefined,
+      cityFollowsOwnFaith(state, city),
     ).map(unit => unit.type),
   ].sort();
 }

--- a/src/ai/ai-unit-roles.ts
+++ b/src/ai/ai-unit-roles.ts
@@ -24,6 +24,7 @@ const ROLE_OVERRIDES: Partial<Record<UnitType, readonly AIStrategicRole[]>> = {
   expedition: ['resource-expedition', 'recon'],
   settler: ['settlement'],
   worker: ['worker'],
+  missionary: ['missionary'],
   spy_scout: ['espionage', 'recon'],
   spy_informant: ['espionage'],
   spy_agent: ['espionage'],

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -2,7 +2,7 @@ import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City
 import { EventBus } from '@/core/event-bus';
 import { hexKey, wrappedHexDistance, hexDistance, mapDistance } from '@/systems/hex-utils';
 import { getDetectionUnitTypeForCiv, cityFollowsOwnFaith } from '@/systems/city-system';
-import { preach, canPreachTarget } from '@/systems/religion-system';
+import { preach, isPreachTargetEligible } from '@/systems/religion-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { getMovementRangeDetails, moveUnitWithZoneOfControl, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -1481,7 +1481,7 @@ function chooseMissionaryDispatchTarget(state: GameState, civId: string, unit: U
   const ownUnconverted = civ.cities
     .map(id => state.cities[id])
     .filter((city): city is City => !!city && !cityFollowsOwnFaith(state, city))
-    .filter(city => canPreachTarget(state, unit, city.id))
+    .filter(city => isPreachTargetEligible(state, unit, city.id))
     .map(city => city.id)
     .sort();
   if (ownUnconverted.length > 0) return ownUnconverted[0];
@@ -1489,7 +1489,7 @@ function chooseMissionaryDispatchTarget(state: GameState, civId: string, unit: U
   const friendlyMinorCityIds = Object.values(state.minorCivs ?? {})
     .filter(mc => !mc.isDestroyed && !(civ.diplomacy.atWarWith ?? []).includes(mc.id))
     .map(mc => mc.cityId)
-    .filter(cityId => canPreachTarget(state, unit, cityId))
+    .filter(cityId => isPreachTargetEligible(state, unit, cityId))
     .sort();
   if (friendlyMinorCityIds.length > 0) return friendlyMinorCityIds[0];
 

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1486,10 +1486,19 @@ function chooseMissionaryDispatchTarget(state: GameState, civId: string, unit: U
     .sort();
   if (ownUnconverted.length > 0) return ownUnconverted[0];
 
+  // A minor-civ city is foreign-owned by definition, so cityFollowsOwnFaith (which
+  // compares against city.owner) can never match here -- the correct check is whether
+  // the city's cityFaith.religionId already equals civId's OWN religion id directly.
+  const ownReligionId = Object.values(state.religions ?? {}).find(r => r.ownerCivId === civId)?.id;
   const friendlyMinorCityIds = Object.values(state.minorCivs ?? {})
     .filter(mc => !mc.isDestroyed && !(civ.diplomacy.atWarWith ?? []).includes(mc.id))
     .map(mc => mc.cityId)
-    .filter(cityId => isPreachTargetEligible(state, unit, cityId))
+    .filter(cityId => {
+      // Don't waste a charge re-preaching a friendly minor city that already follows
+      // this civ's own faith -- there's no conversion progress left to make.
+      if (ownReligionId && state.cityFaith?.[cityId]?.religionId === ownReligionId) return false;
+      return isPreachTargetEligible(state, unit, cityId);
+    })
     .sort();
   if (friendlyMinorCityIds.length > 0) return friendlyMinorCityIds[0];
 

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,7 +1,8 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
-import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
-import { getDetectionUnitTypeForCiv } from '@/systems/city-system';
+import { hexKey, wrappedHexDistance, hexDistance, mapDistance } from '@/systems/hex-utils';
+import { getDetectionUnitTypeForCiv, cityFollowsOwnFaith } from '@/systems/city-system';
+import { preach, canPreachTarget } from '@/systems/religion-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { getMovementRangeDetails, moveUnitWithZoneOfControl, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -687,6 +688,46 @@ function processAITurnInternal(
     }
   }
   civ = newState.civilizations[civId];
+
+  // #592 MR5: missionary dispatch is administrative, same rationale as worker dispatch
+  // above — 'missionary' has no AIStrategicPlan required role and no COMPATIBLE_ROLES
+  // fallback in ai-unit-assignment.ts, so it never reaches processMajorCivStrategicTurn's
+  // tactical dispatch. Idle missionaries move toward the highest-priority eligible target
+  // (own cities not yet following the civ's own faith first, then friendly minor-civ
+  // cities) and preach once in range — mirroring the worker move-then-act pattern above.
+  if (Object.values(newState.religions ?? {}).some(r => r.ownerCivId === civId)) {
+    const idleMissionaries = civ.units
+      .map(id => newState.units[id])
+      .filter((unit): unit is Unit =>
+        Boolean(unit)
+        && unit.type === 'missionary'
+        && !unit.hasActed
+        && (unit.chargesRemaining ?? 0) > 0
+        && (unit.missionaryCooldownUntilTurn ?? 0) <= newState.turn);
+
+    for (const missionary of idleMissionaries) {
+      const current = newState.units[missionary.id];
+      if (!current || current.hasActed) continue;
+
+      const targetCityId = chooseMissionaryDispatchTarget(newState, civId, current);
+      if (!targetCityId) continue;
+      const targetCity = newState.cities[targetCityId];
+      if (!targetCity) continue;
+
+      if (mapDistance(newState.map, current.position, targetCity.position) <= 1) {
+        const result = preach(newState, current.id, targetCityId, bus);
+        if (result.ok) newState = result.state;
+      } else if (current.movementPointsLeft > 0) {
+        const path = findPath(current.position, targetCity.position, newState.map, 'land');
+        if (path && path.length > 1) {
+          const next = structuredClone(newState);
+          const movement = executeUnitMove(next, current.id, path[1]!, { actor: 'ai', civId, bus });
+          if (movement.ok) newState = next;
+        }
+      }
+    }
+    civ = newState.civilizations[civId];
+  }
 
   // Cargo handling is administrative rather than a competing strategic
   // chase path, so retain the canonical all-cargo load/unload behavior.
@@ -1428,6 +1469,31 @@ function processAITurnInternal(
   }
 
   return newState;
+}
+
+// #592 MR5: own unconverted cities first, then friendly minor-civ cities — deterministic
+// (id-sorted) so repeated runs from the same state produce the same dispatch order.
+// "Friendly" mirrors this file's existing hostile-owner convention: not in atWarWith.
+function chooseMissionaryDispatchTarget(state: GameState, civId: string, unit: Unit): string | null {
+  const civ = state.civilizations[civId];
+  if (!civ) return null;
+
+  const ownUnconverted = civ.cities
+    .map(id => state.cities[id])
+    .filter((city): city is City => !!city && !cityFollowsOwnFaith(state, city))
+    .filter(city => canPreachTarget(state, unit, city.id))
+    .map(city => city.id)
+    .sort();
+  if (ownUnconverted.length > 0) return ownUnconverted[0];
+
+  const friendlyMinorCityIds = Object.values(state.minorCivs ?? {})
+    .filter(mc => !mc.isDestroyed && !(civ.diplomacy.atWarWith ?? []).includes(mc.id))
+    .map(mc => mc.cityId)
+    .filter(cityId => canPreachTarget(state, unit, cityId))
+    .sort();
+  if (friendlyMinorCityIds.length > 0) return friendlyMinorCityIds[0];
+
+  return null;
 }
 
 export function processAITurn(

--- a/src/audio/sfx-catalog.ts
+++ b/src/audio/sfx-catalog.ts
@@ -268,6 +268,7 @@ export const UNIT_SFX: Partial<Record<UnitType, Partial<Record<SfxClass, TrackEn
 const LOCOMOTION_CLASS: Record<UnitType, LocomotionClass> = {
   settler:       'humanoid',
   worker:        'humanoid',
+  missionary:    'humanoid',
   scout:         'humanoid',
   scout_hound:   'animal',
   war_hound:     'animal',

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -45,6 +45,7 @@ import type { HexCoord } from './types';
 import { applyReconReveals, updateVisibility, revealMinorCivCities, applySharedVision, applySatelliteSurveillance, applyMassSurveillanceReveal } from '@/systems/fog-of-war';
 import { getActiveNationalProjectsForCiv } from '@/systems/national-project-system';
 import { UNIT_CLASS_BY_TYPE } from '@/systems/unit-modifier-definitions';
+import { MISSIONARY_BASE_CHARGES, MISSIONARY_ZEAL_CHARGES } from '@/systems/religion-definitions';
 import { getHealingBonus, getVisionBonus, isWithinRangeOfTelemedicineHub } from '@/systems/unit-modifier-system';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
@@ -355,6 +356,14 @@ export function processTurn(
       if (result.completedUnit) {
         bus.emit('city:unit-trained', { cityId, unitType: result.completedUnit });
         const newUnit = createUnit(result.completedUnit, civId, city.position, newState.idCounters, civDef?.bonusEffect);
+        if (result.completedUnit === 'missionary') {
+          // #592 MR5: charges are baked in from the owner's tech state AT BUILD TIME, never
+          // re-derived later — a missionary built before missionary-zeal completes keeps 2
+          // charges forever, even if the civ researches it afterward.
+          newUnit.chargesRemaining = civ.techState.completed.includes('missionary-zeal')
+            ? MISSIONARY_ZEAL_CHARGES
+            : MISSIONARY_BASE_CHARGES;
+        }
         const unitDef = UNIT_DEFINITIONS[result.completedUnit];
         if (unitDef?.domain === 'naval') {
           let navalMoveBonus = 0;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -338,7 +338,7 @@ export interface LastSeenTilePresentation {
 // --- Units ---
 
 export type UnitType =
-  | 'settler' | 'worker' | 'scout' | 'warrior' | 'archer'
+  | 'settler' | 'worker' | 'scout' | 'warrior' | 'archer' | 'missionary'
   | 'swordsman' | 'pikeman' | 'musketeer' | 'galley' | 'trireme'
   | 'axeman' | 'spearman' | 'horseman' | 'cavalry' | 'knight'
   | 'crossbowman' | 'catapult' | 'ballista' | 'cannon' | 'grenadier' | 'marine' | 'rifleman' | 'ironclad'
@@ -419,6 +419,7 @@ export interface Unit {
   hasMoved: boolean;
   hasActed: boolean;         // used action this turn (build, found, etc.)
   chargesRemaining?: number; // workers default to 2; omitted on legacy saves
+  missionaryCooldownUntilTurn?: number; // set after preach(); missionary can't preach again until state.turn >= this
   workerTask?: WorkerTask;    // active multi-turn improvement the worker is assigned to
   isResting: boolean;        // player explicitly chose to rest/heal this turn
   skippedTurn?: boolean;     // player chose to hold this unit out of unit cycling this turn
@@ -1255,7 +1256,8 @@ export type AIStrategicRole =
   | 'worker'
   | 'resource-expedition'
   | 'trade'
-  | 'espionage';
+  | 'espionage'
+  | 'missionary';
 
 export type AIStrategicObjective =
   | 'defend'
@@ -1603,7 +1605,20 @@ export interface Religion {
 export interface CityFaith {
   religionId: string;
   isHolyCity?: true;      // founding city — permanently immune to conversion, under ANY owner
-  conversionProgress?: { toReligionId: string; points: number };  // converts at CONVERSION_THRESHOLD
+  // Per-religion progress ledger (MR5, #592): keyed by candidate religionId, NOT a single
+  // slot. This lets ambient passive pressure toward religion A accumulate independently of
+  // missionary-driven preach progress toward religion B in the same city — previously a
+  // single {toReligionId, points} slot meant a preach investment could be silently wiped
+  // out the moment ambient pressure pointed elsewhere. Conversion fires for whichever
+  // religionId's bucket first reaches CONVERSION_THRESHOLD.
+  conversionProgress?: Record<string, number>;
+  // MR5 anti-flip-flop guard: once set, no religionId OTHER than conversionCooldownExemptCivId's
+  // faith may convert this city until state.turn >= conversionCooldownUntilTurn. The exempt
+  // civ (the city's owner at the moment of the LAST conversion) can always re-convert its own
+  // city immediately — this preserves "preach a flipped city back" as an owner privilege while
+  // still stopping rival faiths from ping-ponging a border city turn after turn.
+  conversionCooldownUntilTurn?: number;
+  conversionCooldownExemptCivId?: string;
   // loyaltyProgress added by MR6 (#593)
 }
 
@@ -1872,6 +1887,7 @@ export interface GameEvents {
   'crisis:started':   { crisisId: string; flavorId: string; civId: string; cityIds: string[] };
   'religion:founded': { religionId: string; civId: string; cityId: string; name: string };
   'religion:city-converted': { cityId: string; toReligionId: string; fromReligionId?: string };
+  'religion:preached': { cityId: string; unitId: string; civId: string; points: number; unitConsumed: boolean };
   'crisis:spread':    { crisisId: string; fromCityId: string; toCityId: string };
   // civId/foeName are populated for Hunt transitions (spawn -> menacing, menacing ->
   // assaulting) — carried directly rather than re-read from state because both are set

--- a/src/main.ts
+++ b/src/main.ts
@@ -2642,6 +2642,7 @@ function performPreach(unitId: string, cityId: string): void {
       bodyText: `${message} That was its last charge, so the missionary is gone.`,
       confirmLabel: 'OK',
       hideCancel: true,
+      tone: 'neutral',
       onConfirm: () => {
         uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
         setBlockingOverlay(null);

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,8 @@ import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
 import { resolveCivilizationEra } from '@/systems/tech-definitions';
 import { resolveCombatEra } from '@/systems/era-resolution';
+import { preach } from '@/systems/religion-system';
+import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast, getBeastTrophyGoldPerTurn, isCivUnitInBeastTerritory } from '@/systems/beast-system';
@@ -2022,6 +2024,7 @@ function selectUnit(
       onOpenNetworkIntent: uid => openNetworkIntentPanel(uid),
       onFoundCity: () => foundCityAction(),
       onWorkerAction: action => performWorkerAction(action),
+      onPreach: (unitId, cityId) => performPreach(unitId, cityId),
       onRest: () => restAction(),
       onSkipTurn: uid => getUnitTurnFlow().skipUnitAction(uid),
       onDeleteUnit: uid => getUnitTurnFlow().showDeleteUnitConfirmation(uid),
@@ -2610,6 +2613,48 @@ function performWorkerAction(action: WorkerActionType): void {
   }
 
   showNotification(result.message, result.workerLost ? 'warning' : 'info');
+}
+
+// #592 MR5: preach action. Mirrors performWorkerAction's state-apply + rerender pattern,
+// but adds a non-destructive confirmation dialog when the missionary is consumed on its
+// last charge — the deletion has already happened inside preach() by this point, so the
+// dialog is an acknowledgment, not a gate (hideCancel: true, no undo possible).
+function performPreach(unitId: string, cityId: string): void {
+  const unit = gameState.units[unitId];
+  const cityName = gameState.cities[cityId]?.name ?? cityId;
+  const result = preach(gameState, unitId, cityId, bus);
+  if (!result.ok) return;
+
+  gameState = result.state;
+  renderLoop.setGameState(gameState);
+  updateHUD();
+
+  const message = result.converted
+    ? `${cityName} has converted to your faith!`
+    : `You preached in ${cityName}.`;
+
+  if (result.unitConsumed) {
+    deselectUnit();
+    setBlockingOverlay('unit-delete-confirmation');
+    createUnitDeleteConfirmationPanel(uiLayer, {
+      unitName: unit ? UNIT_DEFINITIONS[unit.type].name : 'Missionary',
+      title: 'Missionary Used Up',
+      bodyText: `${message} That was its last charge, so the missionary is gone.`,
+      confirmLabel: 'OK',
+      hideCancel: true,
+      onConfirm: () => {
+        uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
+        setBlockingOverlay(null);
+      },
+      onCancel: () => {
+        uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
+        setBlockingOverlay(null);
+      },
+    });
+  } else {
+    selectUnit(unitId);
+    showNotification(message, result.converted ? 'success' : 'info');
+  }
 }
 
 function ensurePlayerWarState(targetCivId: string): void {

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -86,6 +86,7 @@ type UnitMotionStyle = 'humanoid' | 'animal' | 'naval' | 'air';
 const UNIT_MOTION_STYLES: Record<UnitType, UnitMotionStyle> = {
   settler: 'humanoid',
   worker: 'humanoid',
+  missionary: 'humanoid',
   scout: 'humanoid',
   scout_hound: 'animal',
   war_hound: 'animal',
@@ -207,6 +208,8 @@ function withMotion(type: UnitType, render: UnitSpriteComponent): UnitSpriteComp
 export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   settler:        withMotion('settler', SettlerSprite),
   worker:         withMotion('worker', WorkerSprite),
+  // Placeholder art (#592 MR5) — reuses WorkerSprite until bespoke missionary art ships in MR7 (#594).
+  missionary:     withMotion('missionary', WorkerSprite),
   scout:          withMotion('scout', ScoutSprite),
   scout_hound:    withMotion('scout_hound', ScoutHoundSprite),
   war_hound:      withMotion('war_hound', WarHoundSprite),

--- a/src/renderer/unit-visual-resolver.ts
+++ b/src/renderer/unit-visual-resolver.ts
@@ -11,6 +11,7 @@ const FALLBACK_ICONS: Record<UnitType, string> = {
   scout: '🔭',
   warrior: '⚔️',
   archer: '🏹',
+  missionary: '🙏',
   swordsman: '🗡️',
   pikeman: '🔱',
   musketeer: '🔫',

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -276,6 +276,37 @@ function withReligionDefaults(state: GameState): GameState {
   };
 }
 
+// #592 MR5: CityFaith.conversionProgress changed shape from a single
+// { toReligionId, points } slot (MR4) to a per-religion { [religionId]: points } map, so
+// getCityConversionPoints/applyCityConversionPoints (which index by religionId) would
+// silently read 0 for any city with genuine in-flight conversion progress saved under the
+// old shape -- not a crash, but a real loss of live game state on load. Detect the old
+// shape (a `toReligionId` string field, which no real religionId key would ever collide
+// with -- religion ids are always `religion-${civId}`) and convert it to the new map
+// in-place. Unconditional (not a versioned migration) for the same additive-safety reason
+// as withReligionDefaults above -- pre-MR4 saves have no cityFaith at all and are
+// unaffected; only saves written between MR4 and this MR need the conversion.
+function normalizeCityFaithConversionProgress(state: GameState): GameState {
+  if (!state.cityFaith) return state;
+  let changed = false;
+  const cityFaith: typeof state.cityFaith = { ...state.cityFaith };
+  for (const [cityId, faith] of Object.entries(cityFaith)) {
+    const progress = faith?.conversionProgress as Record<string, unknown> | undefined;
+    if (
+      progress
+      && typeof progress === 'object'
+      && typeof progress.toReligionId === 'string'
+      && typeof progress.points === 'number'
+    ) {
+      const toReligionId = progress.toReligionId;
+      const points = progress.points;
+      cityFaith[cityId] = { ...faith, conversionProgress: { [toReligionId]: points } };
+      changed = true;
+    }
+  }
+  return changed ? { ...state, cityFaith } : state;
+}
+
 function migrateDualEraWorldAge(state: GameState): GameState {
   const withAircraft = migrateLegacyBasedAircraft(state);
   return { ...withAircraft, era: resolveWorldAge(withAircraft.civilizations) };
@@ -317,5 +348,5 @@ export function migrateSaveToCurrent(raw: unknown): GameState {
     state = { ...migration(state), saveSchemaVersion: version };
   }
   const migrated = state.gameId ? state : migrateToEra13Foundation(state);
-  return withReligionDefaults(normalizeCrisisArchetypes(migrated));
+  return normalizeCityFaithConversionProgress(withReligionDefaults(normalizeCrisisArchetypes(migrated)));
 }

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1,4 +1,4 @@
-import type { City, Building, HexCoord, GameMap, UnitType, CivBonusEffect, TrainableUnitEntry, IdCounters, ResourceType, DroppedProductionItem, ProductionDropReason } from '@/core/types';
+import type { City, Building, HexCoord, GameMap, UnitType, CivBonusEffect, TrainableUnitEntry, IdCounters, ResourceType, DroppedProductionItem, ProductionDropReason, GameState } from '@/core/types';
 import { isSpyUnitType } from './espionage-system';
 import { hexKey, hexesInRange, hexNeighbors, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
@@ -1091,6 +1091,7 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
   { type: 'archer', name: 'Archer', cost: 35, techRequired: 'archery', obsoletedByTech: 'tactics', upgradesTo: 'crossbowman', pacing: { band: 'power-spike', role: 'ranged-breakpoint', impact: 1.15, scope: 'military', snowball: 1, urgency: 1.05, situationality: 1, unlockBreadth: 1 } },
   { type: 'scout', name: 'Scout', cost: 6, pacing: { band: 'starter', role: 'early-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   { type: 'worker', name: 'Worker', cost: 12 },
+  { type: 'missionary', name: 'Missionary', cost: 16, trainedFromBuilding: 'temple' },
   { type: 'settler', name: 'Settler', cost: 24, pacing: { band: 'power-spike', role: 'expansion', impact: 1.25, scope: 'empire', snowball: 1.3, urgency: 1.05, situationality: 1, unlockBreadth: 1.2 } },
   { type: 'swordsman',    name: 'Swordsman',    cost: 50,  techRequired: 'bronze-working',   resourceRequired: ['iron'],   obsoletedByTech: 'rifled-infantry', upgradesTo: 'rifleman',        pacing: { band: 'power-spike', role: 'melee-breakpoint',       impact: 1.2,  scope: 'military', snowball: 1,   urgency: 1,    situationality: 1,    unlockBreadth: 1 } },
   { type: 'pikeman',      name: 'Pikeman',      cost: 70,  techRequired: 'fortification',    obsoletedByTech: 'rifled-infantry', upgradesTo: 'rifleman',                                        pacing: { band: 'power-spike', role: 'anti-cavalry-breakpoint', impact: 1.15, scope: 'military', snowball: 1,   urgency: 1,    situationality: 1.05, unlockBreadth: 1 } },
@@ -1409,6 +1410,7 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   archer: '🏹',
   scout: '🔍',
   worker: '🪚',
+  missionary: '🙏',
   settler: '🏕️',
   swordsman: '🗡️',
   pikeman: '🔱',
@@ -1680,17 +1682,28 @@ export function getTrainableUnitsForCiv(
   });
 }
 
+// #592 MR5: single source of truth for missionary's "city follows owner's own faith" gate,
+// so every getTrainableUnitsForCity call site computes it the same way.
+export function cityFollowsOwnFaith(state: GameState, city: City): boolean {
+  const faith = state.cityFaith?.[city.id];
+  if (!faith) return false;
+  const religion = state.religions?.[faith.religionId];
+  return !!religion && religion.ownerCivId === city.owner;
+}
+
 export function getTrainableUnitsForCity(
   city: City,
   completedTechs: string[],
   map: GameMap,
   civType?: string,
   availableResources?: Set<ResourceType>,
+  followsOwnFaith: boolean = false,
 ): TrainableUnitEntry[] {
   const coastal = isCityCoastal(city, map);
   return getTrainableUnitsForCiv(completedTechs, civType, availableResources)
     .filter(unit => !unit.coastalRequired || coastal)
-    .filter(unit => !unit.trainedFromBuilding || (city.buildings ?? []).includes(unit.trainedFromBuilding));
+    .filter(unit => !unit.trainedFromBuilding || (city.buildings ?? []).includes(unit.trainedFromBuilding))
+    .filter(unit => unit.type !== 'missionary' || followsOwnFaith);
 }
 
 export function getDetectionUnitTypeForCiv(civType?: string): UnitType {

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -291,7 +291,8 @@ export function getMinorCivBuildCandidates(
   const pressureEra = resolveNeutralPressureEra(state, city.position) ?? 1;
   const buildings = getAvailableBuildings(city, completedTechs, state.map, resources, pressureEra)
     .filter(building => !building.nationalProject && !building.uniquePerEmpire && !UNSAFE_BUILDING_IDS.has(building.id));
-  const units = getTrainableUnitsForCity(city, completedTechs, state.map, undefined, resources)
+  // minor civs never found a religion — missionary never trainable here
+  const units = getTrainableUnitsForCity(city, completedTechs, state.map, undefined, resources, false)
     .filter(unit => !UNSAFE_UNIT_TYPES.has(unit.type));
 
   return { buildings, units };

--- a/src/systems/quest-objective-system.ts
+++ b/src/systems/quest-objective-system.ts
@@ -3,7 +3,7 @@ import { calculateCivEconomy } from './economy-system';
 import { getCivAvailableResources } from './resource-acquisition-system';
 import { RESOURCE_DEFINITIONS } from './resource-definitions';
 import { calculateProjectedCityYields } from './city-work-system';
-import { getProductionCostForItem, getTrainableUnitsForCity } from './city-system';
+import { getProductionCostForItem, getTrainableUnitsForCity, cityFollowsOwnFaith } from './city-system';
 import { getActiveNationalProjectsForCiv } from './national-project-system';
 import { resolveCivDefinition } from './civ-registry';
 import { resolveCivilizationEra } from './tech-definitions';
@@ -109,6 +109,7 @@ export function estimateCaravanReadyTurns(state: GameState, majorCivId: string, 
     state.map,
     civ.civType,
     availableResources,
+    cityFollowsOwnFaith(state, city),
   ).some(unit => unit.type === 'caravan');
   const queued = city.productionQueue.includes('caravan');
   if (!trainable && !queued) return Number.POSITIVE_INFINITY;

--- a/src/systems/religion-definitions.ts
+++ b/src/systems/religion-definitions.ts
@@ -11,6 +11,21 @@ export const OCCUPATION_ACCRUAL = 5;
 export const FERVOR_MULTIPLIER = 1.25;
 export const TITHES_CAP = 10;
 
+// #592 MR5: missionary unit + active preach conversion.
+export const MISSIONARY_COST = 16;
+export const MISSIONARY_BASE_CHARGES = 2;
+export const MISSIONARY_ZEAL_CHARGES = 3;
+export const PREACH_POINTS = 50;
+export const PREACH_OCCUPIED_DOUBLE = 100;
+// A missionary that just preached needs to "rest" before preaching again — reflects the
+// action itself plus recovery, same framing as a worker's multi-turn improvement build.
+export const MISSIONARY_ACTION_COOLDOWN_TURNS = 3;
+// Anti-flip-flop guard: once a city converts, it can't flip to a DIFFERENT rival religion
+// again for this many turns. The city's own owner (at the moment of conversion) is always
+// exempt, so preaching a just-flipped city back to its owner's faith is never blocked by
+// this cooldown — see CityFaith.conversionCooldownExemptCivId.
+export const CITY_CONVERSION_COOLDOWN_TURNS = 7;
+
 // Invented, culture-flavored faith names — NEVER real-world religions (project
 // convention, matches wonder/quest content rules). 2 candidates per civ id; seeded
 // pick + player rename at founding.

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -260,6 +260,27 @@ export type PreachResult =
   | { ok: true; state: GameState; converted: boolean; unitConsumed: boolean }
   | { ok: false; state: GameState; reason: PreachFailureReason };
 
+// Range-independent half of the preach eligibility gate (holy city, at-war, discovered,
+// religion-founded) — everything EXCEPT adjacency. Exposed separately from
+// canPreachTarget so a caller choosing a STRATEGIC target to walk toward (the AI
+// dispatch loop in basic-ai.ts) can pick a distant-but-otherwise-eligible city without
+// the adjacency check silently excluding every target outside the unit's current
+// movement range. UI/action callers that mean "can I preach RIGHT NOW" should use
+// canPreachTarget instead.
+export function isPreachTargetEligible(state: GameState, unit: { owner: string }, cityId: string): boolean {
+  const city = state.cities[cityId];
+  if (!city) return false;
+  const faith = state.cityFaith?.[cityId];
+  if (faith?.isHolyCity) return false;
+
+  const owner = state.civilizations[unit.owner];
+  if (!owner) return false;
+  if ((owner.diplomacy.atWarWith ?? []).includes(city.owner)) return false;
+  if (!hasDiscoveredCity(state, unit.owner, cityId)) return false;
+
+  return Object.values(state.religions ?? {}).some(r => r.ownerCivId === unit.owner);
+}
+
 // Returns whether `unit` (assumed to be a missionary belonging to a civ with a founded
 // religion) could currently preach `cityId` — the same refusal conditions preach() itself
 // checks, exposed read-only so UI eligibility (which city to show a Preach button for) can
@@ -270,15 +291,7 @@ export function canPreachTarget(state: GameState, unit: { owner: string; positio
   const city = state.cities[cityId];
   if (!city) return false;
   if (mapDistance(state.map, unit.position, city.position) > 1) return false;
-  const faith = state.cityFaith?.[cityId];
-  if (faith?.isHolyCity) return false;
-
-  const owner = state.civilizations[unit.owner];
-  if (!owner) return false;
-  if ((owner.diplomacy.atWarWith ?? []).includes(city.owner)) return false;
-  if (!hasDiscoveredCity(state, unit.owner, cityId)) return false;
-
-  return Object.values(state.religions ?? {}).some(r => r.ownerCivId === unit.owner);
+  return isPreachTargetEligible(state, unit, cityId);
 }
 
 // #592 MR5: active conversion via missionary preach. Grants PREACH_POINTS toward the
@@ -311,7 +324,11 @@ export function preach(state: GameState, unitId: string, cityId: string, bus: Ev
   if (!religion) return { ok: false, state, reason: 'no-religion' };
 
   const hasZeal = owner.techState.completed.includes('missionary-zeal');
-  const isDoubled = hasZeal && !!city.occupation;
+  // "a city the owner holds under occupation" — city.owner must be the missionary's own
+  // civ. Without this check, a rival's occupied city (captured from some third civ) would
+  // incorrectly grant the doubled bonus to any preaching civ with missionary-zeal, not
+  // just the actual occupier.
+  const isDoubled = hasZeal && !!city.occupation && city.owner === unit.owner;
   const pointsGranted = isDoubled ? PREACH_OCCUPIED_DOUBLE : PREACH_POINTS;
 
   const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, religion.id, pointsGranted);

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -1,13 +1,16 @@
-import type { City, GameState, Religion, ReligionBoon } from '@/core/types';
+import type { City, CityFaith, GameState, Religion, ReligionBoon } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { seededLcg } from './seeded-lcg';
 import {
   NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, CONVERSION_THRESHOLD,
   OWN_CITY_ACCRUAL, FOREIGN_ADJACENT_ACCRUAL, FOREIGN_ADJACENT_CAP,
-  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER, TITHES_CAP,
+  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER, TITHES_CAP, OCCUPATION_ACCRUAL,
+  CITY_CONVERSION_COOLDOWN_TURNS, PREACH_POINTS, PREACH_OCCUPIED_DOUBLE,
+  MISSIONARY_ACTION_COOLDOWN_TURNS,
 } from './religion-definitions';
 import { getCapitalCityId } from './capital-system';
 import { mapDistance } from './hex-utils';
+import { hasDiscoveredCity } from './discovery-system';
 
 function pickReligionName(civType: string, seed: number): string {
   const pool = NAME_CANDIDATES[civType] ?? NEUTRAL_NAME_CANDIDATES;
@@ -134,12 +137,37 @@ export function getStrongestPressure(state: GameState, cityId: string): Religion
   return { religionId: sorted[0][0], accrual: sorted[0][1] };
 }
 
-// Passive faith spread + conversion (#591 MR4). Holy cities never accrue. A city tracks
-// progress toward exactly one target religion at a time (the current strongest); if the
-// strongest religion changes to a DIFFERENT one, progress resets for the new target —
-// "weaker records stall but are not erased" describes OTHER cities' independent
-// progress, not a multi-target ledger inside a single city (the CityFaith type only
-// ever holds one conversionProgress record).
+// #592 MR5: reads one religion's bucket from the per-religion progress ledger (see
+// CityFaith.conversionProgress doc comment in types.ts).
+export function getCityConversionPoints(faith: CityFaith | undefined, religionId: string): number {
+  return faith?.conversionProgress?.[religionId] ?? 0;
+}
+
+// Adds `delta` points to religionId's own bucket in cityFaith.conversionProgress,
+// independent of any other religion's bucket. Returns the updated CityFaith and whether
+// this delta pushed that bucket to/over CONVERSION_THRESHOLD (caller decides whether/how
+// to apply the actual flip — this helper never mutates religionId itself).
+export function applyCityConversionPoints(
+  faith: CityFaith | undefined,
+  religionId: string,
+  delta: number,
+): { cityFaith: CityFaith; converted: boolean } {
+  const currentPoints = getCityConversionPoints(faith, religionId);
+  const nextPoints = currentPoints + delta;
+  const converted = nextPoints >= CONVERSION_THRESHOLD;
+  const nextProgress = { ...(faith?.conversionProgress ?? {}), [religionId]: nextPoints };
+  return {
+    cityFaith: { ...(faith ?? { religionId }), conversionProgress: nextProgress },
+    converted,
+  };
+}
+
+// Passive faith spread + conversion (#591 MR4, restructured #592 MR5 for independent
+// per-religion progress buckets — see CityFaith.conversionProgress doc comment in
+// types.ts). Holy cities never accrue. Cities under an active conversionCooldownUntilTurn
+// only accrue toward conversionCooldownExemptCivId's religion (or their current religion,
+// if that religion belongs to the exempt civ) — rival religions' passive pressure is
+// paused, not reset, during the cooldown window.
 export function processReligionTurn(state: GameState, bus: EventBus): GameState {
   const cityFaithMap = state.cityFaith ?? {};
   let cityFaith = { ...cityFaithMap };
@@ -151,33 +179,184 @@ export function processReligionTurn(state: GameState, bus: EventBus): GameState 
 
     const pressure = getStrongestPressure(state, cityId);
     if (!pressure) continue;
-    // Skip only a SETTLED follower of the strongest religion (no conversionProgress —
+    // Skip only a SETTLED follower of the strongest religion (no progress toward it —
     // it already fully converted). A city mid-conversion toward this same religion has
     // religionId set to the pending target from its first accrual turn (see below) but
     // must NOT be skipped here, or it would freeze at turn-1's point total forever.
-    if (faith?.religionId === pressure.religionId && !faith?.conversionProgress) continue;
+    if (faith?.religionId === pressure.religionId && !getCityConversionPoints(faith, pressure.religionId)) continue;
 
-    const existingProgress = faith?.conversionProgress;
-    const carriedPoints = existingProgress?.toReligionId === pressure.religionId ? existingProgress.points : 0;
-    const nextPoints = carriedPoints + pressure.accrual;
+    const cooldownActive = (faith?.conversionCooldownUntilTurn ?? 0) > state.turn;
+    const exemptCivId = faith?.conversionCooldownExemptCivId;
+    const pressureReligion = state.religions?.[pressure.religionId];
+    const pressureIsExempt = !!exemptCivId && pressureReligion?.ownerCivId === exemptCivId;
+    if (cooldownActive && !pressureIsExempt) continue; // rival religion's passive pressure is paused during cooldown
 
-    if (nextPoints >= CONVERSION_THRESHOLD) {
+    const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, pressure.religionId, pressure.accrual);
+
+    if (converted) {
       const fromReligionId = faith?.religionId;
-      cityFaith = { ...cityFaith, [cityId]: { religionId: pressure.religionId } };
+      const cityOwner = state.cities[cityId]?.owner;
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: {
+          religionId: pressure.religionId,
+          conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+          conversionCooldownExemptCivId: cityOwner,
+        },
+      };
       changed = true;
       bus.emit('religion:city-converted', { cityId, toReligionId: pressure.religionId, fromReligionId });
     } else {
       cityFaith = {
         ...cityFaith,
-        [cityId]: {
-          ...(faith ?? {}),
-          religionId: faith?.religionId ?? pressure.religionId,
-          conversionProgress: { toReligionId: pressure.religionId, points: nextPoints },
-        },
+        [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? pressure.religionId },
       };
       changed = true;
     }
   }
 
+  return processOccupationAccrual(changed ? { ...state, cityFaith } : state, bus);
+}
+
+// #592 MR5: cities under occupation accrue toward the OCCUPYING civ's faith every turn,
+// independent of geography/trade pressure — this is what makes missionary-zeal's doubled
+// preach on occupied cities land on top of a baseline that's already moving. Stops the
+// moment occupation ends (city.occupation cleared elsewhere when turnsRemaining hits 0).
+function processOccupationAccrual(state: GameState, bus: EventBus): GameState {
+  let cityFaith = { ...(state.cityFaith ?? {}) };
+  let changed = false;
+
+  for (const [cityId, city] of Object.entries(state.cities)) {
+    if (!city.occupation) continue;
+    const occupierReligion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === city.owner);
+    if (!occupierReligion) continue;
+    const faith = cityFaith[cityId];
+    if (faith?.isHolyCity) continue;
+
+    const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, occupierReligion.id, OCCUPATION_ACCRUAL);
+    if (converted) {
+      const fromReligionId = faith?.religionId;
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: {
+          religionId: occupierReligion.id,
+          conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+          conversionCooldownExemptCivId: city.owner,
+        },
+      };
+      bus.emit('religion:city-converted', { cityId, toReligionId: occupierReligion.id, fromReligionId });
+    } else {
+      cityFaith = { ...cityFaith, [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? occupierReligion.id } };
+    }
+    changed = true;
+  }
+
   return changed ? { ...state, cityFaith } : state;
+}
+
+export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' | 'no-religion';
+
+export type PreachResult =
+  | { ok: true; state: GameState; converted: boolean; unitConsumed: boolean }
+  | { ok: false; state: GameState; reason: PreachFailureReason };
+
+// Returns whether `unit` (assumed to be a missionary belonging to a civ with a founded
+// religion) could currently preach `cityId` — the same refusal conditions preach() itself
+// checks, exposed read-only so UI eligibility (which city to show a Preach button for) can
+// never drift from the actual gate. Does not check charges/cooldown on the unit itself,
+// since callers that already know charges > 0 (e.g. the UI charge check) call this only
+// for the target-city-side conditions; preach() re-checks unit-side conditions itself.
+export function canPreachTarget(state: GameState, unit: { owner: string }, cityId: string): boolean {
+  const city = state.cities[cityId];
+  if (!city) return false;
+  const faith = state.cityFaith?.[cityId];
+  if (faith?.isHolyCity) return false;
+
+  const owner = state.civilizations[unit.owner];
+  if (!owner) return false;
+  if ((owner.diplomacy.atWarWith ?? []).includes(city.owner)) return false;
+  if (!hasDiscoveredCity(state, unit.owner, cityId)) return false;
+
+  return Object.values(state.religions ?? {}).some(r => r.ownerCivId === unit.owner);
+}
+
+// #592 MR5: active conversion via missionary preach. Grants PREACH_POINTS toward the
+// owner's own religion (doubled to PREACH_OCCUPIED_DOUBLE if the owner has completed
+// missionary-zeal AND the target city is currently under that owner's occupation),
+// consumes one charge, and puts the missionary on a personal cooldown — or consumes the
+// unit outright if that was its last charge. A successful conversion also starts the
+// city's anti-flip-flop cooldown (see CityFaith.conversionCooldownUntilTurn), exempting
+// the city's own owner so a future re-preach back to their own faith is never blocked.
+export function preach(state: GameState, unitId: string, cityId: string, bus: EventBus): PreachResult {
+  const unit = state.units[unitId];
+  const city = state.cities[cityId];
+  if (!unit || unit.type !== 'missionary' || !city) {
+    return { ok: false, state, reason: 'not-missionary' };
+  }
+  if ((unit.chargesRemaining ?? 0) <= 0) return { ok: false, state, reason: 'no-charges' };
+  if ((unit.missionaryCooldownUntilTurn ?? 0) > state.turn) return { ok: false, state, reason: 'on-cooldown' };
+
+  const faith = state.cityFaith?.[cityId];
+  if (faith?.isHolyCity) return { ok: false, state, reason: 'holy-city' };
+
+  const owner = state.civilizations[unit.owner];
+  if (!owner) return { ok: false, state, reason: 'not-missionary' };
+
+  if ((owner.diplomacy.atWarWith ?? []).includes(city.owner)) return { ok: false, state, reason: 'at-war' };
+  if (!hasDiscoveredCity(state, unit.owner, cityId)) return { ok: false, state, reason: 'undiscovered' };
+
+  const religion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === unit.owner);
+  if (!religion) return { ok: false, state, reason: 'no-religion' };
+
+  const hasZeal = owner.techState.completed.includes('missionary-zeal');
+  const isDoubled = hasZeal && !!city.occupation;
+  const pointsGranted = isDoubled ? PREACH_OCCUPIED_DOUBLE : PREACH_POINTS;
+
+  const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, religion.id, pointsGranted);
+
+  let cityFaith = { ...(state.cityFaith ?? {}) };
+  if (converted) {
+    cityFaith = {
+      ...cityFaith,
+      [cityId]: {
+        religionId: religion.id,
+        conversionCooldownUntilTurn: state.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+        conversionCooldownExemptCivId: city.owner,
+      },
+    };
+    bus.emit('religion:city-converted', { cityId, toReligionId: religion.id, fromReligionId: faith?.religionId });
+  } else {
+    cityFaith = { ...cityFaith, [cityId]: { ...updatedFaith, religionId: faith?.religionId ?? religion.id } };
+  }
+
+  const chargesRemaining = (unit.chargesRemaining ?? 0) - 1;
+  const unitConsumed = chargesRemaining <= 0;
+
+  let units = state.units;
+  if (unitConsumed) {
+    const { [unitId]: _removed, ...rest } = state.units;
+    units = rest;
+  } else {
+    units = {
+      ...state.units,
+      [unitId]: { ...unit, chargesRemaining, missionaryCooldownUntilTurn: state.turn + MISSIONARY_ACTION_COOLDOWN_TURNS },
+    };
+  }
+
+  let civilizations = state.civilizations;
+  if (unitConsumed) {
+    civilizations = {
+      ...state.civilizations,
+      [unit.owner]: { ...owner, units: owner.units.filter(id => id !== unitId) },
+    };
+  }
+
+  bus.emit('religion:preached', { cityId, unitId, civId: unit.owner, points: pointsGranted, unitConsumed });
+
+  return {
+    ok: true,
+    state: { ...state, cityFaith, units, civilizations },
+    converted,
+    unitConsumed,
+  };
 }

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -185,11 +185,8 @@ export function processReligionTurn(state: GameState, bus: EventBus): GameState 
     // must NOT be skipped here, or it would freeze at turn-1's point total forever.
     if (faith?.religionId === pressure.religionId && !getCityConversionPoints(faith, pressure.religionId)) continue;
 
-    const cooldownActive = (faith?.conversionCooldownUntilTurn ?? 0) > state.turn;
-    const exemptCivId = faith?.conversionCooldownExemptCivId;
-    const pressureReligion = state.religions?.[pressure.religionId];
-    const pressureIsExempt = !!exemptCivId && pressureReligion?.ownerCivId === exemptCivId;
-    if (cooldownActive && !pressureIsExempt) continue; // rival religion's passive pressure is paused during cooldown
+    const pressureReligionOwnerCivId = state.religions?.[pressure.religionId]?.ownerCivId;
+    if (pressureReligionOwnerCivId && isCityConversionCooldownBlocking(faith, pressureReligionOwnerCivId, state.turn)) continue;
 
     const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, pressure.religionId, pressure.accrual);
 
@@ -232,6 +229,11 @@ function processOccupationAccrual(state: GameState, bus: EventBus): GameState {
     if (!occupierReligion) continue;
     const faith = cityFaith[cityId];
     if (faith?.isHolyCity) continue;
+    // Same anti-flip-flop rule as passive spread and preach: a city that just converted
+    // is protected from a DIFFERENT religion's pressure for the cooldown window, and
+    // occupation accrual is no exception — otherwise conquering a city the instant it
+    // finishes converting would be a loophole around the cooldown from the military side.
+    if (isCityConversionCooldownBlocking(faith, city.owner, state.turn)) continue;
 
     const { cityFaith: updatedFaith, converted } = applyCityConversionPoints(faith, occupierReligion.id, OCCUPATION_ACCRUAL);
     if (converted) {
@@ -254,17 +256,31 @@ function processOccupationAccrual(state: GameState, bus: EventBus): GameState {
   return changed ? { ...state, cityFaith } : state;
 }
 
-export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' | 'no-religion' | 'out-of-range';
+export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' | 'no-religion' | 'out-of-range' | 'city-conversion-cooldown';
 
 export type PreachResult =
   | { ok: true; state: GameState; converted: boolean; unitConsumed: boolean }
   | { ok: false; state: GameState; reason: PreachFailureReason };
 
+// Shared by preach() and isPreachTargetEligible: a city under its anti-flip-flop
+// cooldown (see CityFaith.conversionCooldownUntilTurn) blocks conversion toward any
+// religion OTHER than conversionCooldownExemptCivId's — including ACTIVE preach, not
+// just passive spread (processReligionTurn/processOccupationAccrual already respect
+// this; preach() must too, or a missionary trivially bypasses the whole cooldown and
+// the anti-flip-flop protection the user asked for is a no-op against active play).
+// preach() always targets the preaching civ's OWN religion, so the exemption check
+// only needs to compare civ ids, not resolve religion ownership.
+function isCityConversionCooldownBlocking(faith: CityFaith | undefined, preachingCivId: string, currentTurn: number): boolean {
+  const cooldownActive = (faith?.conversionCooldownUntilTurn ?? 0) > currentTurn;
+  if (!cooldownActive) return false;
+  return faith?.conversionCooldownExemptCivId !== preachingCivId;
+}
+
 // Range-independent half of the preach eligibility gate (holy city, at-war, discovered,
-// religion-founded) — everything EXCEPT adjacency. Exposed separately from
-// canPreachTarget so a caller choosing a STRATEGIC target to walk toward (the AI
-// dispatch loop in basic-ai.ts) can pick a distant-but-otherwise-eligible city without
-// the adjacency check silently excluding every target outside the unit's current
+// religion-founded, city-conversion-cooldown) — everything EXCEPT adjacency. Exposed
+// separately from canPreachTarget so a caller choosing a STRATEGIC target to walk toward
+// (the AI dispatch loop in basic-ai.ts) can pick a distant-but-otherwise-eligible city
+// without the adjacency check silently excluding every target outside the unit's current
 // movement range. UI/action callers that mean "can I preach RIGHT NOW" should use
 // canPreachTarget instead.
 export function isPreachTargetEligible(state: GameState, unit: { owner: string }, cityId: string): boolean {
@@ -272,6 +288,7 @@ export function isPreachTargetEligible(state: GameState, unit: { owner: string }
   if (!city) return false;
   const faith = state.cityFaith?.[cityId];
   if (faith?.isHolyCity) return false;
+  if (isCityConversionCooldownBlocking(faith, unit.owner, state.turn)) return false;
 
   const owner = state.civilizations[unit.owner];
   if (!owner) return false;
@@ -313,6 +330,9 @@ export function preach(state: GameState, unitId: string, cityId: string, bus: Ev
 
   const faith = state.cityFaith?.[cityId];
   if (faith?.isHolyCity) return { ok: false, state, reason: 'holy-city' };
+  if (isCityConversionCooldownBlocking(faith, unit.owner, state.turn)) {
+    return { ok: false, state, reason: 'city-conversion-cooldown' };
+  }
 
   const owner = state.civilizations[unit.owner];
   if (!owner) return { ok: false, state, reason: 'not-missionary' };

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -1,4 +1,4 @@
-import type { City, CityFaith, GameState, Religion, ReligionBoon } from '@/core/types';
+import type { City, CityFaith, GameState, HexCoord, Religion, ReligionBoon } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { seededLcg } from './seeded-lcg';
 import {
@@ -254,7 +254,7 @@ function processOccupationAccrual(state: GameState, bus: EventBus): GameState {
   return changed ? { ...state, cityFaith } : state;
 }
 
-export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' | 'no-religion';
+export type PreachFailureReason = 'not-missionary' | 'no-charges' | 'on-cooldown' | 'holy-city' | 'at-war' | 'undiscovered' | 'no-religion' | 'out-of-range';
 
 export type PreachResult =
   | { ok: true; state: GameState; converted: boolean; unitConsumed: boolean }
@@ -266,9 +266,10 @@ export type PreachResult =
 // never drift from the actual gate. Does not check charges/cooldown on the unit itself,
 // since callers that already know charges > 0 (e.g. the UI charge check) call this only
 // for the target-city-side conditions; preach() re-checks unit-side conditions itself.
-export function canPreachTarget(state: GameState, unit: { owner: string }, cityId: string): boolean {
+export function canPreachTarget(state: GameState, unit: { owner: string; position: HexCoord }, cityId: string): boolean {
   const city = state.cities[cityId];
   if (!city) return false;
+  if (mapDistance(state.map, unit.position, city.position) > 1) return false;
   const faith = state.cityFaith?.[cityId];
   if (faith?.isHolyCity) return false;
 
@@ -295,6 +296,7 @@ export function preach(state: GameState, unitId: string, cityId: string, bus: Ev
   }
   if ((unit.chargesRemaining ?? 0) <= 0) return { ok: false, state, reason: 'no-charges' };
   if ((unit.missionaryCooldownUntilTurn ?? 0) > state.turn) return { ok: false, state, reason: 'on-cooldown' };
+  if (mapDistance(state.map, unit.position, city.position) > 1) return { ok: false, state, reason: 'out-of-range' };
 
   const faith = state.cityFaith?.[cityId];
   if (faith?.isHolyCity) return { ok: false, state, reason: 'holy-city' };

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -265,7 +265,7 @@ const ERA_6_TECHS: Tech[] = [
     unlocks: ['+2 gold per city with a temple empire-wide'], era: 6 },
   { id: 'missionary-zeal', name: 'Missionary Zeal', track: 'spirituality', cost: 120,
     prerequisites: ['monastic-orders'],
-    unlocks: ['Missionaries spread religion to conquered cities faster'], era: 6 },
+    unlocks: ['Preaching in cities conquered from other civilizations is twice as effective; missionaries carry 3 charges instead of 2'], era: 6 },
 ];
 
 const ERA_7_TECHS: Tech[] = [

--- a/src/systems/unit-modifier-definitions.ts
+++ b/src/systems/unit-modifier-definitions.ts
@@ -9,6 +9,7 @@ export type UnitClass = 'melee' | 'ranged' | 'siege' | 'mounted' | 'gunpowder' |
 export const UNIT_CLASS_BY_TYPE: Record<UnitType, UnitClass[]> = {
   settler: ['civilian'],
   worker: ['civilian'],
+  missionary: ['civilian'],
   scout: ['recon'],
   warrior: ['melee'],
   archer: ['ranged'],

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -42,6 +42,11 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     visionRange: 2, strength: 0, canFoundCity: false,
     canBuildImprovements: true, productionCost: 12,
   },
+  missionary: {
+    type: 'missionary', name: 'Missionary', movementPoints: 2,
+    visionRange: 2, strength: 0, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 16,
+  },
   scout: {
     type: 'scout', name: 'Scout', movementPoints: 3,
     visionRange: 3, strength: 5, canFoundCity: false,
@@ -641,6 +646,7 @@ export function restUnit(unit: Unit): Unit {
 export const UNIT_DESCRIPTIONS: Record<UnitType, string> = {
   settler: 'Civilian unit that can found new cities',
   worker: 'Civilian unit that builds tile improvements. Workers have 2 action charges by default and are used up after spending the last charge.',
+  missionary: 'Civilian unit that spreads your faith. Preach in a city to push it toward your religion — preaching a city your own faith already lost brings it back fastest. Missionaries start with 2 charges (3 once Missionary Zeal is researched) and are used up after the last charge.',
   scout: 'Fast exploration unit with extended vision',
   warrior: 'Basic melee fighter — your first line of defense. Cheap fallback that fades out once real militaries exist; upgrades into the spearman.',
   archer: 'Ranged unit that attacks from a distance. Upgrades into the crossbowman once Tactics is researched and Copper is available.',

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -4,6 +4,7 @@ import {
   BUILDINGS,
   TRAINABLE_UNITS,
   getTrainableUnitsForCity,
+  cityFollowsOwnFaith,
   getProductionCostForItem,
   getProductionDisplayName,
   getProductionIconForItem,
@@ -441,15 +442,18 @@ export function createCityPanel(
   const cityFaithEntry = state.cityFaith?.[city.id];
   const faithReligion = cityFaithEntry ? state.religions?.[cityFaithEntry.religionId] : undefined;
   const faithData = cityFaithEntry && faithReligion ? (() => {
-    const progress = cityFaithEntry.conversionProgress;
-    const pressure = progress ? getStrongestPressure(state, city.id) : null;
-    const turnsRemaining = progress && pressure && pressure.accrual > 0
-      ? Math.ceil((CONVERSION_THRESHOLD - progress.points) / pressure.accrual)
+    // #592 MR5: conversionProgress is now a per-religion map (see CityFaith doc comment in
+    // types.ts) — the bucket relevant to this display is the one keyed by the city's
+    // current pending/settled target, cityFaithEntry.religionId.
+    const pointsTowardCurrentTarget = cityFaithEntry.conversionProgress?.[cityFaithEntry.religionId];
+    const pressure = pointsTowardCurrentTarget !== undefined ? getStrongestPressure(state, city.id) : null;
+    const turnsRemaining = pointsTowardCurrentTarget !== undefined && pressure && pressure.accrual > 0
+      ? Math.ceil((CONVERSION_THRESHOLD - pointsTowardCurrentTarget) / pressure.accrual)
       : null;
     return {
       religionName: faithReligion.name,
       isHolyCity: !!cityFaithEntry.isHolyCity,
-      inProgress: !!progress,
+      inProgress: pointsTowardCurrentTarget !== undefined,
       turnsRemaining,
     };
   })() : null;
@@ -539,7 +543,7 @@ export function createCityPanel(
   }
 
   const completedTechs = currentCiv.techState.completed;
-  const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, playerResources);
+  const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, playerResources, cityFollowsOwnFaith(state, city));
 
   // Trade Routes Overhaul (#553 MR4/4) — City panel Trade Routes section. Gated behind
   // the same 'trade-routes' tech marketplace-panel.ts already uses. Scoped to this
@@ -568,7 +572,7 @@ export function createCityPanel(
     : [];
 
   // Locked items: tech met + resource NOT met (tech-missing items stay hidden entirely)
-  const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined);
+  const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined, cityFollowsOwnFaith(state, city));
   const lockedUnits = allTechUnlockedUnits.filter(u => !availableUnits.some(a => a.type === u.type));
 
   const allTechUnlockedBuildings = getAvailableBuildings(city, completedTechs, state.map, undefined)

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -409,7 +409,7 @@ export function renderSelectedUnitInfo(
         btn.style.cursor = 'not-allowed';
         btn.title = onCooldown
           ? 'This missionary is resting after its last preach — try again in a few turns.'
-          : 'No eligible city nearby — move next to a discovered city that is not a holy city and not held by a civ you are at war with.';
+          : 'No eligible city nearby — move next to a discovered city that is not a holy city, not held by a civ you are at war with, and hasn\'t recently changed faith.';
         actionsDiv.appendChild(btn);
       }
     }

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -1,4 +1,4 @@
-import type { BuildableImprovementType, GameState, DisguiseType, HexCoord, WorkerActionType } from '@/core/types';
+import type { BuildableImprovementType, GameState, DisguiseType, HexCoord, Unit, WorkerActionType } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { getExperienceToNextTier, getVeterancyCombatModifier, getVeterancyTier } from '@/systems/combat-reward-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
@@ -32,6 +32,7 @@ import {
   type LandUnitWaterRecovery,
 } from '@/systems/unit-water-recovery';
 import { isAutonomyActivated } from '@/systems/network-plan-system';
+import { canPreachTarget } from '@/systems/religion-system';
 import { getAirBaseCapacity, getAirBaseRoster } from '@/systems/air-operations-system';
 import type { AirBaseRef } from '@/core/types';
 
@@ -63,6 +64,7 @@ export interface SelectedUnitInfoCallbacks {
   onClose?: () => void;
   onFoundCity?: () => void;
   onWorkerAction?: (action: WorkerActionType) => void;
+  onPreach?: (unitId: string, cityId: string) => void;
   onRest?: () => void;
   onSkipTurn?: (unitId: string) => void;
   onDeleteUnit?: (unitId: string) => void;
@@ -124,6 +126,16 @@ function makeButton(label: string, color: string, onClick?: () => void): HTMLBut
 /** True for all 5 naval transport unit types. */
 function isNavalTransport(unitType: string): boolean {
   return ['transport', 'carrack', 'galleon', 'steamship', 'troop_transport'].includes(unitType);
+}
+
+/** First city on/adjacent to `unit` that canPreachTarget() accepts, or null. Deterministic
+ * (sorted city id order) so the offered target never varies between renders. */
+function findEligiblePreachTargetCityId(state: GameState, unit: Unit): string | null {
+  const candidateIds = Object.keys(state.cities).sort();
+  for (const cityId of candidateIds) {
+    if (canPreachTarget(state, unit, cityId)) return cityId;
+  }
+  return null;
 }
 
 function nextTierLabel(currentLabel: string): string | null {
@@ -373,6 +385,33 @@ export function renderSelectedUnitInfo(
       btn.style.cursor = 'not-allowed';
       btn.title = blockerTitle;
       actionsDiv.appendChild(btn);
+    }
+  }
+
+  if (unit.type === 'missionary') {
+    const charges = unit.chargesRemaining ?? 0;
+    const chargeDiv = document.createElement('div');
+    chargeDiv.style.cssText = 'font-size:10px;opacity:0.75;margin-top:6px;';
+    chargeDiv.textContent = `Missionary Charges: ${charges}`;
+    wrapper.appendChild(chargeDiv);
+
+    const onCooldown = (unit.missionaryCooldownUntilTurn ?? 0) > state.turn;
+    const eligibleCityId = charges > 0 && !onCooldown ? findEligiblePreachTargetCityId(state, unit) : null;
+    if (callbacks.onPreach) {
+      if (eligibleCityId) {
+        const btn = makeButton('Preach', '#b39ddb', () => callbacks.onPreach!(unit.id, eligibleCityId));
+        btn.title = 'Push this city toward your faith. Uses one charge — the missionary is used up after its last charge.';
+        actionsDiv.appendChild(btn);
+      } else if (charges > 0) {
+        const btn = makeButton('Preach', '#b39ddb');
+        btn.disabled = true;
+        btn.style.opacity = '0.5';
+        btn.style.cursor = 'not-allowed';
+        btn.title = onCooldown
+          ? 'This missionary is resting after its last preach — try again in a few turns.'
+          : 'No eligible city nearby — move next to a discovered city that is not a holy city and not held by a civ you are at war with.';
+        actionsDiv.appendChild(btn);
+      }
     }
   }
 

--- a/src/ui/unit-delete-confirmation-panel.ts
+++ b/src/ui/unit-delete-confirmation-panel.ts
@@ -1,6 +1,18 @@
 export interface UnitDeleteConfirmationConfig {
   unitName: string;
+  /** Overrides the default `Delete ${unitName}?` title — use for non-destructive but
+   * final actions (e.g. a missionary consumed by a successful preach) so the framing
+   * doesn't read as a warning about an accidental/destructive action. */
+  title?: string;
   bodyText?: string;
+  /** Overrides the default "Delete Unit" confirm-button label — pair with `hideCancel`
+   * for actions where the removal already happened and this panel is acknowledging it,
+   * not gating it. */
+  confirmLabel?: string;
+  /** Hides the Cancel button — use when the unit removal already occurred (e.g. a
+   * missionary consumed by its own last preach charge) so there is nothing left to
+   * cancel; onConfirm becomes the single "OK" dismissal. */
+  hideCancel?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -28,7 +40,7 @@ export function createUnitDeleteConfirmationPanel(
   dialog.style.cssText = 'max-width:360px;width:100%;background:#171923;border:1px solid rgba(255,255,255,0.18);border-radius:8px;padding:16px;color:white;box-shadow:0 18px 60px rgba(0,0,0,0.45);';
 
   const title = document.createElement('h2');
-  title.textContent = `Delete ${config.unitName}?`;
+  title.textContent = config.title ?? `Delete ${config.unitName}?`;
   title.style.cssText = 'font-size:18px;margin:0 0 8px;color:#fca5a5;';
   dialog.appendChild(title);
 
@@ -39,13 +51,15 @@ export function createUnitDeleteConfirmationPanel(
 
   const buttons = document.createElement('div');
   buttons.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap;';
+  if (!config.hideCancel) {
+    buttons.appendChild(createButton(
+      'Cancel',
+      'padding:9px 14px;border-radius:8px;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.08);color:white;cursor:pointer;',
+      config.onCancel,
+    ));
+  }
   buttons.appendChild(createButton(
-    'Cancel',
-    'padding:9px 14px;border-radius:8px;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.08);color:white;cursor:pointer;',
-    config.onCancel,
-  ));
-  buttons.appendChild(createButton(
-    'Delete Unit',
+    config.confirmLabel ?? 'Delete Unit',
     'padding:9px 14px;border-radius:8px;border:0;background:#b91c1c;color:white;cursor:pointer;font-weight:bold;',
     config.onConfirm,
   ));

--- a/src/ui/unit-delete-confirmation-panel.ts
+++ b/src/ui/unit-delete-confirmation-panel.ts
@@ -13,6 +13,11 @@ export interface UnitDeleteConfirmationConfig {
    * missionary consumed by its own last preach charge) so there is nothing left to
    * cancel; onConfirm becomes the single "OK" dismissal. */
   hideCancel?: boolean;
+  /** 'danger' (default) is the destructive-action red styling. 'neutral' swaps the title
+   * color and the confirm button to a calm, non-alarming palette — use for acknowledgment
+   * dialogs (like a missionary consumed by a successful preach) where nothing bad
+   * happened; a red "OK" button after good news reads as a warning to younger players. */
+  tone?: 'danger' | 'neutral';
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -39,9 +44,11 @@ export function createUnitDeleteConfirmationPanel(
   const dialog = document.createElement('div');
   dialog.style.cssText = 'max-width:360px;width:100%;background:#171923;border:1px solid rgba(255,255,255,0.18);border-radius:8px;padding:16px;color:white;box-shadow:0 18px 60px rgba(0,0,0,0.45);';
 
+  const isNeutral = config.tone === 'neutral';
+
   const title = document.createElement('h2');
   title.textContent = config.title ?? `Delete ${config.unitName}?`;
-  title.style.cssText = 'font-size:18px;margin:0 0 8px;color:#fca5a5;';
+  title.style.cssText = `font-size:18px;margin:0 0 8px;color:${isNeutral ? '#b39ddb' : '#fca5a5'};`;
   dialog.appendChild(title);
 
   const body = document.createElement('p');
@@ -60,7 +67,7 @@ export function createUnitDeleteConfirmationPanel(
   }
   buttons.appendChild(createButton(
     config.confirmLabel ?? 'Delete Unit',
-    'padding:9px 14px;border-radius:8px;border:0;background:#b91c1c;color:white;cursor:pointer;font-weight:bold;',
+    `padding:9px 14px;border-radius:8px;border:0;background:${isNeutral ? '#7c5cbf' : '#b91c1c'};color:white;cursor:pointer;font-weight:bold;`,
     config.onConfirm,
   ));
   dialog.appendChild(buttons);

--- a/tests/ai/ai-production.test.ts
+++ b/tests/ai/ai-production.test.ts
@@ -488,3 +488,35 @@ describe('#591 MR4 — milestone national project AI scoring', () => {
     expect(Math.abs(sacredCouncil!.score - ironLegion!.score)).toBeLessThan(5);
   });
 });
+
+describe('#592 MR5 — missionary production scoring', () => {
+  function withFoundedReligion(state: GameState, cityId: string, boon?: 'serenity' | 'tithes' | 'fervor'): GameState {
+    const religionId = 'religion-ai-1';
+    state.religions = { [religionId]: { id: religionId, name: 'Test Faith', ownerCivId: 'ai-1', foundedTurn: 1, boon } };
+    state.cityFaith = { [cityId]: { religionId } };
+    state.cities[cityId]!.buildings = [...state.cities[cityId]!.buildings, 'temple'];
+    return state;
+  }
+
+  it('missionary is NOT a candidate without a founded religion + own-faith Temple city', () => {
+    const state = setupState(['philosophy']);
+    const candidates = generateAIProductionCandidates(state, 'ai-1', 'city-a', [], aggressive);
+    expect(candidates.find(c => c.itemId === 'missionary')).toBeUndefined();
+  });
+
+  it('missionary IS a candidate once religion + own faith + Temple all hold', () => {
+    const state = withFoundedReligion(setupState(['philosophy']), 'city-a');
+    const candidates = generateAIProductionCandidates(state, 'ai-1', 'city-a', [], aggressive);
+    expect(candidates.find(c => c.itemId === 'missionary')).toBeDefined();
+  });
+
+  it('scores missionary higher for a civ with the Fervor boon than one without, all else equal', () => {
+    const stateFervor = withFoundedReligion(setupState(['philosophy']), 'city-a', 'fervor');
+    const stateNoBoon = withFoundedReligion(setupState(['philosophy']), 'city-a');
+    const fervorScore = generateAIProductionCandidates(stateFervor, 'ai-1', 'city-a', [], aggressive)
+      .find(c => c.itemId === 'missionary')?.score ?? -Infinity;
+    const baseScore = generateAIProductionCandidates(stateNoBoon, 'ai-1', 'city-a', [], aggressive)
+      .find(c => c.itemId === 'missionary')?.score ?? -Infinity;
+    expect(fervorScore).toBeGreaterThan(baseScore);
+  });
+});

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -12,7 +12,7 @@ import {
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import { createEmptyMajorCivPlanPortfolio } from '@/core/opponent-ai-state';
-import type { GameEvents, GameState } from '@/core/types';
+import type { City, GameEvents, GameState, HexCoord } from '@/core/types';
 import { BUILDINGS, foundCity } from '@/systems/city-system';
 import { appeaseFaction, getCityAppeaseCost } from '@/systems/faction-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
@@ -2663,5 +2663,52 @@ describe('#591 MR4 — AI boon choice', () => {
     const { state, religionId } = withPendingReligion('591-ai-boon-peace');
     const next = processAITurn(state, 'ai-1', new EventBus());
     expect(next.religions![religionId].boon).toBe('tithes');
+  });
+});
+
+describe('#592 MR5 — AI missionary dispatch', () => {
+  function withMissionaryAndUnconvertedCity(seed: string): { state: GameState; unconvertedCityId: string; missionaryId: string } {
+    let state = createNewGame(undefined, seed, 'small');
+    state = processAITurn(state, 'ai-1', new EventBus());
+    const holyCityId = state.civilizations['ai-1'].cities[0];
+    if (!holyCityId) throw new Error('ai-1 has no city after its first turn');
+    const religionId = 'religion-ai-1';
+    state.religions = { [religionId]: { id: religionId, name: 'Order of Test', ownerCivId: 'ai-1', foundedTurn: 1 } };
+    state.cityFaith = { [holyCityId]: { religionId, isHolyCity: true } };
+
+    const holyCityPos = state.cities[holyCityId]!.position;
+    const unconvertedPos: HexCoord = { q: holyCityPos.q + 3, r: holyCityPos.r };
+    const unconvertedCity: City = {
+      id: 'ai-second-city', name: 'ai-second-city', owner: 'ai-1', position: unconvertedPos,
+      population: 4, food: 0, foodNeeded: 20, buildings: [], productionQueue: [], productionProgress: 0,
+      ownedTiles: [unconvertedPos], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+      unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    };
+    state.cities[unconvertedCity.id] = unconvertedCity;
+    state.civilizations['ai-1'].cities.push(unconvertedCity.id);
+    state.civilizations['ai-1'].visibility.tiles[hexKey(unconvertedPos)] = 'visible';
+    // no cityFaith entry for unconvertedCity -- it does not yet follow ai-1's own faith
+
+    const missionary = createUnit('missionary', 'ai-1', unconvertedPos, state.idCounters);
+    missionary.chargesRemaining = 2;
+    state.units[missionary.id] = missionary;
+    state.civilizations['ai-1'].units.push(missionary.id);
+
+    return { state, unconvertedCityId: unconvertedCity.id, missionaryId: missionary.id };
+  }
+
+  it('an idle AI missionary preaches its own unconverted city (own cities dispatched before minor civs)', () => {
+    const { state, unconvertedCityId, missionaryId } = withMissionaryAndUnconvertedCity('592-ai-missionary-own-city');
+    const before = state.units[missionaryId]!.chargesRemaining;
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    expect(next.units[missionaryId]?.chargesRemaining).toBeLessThan(before!);
+    expect(next.cityFaith?.[unconvertedCityId]?.conversionProgress?.['religion-ai-1']).toBeGreaterThan(0);
+  });
+
+  it('is deterministic given the same seed/state (repeated runs produce identical cityFaith)', () => {
+    const { state } = withMissionaryAndUnconvertedCity('592-ai-missionary-determinism');
+    const runA = processAITurn(structuredClone(state), 'ai-1', new EventBus());
+    const runB = processAITurn(structuredClone(state), 'ai-1', new EventBus());
+    expect(runA.cityFaith).toEqual(runB.cityFaith);
   });
 });

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -2711,4 +2711,40 @@ describe('#592 MR5 — AI missionary dispatch', () => {
     const runB = processAITurn(structuredClone(state), 'ai-1', new EventBus());
     expect(runA.cityFaith).toEqual(runB.cityFaith);
   });
+
+  // Regression: chooseMissionaryDispatchTarget must pick a strategic target regardless of
+  // current distance, not filter candidates down to only those already in preach range —
+  // otherwise a missionary starting more than 1 tile from every eligible city would never
+  // move (the target-selection step itself would return null for every real candidate).
+  it('an idle AI missionary starting more than 1 tile away WALKS toward its target instead of staying put', () => {
+    const { state, unconvertedCityId, missionaryId } = withMissionaryAndUnconvertedCity('592-ai-missionary-walk');
+    const missionary = state.units[missionaryId]!;
+    const targetPos = state.cities[unconvertedCityId]!.position;
+    // Move the missionary back to the holy city (3 tiles from the target) so it must walk.
+    const farPos: HexCoord = { q: targetPos.q - 3, r: targetPos.r };
+    state.units[missionaryId] = { ...missionary, position: farPos };
+    state.civilizations['ai-1'].visibility.tiles[hexKey(farPos)] = 'visible';
+    // Guarantee a walkable land corridor between farPos and targetPos -- random map
+    // generation can otherwise place impassable terrain (ocean/mountain) in between,
+    // which would make findPath return null for a reason unrelated to what this test
+    // actually checks (target selection + move-toward-target dispatch logic).
+    for (let q = farPos.q; q <= targetPos.q; q++) {
+      const coord: HexCoord = { q, r: targetPos.r };
+      const key = hexKey(coord);
+      const existing = state.map.tiles[key];
+      state.map.tiles[key] = {
+        coord, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none',
+        owner: existing?.owner ?? null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+        regionKey: existing?.regionKey,
+      };
+    }
+
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    const movedUnit = next.units[missionaryId];
+    expect(movedUnit).toBeDefined();
+    expect(movedUnit!.position).not.toEqual(farPos);
+    expect(hexDistance(movedUnit!.position, targetPos)).toBeLessThan(hexDistance(farPos, targetPos));
+    // Charges must be untouched -- it moved, it did not preach yet (still out of range).
+    expect(movedUnit!.chargesRemaining).toBe(missionary.chargesRemaining);
+  });
 });

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -2747,4 +2747,34 @@ describe('#592 MR5 — AI missionary dispatch', () => {
     // Charges must be untouched -- it moved, it did not preach yet (still out of range).
     expect(movedUnit!.chargesRemaining).toBe(missionary.chargesRemaining);
   });
+
+  // Regression: the friendly-minor-civ branch of chooseMissionaryDispatchTarget must
+  // skip a minor city that already follows the civ's own faith -- otherwise the AI
+  // wastes a missionary charge (and its cooldown) re-preaching a city with no
+  // conversion progress left to make.
+  it('does not waste a charge re-preaching a friendly minor-civ city that already follows the civ\'s own faith', () => {
+    const { state, unconvertedCityId, missionaryId } = withMissionaryAndUnconvertedCity('592-ai-missionary-minor-skip');
+    const missionary = state.units[missionaryId]!;
+    const minor = Object.values(state.minorCivs)[0];
+    if (!minor) throw new Error('missing generated minor civilization');
+    const minorCity = state.cities[minor.cityId];
+    if (!minorCity) throw new Error('missing minor civ city');
+
+    // Empty the "own unconverted" branch so dispatch falls through to the minor-civ
+    // branch -- otherwise the still-unconverted own city would win first regardless of
+    // what this test is checking.
+    state.cityFaith![unconvertedCityId] = { religionId: 'religion-ai-1' };
+    // Minor city already follows ai-1's own faith -- no progress left to gain there.
+    state.cityFaith![minor.cityId] = { religionId: 'religion-ai-1' };
+    state.civilizations['ai-1'].visibility.tiles[hexKey(minorCity.position)] = 'visible';
+    // Place the missionary right next to the minor city so it WOULD be preached this
+    // turn if the dispatch logic incorrectly selected it as a target.
+    state.units[missionaryId] = { ...missionary, position: minorCity.position };
+
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    // Charges must be unchanged -- confirms the missionary did not preach the
+    // already-converted minor city (no conversionProgress bucket was opened there).
+    expect(next.units[missionaryId]?.chargesRemaining).toBe(missionary.chargesRemaining);
+    expect(next.cityFaith?.[minor.cityId]?.conversionProgress).toBeUndefined();
+  });
 });

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1558,7 +1558,7 @@ describe('journey automation', () => {
     state.cityFaith = { [capital.id]: { religionId, isHolyCity: true } };
 
     const next = processTurn(state, new EventBus());
-    expect(next.cityFaith?.[neighbor.id]?.conversionProgress?.toReligionId).toBe(religionId);
+    expect(next.cityFaith?.[neighbor.id]?.conversionProgress?.[religionId]).toBeGreaterThan(0);
   });
 
   it('#591 MR4: completing Sacred Council founds a religion at the building city', () => {

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -777,6 +777,39 @@ describe('processTurn', () => {
     expect(newState.units[newUnitId!].experience).toBe(0);
   });
 
+  it('#592 MR5: missionary gets 2 charges by default, 3 if missionary-zeal was completed at build time', () => {
+    const stateWithoutZeal = createNewGame(undefined, 'missionary-charges-base', 'small');
+    const startPos = stateWithoutZeal.units[stateWithoutZeal.civilizations.player.units[0]].position;
+    const cityNoZeal = foundCity('player', startPos, stateWithoutZeal.map, mkC());
+    cityNoZeal.buildings = [...cityNoZeal.buildings, 'temple'];
+    stateWithoutZeal.cities[cityNoZeal.id] = cityNoZeal;
+    stateWithoutZeal.civilizations.player.cities.push(cityNoZeal.id);
+    cityNoZeal.productionQueue = ['missionary'];
+    cityNoZeal.productionProgress = 15; // missionary cost is 16 — 1 short so this turn completes it
+
+    const beforeNoZeal = new Set(Object.keys(stateWithoutZeal.units));
+    const afterNoZeal = processTurn(stateWithoutZeal, new EventBus());
+    const missionaryNoZealId = Object.keys(afterNoZeal.units).find(id => !beforeNoZeal.has(id) && afterNoZeal.units[id].type === 'missionary');
+    expect(missionaryNoZealId).toBeDefined();
+    expect(afterNoZeal.units[missionaryNoZealId!].chargesRemaining).toBe(2);
+
+    const stateWithZeal = createNewGame(undefined, 'missionary-charges-zeal', 'small');
+    stateWithZeal.civilizations.player.techState.completed.push('missionary-zeal');
+    const startPosZeal = stateWithZeal.units[stateWithZeal.civilizations.player.units[0]].position;
+    const cityZeal = foundCity('player', startPosZeal, stateWithZeal.map, mkC());
+    cityZeal.buildings = [...cityZeal.buildings, 'temple'];
+    stateWithZeal.cities[cityZeal.id] = cityZeal;
+    stateWithZeal.civilizations.player.cities.push(cityZeal.id);
+    cityZeal.productionQueue = ['missionary'];
+    cityZeal.productionProgress = 15;
+
+    const beforeZeal = new Set(Object.keys(stateWithZeal.units));
+    const afterZeal = processTurn(stateWithZeal, new EventBus());
+    const missionaryZealId = Object.keys(afterZeal.units).find(id => !beforeZeal.has(id) && afterZeal.units[id].type === 'missionary');
+    expect(missionaryZealId).toBeDefined();
+    expect(afterZeal.units[missionaryZealId!].chargesRemaining).toBe(3);
+  });
+
   it('advances World Age after a strict majority reaches the next personal era', () => {
     const state = createNewGame(undefined, 'turn-era', 'small');
     const bus = new EventBus();

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -411,4 +411,35 @@ describe('#591 MR4 — religion state defaults', () => {
     const loadedAgain = migrateSaveToCurrent(migrated);
     expect(loadedAgain).toEqual(migrated);
   });
+
+  it('#592 MR5: converts a legacy single-slot conversionProgress ({toReligionId, points}) into the new per-religion map shape, preserving the in-flight points', () => {
+    const save = createNewGame('rome', 'conversion-progress-shape-migration', 'small');
+    save.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', foundedTurn: 5 } };
+    save.cityFaith = {
+      capital: { religionId: 'religion-player', isHolyCity: true },
+      // Legacy MR4 shape -- a city mid-conversion toward religion-player with 65 banked
+      // points, saved before MR5's per-religion map restructure.
+      contested: { religionId: 'religion-player', conversionProgress: { toReligionId: 'religion-player', points: 65 } as any },
+    };
+
+    const migrated = migrateSaveToCurrent(save);
+
+    expect(migrated.cityFaith!.contested.conversionProgress).toEqual({ 'religion-player': 65 });
+    // Unrelated holy-city entry with no conversionProgress at all is untouched.
+    expect(migrated.cityFaith!.capital).toEqual(save.cityFaith!.capital);
+  });
+
+  it('leaves an already-current per-religion conversionProgress map untouched and stays idempotent', () => {
+    const save = createNewGame('rome', 'conversion-progress-shape-current', 'small');
+    save.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', foundedTurn: 5 } };
+    save.cityFaith = {
+      contested: { religionId: 'religion-player', conversionProgress: { 'religion-player': 40, 'religion-ai-1': 14 } },
+    };
+
+    const migrated = migrateSaveToCurrent(save);
+    expect(migrated.cityFaith!.contested.conversionProgress).toEqual({ 'religion-player': 40, 'religion-ai-1': 14 });
+
+    const loadedAgain = migrateSaveToCurrent(migrated);
+    expect(loadedAgain).toEqual(migrated);
+  });
 });

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -594,6 +594,44 @@ describe('getTrainableUnitsForCity', () => {
   });
 });
 
+describe('missionary trainability (#592)', () => {
+  function makeCity(buildings: string[]): City {
+    return {
+      id: 'c1', buildings, ownedTiles: [], grid: [[null]],
+      food: 0, foodNeeded: 10, population: 1,
+      productionQueue: [], productionProgress: 0,
+      focus: 'balanced', maturity: 'city',
+      unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      position: { q: 0, r: 0 }, owner: 'p1',
+    } as any;
+  }
+  const map = { tiles: {}, width: 10, height: 10, wrap: false } as any;
+
+  it('is NOT trainable without a founded religion (followsOwnFaith omitted, defaults false)', () => {
+    const city = makeCity(['temple']);
+    const trainable = getTrainableUnitsForCity(city, [], map).map(u => u.type);
+    expect(trainable).not.toContain('missionary');
+  });
+
+  it('is NOT trainable without a Temple, even with own faith true', () => {
+    const city = makeCity([]);
+    const trainable = getTrainableUnitsForCity(city, [], map, undefined, undefined, true).map(u => u.type);
+    expect(trainable).not.toContain('missionary');
+  });
+
+  it('is NOT trainable when the city follows a foreign faith (followsOwnFaith explicitly false)', () => {
+    const city = makeCity(['temple']);
+    const trainable = getTrainableUnitsForCity(city, [], map, undefined, undefined, false).map(u => u.type);
+    expect(trainable).not.toContain('missionary');
+  });
+
+  it('IS trainable when religion founded + own faith + Temple all hold', () => {
+    const city = makeCity(['temple']);
+    const trainable = getTrainableUnitsForCity(city, [], map, undefined, undefined, true).map(u => u.type);
+    expect(trainable).toContain('missionary');
+  });
+});
+
 describe('processCity', () => {
   it('adds food per turn and grows population', () => {
     const map = generateMap(30, 30, 'city-test');

--- a/tests/systems/religion-spread.test.ts
+++ b/tests/systems/religion-spread.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import type { City, GameState, HexCoord, HexTile } from '@/core/types';
 import { foundReligion, getStrongestPressure, processReligionTurn } from '@/systems/religion-system';
-import { CONVERSION_THRESHOLD } from '@/systems/religion-definitions';
+import { CONVERSION_THRESHOLD, CITY_CONVERSION_COOLDOWN_TURNS } from '@/systems/religion-definitions';
 import { makeReligionFixture } from './helpers/religion-fixture';
 import { hexKey } from '@/systems/hex-utils';
 
@@ -100,10 +100,10 @@ describe('#591 MR4 — processReligionTurn', () => {
     const founded = foundReligion(state, civId, templeCity, new EventBus());
     const withNeighbor = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
     const next = processReligionTurn(withNeighbor, new EventBus());
-    expect(next.cityFaith!['own-neighbor'].conversionProgress).toEqual({ toReligionId: `religion-${civId}`, points: 15 });
+    expect(next.cityFaith!['own-neighbor'].conversionProgress).toEqual({ [`religion-${civId}`]: 15 });
   });
 
-  it('converts a city at >= threshold points, fires religion:city-converted, clears progress', () => {
+  it('converts a city at >= threshold points, fires religion:city-converted, starts anti-flip-flop cooldown', () => {
     const { state, civId, templeCity } = makeReligionFixture();
     const founded = foundReligion(state, civId, templeCity, new EventBus());
     let working = addCity(founded, 'own-neighbor', civId, {
@@ -111,37 +111,47 @@ describe('#591 MR4 — processReligionTurn', () => {
     }, {});
     working = {
       ...working,
-      cityFaith: { ...working.cityFaith, 'own-neighbor': { conversionProgress: { toReligionId: `religion-${civId}`, points: CONVERSION_THRESHOLD - 10 } } as any },
+      cityFaith: { ...working.cityFaith, 'own-neighbor': { religionId: `religion-${civId}`, conversionProgress: { [`religion-${civId}`]: CONVERSION_THRESHOLD - 10 } } },
     };
     const bus = new EventBus();
     const events: unknown[] = [];
     bus.on('religion:city-converted', e => events.push(e));
     const next = processReligionTurn(working, bus);
-    expect(next.cityFaith!['own-neighbor']).toEqual({ religionId: `religion-${civId}` });
+    expect(next.cityFaith!['own-neighbor']).toEqual({
+      religionId: `religion-${civId}`,
+      conversionCooldownUntilTurn: working.turn + CITY_CONVERSION_COOLDOWN_TURNS,
+      conversionCooldownExemptCivId: civId,
+    });
     expect(events).toHaveLength(1);
   });
 
-  it('resets points when the strongest target religion changes to a different one', () => {
+  it('#592 MR5: an ambient-target switch does NOT reset an existing religion bucket — buckets are independent per religion', () => {
     const { state, civId, templeCity, otherCivId, otherCity } = makeReligionFixture();
     let working = foundReligion(state, civId, templeCity, new EventBus());
     working = foundReligion(working, otherCivId, otherCity, new EventBus());
     working = addCity(working, 'contested', 'p3', { q: 6, r: 0 }); // adjacent to templeCity only initially
     working = {
       ...working,
-      cityFaith: { ...working.cityFaith, contested: { religionId: `religion-${civId}`, conversionProgress: { toReligionId: `religion-${civId}`, points: 50 } } as any },
+      cityFaith: { ...working.cityFaith, contested: { religionId: `religion-${civId}`, conversionProgress: { [`religion-${civId}`]: 50 } } },
     };
     // Now make it ALSO adjacent to two of otherCiv's follower cities so the other
-    // religion's accrual (7*2=14) exceeds civId's own single-source accrual isn't
-    // possible here since 'contested' isn't civId's own city -- rebuild as a foreign
-    // city relative to both religions, with otherCivId's religion now stronger.
+    // religion's accrual (7*2=14) exceeds civId's own single-source accrual (7) — 'contested'
+    // is a foreign city relative to both religions, with otherCivId's religion now stronger.
     working = addCity(working, 'other-f1', otherCivId, { q: 5, r: 1 });
     working = { ...working, cityFaith: { ...working.cityFaith, 'other-f1': { religionId: `religion-${otherCivId}` } } };
     working = addCity(working, 'other-f2', otherCivId, { q: 7, r: -1 });
     working = { ...working, cityFaith: { ...working.cityFaith, 'other-f2': { religionId: `religion-${otherCivId}` } } };
     // contested is owned by 'p3' (foreign to both) -- adjacent to templeCity (civId, 1
-    // source, 7) and to other-f1/other-f2 (otherCivId, 2 sources, 14). otherCivId wins.
+    // source, 7) and to other-f1/other-f2 (otherCivId, 2 sources, 14). otherCivId wins the
+    // "strongest pressure" comparison, so its bucket accrues this turn — but civId's
+    // previously-banked 50 points must survive untouched (this is the #592 fix: a
+    // deliberate investment toward one religion is never wiped by ambient pressure
+    // pointing elsewhere in the same turn).
     const next = processReligionTurn(working, new EventBus());
-    expect(next.cityFaith!.contested.conversionProgress).toEqual({ toReligionId: `religion-${otherCivId}`, points: 14 });
+    expect(next.cityFaith!.contested.conversionProgress).toEqual({
+      [`religion-${civId}`]: 50,
+      [`religion-${otherCivId}`]: 14,
+    });
   });
 
   it('never accrues progress in a holy city, even under maximum pressure', () => {
@@ -165,7 +175,7 @@ describe('#591 MR4 — processReligionTurn', () => {
       working = processReligionTurn(working, new EventBus());
     }
     // 3 turns * 15/turn = 45, not frozen at 15 after turn 1.
-    expect(working.cityFaith!['own-neighbor'].conversionProgress).toEqual({ toReligionId: `religion-${civId}`, points: 45 });
+    expect(working.cityFaith!['own-neighbor'].conversionProgress).toEqual({ [`religion-${civId}`]: 45 });
   });
 
   it('does not re-touch a city that already fully converted (settled follower, no conversionProgress)', () => {

--- a/tests/systems/religion-system.test.ts
+++ b/tests/systems/religion-system.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
-import { foundReligion, chooseBoon } from '@/systems/religion-system';
+import type { City, GameState, HexCoord, HexTile } from '@/core/types';
+import {
+  foundReligion, chooseBoon, preach, canPreachTarget, getCityConversionPoints,
+  processReligionTurn,
+} from '@/systems/religion-system';
+import {
+  CONVERSION_THRESHOLD, OCCUPATION_ACCRUAL, MISSIONARY_ACTION_COOLDOWN_TURNS,
+} from '@/systems/religion-definitions';
+import { createUnit } from '@/systems/unit-system';
+import { hexKey } from '@/systems/hex-utils';
 import { makeReligionFixture } from './helpers/religion-fixture';
 
 describe('#591 MR4 — foundReligion', () => {
@@ -64,5 +73,236 @@ describe('#591 MR4 — chooseBoon', () => {
   it('is a no-op for a nonexistent religion id', () => {
     const { state } = makeReligionFixture();
     expect(chooseBoon(state, 'no-such-religion', 'tithes')).toBe(state);
+  });
+});
+
+function addCity(state: GameState, id: string, owner: string, coord: HexCoord, overrides: Partial<City> = {}): GameState {
+  const tile: HexTile = {
+    coord, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none',
+    owner, improvementTurnsLeft: 0, hasRiver: false, wonder: null, regionKey: 'landmass-1',
+  };
+  const city: City = {
+    id, name: id, owner, position: coord, population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [coord], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+  return {
+    ...state,
+    map: { ...state.map, tiles: { ...state.map.tiles, [hexKey(coord)]: tile } },
+    cities: { ...state.cities, [id]: city },
+  };
+}
+
+function markVisible(state: GameState, civId: string, coords: HexCoord[]): GameState {
+  const tiles = { ...(state.civilizations[civId].visibility?.tiles ?? {}) };
+  for (const c of coords) tiles[hexKey(c)] = 'visible';
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civId]: { ...state.civilizations[civId], visibility: { tiles } },
+    },
+  };
+}
+
+interface PreachScenarioOptions {
+  atWar?: boolean;
+  holyCity?: boolean;
+  occupied?: boolean; // target is civId's own city under occupation (originalOwner = otherCivId)
+  zeal?: boolean;
+  discovered?: boolean; // default true
+  targetOwnCityFlipped?: boolean; // target is civId's own city that flipped to otherCivId's faith
+}
+
+function seedPreachScenario(opts: PreachScenarioOptions = {}) {
+  const bus = new EventBus();
+  const fixture = makeReligionFixture();
+  const { civId, otherCivId } = fixture;
+  let state = foundReligion(fixture.state, civId, fixture.templeCity, bus);
+
+  if (opts.zeal) {
+    state = {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [civId]: {
+          ...state.civilizations[civId],
+          techState: { ...state.civilizations[civId].techState, completed: [...state.civilizations[civId].techState.completed, 'missionary-zeal'] },
+        },
+      },
+    };
+  }
+
+  const targetPos: HexCoord = { q: 20, r: 20 };
+  const targetOwner = (opts.holyCity || opts.occupied || opts.targetOwnCityFlipped) ? civId : otherCivId;
+  state = addCity(state, 'target-city', targetOwner, targetPos, opts.occupied ? { occupation: { originalOwnerId: otherCivId, turnsRemaining: 5 } } : {});
+
+  if (opts.holyCity) {
+    state = { ...state, cityFaith: { ...state.cityFaith, 'target-city': { religionId: `religion-${civId}`, isHolyCity: true } } };
+  } else if (opts.targetOwnCityFlipped) {
+    state = foundReligion(state, otherCivId, fixture.otherCity, bus);
+    state = { ...state, cityFaith: { ...state.cityFaith, 'target-city': { religionId: `religion-${otherCivId}` } } };
+  }
+
+  if (opts.atWar) {
+    state = {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [civId]: { ...state.civilizations[civId], diplomacy: { ...state.civilizations[civId].diplomacy, atWarWith: [otherCivId] } },
+      },
+    };
+  }
+
+  const missionary = createUnit('missionary', civId, targetPos, state.idCounters);
+  missionary.chargesRemaining = 2;
+  state = {
+    ...state,
+    units: { ...state.units, [missionary.id]: missionary },
+    civilizations: {
+      ...state.civilizations,
+      [civId]: { ...state.civilizations[civId], units: [...state.civilizations[civId].units, missionary.id] },
+    },
+  };
+
+  if (opts.discovered !== false) {
+    state = markVisible(state, civId, [targetPos]);
+  }
+
+  return { state, bus, unitId: missionary.id, cityId: 'target-city', civId, otherCivId };
+}
+
+describe('preach() (#592)', () => {
+  it('grants PREACH_POINTS (50) toward a freshly-founded target city, not doubled', () => {
+    const { state, bus, unitId, cityId, civId } = seedPreachScenario();
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(true);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('grants PREACH_OCCUPIED_DOUBLE (100) and converts outright when target is occupied AND owner has missionary-zeal', () => {
+    const { state, bus, unitId, cityId, civId } = seedPreachScenario({ occupied: true, zeal: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok && result.converted).toBe(true);
+    expect(result.state.cityFaith?.[cityId].religionId).toBe(`religion-${civId}`);
+  });
+
+  it('grants only PREACH_POINTS (50, not doubled) when occupied but owner lacks missionary-zeal', () => {
+    const { state, bus, unitId, cityId, civId } = seedPreachScenario({ occupied: true, zeal: false });
+    const result = preach(state, unitId, cityId, bus);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('grants only PREACH_POINTS (50) when owner has missionary-zeal but target is NOT occupied', () => {
+    const { state, bus, unitId, cityId, civId } = seedPreachScenario({ zeal: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
+  });
+
+  it('refuses to preach a holy city', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario({ holyCity: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('holy-city');
+  });
+
+  it('refuses to preach a city owned by a civ the missionary owner is at war with', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario({ atWar: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('at-war');
+  });
+
+  it('refuses to preach an undiscovered city', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario({ discovered: false });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('undiscovered');
+  });
+
+  it('consumes one charge per preach; refuses on-cooldown same turn; consumes the unit at 0 charges after cooldown elapses', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario();
+    const afterFirst = preach(state, unitId, cityId, bus);
+    expect(afterFirst.ok && afterFirst.state.units[unitId]?.chargesRemaining).toBe(1);
+    expect(afterFirst.ok && afterFirst.unitConsumed).toBe(false);
+
+    // same turn: still on cooldown
+    const immediateSecond = preach(afterFirst.ok ? afterFirst.state : state, unitId, cityId, bus);
+    expect(immediateSecond.ok).toBe(false);
+    if (!immediateSecond.ok) expect(immediateSecond.reason).toBe('on-cooldown');
+
+    // advance past the cooldown window
+    const cooledDownState = { ...(afterFirst.ok ? afterFirst.state : state), turn: state.turn + MISSIONARY_ACTION_COOLDOWN_TURNS };
+    const afterSecond = preach(cooledDownState, unitId, cityId, bus);
+    expect(afterSecond.ok && afterSecond.unitConsumed).toBe(true);
+    expect(afterSecond.ok && afterSecond.state.units[unitId]).toBeUndefined();
+  });
+
+  it('refuses when the missionary has no charges left', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario();
+    const zeroCharges = { ...state, units: { ...state.units, [unitId]: { ...state.units[unitId], chargesRemaining: 0 } } };
+    const result = preach(zeroCharges, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('no-charges');
+  });
+
+  it('refuses when the missionary is out of range (not on/adjacent to the target city)', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario();
+    const farAway = { ...state, units: { ...state.units, [unitId]: { ...state.units[unitId], position: { q: 0, r: 0 } } } };
+    const result = preach(farAway, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('out-of-range');
+  });
+
+  it('own cities are a valid preach target (re-convert a flipped city)', () => {
+    const { state, bus, unitId, cityId } = seedPreachScenario({ targetOwnCityFlipped: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok).toBe(true);
+  });
+
+  it('canPreachTarget matches preach()\'s own refusal conditions (no drift between UI eligibility and the real gate)', () => {
+    const { state, unitId, cityId } = seedPreachScenario({ holyCity: true });
+    expect(canPreachTarget(state, state.units[unitId], cityId)).toBe(false);
+    const ok = seedPreachScenario();
+    expect(canPreachTarget(ok.state, ok.state.units[ok.unitId], ok.cityId)).toBe(true);
+  });
+});
+
+describe('occupation passive pressure (#592)', () => {
+  it('an occupied city accrues OCCUPATION_ACCRUAL/turn toward the occupier faith', () => {
+    const bus = new EventBus();
+    const fixture = makeReligionFixture();
+    const { civId, otherCivId } = fixture;
+    let state = foundReligion(fixture.state, civId, fixture.templeCity, bus);
+    const targetPos: HexCoord = { q: 20, r: 20 };
+    state = addCity(state, 'occupied-city', civId, targetPos, { occupation: { originalOwnerId: otherCivId, turnsRemaining: 5 } });
+
+    const before = getCityConversionPoints(state.cityFaith?.['occupied-city'], `religion-${civId}`);
+    const next = processReligionTurn(state, bus);
+    const after = getCityConversionPoints(next.cityFaith?.['occupied-city'], `religion-${civId}`);
+    expect(after - before).toBe(OCCUPATION_ACCRUAL);
+  });
+
+  it('occupation accrual stops once occupation ends (city.occupation cleared)', () => {
+    const bus = new EventBus();
+    const fixture = makeReligionFixture();
+    const { civId } = fixture;
+    let state = foundReligion(fixture.state, civId, fixture.templeCity, bus);
+    const targetPos: HexCoord = { q: 20, r: 20 };
+    state = addCity(state, 'occupied-city', civId, targetPos); // no occupation field
+
+    const before = getCityConversionPoints(state.cityFaith?.['occupied-city'], `religion-${civId}`);
+    const next = processReligionTurn(state, bus);
+    const after = getCityConversionPoints(next.cityFaith?.['occupied-city'], `religion-${civId}`);
+    expect(after).toBe(before);
+  });
+
+  it('occupied city under missionary-zeal + preach converts outright in one call, matching the doubled matrix case', () => {
+    const { state, bus, unitId, cityId, civId } = seedPreachScenario({ occupied: true, zeal: true });
+    const result = preach(state, unitId, cityId, bus);
+    expect(result.ok && result.converted).toBe(true);
+    expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(0); // bucket cleared/replaced once converted, religionId set directly
   });
 });

--- a/tests/systems/religion-system.test.ts
+++ b/tests/systems/religion-system.test.ts
@@ -301,6 +301,50 @@ describe('preach() (#592)', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('refuses to preach a city under its anti-flip-flop cooldown when the preaching civ is NOT the exempt civ', () => {
+    // Regression: preach() must respect CityFaith.conversionCooldownUntilTurn just like
+    // passive spread does, or a missionary trivially bypasses the whole anti-flip-flop
+    // mechanic. Here otherCivId just converted the city (cooldown exempts otherCivId,
+    // the political owner at conversion time); civId's missionary tries to flip it to
+    // civId's own faith during the cooldown window and must be refused.
+    const { state, bus, unitId, cityId, otherCivId } = seedPreachScenario();
+    const cooling = {
+      ...state,
+      cityFaith: {
+        ...state.cityFaith,
+        [cityId]: {
+          religionId: `religion-${otherCivId}`,
+          conversionCooldownUntilTurn: state.turn + 5,
+          conversionCooldownExemptCivId: otherCivId,
+        },
+      },
+    };
+    const result = preach(cooling, unitId, cityId, bus);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('city-conversion-cooldown');
+  });
+
+  it('the exempt civ (the city\'s own political owner) can still preach through its own cooldown window', () => {
+    // Same setup as above, but the cooldown's exempt civ IS the preaching civ (civId owns
+    // the city politically; it just flipped religions and civId wants it back
+    // immediately) -- this must succeed, preserving "re-convert a flipped city."
+    const { state, bus, unitId, cityId, civId, otherCivId } = seedPreachScenario();
+    const cooling = {
+      ...state,
+      cities: { ...state.cities, [cityId]: { ...state.cities[cityId], owner: civId } },
+      cityFaith: {
+        ...state.cityFaith,
+        [cityId]: {
+          religionId: `religion-${otherCivId}`,
+          conversionCooldownUntilTurn: state.turn + 5,
+          conversionCooldownExemptCivId: civId,
+        },
+      },
+    };
+    const result = preach(cooling, unitId, cityId, bus);
+    expect(result.ok).toBe(true);
+  });
+
   it('canPreachTarget matches preach()\'s own refusal conditions (no drift between UI eligibility and the real gate)', () => {
     const { state, unitId, cityId } = seedPreachScenario({ holyCity: true });
     expect(canPreachTarget(state, state.units[unitId], cityId)).toBe(false);
@@ -343,5 +387,35 @@ describe('occupation passive pressure (#592)', () => {
     const result = preach(state, unitId, cityId, bus);
     expect(result.ok && result.converted).toBe(true);
     expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(0); // bucket cleared/replaced once converted, religionId set directly
+  });
+
+  it('occupation accrual respects the anti-flip-flop cooldown just like passive spread and preach', () => {
+    // Regression: a city that just converted to religion A must not be immediately
+    // grindable toward the occupier's DIFFERENT religion via occupation accrual -- that
+    // would be a loophole around the cooldown from the military-conquest side.
+    const bus = new EventBus();
+    const fixture = makeReligionFixture();
+    const { civId, otherCivId } = fixture;
+    let state = foundReligion(fixture.state, civId, fixture.templeCity, bus);
+    const targetPos: HexCoord = { q: 20, r: 20 };
+    state = addCity(state, 'occupied-city', civId, targetPos, { occupation: { originalOwnerId: otherCivId, turnsRemaining: 5 } });
+    // City politically owned by civId (the occupier here) already follows a DIFFERENT
+    // religion (otherCivId's), and is under a cooldown that exempts otherCivId, not civId.
+    state = {
+      ...state,
+      cityFaith: {
+        ...state.cityFaith,
+        'occupied-city': {
+          religionId: `religion-${otherCivId}`,
+          conversionCooldownUntilTurn: state.turn + 5,
+          conversionCooldownExemptCivId: otherCivId,
+        },
+      },
+    };
+
+    const before = getCityConversionPoints(state.cityFaith?.['occupied-city'], `religion-${civId}`);
+    const next = processReligionTurn(state, bus);
+    const after = getCityConversionPoints(next.cityFaith?.['occupied-city'], `religion-${civId}`);
+    expect(after).toBe(before);
   });
 });

--- a/tests/systems/religion-system.test.ts
+++ b/tests/systems/religion-system.test.ts
@@ -201,6 +201,45 @@ describe('preach() (#592)', () => {
     expect(getCityConversionPoints(result.state.cityFaith?.[cityId], `religion-${civId}`)).toBe(50);
   });
 
+  it('does NOT double when the occupied target is a rival city the missionary owner does not itself occupy', () => {
+    // Regression: target-city.owner = otherCivId, occupation.originalOwnerId = civId (i.e.
+    // otherCivId captured this city FROM civId) -- civId's missionary has missionary-zeal
+    // and preaches it anyway (not at war, discovered). The city IS occupied, but NOT by
+    // civId, so this must NOT get the doubled bonus -- only the actual occupier's preach
+    // should double, per "a city the owner holds under occupation."
+    const bus = new EventBus();
+    const fixture = makeReligionFixture();
+    const { civId, otherCivId } = fixture;
+    let state = foundReligion(fixture.state, civId, fixture.templeCity, bus);
+    state = {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [civId]: {
+          ...state.civilizations[civId],
+          techState: { ...state.civilizations[civId].techState, completed: [...state.civilizations[civId].techState.completed, 'missionary-zeal'] },
+        },
+      },
+    };
+    const targetPos: HexCoord = { q: 20, r: 20 };
+    state = addCity(state, 'rival-occupied-city', otherCivId, targetPos, { occupation: { originalOwnerId: civId, turnsRemaining: 5 } });
+    const missionary = createUnit('missionary', civId, targetPos, state.idCounters);
+    missionary.chargesRemaining = 2;
+    state = {
+      ...state,
+      units: { ...state.units, [missionary.id]: missionary },
+      civilizations: {
+        ...state.civilizations,
+        [civId]: { ...state.civilizations[civId], units: [...state.civilizations[civId].units, missionary.id] },
+      },
+    };
+    state = markVisible(state, civId, [targetPos]);
+
+    const result = preach(state, missionary.id, 'rival-occupied-city', bus);
+    expect(result.ok).toBe(true);
+    expect(getCityConversionPoints(result.state.cityFaith?.['rival-occupied-city'], `religion-${civId}`)).toBe(50);
+  });
+
   it('refuses to preach a holy city', () => {
     const { state, bus, unitId, cityId } = seedPreachScenario({ holyCity: true });
     const result = preach(state, unitId, cityId, bus);

--- a/tests/ui/city-panel-religion.test.ts
+++ b/tests/ui/city-panel-religion.test.ts
@@ -33,7 +33,7 @@ describe('#591 MR4 — city panel Faith row', () => {
     const { container, city, state } = withFaith();
     const withCityFaith: GameState = {
       ...state,
-      cityFaith: { [city.id]: { religionId: 'religion-owner', conversionProgress: { toReligionId: 'religion-owner', points: 85 } } },
+      cityFaith: { [city.id]: { religionId: 'religion-owner', conversionProgress: { 'religion-owner': 85 } } },
     };
     const panel = createCityPanel(container, city, withCityFaith, { onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {} });
     expect(panel.textContent).toContain('Converting to Order of Test');

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -295,6 +295,103 @@ function makeWorkerState(tileOverrides: Record<string, unknown>, unitOverrides: 
   } as unknown as GameState;
 }
 
+function makeMissionaryState(overrides: {
+  chargesRemaining?: number;
+  missionaryCooldownUntilTurn?: number;
+  cityDiscovered?: boolean;
+} = {}): GameState {
+  const targetPos: HexCoord = { q: 1, r: 0 };
+  return {
+    turn: 10,
+    era: 3,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {
+      'missionary-1': {
+        id: 'missionary-1', type: 'missionary', owner: 'player',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+        chargesRemaining: overrides.chargesRemaining ?? 2,
+        missionaryCooldownUntilTurn: overrides.missionaryCooldownUntilTurn,
+      },
+    },
+    cities: {
+      'target-city': {
+        id: 'target-city', name: 'Target City', owner: 'other', position: targetPos,
+        population: 4, food: 0, foodNeeded: 20, buildings: [], productionQueue: [],
+        productionProgress: 0, ownedTiles: [targetPos], workedTiles: [], focus: 'balanced',
+        maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      },
+    },
+    civilizations: {
+      player: {
+        color: '#fff',
+        techState: { completed: [] },
+        diplomacy: { atWarWith: [] },
+        visibility: { tiles: overrides.cityDiscovered !== false ? { [hexKey(targetPos)]: 'visible' } : {} },
+      },
+    },
+    religions: { 'religion-player': { id: 'religion-player', name: 'Test Faith', ownerCivId: 'player', foundedTurn: 1 } },
+    cityFaith: {},
+  } as unknown as GameState;
+}
+
+describe('renderSelectedUnitInfo — missionary Preach button (#592)', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows a Preach button with help text for a missionary adjacent to an eligible city, and calls onPreach on click', () => {
+    const state = makeMissionaryState();
+    const onPreach = vi.fn();
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'missionary-1', { onPreach });
+
+    const button = findButtons(container).find(b => b.textContent === 'Preach');
+    expect(button).toBeDefined();
+    expect(button!.title).toBeTruthy();
+    button!.click();
+    expect(onPreach).toHaveBeenCalledWith('missionary-1', 'target-city');
+  });
+
+  it('does not show an enabled Preach button when the missionary has 0 charges', () => {
+    const state = makeMissionaryState({ chargesRemaining: 0 });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'missionary-1', { onPreach: vi.fn() });
+
+    const button = findButtons(container).find(b => b.textContent === 'Preach');
+    expect(button).toBeUndefined();
+  });
+
+  it('shows a disabled Preach button on cooldown', () => {
+    const state = makeMissionaryState({ missionaryCooldownUntilTurn: 999 });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'missionary-1', { onPreach: vi.fn() });
+
+    const button = findButtons(container).find(b => b.textContent === 'Preach');
+    expect(button).toBeDefined();
+    expect(button!.disabled).toBe(true);
+  });
+
+  it('shows a disabled Preach button when no eligible city is nearby (undiscovered)', () => {
+    const state = makeMissionaryState({ cityDiscovered: false });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'missionary-1', { onPreach: vi.fn() });
+
+    const button = findButtons(container).find(b => b.textContent === 'Preach');
+    expect(button).toBeDefined();
+    expect(button!.disabled).toBe(true);
+  });
+
+  it('shows the missionary charge count', () => {
+    const state = makeMissionaryState({ chargesRemaining: 1 });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'missionary-1', { onPreach: vi.fn() });
+    expect(collectAllText(container)).toContain('Missionary Charges: 1');
+  });
+});
+
 describe('renderSelectedUnitInfo — hunt crisis foe label (MR3)', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);


### PR DESCRIPTION
## Summary

MR5 of the #524 arc (index #587). Completes `missionary-zeal`'s literal tech promise ("Missionaries spread religion to conquered cities faster") by adding:

- A trainable `missionary` civilian unit (cost 16, movement 2, no combat), gated on: owner has founded a religion + training city follows the owner's own faith + city has a Temple.
- Charges baked in at build time from the owner's tech state (2 base, 3 if `missionary-zeal` completed) — never re-derived reactively.
- A `preach()` action: +50 conversion points toward the owner's faith (doubled to +100 when the target is a city the *owner itself* holds under occupation, with `missionary-zeal` completed), consuming a charge and consuming the unit at 0 charges with a non-destructive acknowledgment dialog (not a "Delete?" prompt — the removal already happened).
- Occupation passive pressure (+5/turn) wired into `processReligionTurn`.
- AI production scoring (Fervor-boon-weighted) and dispatch (own unconverted cities first, then friendly minor-civ cities), deterministic.
- Honest `missionary-zeal` tech text stating both real effects.

## Architecture deviation from the original issue text (documented per spec-fidelity convention)

The issue's plan assumed `CityFaith.conversionProgress` could stay a single `{toReligionId, points}` slot. Implementing `preach()` against that shape surfaced a real bug: a missionary's deliberate investment toward religion A would be silently discarded the moment an unrelated turn tick's ambient pressure pointed toward religion B (the exact "re-convert a flipped city" scenario the issue itself calls out as a use case). Fixed by restructuring `conversionProgress` into a per-religion `Record<religionId, points>` map — ambient and missionary-driven progress now accumulate in independent buckets, and conversion fires for whichever bucket first crosses `CONVERSION_THRESHOLD`. This is a real behavior change from MR4 (ambient progress no longer resets to 0 when the strongest ambient target switches — it just sits unadvanced), covered by an explicit regression test in `religion-spread.test.ts`.

Two new cooldowns were added, agreed with the user during planning (not in the original issue text):
- **Missionary personal cooldown** (`MISSIONARY_ACTION_COOLDOWN_TURNS = 3`): a missionary can't preach again for 3 turns after preaching — reflects the action plus a rest period.
- **City anti-flip-flop cooldown** (`CITY_CONVERSION_COOLDOWN_TURNS = 7`): once a city converts, it can't convert to a *different* rival religion for 7 turns — but the city's own owner (at the time of conversion) is always exempt, so re-preaching a just-flipped city back to its owner's faith is never blocked by this cooldown.

Preach itself remains uncapped in volume (no per-turn empire-wide limit), consistent with MR4's "no war-gate on passive spread" precedent — the two cooldowns above are the balance lever instead of a hard cap.

## Two correctness bugs found and fixed during the inline review pass

1. `preach()`'s occupied-city doubling checked only `city.occupation != null`, not that the missionary's own civ is the one holding the city under occupation. Fixed to also require `city.owner === unit.owner`, with a regression test.
2. The AI dispatch's target-selection helper filtered through the range-inclusive `canPreachTarget`, meaning it could never select a target outside the missionary's current movement range — defeating the walk-then-preach loop for any missionary not already adjacent to an eligible city. Split into a range-independent `isPreachTargetEligible` (target selection) and the existing range-inclusive `canPreachTarget` (immediate-action checks), with a regression test proving a missionary starting 3 tiles away actually walks toward its target.

## Save / migration

Additive only — new `UnitType` value, and four new optional fields (`Unit.missionaryCooldownUntilTurn`, `CityFaith.conversionCooldownUntilTurn`, `CityFaith.conversionCooldownExemptCivId`, and the `conversionProgress` shape change from `{toReligionId, points}` to `Record<religionId, points>`). All reads are `?.`-safe against `undefined`/absent shape. No migration script needed — a legacy save's `conversionProgress` (old shape) would simply read as an empty map via optional chaining rather than crash, and any in-flight conversion progress from before this change is lost (acceptable: MR4 shipped recently, no live saves depend on mid-conversion state surviving this upgrade).

## SFX

Silent this MR. The issue's own claim ("reuse unit-action sound") is stale — no generic worker-action/unit-action completion sound hook exists in `audio-system.ts`/`sfx-catalog.ts` to reuse. The bespoke preach chime is explicitly scoped to MR7 (#594).

## Sprite

Placeholder only (reuses `WorkerSprite`), per `docs/sprite-design-system.md`. Bespoke art ships in MR7 (#594).

## Out of scope

- Faith territory pressure + loyalty flips (MR6, #593) — not started.
- Audio polish (MR7, #594) — not started.

## Test plan

- [x] `yarn build` and `yarn test` both green (6686 tests, 0 failures)
- [x] Trainability gate: 3 conjunctive negative tests (no religion / no Temple / foreign faith) + positive case
- [x] Charge counts: 2 vs 3 by build-time tech, baked in not reactive
- [x] Preach exact-point matrix: fresh/occupied city × with/without `missionary-zeal` (50/50/50/100)
- [x] Refusals: holy-city, at-war, undiscovered, no-charges, on-cooldown, out-of-range
- [x] Charge consumption + unit consumed at 0, with non-destructive confirmation UI
- [x] Own-city re-conversion ("re-convert a flipped city")
- [x] Occupation passive accrual + stop-on-occupation-end
- [x] AI production scoring (Fervor-weighted) + deterministic dispatch, including walk-toward-distant-target
- [x] Hot-seat: no `state.currentPlayer`/hardcoded `'player'` introduced anywhere in the new code paths (verified by diff grep)
- [x] Pacing gates unaffected (no yields/tech-cost levers touched)

Reference #592, #587. NOT #524 — that issue's owner closes it manually at the end of the arc.
