### PR TITLE
feat(espionage): flip-loyalty spy mission (#604 MR2a)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-issue-604-mr2a-flip-loyalty.md
+++ b/docs/superpowers/plans/2026-07-18-issue-604-mr2a-flip-loyalty.md
@@ -1,0 +1,114 @@
+# MR2a (#604): propaganda's flip-loyalty spy mission
+
+Index: #587. Escalated from MR2 (#589). Source spec: #587's MR2a comment / #604's issue body.
+
+## Goal
+
+`propaganda` (era 6, espionage) claims: "Spy missions to flip loyalties available in
+foreign cities." Make it real: a new `flip_loyalty` spy mission that, on success,
+peacefully transfers a foreign (non-capital) city to the spy's owner.
+
+## Step 1 — types.ts: new mission type
+
+- Add `'flip_loyalty'` to `SpyMissionType` (`src/core/types.ts:773-797`), placed after
+  `arms_smuggling` in the Stage 4 comment block, with its own inline comment noting it's
+  gated by `propaganda` specifically (not the shared Stage 4 tech set).
+
+## Step 2 — espionage-system.ts: gating, tables, resolution
+
+All edits in `src/systems/espionage-system.ts`.
+
+1. New stage constants (mirroring the `STAGE_5` "intentionally standalone" pattern at
+   line ~352-356):
+   ```ts
+   const STAGE_PROPAGANDA_TECHS = ['propaganda']; // era 6 — gates flip_loyalty only, not the shared Stage 4 set
+   const STAGE_PROPAGANDA_MISSIONS: SpyMissionType[] = ['flip_loyalty'];
+   ```
+   Add to `getAvailableMissions`'s union (line ~373-379).
+2. `MISSION_BASE_SUCCESS.flip_loyalty = 0.40` (line ~48) — lowest tier alongside
+   `election_interference` (0.40), reflecting this is the strongest-effect mission in the
+   game (outright city transfer vs. temporary effects).
+3. `MISSION_DURATIONS.flip_loyalty = 8` (line ~68) — longest duration, above
+   `fund_rebels`/`assassinate_advisor` (6), reflecting the stakes.
+4. `XP_PER_MISSION.flip_loyalty = 20` (line ~467) — highest XP, above
+   `assassinate_advisor` (18).
+5. `missionRequiresPlacedSpy('flip_loyalty')` → `true` (already the default for anything
+   not in the remote-capable exclusion list at line ~384 — no change needed, just confirm
+   in a test).
+6. `INFILTRATOR_MISSIONS`/`HANDLER_MISSIONS` (line ~455-459): add `flip_loyalty` to
+   `HANDLER_MISSIONS` — it's an influence mission (fits the handler promotion category
+   description: "bonus to influence missions").
+7. `resolveMissionResult` new case (mirrors `sabotage_relief`'s eligibility-guard style,
+   returns `{}` when ineligible instead of throwing):
+   ```ts
+   case 'flip_loyalty': {
+     if (!targetCity) return {};
+     if (getCapitalCityId(gameState, targetCivId) === targetCityId) return {}; // capitals never flip
+     return { flippedCityId: targetCityId, flippedFromCivId: targetCivId };
+   }
+   ```
+8. New result-application branch in `processEspionageTurn`'s `mission_succeeded` handling
+   (near the `forge_documents` branch, ~line 1422): on `result.flippedCityId`, call
+   `transferCapturedCityOwnership(state, result.flippedCityId, civId, state.turn)`, then
+   apply bilateral `modifyRelationship` (spy owner ↔ victim, -30 — steeper than
+   `forge_documents`'s -25 since this is a direct territorial loss, but shallower than
+   `computeRazeGold`'s implicit -40 raze penalty since it's non-destructive) on **both**
+   sides per the Hot Seat bilateral rule, and `bus.emit('espionage:city-flipped', { civId,
+   victimCivId: targetCivId, cityId: result.flippedCityId })`.
+   - Guard: if `state.cities[result.flippedCityId]` is already owned by `civId` (race:
+     city was captured by combat the same turn the mission resolves), no-op — mirror the
+     `previousOwnerId === newOwnerId` short-circuit already inside
+     `transferCapturedCityOwnership` itself, so this is likely already safe; add a test
+     instead of redundant guard code.
+
+## Step 3 — AI: `chooseAiMission` (`src/ai/basic-ai.ts`)
+
+Add `'flip_loyalty'` into the existing `preferredOrder` arrays (line ~1588-1631) — put it
+in the `aggressive` and `hasStage5`+aggressive orderings near `steal_tech`/`arms_smuggling`
+(high-value aggressive plays), and in the `diplomatic`/`trader` ordering near
+`forge_documents` (both are influence-flavored). Do not add a new branch — this is a
+data-table change like the others.
+
+## Step 4 — UI: `src/ui/espionage-panel.ts`
+
+- `MISSION_LABELS.flip_loyalty = 'Flip Loyalty'`
+- `MISSION_STAGE.flip_loyalty = 4` (Shadow Operations bucket — same UI tier as
+  `assassinate_advisor`/`forge_documents`/`fund_rebels`, matching the precedent that UI
+  stage buckets by rough tier, not literal internal stage number — see the existing
+  `sabotage_relief` comment at line ~110 for the same pattern).
+
+## Step 5 — Tests (`tests/systems/espionage-system.test.ts`, new cases)
+
+- `getAvailableMissions` includes `flip_loyalty` iff `propaganda` is completed.
+- `missionRequiresPlacedSpy('flip_loyalty')` is `true`.
+- `resolveMissionResult('flip_loyalty', ...)` against a capital → `{}` (no flip).
+- `resolveMissionResult('flip_loyalty', ...)` against a non-capital foreign city →
+  `flippedCityId`/`flippedFromCivId` populated.
+- Full `processEspionageTurn` integration: successful mission →
+  `state.cities[cityId].owner` changes to the spy's civ, both civs'
+  `diplomacy.relationships` move by -30, `espionage:city-flipped` event fires.
+- Failure path: mission fails → no ownership change, existing failure-consequence path
+  applies (mirror an existing Stage 4 failure test, e.g. `fund_rebels`'s).
+- Regression: cannot target own civ's city (existing `startMission`/target-selection
+  invariant — confirm rather than re-implement).
+- `tests/ai/basic-ai.test.ts` (or wherever `chooseAiMission` is tested): `flip_loyalty`
+  is selectable when available and preferred tech is present.
+- `tests/ui/espionage-panel.test.ts`: `flip_loyalty` appears in the Stage 4 group when
+  available.
+
+## Step 6 — Content honesty check
+
+`propaganda`'s `unlocks` text ("Spy missions to flip loyalties available in foreign
+cities") is now true — no text change needed. Run
+`tests/systems/description-honesty.test.ts` to confirm no regression.
+
+## Verification
+
+`bash scripts/run-with-mise.sh yarn test` and `bash scripts/run-with-mise.sh yarn build`
+must both exit 0 before PR.
+
+## PR
+
+Title: `feat(espionage): flip-loyalty spy mission (#604 MR2a)`. Body references #604 and
+#587, states save decision (no migration — additive event only, no new persistent
+fields), never "closes #524".

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1605,20 +1605,20 @@ export function chooseAiMission(
   const hasStage5 = available.includes('cyber_attack') || available.includes('misinformation_campaign');
   if (hasStage5 && (civ.civType === 'annuvin' || traits.has('aggressive'))) {
     preferredOrder = [
-      'cyber_attack', 'misinformation_campaign', 'satellite_surveillance',
+      'flip_loyalty', 'cyber_attack', 'misinformation_campaign', 'satellite_surveillance',
       'election_interference', 'steal_tech', 'sabotage_production',
       'arms_smuggling', 'incite_unrest', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('aggressive')) {
     preferredOrder = [
-      'steal_tech', 'sabotage_production', 'arms_smuggling',
+      'flip_loyalty', 'steal_tech', 'sabotage_production', 'arms_smuggling',
       'incite_unrest', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('diplomatic') || traits.has('trader')) {
     preferredOrder = [
-      'forge_documents', 'incite_unrest', 'fund_rebels',
+      'forge_documents', 'flip_loyalty', 'incite_unrest', 'fund_rebels',
       'gather_intel', 'monitor_diplomacy', 'identify_resources',
       'monitor_troops', 'scout_area', 'steal_tech',
     ];

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -1,8 +1,9 @@
-import type { AdvisorType, GameState } from './types';
+import type { AdvisorType, GameEvents, GameState } from './types';
 import { EventBus } from './event-bus';
 import { checkDominationVictory } from '@/systems/victory-system';
 import { resetUnitTurn, createUnit, healUnit, findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { processCity, TRAINABLE_UNITS, BUILDINGS } from '@/systems/city-system';
+import { transferCapturedCityOwnership } from '@/systems/city-capture-system';
 import { baseNewAirUnit, canCompleteAirUnitProduction } from '@/systems/air-operations-system';
 import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
 import { applyCityMaturity } from '@/systems/city-maturity-system';
@@ -1149,7 +1150,20 @@ export function processTurn(
   newState = processCrisisScheduler(newState, bus);
 
   // --- Process espionage ---
+  // flip_loyalty (#524 MR2a): espionage-system.ts cannot import
+  // transferCapturedCityOwnership directly (it would close an import cycle through
+  // city-system.ts — see the comment at the 'espionage:city-flipped' emit site), so the
+  // actual ownership transfer is applied here, immediately after the espionage turn,
+  // using the events that turn just emitted.
+  const pendingCityFlips: GameEvents['espionage:city-flipped'][] = [];
+  const unsubscribeCityFlip = bus.on('espionage:city-flipped', (evt) => pendingCityFlips.push(evt));
   newState = processEspionageTurn(newState, bus);
+  unsubscribeCityFlip();
+  for (const flip of pendingCityFlips) {
+    if (newState.cities[flip.cityId]?.owner === flip.victimCivId) {
+      newState = transferCapturedCityOwnership(newState, flip.cityId, flip.civId, newState.turn);
+    }
+  }
   newState = processDetection(newState, bus);
 
   // Process active interrogations and apply extracted intel to game state

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -788,6 +788,8 @@ export type SpyMissionType =
   | 'forge_documents'     // diplomatic relationship penalty between two other civs
   | 'fund_rebels'         // escalate unrest in already-unrest city
   | 'arms_smuggling'      // spawn hostile units near target city
+  // propaganda tech (#524 MR2a): gates flip_loyalty specifically, not the shared Stage 4 set
+  | 'flip_loyalty'        // on success, peacefully transfers a foreign non-capital city to the spy's owner
   // Stage 5 (digital-surveillance and cyber-warfare tech)
   | 'cyber_attack'
   | 'misinformation_campaign'
@@ -1874,6 +1876,7 @@ export interface GameEvents {
   'espionage:spy-promoted': { civId: string; spyId: string; promotion: SpyPromotion };
   'espionage:advisor-assassinated': { targetCivId: string; advisorType: AdvisorType; disabledUntilTurn: number };
   'espionage:documents-forged': { civA: string; civB: string; relationshipPenalty: number };
+  'espionage:city-flipped': { civId: string; victimCivId: string; cityId: string };
   'espionage:spy-executed': { executingCivId: string; spyOwner: string; spyId: string; spyName: string };
   'espionage:intel-extracted': { captorId: string; intel: InterrogationIntel[] };
   'unit:obsolete': { civId: string; unitId: string; unitType: UnitType };

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,7 +214,7 @@ import {
   unloadUnitFromTransport,
 } from '@/systems/transport-system';
 import { getPendingUnload, getUnloadRange, setPendingUnload, clearPendingUnload } from '@/ui/transport-ui-state';
-import { getCapitalCity } from '@/systems/capital-system';
+import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
 import type { CombatResult, GameState, HexCoord, ImprovementType, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType, TreatyType } from '@/core/types';
 import {
   appendNotification,
@@ -250,6 +250,7 @@ import {
   routeReligionCityConverted,
   routeOpportunisticWar,
   routeSabotageReliefDiscovered,
+  routeCityFlipped,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationDelivery } from '@/ui/notification-delivery';
@@ -1625,8 +1626,18 @@ function togglePanel(panel: string): void {
     const chooseMission = (spyId: string): string | null => {
       const spy = gameState.espionage?.[gameState.currentPlayer]?.spies[spyId];
       const completedTechs = currentCiv().techState.completed ?? [];
+      // #524 MR2a review fix: flip_loyalty can never succeed against a capital (see
+      // resolveMissionResult's guard in espionage-system.ts) -- don't offer it as a
+      // choice when the spy's current target already is one. Without this, a spy
+      // stationed in an enemy capital could "succeed" an 8-turn flip_loyalty mission
+      // that silently does nothing, with no explanation.
+      const spyTargetsCapital = Boolean(
+        spy?.targetCivId && spy.targetCityId
+          && getCapitalCityId(gameState, spy.targetCivId) === spy.targetCityId,
+      );
       const missions = getAvailableMissions(completedTechs)
-        .filter(mission => !missionRequiresPlacedSpy(mission) || Boolean(spy?.targetCivId));
+        .filter(mission => !missionRequiresPlacedSpy(mission) || Boolean(spy?.targetCivId))
+        .filter(mission => mission !== 'flip_loyalty' || !spyTargetsCapital);
       if (missions.length === 0) {
         showNotification('No missions available for this spy.', 'info');
         return null;
@@ -4702,6 +4713,10 @@ bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
 bus.on('espionage:spy-auto-exfiltrated', ({ civId, cityId }) => {
   const city = gameState.cities[cityId];
   appendToCivLog(civId, `Your spy was auto-exfiltrated from ${city?.name ?? 'a city'} after it changed hands.`, 'info');
+});
+
+bus.on('espionage:city-flipped', event => {
+  routeCityFlipped(gameState, event, appendToCivLog);
 });
 
 bus.on('trade:route-created', ({ route }) => {

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -774,9 +774,20 @@ export function resolveMissionResult(
 
     // flip_loyalty (#524 MR2a): capitals never flip -- mirrors the targetIsCapital guard
     // already used elsewhere in this file (see getEspionageModifierBreakdown).
+    //
+    // Review fix: only real civs (state.civilizations entries) are eligible. Minor civs
+    // (state.minorCivs, keyed separately, with exactly one city and no `civilizations`
+    // entry) and any other non-civilizations owner (e.g. 'rebels') must never be flip
+    // targets -- transferCapturedCityOwnership and eliminateCivilization only know how
+    // to update civilizations records, so annexing a minor civ's city this way would
+    // leave its MinorCivState dangling (stale cityId, isDestroyed still false) and its
+    // garrison units stranded inside a city it no longer owns. getCapitalCityId already
+    // silently returns null for a minor civ id (it only checks civilizations), which is
+    // exactly why the capital guard above was not sufficient by itself.
     case 'flip_loyalty': {
       const targetCity = gameState.cities[targetCityId];
       if (!targetCity) return {};
+      if (!gameState.civilizations[targetCivId]) return {};
       if (getCapitalCityId(gameState, targetCivId) === targetCityId) return {};
       if (targetCity.owner !== targetCivId) return {}; // already changed hands this turn
       return { flippedCityId: targetCityId, flippedFromCivId: targetCivId };

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -55,6 +55,7 @@ const MISSION_BASE_SUCCESS = {
   election_interference: 0.40,
   satellite_surveillance: 0.70,
   sabotage_relief: 0.60, // #526 MR7: reuses sabotage_production's detection parameters
+  flip_loyalty: 0.40, // #524 MR2a: lowest tier alongside election_interference — outright city transfer, not a temporary effect
 } as Record<SpyMissionType, number>;
 
 const MISSION_DURATIONS = {
@@ -75,6 +76,7 @@ const MISSION_DURATIONS = {
   election_interference: 5,
   satellite_surveillance: 1,
   sabotage_relief: 4, // #526 MR7: reuses sabotage_production's duration
+  flip_loyalty: 8, // #524 MR2a: longest duration in the game, above fund_rebels/assassinate_advisor (6) — matches the stakes
 } as Record<SpyMissionType, number>;
 
 // --- State creation ---
@@ -358,6 +360,7 @@ const STAGE_7_TECHS = ['cyber-intelligence'];        // era 12 — cyber operati
 // than folded into STAGE_4_TECHS, since covert-operations isn't one of that stage's
 // gating techs (cryptography/counter-intelligence) and gates only this one mission.
 const SABOTAGE_RELIEF_TECHS = ['covert-operations'];
+const PROPAGANDA_TECHS = ['propaganda']; // era 6 — gates flip_loyalty specifically, not the shared Stage 4 set
 
 const STAGE_1_MISSIONS: SpyMissionType[] = ['scout_area', 'monitor_troops'];
 const STAGE_2_MISSIONS: SpyMissionType[] = ['gather_intel', 'identify_resources', 'monitor_diplomacy'];
@@ -367,6 +370,7 @@ const STAGE_5_MISSIONS: SpyMissionType[] = ['misinformation_campaign', 'election
 const STAGE_6_MISSIONS: SpyMissionType[] = ['satellite_surveillance'];
 const STAGE_7_MISSIONS: SpyMissionType[] = ['cyber_attack'];
 const SABOTAGE_RELIEF_MISSIONS: SpyMissionType[] = ['sabotage_relief'];
+const PROPAGANDA_MISSIONS: SpyMissionType[] = ['flip_loyalty'];
 
 export function getAvailableMissions(completedTechs: string[]): SpyMissionType[] {
   const missions: SpyMissionType[] = [];
@@ -378,6 +382,7 @@ export function getAvailableMissions(completedTechs: string[]): SpyMissionType[]
   if (STAGE_6_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_6_MISSIONS);
   if (STAGE_7_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_7_MISSIONS);
   if (SABOTAGE_RELIEF_TECHS.some(t => completedTechs.includes(t))) missions.push(...SABOTAGE_RELIEF_MISSIONS);
+  if (PROPAGANDA_TECHS.some(t => completedTechs.includes(t))) missions.push(...PROPAGANDA_MISSIONS);
   return missions;
 }
 
@@ -452,7 +457,7 @@ const INFILTRATOR_MISSIONS = new Set<SpyMissionType>([
   'steal_tech', 'sabotage_production', 'assassinate_advisor', 'arms_smuggling', 'sabotage_relief',
 ]);
 const HANDLER_MISSIONS = new Set<SpyMissionType>([
-  'incite_unrest', 'forge_documents', 'fund_rebels', 'monitor_diplomacy',
+  'incite_unrest', 'forge_documents', 'fund_rebels', 'monitor_diplomacy', 'flip_loyalty',
 ]);
 // Sentinel: everything else (intel, scouting, defensive)
 
@@ -474,6 +479,7 @@ const XP_PER_MISSION = {
   election_interference: 16,
   satellite_surveillance: 8,
   sabotage_relief: 12, // #526 MR7: matches sabotage_production's xp
+  flip_loyalty: 20, // #524 MR2a: highest xp in the game, above assassinate_advisor (18)
 } as Record<SpyMissionType, number>;
 
 const EXPULSION_COOLDOWN = 5;
@@ -636,6 +642,10 @@ export interface MissionResult {
   // sabotage_relief (#526 MR7): the outbreak crisis to pause, if the target civ has one
   // eligible (active, no existing sabotage already in place).
   sabotageCrisisId?: string;
+  // flip_loyalty (#524 MR2a): the city and its former owner, if the flip is eligible
+  // (non-capital, still owned by targetCivId).
+  flippedCityId?: string;
+  flippedFromCivId?: string;
 }
 
 const SCOUT_VISION_RADIUS = 3;
@@ -760,6 +770,16 @@ export function resolveMissionResult(
       const targetCity = gameState.cities[targetCityId];
       if (!targetCity || targetCity.unrestLevel === 0) return {};
       return { unrestInjected: 35 };
+    }
+
+    // flip_loyalty (#524 MR2a): capitals never flip -- mirrors the targetIsCapital guard
+    // already used elsewhere in this file (see getEspionageModifierBreakdown).
+    case 'flip_loyalty': {
+      const targetCity = gameState.cities[targetCityId];
+      if (!targetCity) return {};
+      if (getCapitalCityId(gameState, targetCivId) === targetCityId) return {};
+      if (targetCity.owner !== targetCivId) return {}; // already changed hands this turn
+      return { flippedCityId: targetCityId, flippedFromCivId: targetCivId };
     }
 
     case 'counter_espionage': {
@@ -1437,6 +1457,37 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
             bus.emit('espionage:documents-forged', {
               civA, civB, relationshipPenalty: penalty,
             });
+          }
+
+          // flip_loyalty (#524 MR2a): the actual ownership transfer happens in
+          // turn-manager.ts (subscribed to 'espionage:city-flipped'), via the shared
+          // non-combat ownership-transfer helper in city-capture-system.ts -- NOT here.
+          // espionage-system.ts cannot import city-capture-system.ts directly: doing so
+          // closes a real import cycle (city-system -> espionage-system ->
+          // city-capture-system -> city-system, since city-capture-system imports
+          // BUILDINGS from city-system). The bilateral relationship penalty is applied
+          // here since diplomacy-system has no such cycle.
+          // -30: steeper than forge_documents (-25, no territorial loss) but shallower
+          // than a raze (-40, destructive), reflecting a non-destructive but direct
+          // territorial loss.
+          if (evt.missionType === 'flip_loyalty' && result.flippedCityId && result.flippedFromCivId) {
+            const victimCivId = result.flippedFromCivId as string;
+            const flippedCityId = result.flippedCityId as string;
+            if (state.cities[flippedCityId] && state.cities[flippedCityId].owner === victimCivId) {
+              if (state.civilizations[civId]) {
+                state.civilizations[civId].diplomacy = modifyRelationship(
+                  state.civilizations[civId].diplomacy, victimCivId, -30,
+                );
+              }
+              if (state.civilizations[victimCivId]) {
+                state.civilizations[victimCivId].diplomacy = modifyRelationship(
+                  state.civilizations[victimCivId].diplomacy, civId, -30,
+                );
+              }
+              bus.emit('espionage:city-flipped', {
+                civId, victimCivId, cityId: flippedCityId,
+              });
+            }
           }
 
           // arms_smuggling: spawn a hostile 'rebels' unit near the target city

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -82,6 +82,7 @@ const MISSION_LABELS: Record<SpyMissionType, string> = {
   forge_documents: 'Forge Documents',
   fund_rebels: 'Fund Rebels',
   arms_smuggling: 'Arms Smuggling',
+  flip_loyalty: 'Flip Loyalty',
   cyber_attack: 'Cyber Attack',
   misinformation_campaign: 'Misinformation Campaign',
   election_interference: 'Election Interference',
@@ -103,6 +104,7 @@ const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
   forge_documents: 4,
   fund_rebels: 4,
   arms_smuggling: 4,
+  flip_loyalty: 4, // propaganda is era 6, same "Shadow Operations" UI bucket as the other era 5-6 Stage 4 missions
   cyber_attack: 5,
   misinformation_campaign: 5,
   election_interference: 5,

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -667,6 +667,24 @@ export function routeSabotageReliefDiscovered(
   }
 }
 
+// flip_loyalty (#524 MR2a review fix): the flip itself already happened by the time
+// this event fires -- turn-manager.ts applies transferCapturedCityOwnership right after
+// processEspionageTurn returns, before any listener runs. Both sides must be told: the
+// victim especially, since losing a city with zero in-game feedback (the original gap
+// this router closes) is far worse than any other espionage consequence.
+export function routeCityFlipped(
+  state: GameState,
+  event: GameEvents['espionage:city-flipped'],
+  sink: NotificationSink,
+): void {
+  const cityName = state.cities[event.cityId]?.name ?? 'A city';
+  const flipperName = state.civilizations[event.civId]?.name ?? 'a rival';
+  const victimName = state.civilizations[event.victimCivId]?.name ?? 'a rival';
+
+  sink(event.civId, `${cityName} defected to you after a propaganda campaign against ${victimName}!`, 'success');
+  sink(event.victimCivId, `${cityName} defected to ${flipperName} after a propaganda campaign!`, 'warning');
+}
+
 // Fans out to viewers who know the AI target civ (met-civ gate, spec §Visibility).
 // AI-targeted crises only -- a human's own crisis already notifies its owner via
 // routeCrisisStarted above. Fires on crisis:started only, never per spread/siege tick:

--- a/tests/ai/ai-espionage.test.ts
+++ b/tests/ai/ai-espionage.test.ts
@@ -189,6 +189,27 @@ describe('AI espionage decisions', () => {
       const mission = chooseAiMission(state, 'ai-egypt');
       expect(mission).not.toBe('sabotage_relief');
     });
+
+    // #524 MR2a: aggressive civs should reach for the strongest available mission.
+    it('aggressive civs prefer flip_loyalty over other missions once propaganda is researched', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'annuvin';
+      state.civilizations['ai-egypt'].techState.completed = [
+        'espionage-scouting', 'espionage-informants', 'spy-networks', 'cryptography', 'propaganda',
+      ];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('flip_loyalty');
+    });
+
+    it('flip_loyalty is not chosen without propaganda even for aggressive civs', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'annuvin';
+      state.civilizations['ai-egypt'].techState.completed = [
+        'espionage-scouting', 'espionage-informants', 'spy-networks', 'cryptography',
+      ];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).not.toBe('flip_loyalty');
+    });
   });
 
   // #526 MR7 review fix: infiltrated (embedded) spies pick their next mission via a

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -25,10 +25,12 @@ import {
   setCounterIntelligence,
   turnCapturedSpy,
   verifyAgent,
+  missionRequiresPlacedSpy,
   } from '@/systems/espionage-system';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
+import { transferCapturedCityOwnership } from '@/systems/city-capture-system';
 
 // MR1: legacy fixture helper for tests that need a spy in state without going through city production
 function makeTestSpy(id: string, owner: string, overrides: Partial<Spy> = {}): Spy {
@@ -716,6 +718,164 @@ describe('resolveMissionResult', () => {
     const gameState = makeTestGameState();
     const result = resolveMissionResult('satellite_surveillance', 'ai-egypt', 'city-egypt-1', gameState, 'player', 'spy-1');
     expect(result.grantTerritoryVision).toBe(true);
+  });
+
+  describe('flip_loyalty (#524 MR2a)', () => {
+    it('never flips a capital city (city-egypt-1 is ai-egypt.cities[0])', () => {
+      const gameState = makeTestGameState();
+      const result = resolveMissionResult('flip_loyalty', 'ai-egypt', 'city-egypt-1', gameState, 'player', 'spy-1');
+      expect(result.flippedCityId).toBeUndefined();
+      expect(result.flippedFromCivId).toBeUndefined();
+    });
+
+    it('flips a non-capital foreign city', () => {
+      const gameState = makeTestGameState();
+      gameState.cities['city-egypt-2'] = {
+        ...gameState.cities['city-egypt-1'],
+        id: 'city-egypt-2', name: 'Memphis', position: { q: 8, r: 3 },
+      };
+      gameState.civilizations['ai-egypt'].cities = ['city-egypt-1', 'city-egypt-2'];
+      const result = resolveMissionResult('flip_loyalty', 'ai-egypt', 'city-egypt-2', gameState, 'player', 'spy-1');
+      expect(result.flippedCityId).toBe('city-egypt-2');
+      expect(result.flippedFromCivId).toBe('ai-egypt');
+    });
+
+    it('does not fire against a city that already changed owner this turn', () => {
+      const gameState = makeTestGameState();
+      gameState.cities['city-egypt-2'] = {
+        ...gameState.cities['city-egypt-1'],
+        id: 'city-egypt-2', name: 'Memphis', position: { q: 8, r: 3 }, owner: 'player',
+      };
+      gameState.civilizations['ai-egypt'].cities = ['city-egypt-1', 'city-egypt-2'];
+      const result = resolveMissionResult('flip_loyalty', 'ai-egypt', 'city-egypt-2', gameState, 'player', 'spy-1');
+      expect(result.flippedCityId).toBeUndefined();
+    });
+  });
+});
+
+describe('flip_loyalty gating and end-to-end resolution (#524 MR2a)', () => {
+  function makeFlipLoyaltyFixture() {
+    let state = createNewGame(undefined, 'flip-loyalty-fixture', 'small');
+    const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+    const capitalStartPos = state.units[state.civilizations[targetCivId].units[0]].position;
+    const capital = foundCity(targetCivId, capitalStartPos, state.map, state.idCounters);
+    const nonCapital = foundCity(
+      targetCivId,
+      { q: capitalStartPos.q + 6, r: capitalStartPos.r },
+      state.map,
+      state.idCounters,
+    );
+    state = {
+      ...state,
+      cities: { ...state.cities, [capital.id]: capital, [nonCapital.id]: nonCapital },
+      civilizations: {
+        ...state.civilizations,
+        player: {
+          ...state.civilizations.player,
+          techState: { ...state.civilizations.player.techState, completed: ['propaganda'] },
+        },
+        [targetCivId]: {
+          ...state.civilizations[targetCivId],
+          cities: [capital.id, nonCapital.id],
+        },
+      },
+      espionage: {
+        player: {
+          ...createEspionageCivState(),
+          spies: {
+            'spy-1': makeTestSpy('spy-1', 'player', {
+              status: 'stationed', targetCivId, targetCityId: nonCapital.id,
+              position: nonCapital.position,
+            }),
+          },
+        },
+        [targetCivId]: createEspionageCivState(),
+      },
+    };
+    return { state, targetCivId, capitalId: capital.id, nonCapitalId: nonCapital.id };
+  }
+
+  it('propaganda gates flip_loyalty (unavailable without the tech, available with it)', () => {
+    expect(getAvailableMissions([])).not.toContain('flip_loyalty');
+    expect(getAvailableMissions(['propaganda'])).toContain('flip_loyalty');
+  });
+
+  it('flip_loyalty requires a placed (stationed) spy', () => {
+    expect(missionRequiresPlacedSpy('flip_loyalty')).toBe(true);
+  });
+
+  it('a completed flip_loyalty mission transfers the non-capital city and records a bilateral grievance', () => {
+    const { state: baseState, targetCivId, nonCapitalId } = makeFlipLoyaltyFixture();
+    let succeeded = false;
+    for (let turn = 1; turn <= 200 && !succeeded; turn++) {
+      const state: GameState = {
+        ...baseState,
+        turn,
+        espionage: {
+          ...baseState.espionage!,
+          player: {
+            ...baseState.espionage!.player,
+            spies: {
+              'spy-1': startMission(baseState.espionage!.player, 'spy-1', 'flip_loyalty').spies['spy-1'],
+            },
+          },
+        },
+      };
+      // force resolution this turn by setting turnsRemaining to 1
+      state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+      // Mirrors turn-manager.ts: espionage-system.ts cannot import
+      // transferCapturedCityOwnership directly (import cycle through city-system.ts),
+      // so the caller subscribes to 'espionage:city-flipped' and applies the transfer
+      // immediately after processEspionageTurn returns.
+      const bus = new EventBus();
+      const pendingFlips: Array<{ civId: string; victimCivId: string; cityId: string }> = [];
+      bus.on('espionage:city-flipped', evt => pendingFlips.push(evt));
+      let result = processEspionageTurn(state, bus);
+      for (const flip of pendingFlips) {
+        if (result.cities[flip.cityId]?.owner === flip.victimCivId) {
+          result = transferCapturedCityOwnership(result, flip.cityId, flip.civId, result.turn);
+        }
+      }
+
+      if (result.cities[nonCapitalId].owner === 'player') {
+        succeeded = true;
+        expect(pendingFlips).toHaveLength(1);
+        expect(result.civilizations.player.diplomacy.relationships[targetCivId]).toBeLessThanOrEqual(-30);
+        expect(result.civilizations[targetCivId].diplomacy.relationships.player).toBeLessThanOrEqual(-30);
+        expect(result.civilizations.player.cities).toContain(nonCapitalId);
+        expect(result.civilizations[targetCivId].cities).not.toContain(nonCapitalId);
+      }
+    }
+    expect(succeeded).toBe(true);
+  });
+
+  it('never flips the target civ\'s capital, even across many resolution attempts', () => {
+    const { state: baseState, capitalId } = makeFlipLoyaltyFixture();
+    for (let turn = 1; turn <= 200; turn++) {
+      const state: GameState = {
+        ...baseState,
+        turn,
+        espionage: {
+          ...baseState.espionage!,
+          player: {
+            ...baseState.espionage!.player,
+            spies: {
+              'spy-1': startMission(baseState.espionage!.player, 'spy-1', 'flip_loyalty', undefined, undefined, capitalId).spies['spy-1'],
+            },
+          },
+        },
+      };
+      state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+      state.espionage!.player.spies['spy-1'].targetCityId = capitalId;
+
+      const bus = new EventBus();
+      const pendingFlips: Array<{ civId: string; victimCivId: string; cityId: string }> = [];
+      bus.on('espionage:city-flipped', evt => pendingFlips.push(evt));
+      const result = processEspionageTurn(state, bus);
+      expect(pendingFlips).toHaveLength(0);
+      expect(result.cities[capitalId].owner).not.toBe('player');
+    }
   });
 });
 

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -750,6 +750,22 @@ describe('resolveMissionResult', () => {
       const result = resolveMissionResult('flip_loyalty', 'ai-egypt', 'city-egypt-2', gameState, 'player', 'spy-1');
       expect(result.flippedCityId).toBeUndefined();
     });
+
+    // Review fix: a minor civ's only city has no state.civilizations entry (minor civs
+    // live in state.minorCivs with a single cityId), so getCapitalCityId silently
+    // returns null for it and the capital guard alone never blocked this. Without the
+    // explicit civilizations-membership check, this would let flip_loyalty permanently
+    // annex a minor civ's sole city and leave its MinorCivState dangling.
+    it('never fires against a city owned by a non-civilizations owner (e.g. a minor civ)', () => {
+      const gameState = makeTestGameState();
+      gameState.cities['city-minor-1'] = {
+        ...gameState.cities['city-egypt-1'],
+        id: 'city-minor-1', name: 'Petra', position: { q: 9, r: 3 }, owner: 'minor-nabatea',
+      };
+      const result = resolveMissionResult('flip_loyalty', 'minor-nabatea', 'city-minor-1', gameState, 'player', 'spy-1');
+      expect(result.flippedCityId).toBeUndefined();
+      expect(result.flippedFromCivId).toBeUndefined();
+    });
   });
 });
 

--- a/tests/ui/espionage-panel.test.ts
+++ b/tests/ui/espionage-panel.test.ts
@@ -242,6 +242,24 @@ describe('espionage-panel', () => {
       expect(view.missionStages[2].missions.some(m => m.id === 'steal_tech')).toBe(true);
     });
 
+    // #524 MR2a
+    it('shows flip_loyalty in the Stage 4 (Shadow Operations) group once propaganda is researched', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['propaganda'];
+      const view = getEspionagePanelViewModel(state);
+      const stage4 = view.missionStages.find(s => s.stage === 4)!;
+      expect(stage4.missions.some(m => m.id === 'flip_loyalty')).toBe(true);
+      expect(stage4.missions.find(m => m.id === 'flip_loyalty')!.label).toBe('Flip Loyalty');
+    });
+
+    it('does not show flip_loyalty without propaganda', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = [];
+      const view = getEspionagePanelViewModel(state);
+      const allMissionIds = view.missionStages.flatMap(s => s.missions.map(m => m.id));
+      expect(allMissionIds).not.toContain('flip_loyalty');
+    });
+
     it('never exposes other players spy data', () => {
       const state = makeEspUiState();
       const aiSpy = makeTestSpy('spy-ai-1', 'ai-egypt');

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -26,6 +26,7 @@ import {
   routeCrisisAidSent,
   routeOpportunisticWar,
   routeSabotageReliefDiscovered,
+  routeCityFlipped,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -964,5 +965,37 @@ describe('espionage:sabotage-relief-discovered routing (#526 MR7 Task 7.2)', () 
     expect(civIds).toContain('egypt');
     expect(civIds).not.toContain('nubia');
     expect(calls.every(c => c.message === "Rome's spies were caught sabotaging Carthage's relief!")).toBe(true);
+  });
+});
+
+describe('espionage:city-flipped routing (#524 MR2a review fix)', () => {
+  function flipState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+      } as any,
+      cities: { 'city-1': { id: 'city-1', name: 'Utica', owner: 'rome', position: { q: 0, r: 0 } } } as any,
+    });
+  }
+
+  it('notifies both the flipping civ and the victim civ, with distinct messages', () => {
+    const { sink, calls } = makeSink();
+    routeCityFlipped(flipState(), { civId: 'rome', victimCivId: 'carthage', cityId: 'city-1' }, sink);
+    expect(calls).toHaveLength(2);
+    const romeCall = calls.find(c => c.civId === 'rome')!;
+    const carthageCall = calls.find(c => c.civId === 'carthage')!;
+    expect(romeCall.message).toContain('Utica');
+    expect(romeCall.message).toContain('Carthage');
+    expect(romeCall.type).toBe('success');
+    expect(carthageCall.message).toContain('Utica');
+    expect(carthageCall.message).toContain('Rome');
+    expect(carthageCall.type).toBe('warning');
+  });
+
+  it('falls back to generic names when a civ record is missing', () => {
+    const { sink, calls } = makeSink();
+    routeCityFlipped(flipState(), { civId: 'rome', victimCivId: 'unknown-civ', cityId: 'city-1' }, sink);
+    expect(calls.every(c => typeof c.message === 'string' && c.message.length > 0)).toBe(true);
   });
 });


### PR DESCRIPTION
Implements #604 (MR2a of the #524 dead-promises arc; index: #587).

## What

`propaganda` (era 6, espionage) claimed *"Spy missions to flip loyalties available in foreign cities"* — no such mission existed. Adds `flip_loyalty`:

- New `SpyMissionType`, gated by `propaganda` alone (standalone stage, same pattern as `sabotage_relief`/`covert-operations` — not folded into the shared Stage 4 tech set).
- Success rate 0.40, duration 8 turns, 20 XP — lowest success/longest duration/highest XP in the mission roster, reflecting that this is the only mission that outright transfers a city rather than producing a temporary effect.
- On success: transfers the target city via the existing `transferCapturedCityOwnership` helper (`city-capture-system.ts`) — not hand-rolled — and applies a bilateral -30 relationship penalty (steeper than `forge_documents`'s -25, shallower than a raze's -40).
- Guard: never targets a civ's capital city (mirrors the existing `targetIsCapital` guard already used elsewhere in `espionage-system.ts`).
- `chooseAiMission` (`basic-ai.ts`): aggressive and diplomatic AI personalities will pick it once available.
- Espionage panel mission picker: `MISSION_LABELS`/`MISSION_STAGE` (Stage 4 "Shadow Operations" bucket).

## Architectural note

The ownership transfer is applied in `turn-manager.ts`, not inside `espionage-system.ts`'s `processEspionageTurn`. `espionage-system.ts` cannot import `city-capture-system.ts` directly — doing so closes a real import cycle (`city-system.ts` → `espionage-system.ts` → `city-capture-system.ts` → `city-system.ts`, since `city-capture-system.ts` imports `BUILDINGS` from `city-system.ts`). Confirmed by reverting the change locally and re-running `tests/ai/ai-espionage.test.ts`, which failed with `Cannot read properties of undefined` on `BUILDINGS` before the fix. `turn-manager.ts` now subscribes to the `espionage:city-flipped` event `processEspionageTurn` emits and applies `transferCapturedCityOwnership` immediately afterward, in the same turn-processing pass.

## Save decision

Additive only — new `SpyMissionType` variant, new `espionage:city-flipped` event. No new persistent fields, no migration.

## Tests

- `resolveMissionResult('flip_loyalty', ...)`: capital guard, non-capital success, race-condition guard (city already changed hands this turn).
- Full `processEspionageTurn` → transfer integration: probabilistic success looped across up to 200 turn seeds (0.40 success chance makes this reliable), asserting city ownership, bilateral relationship penalty, and civ `cities` array updates.
- Capital-immunity regression across the same 200-turn sweep.
- `chooseAiMission`: aggressive civs prefer `flip_loyalty` once `propaganda` is researched; not chosen without the tech.
- Espionage panel: `flip_loyalty` appears in the Stage 4 group with `propaganda`, absent without it.

`yarn build` and `yarn test` both pass (407 test files, 6703 passed / 3 pre-existing skips).

Reference #604 and #587; does not close #524 (the arc index stays open pending MR6/MR7).