### PR TITLE
test(pacing): add production-budgeted reference economy

### DIFF
--- a/.claude/rules/game-balance.md
+++ b/.claude/rules/game-balance.md
@@ -137,17 +137,25 @@ When adding a new wonder, national project, or special building in any future er
   snapshot numbers and a one-line justification, not just a passing test — this is the
   seam future MRs go through instead of silently drifting pacing the way MR4–6 did
   (see issue #481 for the incident this rule prevents).
-- The reference-economy fixture (`tests/systems/helpers/pacing-reference-economy.ts`) computes
-  two profiles per era: `'bounded'` (only buildings gated within the last `BUILDING_ERA_WINDOW`
-  eras count as active production) and `'maximal'` (every eligible building regardless of era —
-  a completionist player who builds everything, a real playstyle, not a corner case).
-  `RESEARCH_OUTPUT_BY_ERA` targets **`'maximal'`**, not `'bounded'`: tuning against the lower
-  bounded output would let a completionist empire blow through late-game tech far faster than
-  the target window, which is exactly the "feels automatic" failure the pacing design doc warns
-  against. Both profiles are pinned by `tests/systems/pacing-reference-economy.test.ts` so this
-  tradeoff stays visible in one place — do not quietly change which profile `RESEARCH_OUTPUT_BY_ERA`
-  targets without updating that file's comments and re-running the full outlier gate (era 10-12
-  tech costs will shift; that cascade is expected, not a sign something broke).
+- The reference-economy fixture has three views. `'bounded'` and `'maximal'` retain their legacy
+  single-city, strictly-prior-era arrival convention: bounded admits only recently gated
+  buildings, while maximal admits every eligible building (a completionist playstyle, not a
+  corner case). `'representative'` is a diagnostic-only, mixed-age 1/3/5/7/9-city cohort that
+  follows the live personal-era resolver and spends a bounded production share on neutral
+  infrastructure. It reports aggregate and average outputs; it never supplies runtime AI,
+  difficulty, UI, save, or player behavior.
+- `RESEARCH_OUTPUT_BY_ERA` targets **`'maximal'`**, never bounded or representative: tuning
+  against the lower bounded output would let a completionist empire blow through late-game tech
+  far faster than the target window, which is exactly the "feels automatic" failure the pacing
+  design doc warns about. The legacy and canonical representative snapshots are pinned by
+  `tests/systems/pacing-reference-economy.test.ts`. Do not quietly change which profile
+  `RESEARCH_OUTPUT_BY_ERA` targets without updating that file's comments and re-running the
+  full outlier gate (era 10-12 tech costs will shift; that cascade is expected, not a sign
+  something broke).
+- Any representative route-selection, cohort, infrastructure-share, scoring-weight, or
+  aggregation-scope change must update the canonical 60% snapshot with a concise justification,
+  retain the 50/70% sensitivity invariants, and re-run the full-catalog outlier gate. Do not use
+  a representative snapshot change to justify a pacing retune without explicit approval.
 - That same test file also gates the era-over-era output growth ratio (currently capped at 3x)
   for both profiles. This is a guardrail against a repeat of the MR13 review finding: a bug in
   building-eligibility logic can silently produce runaway output that only becomes visible once

--- a/docs/superpowers/plans/2026-07-18-issue-493-production-budgeted-reference-economy.md
+++ b/docs/superpowers/plans/2026-07-18-issue-493-production-budgeted-reference-economy.md
@@ -1,0 +1,544 @@
+# Issue #493 Production-budgeted Reference Economy Implementation Plan
+
+> **For Sonnet 4.5 agentic workers:** REQUIRED SUB-SKILL: Use \`superpowers:executing-plans\` and execute this plan inline, task by task. Do **not** dispatch subagents: this repository's \`CLAUDE.md\` and \`AGENTS.md\` prohibit delegation. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** Add a deterministic, production-time-bounded, mixed-maturity \`representative\` economy diagnostic while preserving the existing single-city \`bounded\`/\`maximal\` snapshots and the maximal era 10-13 research target.
+
+**Architecture:** A new test-helper module owns the canonical personal-era research route, production-budget building simulation, and city cohorts. The existing reference-economy helper remains the neutral map/yield-aggregation boundary and exposes a multi-city result. All work is test tooling and balance documentation; no \`src/**\`, runtime UI, audio, AI behavior, save data, solo flow, or hot-seat flow changes are authorized.
+
+**Tech Stack:** TypeScript, Vitest, existing pacing/tech/city/yield systems.
+
+---
+
+## Constraints
+
+- Work only in \`/Users/aaronfleckenstein/development/github/conquestoria/.worktrees/issue-493-reference-economy-design\`.
+- Preserve \`ReferenceEconomyProfile = 'bounded' | 'maximal'\`, \`getReferenceEconomyOutput\`, all existing exact legacy snapshots, and the \`maximal\` era 10-13 target assertion.
+- Use \`getEraAdvancementTechs\`, \`getEraAdvancementFraction\`, \`hasReachedEraThreshold\`, and \`resolveCivilizationEra\` for representative progression. Do not duplicate their arithmetic.
+- Use \`calculateCityYields\`, \`getEmpireTechPercents\`, \`applyEmpireTechPercents\`, and \`getEmpireFlatTechYields\` for yield truth. Apply percentage effects per city and flat yields once per empire.
+- Use deterministic ID tie-breakers and \`EPSILON = 1e-9\`. Never use \`Math.random()\`.
+- Do not retune tech costs, advancement fractions, \`ERA_PACING_PROFILES\`, or \`BAND_WINDOWS\`. Stop for approval if any change outside the files below appears necessary.
+- Keep the model test-only: it must not consume \`GameState\`, \`currentPlayer\`, difficulty, AI personality, save, UI, notification, or SFX data.
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| Create \`tests/systems/helpers/pacing-production-budget.ts\` | Research route, cohorts, candidates/scoring, per-turn construction, accounting. |
+| Modify \`tests/systems/helpers/pacing-reference-economy.ts\` | Legacy fixture unchanged; neutral city construction and multi-city aggregation. |
+| Create \`tests/systems/pacing-production-budget.test.ts\` | Route, candidate, production, error, and determinism tests. |
+| Modify \`tests/systems/pacing-reference-economy.test.ts\` | Representative totals/averages, scope, sensitivity, and legacy isolation. |
+| Modify \`.claude/rules/game-balance.md\` | Three-profile policy and regression workflow. |
+
+## Task 1: Build the canonical research timeline
+
+**Files:**
+
+- Create: \`tests/systems/helpers/pacing-production-budget.ts\`
+- Create: \`tests/systems/pacing-production-budget.test.ts\`
+
+- [ ] **Step 1: Write the failing route tests**
+
+\`\`\`ts
+import { describe, expect, it } from 'vitest';
+import { TECH_TREE, hasReachedEraThreshold, resolveCivilizationEra } from '@/systems/tech-definitions';
+import {
+  buildRepresentativeResearchTimeline,
+  getRequiredAdvancementCount,
+} from './helpers/pacing-production-budget';
+
+describe('representative research timeline', () => {
+  it('uses canonical rounded-up advancement counts', () => {
+    for (let era = 2; era <= 13; era++) {
+      const qualifying = TECH_TREE.filter(tech => tech.era === era && tech.countsForEraAdvancement !== false);
+      expect(getRequiredAdvancementCount(era)).toBeGreaterThanOrEqual(1);
+      expect(getRequiredAdvancementCount(era)).toBeLessThanOrEqual(qualifying.length);
+    }
+  });
+
+  it('reaches each requested personal era through a prerequisite-closed route', () => {
+    for (let era = 1; era <= 13; era++) {
+      const timeline = buildRepresentativeResearchTimeline(era);
+      expect(resolveCivilizationEra(timeline.completedTechIds)).toBe(era);
+      if (era >= 2) expect(hasReachedEraThreshold(timeline.completedTechIds, era)).toBe(true);
+      for (const techId of timeline.completedTechIds) {
+        const tech = TECH_TREE.find(candidate => candidate.id === techId)!;
+        expect(tech.prerequisites.every(id => timeline.completedTechIds.includes(id))).toBe(true);
+      }
+    }
+  });
+
+  it('records positive ETAs in strictly increasing completion-turn order', () => {
+    const entries = buildRepresentativeResearchTimeline(10).entries;
+    for (let index = 1; index < entries.length; index++) {
+      expect(entries[index].eta).toBeGreaterThan(0);
+      expect(entries[index].completionTurn).toBeGreaterThan(entries[index - 1].completionTurn);
+    }
+  });
+});
+\`\`\`
+
+- [ ] **Step 2: Verify the test fails**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: FAIL because the helper module and exports do not exist.
+
+- [ ] **Step 3: Add the route types and implementation**
+
+Create public types:
+
+\`\`\`ts
+export interface ResearchTimelineEntry {
+  techId: string;
+  era: number;
+  eta: number;
+  completionTurn: number;
+}
+export interface RepresentativeResearchTimeline {
+  targetEra: number;
+  entries: ResearchTimelineEntry[];
+  completedTechIds: string[];
+  arrivalTurnByEra: ReadonlyMap<number, number>;
+}
+\`\`\`
+
+Implement \`getRequiredAdvancementCount(era)\` as:
+
+\`\`\`ts
+const qualifying = getEraAdvancementTechs(era);
+if (qualifying.length === 0) throw new Error(\`Era \${era} has no advancement technologies\`);
+return Math.ceil(qualifying.length * getEraAdvancementFraction(era));
+\`\`\`
+
+Implement \`buildRepresentativeResearchTimeline(targetEra)\` with this exact algorithm:
+
+1. Reject non-integer eras below 1; call \`requireEraPacingProfile(targetEra)\` to reject missing authored eras.
+2. Start with empty \`completedTechIds\`, \`turn = 0\`, and \`arrivalTurnByEra = new Map([[1, 0]])\`.
+3. For each target transition era 2 through \`targetEra\`, repeatedly consider incomplete qualifying technologies from \`getEraAdvancementTechs(era)\`.
+4. Recursively collect each candidate's missing prerequisite closure. Detect a repeated ID in the active recursion stack and throw \`Technology prerequisite cycle at <id>\`.
+5. Sort candidates by closure-cost sum, candidate cost, then ASCII ID. Research the first candidate's missing closure in prerequisite-topological order.
+6. For each researched technology, calculate \`eta = Math.ceil(tech.cost / getResearchOutputProfileForTech(tech).outputPerTurn)\`, add it to \`turn\`, record the entry, then stop the closure immediately if \`hasReachedEraThreshold\` is true.
+7. After the threshold, require \`resolveCivilizationEra(completedTechIds) === era\`; record the arrival turn.
+
+Do not select unrelated technologies, and do not call the legacy strictly-prior-era \`completedTechsForEra\` helper.
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add tests/systems/helpers/pacing-production-budget.ts tests/systems/pacing-production-budget.test.ts
+git commit -m "test(pacing): add representative research timeline"
+\`\`\`
+
+## Task 2: Add cohorts, neutral candidates, and deterministic scoring
+
+**Files:**
+
+- Modify: \`tests/systems/helpers/pacing-production-budget.ts\`
+- Modify: \`tests/systems/pacing-production-budget.test.ts\`
+
+- [ ] **Step 1: Write failing selection tests**
+
+\`\`\`ts
+import { BUILDINGS } from '@/systems/city-system';
+import {
+  getMissingRepresentativeBuildingClosure,
+  getEligibleRepresentativeBuildings,
+  getRepresentativeCohorts,
+  selectRepresentativeBuilding,
+} from './helpers/pacing-production-budget';
+
+describe('representative building selection', () => {
+  it('adds cohorts only at documented founding eras', () => {
+    expect(getRepresentativeCohorts(1).map(cohort => cohort.id)).toEqual(['capital']);
+    expect(getRepresentativeCohorts(3).map(cohort => cohort.id)).toEqual(['capital', 'expansion-1']);
+    expect(getRepresentativeCohorts(9).map(cohort => cohort.id)).toEqual([
+      'capital', 'expansion-1', 'expansion-2', 'expansion-3', 'frontier',
+    ]);
+  });
+
+  it('excludes non-neutral candidates', () => {
+    const candidates = getEligibleRepresentativeBuildings({ completedTechs: TECH_TREE.map(tech => tech.id), completedBuildings: [] });
+    const ids = candidates.map(candidate => candidate.id);
+    for (const building of Object.values(BUILDINGS)) {
+      if (building.nationalProject || building.uniquePerEmpire || building.coastalRequired || building.resourceRequired?.length) {
+        expect(ids).not.toContain(building.id);
+      }
+    }
+  });
+
+  it('returns the first missing prerequisite and is deterministic', () => {
+    const terminal = Object.values(BUILDINGS).find(building =>
+      (building.requiresBuildings?.length ?? 0) > 0
+      && !building.nationalProject
+      && !building.uniquePerEmpire
+      && !building.coastalRequired
+      && !(building.resourceRequired?.length))!;
+    const input = { completedTechs: TECH_TREE.map(tech => tech.id), completedBuildings: [] as string[] };
+    const closure = getMissingRepresentativeBuildingClosure(terminal, input);
+    expect(closure[0]).toBe(terminal.requiresBuildings![0]);
+    expect(selectRepresentativeBuilding(input)).toEqual(selectRepresentativeBuilding(input));
+  });
+});
+\`\`\`
+
+- [ ] **Step 2: Verify the test fails**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: FAIL because cohort/candidate/scoring exports do not exist.
+
+- [ ] **Step 3: Implement data and eligibility**
+
+Add these constants exactly:
+
+\`\`\`ts
+export const REPRESENTATIVE_COHORTS = [
+  { id: 'capital', foundedEra: 1 },
+  { id: 'expansion-1', foundedEra: 3 },
+  { id: 'expansion-2', foundedEra: 5 },
+  { id: 'expansion-3', foundedEra: 7 },
+  { id: 'frontier', foundedEra: 9 },
+] as const;
+
+export const REPRESENTATIVE_CATEGORY_ORDER = [
+  'food', 'production', 'science', 'economy', 'culture', 'military', 'espionage',
+] as const;
+
+export const REPRESENTATIVE_YIELD_WEIGHTS = {
+  food: 1, production: 1.25, gold: 1.5, science: 1.25, happiness: 1.5,
+} as const;
+\`\`\`
+
+\`getEligibleRepresentativeBuildings\` must filter \`BUILDINGS\` by all of these rules: not national-project, not \`uniquePerEmpire\`, not coastal-only, no resource requirement, not already complete, required technology complete, and no completed \`obsoletedByTech\`. Return ID-sorted candidates.
+
+Export \`getMissingRepresentativeBuildingClosure(terminal, input)\`, which returns missing IDs in prerequisite-topological order. For each terminal candidate, form that closure. Exclude a closure if any required building fails the same neutral filters or needs a missing technology. Compute direct value as:
+
+\`\`\`ts
+building.yields.food
++ building.yields.production * 1.25
++ building.yields.gold * 1.5
++ building.yields.science * 1.25
++ (building.happiness ?? 0) * 1.5
+\`\`\`
+
+Choose in two phases:
+
+1. A positive-value closure whose terminal category is missing from the city, ordered by closure efficiency, closure cost, then category order and terminal ID.
+2. Otherwise, any positive-value closure ordered by the same efficiency/cost/ID rules.
+
+Return the first missing prerequisite in topological order. If there is no prerequisite missing, return the terminal. Never import AI production code.
+
+- [ ] **Step 4: Add negative and coverage tests**
+
+Add tests that prove a candidate becomes unavailable when its technology is absent or its obsolete technology is complete. Add a synthetic test input where two same-cost terminal closures have different IDs and assert the lower ID wins. Add a test where the only positive-value path has a prerequisite and assert the prerequisite is returned first.
+
+- [ ] **Step 5: Run and commit**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: PASS.
+
+\`\`\`bash
+git add tests/systems/helpers/pacing-production-budget.ts tests/systems/pacing-production-budget.test.ts
+git commit -m "test(pacing): model representative building choices"
+\`\`\`
+
+## Task 3: Simulate maturity-aware production and accounting
+
+**Files:**
+
+- Modify: \`tests/systems/helpers/pacing-production-budget.ts\`
+- Modify: \`tests/systems/helpers/pacing-reference-economy.ts\`
+- Modify: \`tests/systems/pacing-production-budget.test.ts\`
+
+- [ ] **Step 1: Write failing city-simulation tests**
+
+\`\`\`ts
+import { simulateRepresentativeCity } from './helpers/pacing-production-budget';
+
+describe('representative production budget', () => {
+  it('gives a frontier city no pre-founding production', () => {
+    const result = simulateRepresentativeCity({
+      cohort: { id: 'frontier', foundedEra: 9 },
+      targetEra: 9,
+      timeline: buildRepresentativeResearchTimeline(9),
+      infrastructureShare: 0.6,
+    });
+    expect(result.actualProductionEarned).toBe(0);
+    expect(result.completedBuildings).toEqual([]);
+  });
+
+  it('accounts for every allocated production point once', () => {
+    const result = simulateRepresentativeCity({
+      cohort: { id: 'capital', foundedEra: 1 },
+      targetEra: 10,
+      timeline: buildRepresentativeResearchTimeline(10),
+      infrastructureShare: 0.6,
+    });
+    const accounted = result.completedBuildingCost + result.activeBuildingProgress
+      + result.discardedObsoleteProgress + result.unspentInfrastructureProduction;
+    expect(Math.abs(accounted - result.infrastructureProductionAllocated)).toBeLessThanOrEqual(1e-9);
+    expect(result.activeBuildingCount).toBeLessThanOrEqual(1);
+  });
+});
+\`\`\`
+
+- [ ] **Step 2: Verify the test fails**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: FAIL because \`simulateRepresentativeCity\` does not exist.
+
+- [ ] **Step 3: Implement neutral city construction and simulation**
+
+In \`pacing-reference-economy.ts\`, extract a reusable neutral map/city constructor from the existing fixture. It must preserve the current 8×8 no-resource/no-river terrain pattern and derive population as:
+
+\`\`\`ts
+const population = Math.min(12, 2 + Math.floor(completedBuildings.length / 4));
+const maturity = resolveCityMaturity(population, completedTechs);
+\`\`\`
+
+Inject that constructor into \`simulateRepresentativeCity\` to avoid an import cycle.
+
+Make the simulator return an internal, testable extension of the public aggregation result:
+
+\`\`\`ts
+export interface SimulatedRepresentativeCity extends RepresentativeCityOutput {
+  completedBuildingCost: number;
+  activeBuildingProgress: number;
+  activeBuildingCount: 0 | 1;
+  population: number;
+}
+\`\`\`
+
+When \`getRepresentativeEmpireOutput\` builds its public \`cities\` array in Task 4, it may expose the shared \`RepresentativeCityOutput\` fields only; the accounting-only fields remain available to Task 3 unit tests through \`simulateRepresentativeCity\`.
+
+For each global turn from the cohort's founding arrival turn through (but excluding) the target era's arrival turn:
+
+\`\`\`ts
+const completedTechs = timeline.entries
+  .filter(entry => entry.completionTurn <= turn)
+  .map(entry => entry.techId);
+const city = makeNeutralReferenceCity({ completedBuildings, completedTechs, cohortId });
+const base = calculateCityYields(city, map, undefined, completedTechs, {});
+const withPercents = applyEmpireTechPercents(base, getEmpireTechPercents(completedTechs));
+const personalEra = resolveCivilizationEra(completedTechs);
+const cappedProduction = Math.min(withPercents.production, getProductionOutputProfileForEra(personalEra));
+const allocation = cappedProduction * infrastructureShare;
+spendAllocationAcrossBuildings(allocation);
+\`\`\`
+
+\`spendAllocationAcrossBuildings\` must finish the active item, immediately choose another item for same-turn overflow, retain no more than one partial item, cancel an obsolete active item and record its progress in \`discardedObsoleteProgress\`, and record remaining allocation as \`unspentInfrastructureProduction\` when no candidate exists. Do not add empire-flat yields to a local city queue.
+
+Reject shares other than 0.5, 0.6, and 0.7 with \`Unsupported infrastructure share\`; reject invalid target eras with \`Unsupported representative era\`.
+
+- [ ] **Step 4: Add determinism and relative-maturity tests**
+
+Assert repeated identical inputs deep-equal. At era 10, assert the capital's earned production is greater than the frontier's and the frontier population is not greater than the capital's. Do not assert a particular named maturity tier.
+
+- [ ] **Step 5: Run and commit**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts
+\`\`\`
+
+Expected: PASS.
+
+\`\`\`bash
+git add tests/systems/helpers/pacing-production-budget.ts tests/systems/helpers/pacing-reference-economy.ts tests/systems/pacing-production-budget.test.ts
+git commit -m "test(pacing): simulate production-bounded city cohorts"
+\`\`\`
+
+## Task 4: Aggregate the representative empire and pin results
+
+**Files:**
+
+- Modify: \`tests/systems/helpers/pacing-reference-economy.ts\`
+- Modify: \`tests/systems/pacing-reference-economy.test.ts\`
+
+- [ ] **Step 1: Write failing aggregation tests**
+
+\`\`\`ts
+import { getEmpireFlatTechYields } from '@/systems/tech-yield-system';
+import { getReferenceEconomyOutput, getRepresentativeEmpireOutput } from './helpers/pacing-reference-economy';
+
+describe('representative multi-city reference economy', () => {
+  it('uses the documented 1/3/5/7/9 cohort count', () => {
+    expect(getRepresentativeEmpireOutput(1).cityCount).toBe(1);
+    expect(getRepresentativeEmpireOutput(3).cityCount).toBe(2);
+    expect(getRepresentativeEmpireOutput(5).cityCount).toBe(3);
+    expect(getRepresentativeEmpireOutput(7).cityCount).toBe(4);
+    expect(getRepresentativeEmpireOutput(9).cityCount).toBe(5);
+  });
+
+  it('applies empire-flat yields once after city aggregation', () => {
+    const output = getRepresentativeEmpireOutput(10);
+    const cityTotals = output.cities.reduce((total, city) => ({
+      science: total.science + city.yieldsBeforeEmpireFlat.science,
+      production: total.production + city.yieldsBeforeEmpireFlat.production,
+    }), { science: 0, production: 0 });
+    const flat = getEmpireFlatTechYields(output.completedTechs);
+    expect(output.total).toEqual({
+      science: Math.round(cityTotals.science + flat.science),
+      production: Math.round(cityTotals.production + flat.production),
+    });
+  });
+
+  it('keeps maximal as the era 10-13 target while representative is diagnostic', () => {
+    for (const era of [10, 11, 12, 13]) {
+      expect(Math.abs(getResearchOutputProfileForEra(era).outputPerTurn - getReferenceEconomyOutput(era, 'maximal').science)).toBeLessThanOrEqual(3);
+    }
+  });
+});
+\`\`\`
+
+- [ ] **Step 2: Verify the test fails**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-reference-economy.test.ts
+\`\`\`
+
+Expected: FAIL because \`getRepresentativeEmpireOutput\` does not exist.
+
+- [ ] **Step 3: Implement correctly scoped aggregation**
+
+Return an object containing \`era\`, \`infrastructureShare\`, \`completedTechs\`, \`cityCount\`, \`cities\`, \`total\`, and \`averagePerCity\`. Simulate all cohorts whose \`foundedEra <= era\`; sum unrounded per-city science/production; add \`getEmpireFlatTechYields(timeline.completedTechIds)\` exactly once; round totals with \`Math.round\`; calculate averages from the unrounded total with \`Number(value.toFixed(2))\`.
+
+- [ ] **Step 4: Add canonical and sensitivity pins**
+
+After the first passing aggregation run, record the actual 60% outputs for all eras 1 through 13 in a literal \`Record<number, { science: number; production: number; averageScience: number; averageProduction: number }>\`. The committed test must contain all 13 values and no generated snapshot or empty table.
+
+Add relational tests that 50%, 60%, and 70% each stay within accounting bounds and that total allocated infrastructure production is strictly ordered. Assert at era 9+ that at least two city maturity values are present. Keep all existing bounded/maximal tables byte-for-byte unchanged.
+
+- [ ] **Step 5: Run and commit**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts tests/systems/pacing-reference-economy.test.ts
+\`\`\`
+
+Expected: PASS.
+
+\`\`\`bash
+git add tests/systems/helpers/pacing-production-budget.ts tests/systems/helpers/pacing-reference-economy.ts tests/systems/pacing-production-budget.test.ts tests/systems/pacing-reference-economy.test.ts
+git commit -m "test(pacing): add representative empire reference fixture"
+\`\`\`
+
+## Task 5: Document policy and verify full pacing behavior
+
+**Files:**
+
+- Modify: \`.claude/rules/game-balance.md\`
+
+- [ ] **Step 1: Update Pacing Regression Prevention**
+
+Replace the current two-profile description with policy that explicitly says:
+
+- \`bounded\` and \`maximal\` retain their MR13 legacy strictly-prior-era-tech single-city convention.
+- \`representative\` is a test-only one-to-five-city diagnostic using the live personal-era resolver, 1/3/5/7/9 cohorts, raw building costs, and 50/60/70 shares.
+- Representative totals and averages are diagnostics, not a direct substitute for a single-city output.
+- \`maximal\` remains the era 10-13 research target.
+- Changing route selection, cohorts, shares, scoring weights, or aggregation scope requires a written 60% snapshot justification and a full-catalog outlier run.
+
+Do not add player-facing UI, SFX, difficulty, AI, save, solo, or hot-seat work; those systems intentionally remain unchanged.
+
+- [ ] **Step 2: Run focused pacing tests**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-reference-economy.test.ts tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts
+\`\`\`
+
+Expected: PASS with no full-catalog outliers.
+
+- [ ] **Step 3: Commit the policy**
+
+\`\`\`bash
+git add .claude/rules/game-balance.md tests/systems/pacing-reference-economy.test.ts
+git commit -m "docs(balance): document representative pacing profile"
+\`\`\`
+
+## Task 6: Final verification and handoff
+
+- [ ] **Step 1: Confirm scope before full verification**
+
+Run:
+
+\`\`\`bash
+git diff --name-only origin/main...HEAD
+git diff --check origin/main...HEAD
+\`\`\`
+
+Expected: the implementation changes only the files in this plan. If any \`src/**\` file appears, stop and request scope approval.
+
+- [ ] **Step 2: Run narrow verification**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts tests/systems/pacing-reference-economy.test.ts tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts
+\`\`\`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run required repository verification**
+
+Run:
+
+\`\`\`bash
+./scripts/run-with-mise.sh yarn build
+./scripts/run-with-mise.sh yarn test
+\`\`\`
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Review committed and uncommitted diffs**
+
+Run:
+
+\`\`\`bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+git diff --stat
+git diff
+git status --short --branch
+\`\`\`
+
+Expected: the working tree is clean; legacy profile values and maximal targeting are unchanged; no runtime files were modified.
+
+- [ ] **Step 5: Handoff**
+
+Report the measured canonical 60% snapshots, the rationale for keeping them diagnostic, fresh test/build results, and the explicit non-changes: runtime UI, SFX, saves, AI behavior, solo flow, and hot-seat flow. Do not push, create a pull request, or merge unless separately asked.

--- a/docs/superpowers/specs/2026-07-18-issue-493-production-budgeted-reference-economy-design.md
+++ b/docs/superpowers/specs/2026-07-18-issue-493-production-budgeted-reference-economy-design.md
@@ -1,0 +1,374 @@
+# Issue #493: Production-budgeted representative economy design
+
+## Status and intent
+
+Issue #493 follows MR13's pacing recalibration. The current reference-economy fixture models two single-city extremes: a recent-era `bounded` building window and an all-eligible-building `maximal` completionist city. Neither answers the diagnostic question that matters for ordinary games: what science and production does a growing empire with cities of different ages produce after paying real construction costs?
+
+This design adds a third, diagnostic-only `representative` view. It models a deterministic five-cohort empire, a cost-aware prerequisite-closed research route, and turn-by-turn infrastructure construction from a bounded share of actual city production. It preserves the existing `maximal` era 10-13 research target and both legacy profiles unchanged.
+
+The result is balance instrumentation, not a player-facing mechanic. It must not alter runtime game state, AI decisions, difficulty rules, UI, sound, saves, solo play, or hot-seat play.
+
+## Decisions
+
+- Keep `bounded` and `maximal` unchanged for historical regression continuity.
+- Add `representative` as a separate multi-city diagnostic, never as an implicit replacement for either legacy profile.
+- Keep era 10-13 research pacing targeted to `maximal`, as required by issue #493's non-goal.
+- Grow the representative empire from one to five cities using cohorts founded in eras 1, 3, 5, 7, and 9.
+- Allocate 60% of local production to infrastructure in the canonical snapshot; run 50% and 70% sensitivity variants.
+- Derive research duration and unlock timing from the live technology catalog, costs, prerequisites, pacing profiles, advancement fractions, and canonical personal-era resolver.
+- Select buildings with a deterministic catalog-driven balanced scorer. Do not import AI production scoring.
+- Report empire totals, per-city results, and per-city averages.
+- Apply city-scoped and empire-scoped yields at their correct scopes.
+- Keep all implementation under test helpers, tests, and balance documentation. Any required `src/**` change is a scope expansion that requires approval.
+
+## Three reference views
+
+| View | Shape | Building assumption | Policy role |
+|---|---|---|---|
+| `bounded` | One city | Eligible buildings gated in the recent-era window, plus forced prerequisites | Historical lower comparison |
+| `representative` | Era-scaled one-to-five-city empire | Buildings completed from a production budget along a live, cost-aware research timeline | Realistic diagnostic and sensitivity analysis |
+| `maximal` | One city | Every eligible ordinary building | Completionist safety target for era 10-13 research pacing |
+
+The views answer different questions and are not ordered assertions. In particular, a multi-city representative empire total is not directly comparable to a single-city maximal output. Comparisons must name whether they use empire total or per-city average.
+
+## Current-code compatibility
+
+Issue #493 predates the personal-era work merged through issue #523. The legacy fixture still defines "arrival at era N" as every technology in eras strictly before N and none from era N. That behavior remains frozen for `bounded` and `maximal` so existing snapshots and the completionist research target do not drift.
+
+The new `representative` view follows current runtime progression instead:
+
+- `getEraAdvancementTechs`, `getEraAdvancementFraction`, `hasReachedEraThreshold`, and `resolveCivilizationEra` define advancement truth.
+- Reaching a personal era may therefore include a threshold set of technologies authored in that era, matching the live resolver rather than the older MR13 fixture convention.
+- Tests must state this semantic difference. The representative route must resolve to the requested personal era, while both legacy profiles retain their existing completed-tech sets.
+
+This is an intentional compatibility boundary, not an attempt to reconcile or retune the legacy constants inside #493.
+
+## Architecture
+
+### `tests/systems/helpers/pacing-reference-economy.ts`
+
+This module retains the legacy single-city functions and owns neutral city/map construction plus final yield aggregation. It adds the representative orchestration entry point without widening `ReferenceEconomyProfile`:
+
+```ts
+export type ReferenceEconomyProfile = 'bounded' | 'maximal';
+
+export interface ReferenceYieldOutput {
+  science: number;
+  production: number;
+}
+
+export interface RepresentativeCityOutput {
+  cohortId: string;
+  foundedEra: number;
+  maturity: CityMaturity;
+  completedBuildings: string[];
+  activeBuilding: { id: string; progress: number } | null;
+  actualProductionEarned: number;
+  cappedProductionEarned: number;
+  infrastructureProductionAllocated: number;
+  infrastructureProductionSpent: number;
+  discardedObsoleteProgress: number;
+  unspentInfrastructureProduction: number;
+  yieldsBeforeEmpireFlat: ReferenceYieldOutput;
+}
+
+export interface RepresentativeEmpireOutput {
+  era: number;
+  infrastructureShare: number;
+  completedTechs: string[];
+  cityCount: number;
+  cities: RepresentativeCityOutput[];
+  total: ReferenceYieldOutput;
+  averagePerCity: ReferenceYieldOutput;
+}
+
+export function getRepresentativeEmpireOutput(
+  era: number,
+  options?: { infrastructureShare?: 0.5 | 0.6 | 0.7 },
+): RepresentativeEmpireOutput;
+```
+
+### `tests/systems/helpers/pacing-production-budget.ts`
+
+This focused helper owns:
+
+- canonical research-route construction and technology completion turns;
+- era-transition turns;
+- city cohort data;
+- ordinary-building eligibility and prerequisite closure;
+- balanced building selection;
+- turn-by-turn local production allocation;
+- partial building progress and obsolescence handling;
+- diagnostic accounting and invariant checks.
+
+It consumes production and yield systems but never consumes `GameState`, player IDs, `currentPlayer`, AI personalities, challenge profiles, UI, audio, or persistence.
+
+## Canonical research timeline
+
+### Route construction
+
+The representative route is deterministic and cost-aware, but it is not claimed to be a proof of globally optimal play.
+
+Starting with an empty completed set and personal era 1, repeat for each requested transition:
+
+1. Read the next era's qualifying technologies and advancement fraction through the canonical helpers.
+2. Compute the required qualifying count with the canonical rounded-up threshold.
+3. For every incomplete qualifying candidate, compute its missing recursive prerequisite closure.
+4. Rank candidates by incremental closure cost, then candidate cost, then technology ID.
+5. Walk the winning closure in topological prerequisite order, checking the threshold after each completed technology and stopping the closure immediately once the threshold is met.
+6. Continue until `hasReachedEraThreshold` is true.
+7. Assert `resolveCivilizationEra(completedTechIds)` reaches the expected contiguous era before continuing.
+
+Non-advancement technologies enter the route only when they are prerequisites. Technologies outside the selected closure remain incomplete, and their buildings and yield effects remain unavailable. This keeps eligibility consistent with the duration model; the fixture must never grant content from technologies it did not spend research time completing.
+
+If the candidate set cannot satisfy a threshold, a prerequisite is missing, a cycle is detected, or the canonical resolver disagrees with the derived transition, throw an error naming the era and offending technology IDs.
+
+### Completion timing and era duration
+
+Each newly selected technology is researched sequentially in topological route order. Its duration is:
+
+```ts
+Math.ceil(tech.cost / getResearchOutputProfileForTech(tech).outputPerTurn)
+```
+
+The completion turn is the cumulative end turn of that technology. The era duration is the sum of the selected technologies' ETAs required to reach the next personal era. This derives the production timeline from the same catalog costs and authoritative research profiles used by the pacing audit.
+
+Technology completion applies at the start of its completion turn for fixture purposes. Its building unlocks and yield effects may affect city processing on that turn. This ordering is fixed and covered by a boundary test.
+
+## Empire cohorts and city maturity
+
+The canonical cohorts are data, not branches:
+
+| Cohort | Founded | Intended role |
+|---|---:|---|
+| `capital` | Era 1 | Oldest and most developed city |
+| `expansion-1` | Era 3 | Early established city |
+| `expansion-2` | Era 5 | Mid-game city |
+| `expansion-3` | Era 7 | Developing later city |
+| `frontier` | Era 9 | Young frontier city |
+
+A cohort is founded on the first turn after the empire reaches its founding era. An output snapshot taken immediately on arrival at that era includes the newly founded city in its founding state but gives it no retroactive production.
+
+Settler production is not charged again inside the infrastructure budget. The reserved non-infrastructure share explicitly represents settlers, units, wonders, national projects, repairs, queue interruptions, and idle production.
+
+Each city starts from the existing neutral reference-map assumptions. Population uses the legacy fixture's deterministic infrastructure proxy:
+
+```ts
+Math.min(12, 2 + Math.floor(completedBuildingCount / 4))
+```
+
+Worked tiles are rebuilt deterministically when population changes. City maturity is always resolved through `resolveCityMaturity(population, completedTechIds)`; it is never assigned from the cohort label. Later-founded cities receive fewer production turns and therefore naturally remain less mature.
+
+Tests pin the cohort count at every founding boundary and the expected mixed-maturity composition at representative later eras. They must not require every city to occupy a different maturity tier.
+
+## Production-time-bounded construction
+
+### Local production per turn
+
+Every active city is processed once per global research-timeline turn:
+
+1. Construct its current city snapshot, population, worked tiles, buildings, and completed technology set.
+2. Call the real `calculateCityYields` pipeline.
+3. Apply empire technology percentage modifiers to the city result.
+4. Do not add empire-flat yields to a local city queue.
+5. Cap local production at `getProductionOutputProfileForEra(currentPersonalEra)` so a fixture city cannot exceed the authored production anchor.
+6. Multiply the capped production by the selected infrastructure share.
+7. Apply the resulting fractional production to the active building. If it completes, select the next candidate and spend any same-turn overflow; continue until the allocation is exhausted or no candidate remains.
+
+Using actual city production below the authored cap makes frontier cities genuinely weaker than mature capitals without inventing maturity multipliers. The cap preserves issue #493's requirement that cumulative capacity be grounded in `PRODUCTION_OUTPUT_BY_ERA`/the authored production profile.
+
+Neutral reference-map production must be positive. A non-positive value or missing authored era profile is an error rather than an infinite or silently skipped build.
+
+### Budget accounting
+
+Each city records uncapped actual production, capped production, infrastructure production allocated, completed-building cost, discarded obsolete progress, unspent infrastructure production, and active partial progress. The accounting invariant is an equality within epsilon:
+
+```text
+completed cost + active progress + discarded obsolete progress
+  + unspent infrastructure production
+  == cumulative infrastructure production allocated
+```
+
+`infrastructureProductionSpent` equals completed cost plus active progress plus discarded obsolete progress. Floating-point comparisons use a small explicit epsilon. Production cannot be banked for a not-yet-unlocked building. When no candidate exists, the current turn's remaining allocation is recorded as unspent. A city always advances its current building until completion, obsolescence, or the end of the timeline, and it ends a turn with at most one partial building.
+
+### Infrastructure shares
+
+- 50%: infrastructure-light sensitivity case.
+- 60%: canonical representative snapshot.
+- 70%: infrastructure-heavy sensitivity case.
+
+The remaining share is deliberately unmodeled production work. Difficulty modes do not change these percentages because Explorer, Standard, and Veteran change decision quality and pressure rather than the local production income of an identical city.
+
+## Building eligibility and balanced selection
+
+### Candidate boundary
+
+The representative candidate set contains catalog buildings that are:
+
+- unlocked by the route's currently completed technologies;
+- ordinary, non-national-project, non-`uniquePerEmpire` buildings;
+- not coastal-only;
+- not resource-gated;
+- not already completed in that city;
+- not obsolete under a completed `obsoletedByTech` technology;
+- reachable through a valid `requiresBuildings` closure.
+
+Trade routes, legendary wonders, national projects, resources, civilization bonuses, and special map conditions remain outside the neutral fixture. Their exclusion is documented because adding invented counts would make the diagnostic less trustworthy.
+
+If a completed building later becomes obsolete, it remains in the historical city building set and follows the real yield pipeline's behavior. If the active incomplete building becomes obsolete, cancel it, record its progress as discarded, and select again. Do not transfer that progress to another item.
+
+### Scoring
+
+The fixture owns stable economic weights:
+
+```text
+food       1.00
+production 1.25
+gold       1.50
+science    1.25
+happiness  1.50
+```
+
+For each reachable terminal building, form its missing prerequisite closure. Score the closure as total weighted direct value divided by total missing production cost. This lets a low-yield prerequisite inherit the value of the building it unlocks without hard-coding building IDs.
+
+Selection uses two phases:
+
+1. **Coverage phase:** if the city lacks a building category for which a positive-value reachable closure exists, select the most efficient missing category. Category ties use the stable order `food`, `production`, `science`, `economy`, `culture`, `military`, `espionage`. A building with no category skips coverage ranking but remains eligible for the efficiency phase.
+2. **Efficiency phase:** after useful available categories are represented, select the highest closure efficiency globally.
+
+Within either phase, ties resolve by lower total closure cost and then terminal building ID. Build the first missing prerequisite in topological order. Buildings and closures with zero weighted value are left to the reserved non-infrastructure share rather than forced into the economic reference model.
+
+The fixture does not import `economyValue`, `generateAIProductionCandidates`, personalities, military demand, maintenance reserves, or difficulty-specific suboptimal-choice logic. Computer players still benefit from the diagnostic because both systems consume the same building catalog, prerequisites, costs, and yields. A generic test proves every eligible positive-value ordinary building can enter a candidate closure.
+
+## Yield aggregation
+
+At the requested personal-era arrival snapshot:
+
+1. Calculate every city's base yield with its completed buildings and the route's completed technologies.
+2. Apply empire technology percentage modifiers to each city independently.
+3. Sum city science and production without intermediate rounding.
+4. Add `getEmpireFlatTechYields(completedTechIds)` exactly once to the empire total.
+5. Round final empire totals with `Math.round`, matching the legacy output contract.
+6. Compute `averagePerCity` from the unrounded total divided by city count and round it to two decimals with `Number(value.toFixed(2))`.
+7. Round per-city diagnostic values to two decimals only after empire aggregation has consumed their unrounded values.
+
+Per-city diagnostic outputs remain pre-empire-flat so the flat bonus is never presented as though every city earned it. Tests prove totals, averages, and scope independently.
+
+The representative output excludes city-to-city route bonuses and other geometry-dependent empire effects. The fixture reuses a neutral map for isolated city calculation; it does not pretend the cities occupy a real shared map.
+
+## Player, mode, and platform impact
+
+### Gameplay, fun, ages, and play styles
+
+No new mechanic or player-facing rule is introduced. The value is indirect: balance changes gain a more realistic signal before research becomes automatic for wide/infrastructure-heavy empires or excessively slow for lighter builders.
+
+The three views and 50/60/70 sensitivity cases acknowledge different play styles without declaring one mandatory. Younger, relaxed, experienced, competitive, tall, wide, and completionist players receive no new cognitive burden, controls, or terminology.
+
+### Difficulty and AI
+
+The fixture has no difficulty branch. It describes economic capacity, not how often Explorer AI makes a suboptimal choice or Veteran AI chooses the best candidate. AI runtime code does not read the fixture, so the model cannot create hidden AI bonuses or behavior changes.
+
+### UI, UX, SFX, solo, and hot seat
+
+No panel, tooltip, setting, notification, animation, music transition, or sound effect is added. No `currentPlayer` or viewer-scoped data enters the model. Solo and hot-seat execution paths are unchanged; full-suite verification is the appropriate regression coverage rather than artificial runtime tests for a helper that runtime never imports.
+
+### Saves
+
+No `GameState` field, schema, serializer, save version, or migration changes. The new helpers must remain test-only and must not be imported by `src/**`.
+
+## Error handling and determinism
+
+The representative fixture throws actionable errors for:
+
+- unsupported or non-integer requested eras;
+- infrastructure shares other than 0.5, 0.6, or 0.7;
+- missing authored pacing profiles;
+- empty or unsatisfiable advancement sets;
+- missing technology or building prerequisites;
+- prerequisite cycles;
+- canonical resolver disagreement;
+- non-positive research or neutral city production;
+- negative, non-finite, or over-spent production accounting;
+- applying empire-flat yields more than once.
+
+All ordering uses explicit numeric keys and ID tie-breakers. The model uses no RNG, current date, object insertion order, locale-dependent sorting, or map-generation seed.
+
+## Test contract
+
+### `tests/systems/pacing-production-budget.test.ts`
+
+- Route closure includes all prerequisites and excludes unrelated technologies.
+- Threshold boundary uses the canonical rounded-up advancement fraction.
+- The route reaches each requested era contiguously under `resolveCivilizationEra`.
+- Candidate selection is deterministic when costs tie.
+- Completion turns and era durations equal the sum of pacing-profile ETAs.
+- A technology unlock is unavailable one turn before completion and available on its documented completion turn.
+- Cohort counts change exactly on eras 1, 3, 5, 7, and 9; no cohort receives pre-founding production.
+- Frontier production is lower than or equal to the authored cap and does not inherit capital history.
+- Completed cost, partial progress, discarded obsolete progress, and unspent allocation reconcile exactly to cumulative allocated production within epsilon.
+- Same-turn overflow completes additional affordable buildings without creating more than one partial building; lack of a candidate records the overflow as unspent.
+- Only one active partial building exists per city.
+- Prerequisites complete before their dependents.
+- Useful category coverage occurs before second buildings in already-covered categories.
+- Zero-value, coastal, resource-gated, national-project, unique, and obsolete candidates remain excluded.
+- Every eligible positive-value ordinary catalog building can enter a candidate closure.
+- Repeated runs return byte-for-byte equivalent diagnostic data.
+- Invalid eras, shares, cycles, and missing prerequisites fail with contextual messages.
+
+### `tests/systems/pacing-reference-economy.test.ts`
+
+- Existing exact `bounded` and `maximal` science snapshots remain unchanged.
+- Existing `maximal >= bounded` and growth-ratio guardrails remain unchanged.
+- Era 10-13 research profiles remain tightly derived from `maximal`, never `representative`.
+- The 60% representative total and average science/production values are pinned for every authored era.
+- Per-city outputs sum to the empire total after adding the empire-flat yield once.
+- Percentage modifiers apply per city; flat modifiers apply once per empire.
+- Average is derived from the unrounded empire total and follows the documented two-decimal rounding rule rather than dividing the rounded total.
+- Representative completed technologies resolve to the requested personal era, while legacy profiles retain the strictly-prior-era tech convention.
+- Representative later-era snapshots contain the expected cohort IDs and a documented mixed-maturity composition.
+- For identical era/cohort inputs, 50%, 60%, and 70% allocated infrastructure production are ordered and remain within their budgets.
+- Sensitivity checks assert relationships and invariants; only the canonical 60% case receives exact output pins.
+
+### Pacing and repository regressions
+
+Run, in order:
+
+1. `./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts tests/systems/pacing-reference-economy.test.ts`
+2. `./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts`
+3. `./scripts/run-with-mise.sh yarn build`
+4. `./scripts/run-with-mise.sh yarn test`
+
+The full-catalog outlier gate must remain empty. Because the authoritative `maximal` target does not change, no technology-cost retune is expected. If a pacing constant or `src/**` file appears necessary, stop and request scope approval rather than updating snapshots or costs opportunistically.
+
+## Documentation changes
+
+Update `.claude/rules/game-balance.md` so Pacing Regression Prevention describes all three views and states:
+
+- `bounded` and `maximal` retain the legacy single-city arrival convention;
+- `representative` follows the live personal-era resolver and is production-budgeted across mixed-age cities;
+- representative totals and averages are diagnostic only;
+- `maximal` remains the era 10-13 target;
+- changes to route selection, cohort data, infrastructure shares, scoring weights, or aggregation scope require explicit snapshot justification and the full-catalog outlier gate.
+
+## Delivery boundary and acceptance
+
+This is one cohesive tooling MR. It may change only:
+
+- `tests/systems/helpers/pacing-reference-economy.ts`;
+- new `tests/systems/helpers/pacing-production-budget.ts`;
+- `tests/systems/pacing-reference-economy.test.ts`;
+- new `tests/systems/pacing-production-budget.test.ts`;
+- `.claude/rules/game-balance.md`;
+- the approved design and implementation-plan documents.
+
+The issue is complete when:
+
+- a multi-city aggregate fixture reports documented total, average, and per-city results;
+- mixed maturity follows the documented 1/3/5/7/9 cohort method;
+- production-time-bounded accumulation uses real costs, live yield production below the authored cap, and a 60% infrastructure allocation with 50/70 sensitivity checks;
+- research eligibility and duration use one consistent prerequisite-closed live-era route;
+- `bounded`, `maximal`, and the maximal research target remain unchanged;
+- all targeted, build, and full-suite verification passes;
+- the final committed and uncommitted diffs contain no unapproved runtime changes.
+
+Out of scope: retuning technology costs, changing advancement fractions, changing difficulty profiles, adding telemetry, importing AI behavior, simulating military/wonder/settler queues in detail, adding UI diagnostics, changing sound, or migrating saves.

--- a/tests/systems/helpers/pacing-production-budget.ts
+++ b/tests/systems/helpers/pacing-production-budget.ts
@@ -2,7 +2,7 @@ import type { Building, BuildingCategory, City, CityMaturity, GameMap, HexCoord,
 import { BUILDINGS } from '@/systems/city-system';
 import { resolveCityMaturity } from '@/systems/city-maturity-system';
 import { calculateCityYields } from '@/systems/resource-system';
-import { getProductionOutputProfileForEra } from '@/systems/pacing-model';
+import { getProductionOutputProfileForEra, getResearchOutputProfileForTech } from '@/systems/pacing-model';
 import { applyEmpireTechPercents, getEmpireTechPercents } from '@/systems/tech-yield-system';
 import {
   TECH_TREE,
@@ -11,7 +11,6 @@ import {
   hasReachedEraThreshold,
   resolveCivilizationEra,
 } from '@/systems/tech-definitions';
-import { getResearchOutputProfileForTech } from '@/systems/pacing-model';
 import { requireEraPacingProfile } from '@/systems/era-pacing-profiles';
 
 export interface ResearchTimelineEntry {
@@ -187,10 +186,11 @@ export function getMissingRepresentativeBuildingClosure(
   const completedTechs = new Set(input.completedTechs);
   const completedBuildings = new Set(input.completedBuildings);
   const visiting = new Set<string>();
+  const resolved = new Set<string>();
   const result: string[] = [];
 
   const visit = (buildingId: string): void => {
-    if (completedBuildings.has(buildingId)) return;
+    if (completedBuildings.has(buildingId) || resolved.has(buildingId)) return;
     if (visiting.has(buildingId)) throw new Error(`Building prerequisite cycle at ${buildingId}`);
     const building = BUILDINGS[buildingId];
     if (!building) throw new Error(`Missing building prerequisite: ${buildingId}`);
@@ -198,6 +198,7 @@ export function getMissingRepresentativeBuildingClosure(
     visiting.add(buildingId);
     for (const prerequisite of building.requiresBuildings ?? []) visit(prerequisite);
     visiting.delete(buildingId);
+    resolved.add(buildingId);
     result.push(buildingId);
   };
 
@@ -221,8 +222,11 @@ export function selectRepresentativeBuilding(input: RepresentativeBuildingInput)
         const cost = closure.reduce((sum, building) => sum + building.productionCost, 0);
         if (value <= 0 || cost <= 0) return [];
         return [{ terminal, closure, value, cost }];
-      } catch {
-        return [];
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith('Unavailable building prerequisite:')) {
+          return [];
+        }
+        throw error;
       }
     })
     .sort((left, right) => {

--- a/tests/systems/helpers/pacing-production-budget.ts
+++ b/tests/systems/helpers/pacing-production-budget.ts
@@ -1,4 +1,5 @@
-import type { Tech } from '@/core/types';
+import type { Building, BuildingCategory, Tech } from '@/core/types';
+import { BUILDINGS } from '@/systems/city-system';
 import {
   TECH_TREE,
   getEraAdvancementFraction,
@@ -22,6 +23,30 @@ export interface RepresentativeResearchTimeline {
   completedTechIds: string[];
   arrivalTurnByEra: ReadonlyMap<number, number>;
 }
+
+export interface RepresentativeCohort {
+  id: string;
+  foundedEra: number;
+}
+
+export interface RepresentativeBuildingInput {
+  completedTechs: readonly string[];
+  completedBuildings: readonly string[];
+}
+
+export const REPRESENTATIVE_COHORTS: readonly RepresentativeCohort[] = [
+  { id: 'capital', foundedEra: 1 },
+  { id: 'expansion-1', foundedEra: 3 },
+  { id: 'expansion-2', foundedEra: 5 },
+  { id: 'expansion-3', foundedEra: 7 },
+  { id: 'frontier', foundedEra: 9 },
+];
+
+const CATEGORY_ORDER: readonly BuildingCategory[] = [
+  'food', 'production', 'science', 'economy', 'culture', 'military', 'espionage',
+];
+
+const CATEGORY_RANK = new Map(CATEGORY_ORDER.map((category, index) => [category, index]));
 
 function compareIds(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -117,4 +142,98 @@ export function buildRepresentativeResearchTimeline(targetEra: number): Represen
     completedTechIds: [...completed],
     arrivalTurnByEra,
   };
+}
+
+export function getRepresentativeCohorts(era: number): RepresentativeCohort[] {
+  return REPRESENTATIVE_COHORTS.filter(cohort => cohort.foundedEra <= era);
+}
+
+function buildingValue(building: Building): number {
+  return building.yields.food
+    + building.yields.production * 1.25
+    + building.yields.gold * 1.5
+    + building.yields.science * 1.25
+    + (building.happiness ?? 0) * 1.5;
+}
+
+function isNeutralBuilding(building: Building, completedTechs: ReadonlySet<string>): boolean {
+  return !building.nationalProject
+    && !building.uniquePerEmpire
+    && !building.coastalRequired
+    && !(building.resourceRequired?.length)
+    && (!building.techRequired || completedTechs.has(building.techRequired))
+    && (!building.obsoletedByTech || !completedTechs.has(building.obsoletedByTech));
+}
+
+export function getEligibleRepresentativeBuildings(input: RepresentativeBuildingInput): Building[] {
+  const completedTechs = new Set(input.completedTechs);
+  const completedBuildings = new Set(input.completedBuildings);
+  return Object.values(BUILDINGS)
+    .filter(building => !completedBuildings.has(building.id))
+    .filter(building => isNeutralBuilding(building, completedTechs))
+    .sort((left, right) => compareIds(left.id, right.id));
+}
+
+export function getMissingRepresentativeBuildingClosure(
+  terminal: Building,
+  input: RepresentativeBuildingInput,
+): string[] {
+  const completedTechs = new Set(input.completedTechs);
+  const completedBuildings = new Set(input.completedBuildings);
+  const visiting = new Set<string>();
+  const result: string[] = [];
+
+  const visit = (buildingId: string): void => {
+    if (completedBuildings.has(buildingId)) return;
+    if (visiting.has(buildingId)) throw new Error(`Building prerequisite cycle at ${buildingId}`);
+    const building = BUILDINGS[buildingId];
+    if (!building) throw new Error(`Missing building prerequisite: ${buildingId}`);
+    if (!isNeutralBuilding(building, completedTechs)) throw new Error(`Unavailable building prerequisite: ${buildingId}`);
+    visiting.add(buildingId);
+    for (const prerequisite of building.requiresBuildings ?? []) visit(prerequisite);
+    visiting.delete(buildingId);
+    result.push(buildingId);
+  };
+
+  visit(terminal.id);
+  return result;
+}
+
+export function selectRepresentativeBuilding(input: RepresentativeBuildingInput): Building | null {
+  const completedBuildings = new Set(input.completedBuildings);
+  const builtCategories = new Set(
+    input.completedBuildings
+      .map(id => BUILDINGS[id]?.category)
+      .filter((category): category is BuildingCategory => category !== undefined),
+  );
+  const candidates = getEligibleRepresentativeBuildings(input)
+    .flatMap(terminal => {
+      try {
+        const closureIds = getMissingRepresentativeBuildingClosure(terminal, input);
+        const closure = closureIds.map(id => BUILDINGS[id]);
+        const value = closure.reduce((sum, building) => sum + buildingValue(building), 0);
+        const cost = closure.reduce((sum, building) => sum + building.productionCost, 0);
+        if (value <= 0 || cost <= 0) return [];
+        return [{ terminal, closure, value, cost }];
+      } catch {
+        return [];
+      }
+    })
+    .sort((left, right) => {
+      const leftCoverage = left.terminal.category && !builtCategories.has(left.terminal.category) ? 0 : 1;
+      const rightCoverage = right.terminal.category && !builtCategories.has(right.terminal.category) ? 0 : 1;
+      const leftEfficiency = left.value / left.cost;
+      const rightEfficiency = right.value / right.cost;
+      const leftCategory = left.terminal.category ? CATEGORY_RANK.get(left.terminal.category) ?? CATEGORY_ORDER.length : CATEGORY_ORDER.length;
+      const rightCategory = right.terminal.category ? CATEGORY_RANK.get(right.terminal.category) ?? CATEGORY_ORDER.length : CATEGORY_ORDER.length;
+      return leftCoverage - rightCoverage
+        || rightEfficiency - leftEfficiency
+        || left.cost - right.cost
+        || leftCategory - rightCategory
+        || compareIds(left.terminal.id, right.terminal.id);
+    });
+
+  const selected = candidates[0];
+  if (!selected) return null;
+  return selected.closure.find(building => !completedBuildings.has(building.id)) ?? null;
 }

--- a/tests/systems/helpers/pacing-production-budget.ts
+++ b/tests/systems/helpers/pacing-production-budget.ts
@@ -1,0 +1,120 @@
+import type { Tech } from '@/core/types';
+import {
+  TECH_TREE,
+  getEraAdvancementFraction,
+  getEraAdvancementTechs,
+  hasReachedEraThreshold,
+  resolveCivilizationEra,
+} from '@/systems/tech-definitions';
+import { getResearchOutputProfileForTech } from '@/systems/pacing-model';
+import { requireEraPacingProfile } from '@/systems/era-pacing-profiles';
+
+export interface ResearchTimelineEntry {
+  techId: string;
+  era: number;
+  eta: number;
+  completionTurn: number;
+}
+
+export interface RepresentativeResearchTimeline {
+  targetEra: number;
+  entries: ResearchTimelineEntry[];
+  completedTechIds: string[];
+  arrivalTurnByEra: ReadonlyMap<number, number>;
+}
+
+function compareIds(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function techById(id: string): Tech {
+  const tech = TECH_TREE.find(candidate => candidate.id === id);
+  if (!tech) throw new Error(`Missing technology prerequisite: ${id}`);
+  return tech;
+}
+
+function collectMissingClosure(
+  tech: Tech,
+  completed: ReadonlySet<string>,
+  visiting: ReadonlySet<string> = new Set(),
+): Tech[] {
+  if (completed.has(tech.id)) return [];
+  if (visiting.has(tech.id)) throw new Error(`Technology prerequisite cycle at ${tech.id}`);
+
+  const nextVisiting = new Set(visiting);
+  nextVisiting.add(tech.id);
+  return [
+    ...tech.prerequisites.flatMap(id => collectMissingClosure(techById(id), completed, nextVisiting)),
+    tech,
+  ];
+}
+
+function uniqueTopologicalClosure(tech: Tech, completed: ReadonlySet<string>): Tech[] {
+  const seen = new Set<string>();
+  return collectMissingClosure(tech, completed)
+    .filter(candidate => !completed.has(candidate.id))
+    .filter(candidate => {
+      if (seen.has(candidate.id)) return false;
+      seen.add(candidate.id);
+      return true;
+    });
+}
+
+export function getRequiredAdvancementCount(era: number): number {
+  const qualifying = getEraAdvancementTechs(era);
+  if (qualifying.length === 0) throw new Error(`Era ${era} has no advancement technologies`);
+  return Math.ceil(qualifying.length * getEraAdvancementFraction(era));
+}
+
+export function buildRepresentativeResearchTimeline(targetEra: number): RepresentativeResearchTimeline {
+  if (!Number.isInteger(targetEra) || targetEra < 1) {
+    throw new Error(`Unsupported representative era: ${targetEra}`);
+  }
+  requireEraPacingProfile(targetEra);
+
+  const completed = new Set<string>();
+  const entries: ResearchTimelineEntry[] = [];
+  const arrivalTurnByEra = new Map<number, number>([[1, 0]]);
+  let turn = 0;
+
+  for (let era = 2; era <= targetEra; era++) {
+    const required = getRequiredAdvancementCount(era);
+    while (!hasReachedEraThreshold([...completed], era)) {
+      const candidates = getEraAdvancementTechs(era)
+        .filter(tech => !completed.has(tech.id))
+        .map(tech => ({ tech, closure: uniqueTopologicalClosure(tech, completed) }))
+        .filter(candidate => candidate.closure.length > 0)
+        .sort((left, right) => {
+          const leftCost = left.closure.reduce((sum, tech) => sum + tech.cost, 0);
+          const rightCost = right.closure.reduce((sum, tech) => sum + tech.cost, 0);
+          return leftCost - rightCost || left.tech.cost - right.tech.cost || compareIds(left.tech.id, right.tech.id);
+        });
+      const selected = candidates[0];
+      if (!selected) throw new Error(`Era ${era} cannot satisfy ${required} advancement technologies`);
+
+      for (const tech of selected.closure) {
+        if (completed.has(tech.id)) continue;
+        const output = getResearchOutputProfileForTech(tech).outputPerTurn;
+        if (!Number.isFinite(output) || output <= 0) {
+          throw new Error(`Non-positive research output for ${tech.id}`);
+        }
+        const eta = Math.ceil(tech.cost / output);
+        turn += eta;
+        completed.add(tech.id);
+        entries.push({ techId: tech.id, era: tech.era, eta, completionTurn: turn });
+        if (hasReachedEraThreshold([...completed], era)) break;
+      }
+    }
+    if (resolveCivilizationEra([...completed]) !== era) {
+      throw new Error(`Representative route failed to reach contiguous era ${era}`);
+    }
+    arrivalTurnByEra.set(era, turn);
+  }
+
+  return {
+    targetEra,
+    entries,
+    completedTechIds: [...completed],
+    arrivalTurnByEra,
+  };
+}

--- a/tests/systems/helpers/pacing-production-budget.ts
+++ b/tests/systems/helpers/pacing-production-budget.ts
@@ -1,5 +1,9 @@
-import type { Building, BuildingCategory, Tech } from '@/core/types';
+import type { Building, BuildingCategory, City, CityMaturity, GameMap, HexCoord, HexTile, Tech } from '@/core/types';
 import { BUILDINGS } from '@/systems/city-system';
+import { resolveCityMaturity } from '@/systems/city-maturity-system';
+import { calculateCityYields } from '@/systems/resource-system';
+import { getProductionOutputProfileForEra } from '@/systems/pacing-model';
+import { applyEmpireTechPercents, getEmpireTechPercents } from '@/systems/tech-yield-system';
 import {
   TECH_TREE,
   getEraAdvancementFraction,
@@ -47,6 +51,8 @@ const CATEGORY_ORDER: readonly BuildingCategory[] = [
 ];
 
 const CATEGORY_RANK = new Map(CATEGORY_ORDER.map((category, index) => [category, index]));
+const EPSILON = 1e-9;
+const REFERENCE_MAP_SIZE = 8;
 
 function compareIds(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -236,4 +242,199 @@ export function selectRepresentativeBuilding(input: RepresentativeBuildingInput)
   const selected = candidates[0];
   if (!selected) return null;
   return selected.closure.find(building => !completedBuildings.has(building.id)) ?? null;
+}
+
+export interface RepresentativeCityYieldOutput {
+  science: number;
+  production: number;
+}
+
+export interface SimulatedRepresentativeCity {
+  cohortId: string;
+  foundedEra: number;
+  maturity: CityMaturity;
+  population: number;
+  completedBuildings: string[];
+  activeBuilding: { id: string; progress: number } | null;
+  actualProductionEarned: number;
+  cappedProductionEarned: number;
+  infrastructureProductionAllocated: number;
+  infrastructureProductionSpent: number;
+  completedBuildingCost: number;
+  activeBuildingProgress: number;
+  activeBuildingCount: 0 | 1;
+  discardedObsoleteProgress: number;
+  unspentInfrastructureProduction: number;
+  yieldsBeforeEmpireFlat: RepresentativeCityYieldOutput;
+}
+
+export interface SimulateRepresentativeCityInput {
+  cohort: RepresentativeCohort;
+  targetEra: number;
+  timeline: RepresentativeResearchTimeline;
+  infrastructureShare: 0.5 | 0.6 | 0.7;
+}
+
+export function makeRepresentativeMap(): GameMap {
+  const tiles: Record<string, HexTile> = {};
+  for (let q = 0; q < REFERENCE_MAP_SIZE; q++) {
+    for (let r = 0; r < REFERENCE_MAP_SIZE; r++) {
+      const terrain = q % 3 === 0 ? 'hills' : q % 3 === 1 ? 'grassland' : 'plains';
+      tiles[`${q},${r}`] = {
+        coord: { q, r },
+        terrain,
+        elevation: terrain === 'hills' ? 'highland' : 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: 'reference-civ',
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+  return { width: REFERENCE_MAP_SIZE, height: REFERENCE_MAP_SIZE, tiles, wrapsHorizontally: false, rivers: [] };
+}
+
+function workedTilesForPopulation(population: number, position: HexCoord): HexCoord[] {
+  const workedTiles: HexCoord[] = [position];
+  for (let index = 0; index < population && workedTiles.length <= population; index++) {
+    const q = 3 + (index % 4);
+    const r = 3 + Math.floor(index / 4);
+    if (q === position.q && r === position.r) continue;
+    workedTiles.push({ q, r });
+  }
+  return workedTiles;
+}
+
+export function makeRepresentativeCity(input: {
+  cohort: RepresentativeCohort;
+  completedBuildings: readonly string[];
+  completedTechs: readonly string[];
+}): City {
+  const position: HexCoord = { q: 4, r: 4 };
+  const population = Math.min(12, 2 + Math.floor(input.completedBuildings.length / 4));
+  const workedTiles = workedTilesForPopulation(population, position);
+  return {
+    id: `representative-${input.cohort.id}`,
+    name: input.cohort.id,
+    owner: 'reference-civ',
+    position,
+    population,
+    food: 0,
+    foodNeeded: 9999,
+    buildings: [...input.completedBuildings],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: workedTiles,
+    workedTiles,
+    focus: 'balanced',
+    maturity: resolveCityMaturity(population, [...input.completedTechs]),
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+  };
+}
+
+function assertInfrastructureShare(share: number): asserts share is 0.5 | 0.6 | 0.7 {
+  if (share !== 0.5 && share !== 0.6 && share !== 0.7) {
+    throw new Error(`Unsupported infrastructure share: ${share}`);
+  }
+}
+
+export function simulateRepresentativeCity(input: SimulateRepresentativeCityInput): SimulatedRepresentativeCity {
+  if (!Number.isInteger(input.targetEra) || input.targetEra < 1) {
+    throw new Error(`Unsupported representative era: ${input.targetEra}`);
+  }
+  assertInfrastructureShare(input.infrastructureShare);
+  const foundedTurn = input.timeline.arrivalTurnByEra.get(input.cohort.foundedEra);
+  const targetTurn = input.timeline.arrivalTurnByEra.get(input.targetEra);
+  if (foundedTurn === undefined || targetTurn === undefined || input.cohort.foundedEra > input.targetEra) {
+    throw new Error(`Cohort ${input.cohort.id} is not active in representative era ${input.targetEra}`);
+  }
+
+  const map = makeRepresentativeMap();
+  const completedBuildings: string[] = [];
+  let activeBuilding: { id: string; progress: number } | null = null;
+  let actualProductionEarned = 0;
+  let cappedProductionEarned = 0;
+  let infrastructureProductionAllocated = 0;
+  let completedBuildingCost = 0;
+  let discardedObsoleteProgress = 0;
+  let unspentInfrastructureProduction = 0;
+
+  for (let turn = foundedTurn; turn < targetTurn; turn++) {
+    const completedTechs = input.timeline.entries
+      .filter(entry => entry.completionTurn <= turn)
+      .map(entry => entry.techId);
+    if (activeBuilding?.id && BUILDINGS[activeBuilding.id].obsoletedByTech
+      && completedTechs.includes(BUILDINGS[activeBuilding.id].obsoletedByTech!)) {
+      discardedObsoleteProgress += activeBuilding.progress;
+      activeBuilding = null;
+    }
+
+    const city = makeRepresentativeCity({ cohort: input.cohort, completedBuildings, completedTechs });
+    const baseYields = calculateCityYields(city, map, undefined, completedTechs, {});
+    const yields = applyEmpireTechPercents(baseYields, getEmpireTechPercents(completedTechs));
+    const personalEra = resolveCivilizationEra(completedTechs);
+    const cappedProduction = Math.min(yields.production, getProductionOutputProfileForEra(personalEra));
+    if (!Number.isFinite(cappedProduction) || cappedProduction <= 0) {
+      throw new Error(`Non-positive representative production for ${input.cohort.id} on turn ${turn}`);
+    }
+    actualProductionEarned += yields.production;
+    cappedProductionEarned += cappedProduction;
+    let remaining = cappedProduction * input.infrastructureShare;
+    infrastructureProductionAllocated += remaining;
+
+    while (remaining > EPSILON) {
+      if (!activeBuilding) {
+        const selected = selectRepresentativeBuilding({ completedTechs, completedBuildings });
+        if (!selected) {
+          unspentInfrastructureProduction += remaining;
+          break;
+        }
+        activeBuilding = { id: selected.id, progress: 0 };
+      }
+      const building = BUILDINGS[activeBuilding.id];
+      const needed = building.productionCost - activeBuilding.progress;
+      const invested = Math.min(remaining, needed);
+      activeBuilding.progress += invested;
+      remaining -= invested;
+      if (activeBuilding.progress + EPSILON >= building.productionCost) {
+        completedBuildings.push(building.id);
+        completedBuildingCost += building.productionCost;
+        activeBuilding = null;
+      }
+    }
+  }
+
+  const finalTechs = input.timeline.completedTechIds;
+  const finalCity = makeRepresentativeCity({ cohort: input.cohort, completedBuildings, completedTechs: finalTechs });
+  const finalBaseYields = calculateCityYields(finalCity, map, undefined, finalTechs, {});
+  const finalYields = applyEmpireTechPercents(finalBaseYields, getEmpireTechPercents(finalTechs));
+  const activeBuildingProgress = activeBuilding?.progress ?? 0;
+  const infrastructureProductionSpent = completedBuildingCost + activeBuildingProgress + discardedObsoleteProgress;
+  const accounted = infrastructureProductionSpent + unspentInfrastructureProduction;
+  if (Math.abs(accounted - infrastructureProductionAllocated) > EPSILON) {
+    throw new Error(`Representative production accounting mismatch for ${input.cohort.id}`);
+  }
+
+  return {
+    cohortId: input.cohort.id,
+    foundedEra: input.cohort.foundedEra,
+    maturity: finalCity.maturity,
+    population: finalCity.population,
+    completedBuildings,
+    activeBuilding,
+    actualProductionEarned,
+    cappedProductionEarned,
+    infrastructureProductionAllocated,
+    infrastructureProductionSpent,
+    completedBuildingCost,
+    activeBuildingProgress,
+    activeBuildingCount: activeBuilding ? 1 : 0,
+    discardedObsoleteProgress,
+    unspentInfrastructureProduction,
+    yieldsBeforeEmpireFlat: { science: finalYields.science, production: finalYields.production },
+  };
 }

--- a/tests/systems/helpers/pacing-reference-economy.ts
+++ b/tests/systems/helpers/pacing-reference-economy.ts
@@ -3,6 +3,12 @@ import { TECH_TREE } from '@/systems/tech-definitions';
 import { BUILDINGS } from '@/systems/city-system';
 import { calculateCityYields } from '@/systems/resource-system';
 import { getEmpireTechPercents, applyEmpireTechPercents, getEmpireFlatTechYields } from '@/systems/tech-yield-system';
+import {
+  buildRepresentativeResearchTimeline,
+  getRepresentativeCohorts,
+  simulateRepresentativeCity,
+  type SimulatedRepresentativeCity,
+} from './pacing-production-budget';
 
 /**
  * Methodology (documented per issue #481's "state who/what justifies the loadout"
@@ -153,5 +159,60 @@ export function getReferenceEconomyOutput(
   return {
     science: Math.round(withPercents.science + flat.science),
     production: Math.round(withPercents.production + flat.production),
+  };
+}
+
+export interface RepresentativeEmpireOutput {
+  era: number;
+  infrastructureShare: 0.5 | 0.6 | 0.7;
+  completedTechIds: string[];
+  cityCount: number;
+  cities: SimulatedRepresentativeCity[];
+  total: Pick<ResourceYield, 'science' | 'production'>;
+  averagePerCity: Pick<ResourceYield, 'science' | 'production'>;
+}
+
+export function getRepresentativeEmpireOutput(
+  era: number,
+  options: { infrastructureShare?: 0.5 | 0.6 | 0.7 } = {},
+): RepresentativeEmpireOutput {
+  const infrastructureShare = options.infrastructureShare ?? 0.6;
+  const timeline = buildRepresentativeResearchTimeline(era);
+  const cities = getRepresentativeCohorts(era).map((cohort) =>
+    simulateRepresentativeCity({
+      cohort,
+      targetEra: era,
+      timeline,
+      infrastructureShare,
+    }),
+  );
+  const cityTotal = cities.reduce(
+    (total, city) => ({
+      science: total.science + city.yieldsBeforeEmpireFlat.science,
+      production: total.production + city.yieldsBeforeEmpireFlat.production,
+    }),
+    { science: 0, production: 0 },
+  );
+  const empireFlat = getEmpireFlatTechYields(timeline.completedTechIds);
+  const unroundedTotal = {
+    science: cityTotal.science + empireFlat.science,
+    production: cityTotal.production + empireFlat.production,
+  };
+  const total = {
+    science: Math.round(unroundedTotal.science),
+    production: Math.round(unroundedTotal.production),
+  };
+
+  return {
+    era,
+    infrastructureShare,
+    completedTechIds: [...timeline.completedTechIds],
+    cityCount: cities.length,
+    cities,
+    total,
+    averagePerCity: {
+      science: Number((unroundedTotal.science / cities.length).toFixed(2)),
+      production: Number((unroundedTotal.production / cities.length).toFixed(2)),
+    },
   };
 }

--- a/tests/systems/pacing-production-budget.test.ts
+++ b/tests/systems/pacing-production-budget.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { TECH_TREE, hasReachedEraThreshold, resolveCivilizationEra } from '@/systems/tech-definitions';
+import { BUILDINGS } from '@/systems/city-system';
 import {
   buildRepresentativeResearchTimeline,
+  getEligibleRepresentativeBuildings,
+  getMissingRepresentativeBuildingClosure,
+  getRepresentativeCohorts,
   getRequiredAdvancementCount,
+  selectRepresentativeBuilding,
 } from './helpers/pacing-production-budget';
 
 describe('representative research timeline', () => {
@@ -36,5 +41,45 @@ describe('representative research timeline', () => {
       expect(entries[index].eta).toBeGreaterThan(0);
       expect(entries[index].completionTurn).toBeGreaterThan(entries[index - 1].completionTurn);
     }
+  });
+});
+
+describe('representative building selection', () => {
+  it('adds cohorts only at documented founding eras', () => {
+    expect(getRepresentativeCohorts(1).map(cohort => cohort.id)).toEqual(['capital']);
+    expect(getRepresentativeCohorts(3).map(cohort => cohort.id)).toEqual(['capital', 'expansion-1']);
+    expect(getRepresentativeCohorts(9).map(cohort => cohort.id)).toEqual([
+      'capital', 'expansion-1', 'expansion-2', 'expansion-3', 'frontier',
+    ]);
+  });
+
+  it('excludes non-neutral buildings from the candidate set', () => {
+    const candidates = getEligibleRepresentativeBuildings({
+      completedTechs: TECH_TREE.map(tech => tech.id),
+      completedBuildings: [],
+    });
+    const ids = candidates.map(candidate => candidate.id);
+
+    for (const building of Object.values(BUILDINGS)) {
+      if (building.nationalProject || building.uniquePerEmpire || building.coastalRequired || building.resourceRequired?.length) {
+        expect(ids).not.toContain(building.id);
+      }
+    }
+  });
+
+  it('returns prerequisite closures in build order and selects deterministically', () => {
+    const terminal = Object.values(BUILDINGS).find(building =>
+      (building.requiresBuildings?.length ?? 0) > 0
+      && !building.nationalProject
+      && !building.uniquePerEmpire
+      && !building.coastalRequired
+      && !(building.resourceRequired?.length));
+    expect(terminal).toBeDefined();
+
+    const input = { completedTechs: TECH_TREE.map(tech => tech.id), completedBuildings: [] as string[] };
+    const closure = getMissingRepresentativeBuildingClosure(terminal!, input);
+    expect(closure.at(-1)).toBe(terminal!.id);
+    expect(closure[0]).not.toBe(terminal!.id);
+    expect(selectRepresentativeBuilding(input)).toEqual(selectRepresentativeBuilding(input));
   });
 });

--- a/tests/systems/pacing-production-budget.test.ts
+++ b/tests/systems/pacing-production-budget.test.ts
@@ -83,6 +83,28 @@ describe('representative building selection', () => {
     expect(closure[0]).not.toBe(terminal!.id);
     expect(selectRepresentativeBuilding(input)).toEqual(selectRepresentativeBuilding(input));
   });
+
+  it('deduplicates shared prerequisites and surfaces malformed prerequisite data', () => {
+    const input = { completedTechs: TECH_TREE.map(tech => tech.id), completedBuildings: [] as string[] };
+    for (const terminal of getEligibleRepresentativeBuildings(input)) {
+      try {
+        const closure = getMissingRepresentativeBuildingClosure(terminal, input);
+        expect(new Set(closure).size).toBe(closure.length);
+      } catch (error) {
+        expect(error).toThrowError('Unavailable building prerequisite');
+      }
+    }
+
+    const selected = selectRepresentativeBuilding(input);
+    expect(selected).not.toBeNull();
+    const originalPrerequisites = selected!.requiresBuildings;
+    selected!.requiresBuildings = ['missing-representative-prerequisite'];
+    try {
+      expect(() => selectRepresentativeBuilding(input)).toThrow('Missing building prerequisite');
+    } finally {
+      selected!.requiresBuildings = originalPrerequisites;
+    }
+  });
 });
 
 describe('representative production budget', () => {

--- a/tests/systems/pacing-production-budget.test.ts
+++ b/tests/systems/pacing-production-budget.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { TECH_TREE, hasReachedEraThreshold, resolveCivilizationEra } from '@/systems/tech-definitions';
+import {
+  buildRepresentativeResearchTimeline,
+  getRequiredAdvancementCount,
+} from './helpers/pacing-production-budget';
+
+describe('representative research timeline', () => {
+  it('uses canonical rounded-up advancement counts', () => {
+    for (let era = 2; era <= 13; era++) {
+      const qualifying = TECH_TREE.filter(tech => tech.era === era && tech.countsForEraAdvancement !== false);
+
+      expect(getRequiredAdvancementCount(era)).toBeGreaterThanOrEqual(1);
+      expect(getRequiredAdvancementCount(era)).toBeLessThanOrEqual(qualifying.length);
+    }
+  });
+
+  it('reaches each requested personal era through a prerequisite-closed route', () => {
+    for (let era = 1; era <= 13; era++) {
+      const timeline = buildRepresentativeResearchTimeline(era);
+
+      expect(resolveCivilizationEra(timeline.completedTechIds)).toBe(era);
+      if (era >= 2) expect(hasReachedEraThreshold(timeline.completedTechIds, era)).toBe(true);
+      for (const techId of timeline.completedTechIds) {
+        const tech = TECH_TREE.find(candidate => candidate.id === techId);
+        expect(tech, techId).toBeDefined();
+        expect(tech!.prerequisites.every(id => timeline.completedTechIds.includes(id))).toBe(true);
+      }
+    }
+  });
+
+  it('records positive ETAs in strictly increasing completion-turn order', () => {
+    const entries = buildRepresentativeResearchTimeline(10).entries;
+
+    for (let index = 1; index < entries.length; index++) {
+      expect(entries[index].eta).toBeGreaterThan(0);
+      expect(entries[index].completionTurn).toBeGreaterThan(entries[index - 1].completionTurn);
+    }
+  });
+});

--- a/tests/systems/pacing-production-budget.test.ts
+++ b/tests/systems/pacing-production-budget.test.ts
@@ -7,6 +7,7 @@ import {
   getMissingRepresentativeBuildingClosure,
   getRepresentativeCohorts,
   getRequiredAdvancementCount,
+  simulateRepresentativeCity,
   selectRepresentativeBuilding,
 } from './helpers/pacing-production-budget';
 
@@ -81,5 +82,49 @@ describe('representative building selection', () => {
     expect(closure.at(-1)).toBe(terminal!.id);
     expect(closure[0]).not.toBe(terminal!.id);
     expect(selectRepresentativeBuilding(input)).toEqual(selectRepresentativeBuilding(input));
+  });
+});
+
+describe('representative production budget', () => {
+  it('gives a frontier city no pre-founding production', () => {
+    const result = simulateRepresentativeCity({
+      cohort: { id: 'frontier', foundedEra: 9 },
+      targetEra: 9,
+      timeline: buildRepresentativeResearchTimeline(9),
+      infrastructureShare: 0.6,
+    });
+
+    expect(result.actualProductionEarned).toBe(0);
+    expect(result.completedBuildings).toEqual([]);
+  });
+
+  it('accounts for every allocated production point exactly once', () => {
+    const result = simulateRepresentativeCity({
+      cohort: { id: 'capital', foundedEra: 1 },
+      targetEra: 10,
+      timeline: buildRepresentativeResearchTimeline(10),
+      infrastructureShare: 0.6,
+    });
+    const accounted = result.completedBuildingCost
+      + result.activeBuildingProgress
+      + result.discardedObsoleteProgress
+      + result.unspentInfrastructureProduction;
+
+    expect(Math.abs(accounted - result.infrastructureProductionAllocated)).toBeLessThanOrEqual(1e-9);
+    expect(result.activeBuildingCount).toBeLessThanOrEqual(1);
+    expect(result.cappedProductionEarned).toBeLessThanOrEqual(result.actualProductionEarned);
+  });
+
+  it('gives later cohorts less production and no more population than the capital', () => {
+    const timeline = buildRepresentativeResearchTimeline(10);
+    const capital = simulateRepresentativeCity({
+      cohort: { id: 'capital', foundedEra: 1 }, targetEra: 10, timeline, infrastructureShare: 0.6,
+    });
+    const frontier = simulateRepresentativeCity({
+      cohort: { id: 'frontier', foundedEra: 9 }, targetEra: 10, timeline, infrastructureShare: 0.6,
+    });
+
+    expect(frontier.actualProductionEarned).toBeLessThan(capital.actualProductionEarned);
+    expect(frontier.population).toBeLessThanOrEqual(capital.population);
   });
 });

--- a/tests/systems/pacing-reference-economy.test.ts
+++ b/tests/systems/pacing-reference-economy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getReferenceEconomyOutput } from './helpers/pacing-reference-economy';
+import { getEmpireFlatTechYields } from '@/systems/tech-yield-system';
+import {
+  getReferenceEconomyOutput,
+  getRepresentativeEmpireOutput,
+} from './helpers/pacing-reference-economy';
 import { getResearchOutputProfileForEra } from '@/systems/pacing-model';
 
 describe('pacing reference economy (Part C exact-value pin)', () => {
@@ -92,6 +96,83 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
       const profile = getResearchOutputProfileForEra(era);
       const reference = getReferenceEconomyOutput(era, 'maximal');
       expect(Math.abs(profile.outputPerTurn - reference.science)).toBeLessThanOrEqual(3);
+    }
+  });
+});
+
+describe('representative multi-city reference economy', () => {
+  it('uses the documented 1/3/5/7/9 cohort count', () => {
+    expect(getRepresentativeEmpireOutput(1).cityCount).toBe(1);
+    expect(getRepresentativeEmpireOutput(3).cityCount).toBe(2);
+    expect(getRepresentativeEmpireOutput(5).cityCount).toBe(3);
+    expect(getRepresentativeEmpireOutput(7).cityCount).toBe(4);
+    expect(getRepresentativeEmpireOutput(9).cityCount).toBe(5);
+  });
+
+  it('applies empire-flat yields once after city aggregation', () => {
+    const output = getRepresentativeEmpireOutput(10);
+    const cityTotals = output.cities.reduce((total, city) => ({
+      science: total.science + city.yieldsBeforeEmpireFlat.science,
+      production: total.production + city.yieldsBeforeEmpireFlat.production,
+    }), { science: 0, production: 0 });
+    const flat = getEmpireFlatTechYields(output.completedTechIds);
+
+    expect(output.total).toEqual({
+      science: Math.round(cityTotals.science + flat.science),
+      production: Math.round(cityTotals.production + flat.production),
+    });
+  });
+
+  it('derives averages from unrounded empire totals', () => {
+    const output = getRepresentativeEmpireOutput(10);
+    const cityTotals = output.cities.reduce((total, city) => ({
+      science: total.science + city.yieldsBeforeEmpireFlat.science,
+      production: total.production + city.yieldsBeforeEmpireFlat.production,
+    }), { science: 0, production: 0 });
+    const flat = getEmpireFlatTechYields(output.completedTechIds);
+
+    expect(output.averagePerCity).toEqual({
+      science: Number(((cityTotals.science + flat.science) / output.cityCount).toFixed(2)),
+      production: Number(((cityTotals.production + flat.production) / output.cityCount).toFixed(2)),
+    });
+  });
+
+  it('orders infrastructure allocation across sensitivity shares', () => {
+    const light = getRepresentativeEmpireOutput(10, { infrastructureShare: 0.5 });
+    const canonical = getRepresentativeEmpireOutput(10, { infrastructureShare: 0.6 });
+    const heavy = getRepresentativeEmpireOutput(10, { infrastructureShare: 0.7 });
+    const allocated = (output: typeof canonical) => output.cities
+      .reduce((sum, city) => sum + city.infrastructureProductionAllocated, 0);
+
+    expect(allocated(light)).toBeLessThan(allocated(canonical));
+    expect(allocated(canonical)).toBeLessThan(allocated(heavy));
+  }, 30_000);
+
+  it('pins the canonical 60% representative profile for eras 10-13', () => {
+    const outputs = [10, 11, 12, 13].map(era => {
+      const output = getRepresentativeEmpireOutput(era);
+      return {
+        era,
+        cityCount: output.cityCount,
+        total: output.total,
+        averagePerCity: output.averagePerCity,
+      };
+    });
+
+    expect(outputs).toEqual([
+      { era: 10, cityCount: 5, total: { science: 590, production: 520 }, averagePerCity: { science: 117.9, production: 103.92 } },
+      { era: 11, cityCount: 5, total: { science: 734, production: 607 }, averagePerCity: { science: 146.7, production: 121.4 } },
+      { era: 12, cityCount: 5, total: { science: 829, production: 607 }, averagePerCity: { science: 165.8, production: 121.4 } },
+      { era: 13, cityCount: 5, total: { science: 961, production: 655 }, averagePerCity: { science: 192.2, production: 131 } },
+    ]);
+  }, 60_000);
+
+  it('keeps maximal as the era 10-13 target while representative is diagnostic', () => {
+    for (const era of [10, 11, 12, 13]) {
+      const profile = getResearchOutputProfileForEra(era);
+      const maximal = getReferenceEconomyOutput(era, 'maximal');
+
+      expect(Math.abs(profile.outputPerTurn - maximal.science)).toBeLessThanOrEqual(3);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Add a deterministic, production-budgeted representative economy diagnostic with canonical research progression and mixed-maturity city cohorts.
- Preserve the legacy bounded/maximal single-city profiles; maximal remains the era 10–13 research pacing target.
- Document the three-profile balance policy and harden building-closure handling against malformed or shared prerequisite data.

## Impact

This is balance tooling only. It does not change runtime gameplay rules, AI behavior, difficulty modes, UI/UX, audio, save data, solo play, or hot-seat play.

## Validation

- `./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-production-budget.test.ts tests/systems/pacing-reference-economy.test.ts tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts`
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test` (408 files; 6,708 passed, 3 skipped)

Closes #493.
