### PR TITLE
fix(test): resolve #608 local test timeouts from multi-agent CPU contention

### DIFF
--- a/.claude/hooks/require-green-before-push.sh
+++ b/.claude/hooks/require-green-before-push.sh
@@ -32,7 +32,7 @@ fi
 VERIFY_LOG="$(mktemp)"
 trap 'rm -f "$VERIFY_LOG"' EXIT
 
-if (cd "$PROJECT_DIR" && "$VERIFY") >"$VERIFY_LOG" 2>&1; then
+if (cd "$PROJECT_DIR" && "$VERIFY" --fast) >"$VERIFY_LOG" 2>&1; then
   exit 0
 fi
 

--- a/.claude/rules/hooks-and-tooling.md
+++ b/.claude/rules/hooks-and-tooling.md
@@ -42,21 +42,25 @@ paths:
 
 ## Pre-push gate: what it runs and how long it takes
 
-`require-green-before-push.sh` fires only for `git push`, `gh pr create`, and `gh pr merge` — not for `git commit`.
+`require-green-before-push.sh` fires only for `git push`, `gh pr create`, and `gh pr merge` — not for `git commit`. It delegates to `scripts/verify-before-push.sh`, which runs `yarn test`, then `yarn build` — **sequentially**, not in parallel (each `run_phase` call blocks before the next line runs).
 
-**From a worktree** (the common case for all Claude sessions):
-- `yarn install --immutable` — serial, ~3s
-- `tsc` + `vitest run --root <worktree>` — **parallel**, wall-clock ~25s (vitest dominates)
-- Shell hook smoke tests — serial after vitest, ~5s
-- **Total: ~35–45 seconds**
-
-**From the main tree:**
-- `yarn build` (tsc + vite bundle) then `yarn test` — sequential, ~50s total
+- **Local gate** (the real `.githooks/pre-push` hook, and this Claude Code hook): both call `verify-before-push.sh --fast`, which runs `yarn test:fast` — the fast tier only, see "Fast/slow test split" below.
+- **CI** (`yarn verify:push`, the `test` job in `.github/workflows/deploy.yml`, a required branch-protection status check on `main`): calls `verify-before-push.sh --no-mise` with no `--fast`, so it always runs the full `yarn test` (fast + slow tiers) as the actual merge gate, on isolated hardware.
 
 **Set Bash tool timeout to match the command, not the hook:**
 - `git commit` — **30 000 ms**. No hook runs tests; the commit itself takes < 1s.
-- `git push` / `gh pr create` / `gh pr merge` — **120 000 ms**. The hook runs tsc + vitest.
+- `git push` / `gh pr create` / `gh pr merge` — **120 000 ms** is enough for the local `--fast` gate. If you've just changed a slow-tier file and want to also verify it locally first (`yarn test:slow` or a targeted `yarn vitest run <file>`), do that as its own step before pushing — see #608 investigation notes above for observed durations up to ~600s worst case.
 - A 360 000 ms timeout on `git commit` papers over the wrong symptom. Match the timeout to what the command actually does.
+
+## Fast/slow test split (#608)
+
+`scripts/run-tests-by-tier.sh` splits the suite into two tiers, to keep the local push gate fast without losing coverage at merge time:
+
+- `yarn test:fast` (`run-tests-by-tier.sh fast`) — excludes the `SLOW_TEST_FILES` list defined in that script (currently: `ai-prepared-turn`, `basic-ai-worker-roads`, `turn-manager-beasts`, `save-load-mass-discovery`, `tech-panel`, `pacing-production-budget`, `pacing-reference-economy`, `start-placement-system`, `world-pressure-fairness`). This is what the local pre-push hook and the Claude Code push-gate hook actually run.
+- `yarn test:slow` (`run-tests-by-tier.sh slow`) — runs ONLY those files, for a developer working directly on one of those systems.
+- `yarn test` (full, unchanged) — always runs everything. This is what CI's required `test` status check runs; it is never given `--fast`, so slow-tier regressions still block merge, just not every local push.
+
+**When adding a new heavy multi-city/era/seed simulation test:** add its path to `SLOW_TEST_FILES` in `scripts/run-tests-by-tier.sh`, in addition to giving it an explicit headroom-sized timeout (see below) — the two are complementary: the timeout stops it from spuriously failing under contention, the tier split stops it from adding wall-clock/CPU cost to every local push-gate run in the first place.
 
 ## Vitest cache config
 
@@ -64,7 +68,46 @@ paths:
 
 **What this fixes:** Vite's dependency pre-bundling cache is shared across all worktrees.
 
-**What this does NOT change:** esbuild TypeScript transforms (~17s cumulative / ~2–3s wall-clock). That time is proportional to suite size (~300 files × 8 workers) and is inherent to every run. The ~26s floor is the cost of running the suite, not a cache miss.
+**What this does NOT change:** esbuild TypeScript transforms. That time is proportional to suite size and worker count (`test.maxWorkers: 4`, see #608 below) and is inherent to every run — it is not a cache miss.
+
+## Heavy simulation tests need an explicit, headroom-sized timeout (#608)
+
+This dev machine routinely runs several Claude Code worktree agents in parallel (verified: 200+
+worktree directories exist; a live agent was directly observed running the same test files
+concurrently during the #608 investigation), each invoking `yarn test` independently and each
+defaulting to vitest's own multi-worker sizing. That oversubscribes the machine's CPU whenever
+2-3 agents' test runs overlap, and it is not something a single repo-side config change can fully
+eliminate (`vite.config.ts`'s `test.maxWorkers: 4` caps one process's own worker count but can't
+stop several concurrent processes from adding up).
+
+Most of this suite is fine regardless, because most tests are cheap unit tests that finish in
+milliseconds even under contention. The failure mode is specific to a growing minority of tests
+that simulate real work — multi-city, multi-era, or multi-seed economic/AI projections
+(`pacing-reference-economy.test.ts`, `pacing-production-budget.test.ts`,
+`world-pressure-fairness.test.ts` are the current examples) — left on vitest's implicit 5s
+default. Only ~20 of the ~410 test files in this repo set an explicit timeout; everything else
+inherits that default, which assumes a quiet, uncontended machine and a cheap unit test. A new
+simulation-style test that forgets to override it will pass in isolation and then intermittently
+fail the moment a second agent's test run overlaps it — indistinguishable from a real regression
+until someone re-runs it alone.
+
+**When adding a test that simulates multiple cities/eras/seeds, builds a full timeline, or
+otherwise does real computational work rather than asserting against a small fixture:**
+
+- [ ] Set an explicit `it(name, fn, timeoutMs)` (or `{ timeout }` options object) — never rely on
+      the 5s default for this class of test.
+- [ ] Measure the test's actual duration under realistic local contention (run it while at least
+      one other `yarn test`/`vitest` process is active elsewhere), not just a solo run — a solo
+      timing will understate the real worst case.
+- [ ] Size the timeout at roughly 2x the worst observed duration, not the solo duration. This
+      repo's existing widened timeouts follow that ratio (e.g. `world-pressure-fairness.test.ts`
+      observed 462.7s under heavy contention → set to 600s; `pacing-reference-economy.test.ts`'s
+      four tests observed 11-42s → set to 45s/60s/75s/150s respectively).
+- [ ] Leave a one-line comment at the timeout citing the observed duration and referencing #608,
+      so a future reader doesn't "fix" the number back down to something that looks tighter but
+      reintroduces the flake.
+- [ ] Do not just raise the global vitest default instead of setting per-test timeouts — that
+      would mask a real hang in an actual cheap unit test for the other ~390 files.
 
 ## Worktree setup: trust mise before the first push
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,4 +40,4 @@ if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
   exit 1
 fi
 
-./scripts/verify-before-push.sh
+./scripts/verify-before-push.sh --fast

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ Civilization-building strategy game. TypeScript + Canvas 2D + Vite.
 1. Check if already in a worktree (`git worktree list`).
 2. If not, create one via `EnterWorktree` tool BEFORE writing any code.
 3. Never write code on `main` or on a feature branch in the main working tree — always use a worktree.
-4. After creating a new worktree, run `mise trust <worktree-path>/mise.toml` before the first push — otherwise the `run-with-mise-worktree.test.sh` smoke test will block the push.
+4. After creating a new worktree, run `./scripts/setup-git-hooks.sh` (or `bash scripts/run-with-mise.sh yarn setup:hooks`) immediately, then verify `git config --worktree --get core.hooksPath` returns `.githooks` — a worktree without this has its hooks silently resolve to `main`'s checkout or the plain git default, and `#608`'s investigation found this had regressed on 12 already-active worktrees.
+5. Also run `mise trust <worktree-path>/mise.toml` before the first push — otherwise the `run-with-mise-worktree.test.sh` smoke test will block the push.
 
 This is enforced by the user and is not optional.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "tauri:check:mac-artifacts": "node scripts/check-tauri-macos-artifacts.mjs",
     "setup:hooks": "sh scripts/setup-git-hooks.sh",
     "test": "vitest run && bash tests/hooks/run.sh",
+    "test:fast": "sh scripts/run-tests-by-tier.sh fast && bash tests/hooks/run.sh",
+    "test:slow": "sh scripts/run-tests-by-tier.sh slow",
     "test:ai-playability": "bash scripts/run-ai-playability-regressions.sh",
     "test:hooks": "bash tests/hooks/run.sh",
     "test:web-smoke": "playwright test",

--- a/scripts/run-tests-by-tier.sh
+++ b/scripts/run-tests-by-tier.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Splits the vitest suite into two tiers (#608). Most tests are cheap and
+# safe to run on every local push-gate. A small set of multi-city/era/seed
+# simulation tests are CPU-heavy enough that running them locally on a
+# machine that's also running other Claude Code worktree agents can
+# oversubscribe CPU and produce spurious timeouts even with no code
+# regression — see .claude/rules/hooks-and-tooling.md.
+#
+# fast: excludes SLOW_TEST_FILES. Used by the local git pre-push hook, the
+#       Claude Code push-gate hook, and `yarn test:fast` for day-to-day
+#       iteration.
+# slow: runs ONLY SLOW_TEST_FILES. For a developer working directly on one
+#       of these systems (`yarn test:slow`). CI's `yarn verify:push` does
+#       NOT use this split — it runs the full `yarn test` (fast + slow) as
+#       the required merge gate, on isolated hardware where contention isn't
+#       a factor.
+#
+# Adding a new heavy multi-city/era/seed simulation test? Add its path to
+# SLOW_TEST_FILES below, and give it an explicit headroom-sized timeout per
+# .claude/rules/hooks-and-tooling.md.
+
+set -eu
+
+SLOW_TEST_FILES="tests/ai/ai-prepared-turn.test.ts
+tests/ai/basic-ai-worker-roads.test.ts
+tests/core/turn-manager-beasts.test.ts
+tests/integration/save-load-mass-discovery.test.ts
+tests/ui/tech-panel.test.ts
+tests/systems/pacing-production-budget.test.ts
+tests/systems/pacing-reference-economy.test.ts
+tests/systems/start-placement-system.test.ts
+tests/systems/world-pressure-fairness.test.ts"
+
+MODE="${1:-}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+# Any remaining args (e.g. `--root <worktree>`, appended by
+# scripts/run-with-mise.sh so vitest targets the calling worktree) are kept
+# in "$@" and passed through to the final vitest invocation in both modes.
+case "$MODE" in
+  fast)
+    for f in $SLOW_TEST_FILES; do
+      set -- "$@" --exclude "$f"
+    done
+    exec yarn vitest run "$@"
+    ;;
+  slow)
+    # shellcheck disable=SC2086
+    exec yarn vitest run $SLOW_TEST_FILES "$@"
+    ;;
+  *)
+    echo "Usage: run-tests-by-tier.sh fast|slow [-- extra vitest args]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/run-with-mise.sh
+++ b/scripts/run-with-mise.sh
@@ -81,6 +81,20 @@ if [ -n "$MAIN_ROOT" ] && [ "$CURRENT_ROOT" != "$MAIN_ROOT" ]; then
         && run_without_local_git_env bash "$CURRENT_ROOT/tests/hooks/run.sh"
       exit
       ;;
+    yarn,test:fast)
+      # Same expansion as yarn,test, but via run-tests-by-tier.sh (#608) so
+      # the excluded heavy-simulation file list stays defined in one place.
+      shift 2
+      (cd "$MAIN_ROOT" && run_without_local_git_env "$MAIN_RUN" sh "$CURRENT_ROOT/scripts/run-tests-by-tier.sh" fast --root "$CURRENT_ROOT" "$@") \
+        && run_without_local_git_env bash "$CURRENT_ROOT/tests/hooks/run.sh"
+      exit
+      ;;
+    yarn,test:slow)
+      shift 2
+      cd "$MAIN_ROOT"
+      run_without_local_git_env "$MAIN_RUN" sh "$CURRENT_ROOT/scripts/run-tests-by-tier.sh" slow --root "$CURRENT_ROOT" "$@"
+      exit
+      ;;
     yarn,test:hooks)
       run_without_local_git_env bash "$CURRENT_ROOT/tests/hooks/run.sh"
       exit

--- a/scripts/verify-before-push.sh
+++ b/scripts/verify-before-push.sh
@@ -7,24 +7,37 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN="$REPO_ROOT/scripts/run-with-mise.sh"
 TIMEOUT_RUNNER="$REPO_ROOT/scripts/run-with-timeout.mjs"
 USE_MISE=1
+TEST_SCOPE=full
 
-case "${1:-}" in
-  --no-mise)
-    USE_MISE=0
-    shift
-    ;;
-  '')
-    ;;
-  *)
-    echo "Usage: verify-before-push.sh [--no-mise]" >&2
-    exit 2
-    ;;
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-mise)
+      USE_MISE=0
+      shift
+      ;;
+    --fast)
+      TEST_SCOPE=fast
+      shift
+      ;;
+    *)
+      echo "Usage: verify-before-push.sh [--no-mise] [--fast]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# --fast (#608) runs `yarn test:fast` instead of the full `yarn test`,
+# skipping the heavy multi-city/era/seed simulation tests tracked in
+# scripts/run-tests-by-tier.sh so the local push gate stays quick and
+# doesn't add CPU pressure on top of whatever else is running on this
+# machine. Only the local git pre-push hook and the Claude Code push-gate
+# hook pass --fast. CI's `yarn verify:push` never does — it always runs the
+# full suite as the required merge gate, on isolated hardware where
+# contention isn't a factor.
+case "$TEST_SCOPE" in
+  fast) TEST_YARN_SCRIPT=test:fast ;;
+  *) TEST_YARN_SCRIPT=test ;;
 esac
-
-[ "$#" -eq 0 ] || {
-  echo "Usage: verify-before-push.sh [--no-mise]" >&2
-  exit 2
-}
 
 TEST_TIMEOUT_SECONDS="${VERIFY_TEST_TIMEOUT_SECONDS:-600}"
 BUILD_TIMEOUT_SECONDS="${VERIFY_BUILD_TIMEOUT_SECONDS:-300}"
@@ -43,9 +56,9 @@ run_phase() {
 
 echo "Running pre-push verification: tests"
 if [ "$USE_MISE" -eq 1 ]; then
-  run_phase "$TEST_TIMEOUT_SECONDS" "test suite" "$RUN" yarn test
+  run_phase "$TEST_TIMEOUT_SECONDS" "test suite" "$RUN" yarn "$TEST_YARN_SCRIPT"
 else
-  run_phase "$TEST_TIMEOUT_SECONDS" "test suite" yarn test
+  run_phase "$TEST_TIMEOUT_SECONDS" "test suite" yarn "$TEST_YARN_SCRIPT"
 fi
 
 echo "Running pre-push verification: build"

--- a/tests/hooks/git-pre-push.test.sh
+++ b/tests/hooks/git-pre-push.test.sh
@@ -23,10 +23,12 @@ git -C "$tmpdir" commit -q -m base
 mkdir -p "$tmpdir/scripts"
 
 marker="$tmpdir/verifier-ran"
+args_log="$tmpdir/verifier-args"
 cat > "$tmpdir/scripts/verify-before-push.sh" <<'EOF'
 #!/bin/sh
 set -eu
 printf 'ran\n' >> "$VERIFY_MARKER"
+printf '%s\n' "$*" >> "$VERIFY_ARGS_LOG"
 exit "${VERIFY_STUB_STATUS:-0}"
 EOF
 chmod +x "$tmpdir/scripts/verify-before-push.sh"
@@ -39,12 +41,13 @@ zero_sha="$(printf '0%.0s' {1..40})"
 run_hook() {
   payload="$1"
   verifier_status="${2:-0}"
-  rm -f "$marker"
+  rm -f "$marker" "$args_log"
   set +e
   (
     cd "$tmpdir"
     printf '%s\n' "$payload" |
       VERIFY_MARKER="$marker" \
+      VERIFY_ARGS_LOG="$args_log" \
       VERIFY_STUB_STATUS="$verifier_status" \
       bash "$HOOK" origin unused
   ) >/dev/null 2>&1
@@ -59,6 +62,10 @@ run_hook "refs/heads/main $head_sha refs/heads/main $zero_sha"
 }
 [ -f "$marker" ] || {
   echo "pre-push did not invoke the canonical verifier"
+  exit 1
+}
+grep -q -- '--fast' "$args_log" || {
+  echo "pre-push did not invoke the canonical verifier with --fast (#608)"
   exit 1
 }
 

--- a/tests/hooks/require-green-before-push.test.sh
+++ b/tests/hooks/require-green-before-push.test.sh
@@ -10,10 +10,12 @@ trap 'rm -rf "$tmpdir"' EXIT
 mkdir -p "$tmpdir/scripts"
 
 marker="$tmpdir/verifier-ran"
+args_log="$tmpdir/verifier-args"
 cat > "$tmpdir/scripts/verify-before-push.sh" <<'EOF'
 #!/bin/sh
 set -eu
 printf 'ran\n' >> "$VERIFY_MARKER"
+printf '%s\n' "$*" >> "$VERIFY_ARGS_LOG"
 exit "${VERIFY_STUB_STATUS:-0}"
 EOF
 chmod +x "$tmpdir/scripts/verify-before-push.sh"
@@ -21,9 +23,10 @@ chmod +x "$tmpdir/scripts/verify-before-push.sh"
 run_hook() {
   payload="$1"
   verifier_status="${2:-0}"
-  rm -f "$marker"
+  rm -f "$marker" "$args_log"
   set +e
   VERIFY_MARKER="$marker" \
+    VERIFY_ARGS_LOG="$args_log" \
     VERIFY_STUB_STATUS="$verifier_status" \
     CLAUDE_PROJECT_DIR="$tmpdir" \
     bash "$HOOK" <<<"$payload" >/dev/null 2>&1
@@ -48,6 +51,10 @@ run_hook "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $tmpdir && gi
 }
 [ -f "$marker" ] || {
   echo "Claude push gate did not invoke the canonical verifier"
+  exit 1
+}
+grep -q -- '--fast' "$args_log" || {
+  echo "Claude push gate did not invoke the canonical verifier with --fast (#608)"
   exit 1
 }
 

--- a/tests/hooks/verify-before-push.test.sh
+++ b/tests/hooks/verify-before-push.test.sh
@@ -33,7 +33,7 @@ cat > "$fake_bin/yarn" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >> "$VERIFY_COMMAND_LOG"
 case "${1:-}" in
-  test) exit "${VERIFY_TEST_STATUS:-0}" ;;
+  test|test:fast) exit "${VERIFY_TEST_STATUS:-0}" ;;
   build) exit "${VERIFY_BUILD_STATUS:-0}" ;;
 esac
 exit 97
@@ -76,5 +76,34 @@ run_verifier 9 0
 }
 [ "$(wc -l < "$command_log" | tr -d ' ')" -eq 1 ] || {
   echo "canonical verifier ran build after tests failed"
+  exit 1
+}
+
+run_verifier_fast() {
+  rm -f "$command_log"
+  set +e
+  (
+    cd "$tmpdir"
+    PATH="$fake_bin:$PATH" \
+      VERIFY_COMMAND_LOG="$command_log" \
+      VERIFY_TEST_STATUS="${1:-0}" \
+      VERIFY_BUILD_STATUS="${2:-0}" \
+      sh scripts/verify-before-push.sh --no-mise --fast
+  ) >/dev/null 2>&1
+  verifier_status=$?
+  set -e
+}
+
+run_verifier_fast 0 0
+[ "$verifier_status" -eq 0 ] || {
+  echo "canonical verifier --fast rejected passing test/build phases"
+  exit 1
+}
+[ "$(sed -n '1p' "$command_log")" = "test:fast" ] || {
+  echo "canonical verifier --fast did not run the fast test suite: got $(sed -n '1p' "$command_log")"
+  exit 1
+}
+[ "$(sed -n '2p' "$command_log")" = "build" ] || {
+  echo "canonical verifier --fast did not run build second"
   exit 1
 }

--- a/tests/systems/pacing-production-budget.test.ts
+++ b/tests/systems/pacing-production-budget.test.ts
@@ -120,6 +120,12 @@ describe('representative production budget', () => {
     expect(result.completedBuildings).toEqual([]);
   });
 
+  // Timeouts below are widened from vitest's 5s default (#608): this machine
+  // routinely runs several Claude Code worktree agents concurrently, each
+  // invoking `yarn test` independently, and this simulation is CPU-heavy
+  // enough to blow past the default under that contention with no code
+  // regression (worst observed: 9.5s and 13.5s respectively). Each timeout
+  // carries roughly 2x headroom over the worst observed value.
   it('accounts for every allocated production point exactly once', () => {
     const result = simulateRepresentativeCity({
       cohort: { id: 'capital', foundedEra: 1 },
@@ -135,7 +141,7 @@ describe('representative production budget', () => {
     expect(Math.abs(accounted - result.infrastructureProductionAllocated)).toBeLessThanOrEqual(1e-9);
     expect(result.activeBuildingCount).toBeLessThanOrEqual(1);
     expect(result.cappedProductionEarned).toBeLessThanOrEqual(result.actualProductionEarned);
-  });
+  }, 25_000);
 
   it('gives later cohorts less production and no more population than the capital', () => {
     const timeline = buildRepresentativeResearchTimeline(10);
@@ -148,5 +154,5 @@ describe('representative production budget', () => {
 
     expect(frontier.actualProductionEarned).toBeLessThan(capital.actualProductionEarned);
     expect(frontier.population).toBeLessThanOrEqual(capital.population);
-  });
+  }, 30_000);
 });

--- a/tests/systems/pacing-reference-economy.test.ts
+++ b/tests/systems/pacing-reference-economy.test.ts
@@ -101,13 +101,23 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
 });
 
 describe('representative multi-city reference economy', () => {
+  // Timeouts below are widened from vitest's 5s/30s defaults (#608): this
+  // machine routinely runs several Claude Code worktree agents concurrently,
+  // each invoking `yarn test` independently, and this describe block's cohort
+  // simulation is CPU-heavy enough to blow past the defaults under that
+  // contention even with no code regression. Measured worst observed
+  // durations across two contended runs: cohort count 19.1s, empire-flat
+  // yields 31.7s, unrounded averages 40.6s, infrastructure ordering 84.9s.
+  // Each timeout below carries roughly 2x headroom over the worst observed
+  // value, not the solo-run duration, so it still catches a genuine
+  // regression while tolerating 2-3 concurrent agents on this hardware.
   it('uses the documented 1/3/5/7/9 cohort count', () => {
     expect(getRepresentativeEmpireOutput(1).cityCount).toBe(1);
     expect(getRepresentativeEmpireOutput(3).cityCount).toBe(2);
     expect(getRepresentativeEmpireOutput(5).cityCount).toBe(3);
     expect(getRepresentativeEmpireOutput(7).cityCount).toBe(4);
     expect(getRepresentativeEmpireOutput(9).cityCount).toBe(5);
-  });
+  }, 45_000);
 
   it('applies empire-flat yields once after city aggregation', () => {
     const output = getRepresentativeEmpireOutput(10);
@@ -121,7 +131,7 @@ describe('representative multi-city reference economy', () => {
       science: Math.round(cityTotals.science + flat.science),
       production: Math.round(cityTotals.production + flat.production),
     });
-  });
+  }, 60_000);
 
   it('derives averages from unrounded empire totals', () => {
     const output = getRepresentativeEmpireOutput(10);
@@ -135,7 +145,7 @@ describe('representative multi-city reference economy', () => {
       science: Number(((cityTotals.science + flat.science) / output.cityCount).toFixed(2)),
       production: Number(((cityTotals.production + flat.production) / output.cityCount).toFixed(2)),
     });
-  });
+  }, 75_000);
 
   it('orders infrastructure allocation across sensitivity shares', () => {
     const light = getRepresentativeEmpireOutput(10, { infrastructureShare: 0.5 });
@@ -146,7 +156,7 @@ describe('representative multi-city reference economy', () => {
 
     expect(allocated(light)).toBeLessThan(allocated(canonical));
     expect(allocated(canonical)).toBeLessThan(allocated(heavy));
-  }, 30_000);
+  }, 150_000);
 
   it('pins the canonical 60% representative profile for eras 10-13', () => {
     const outputs = [10, 11, 12, 13].map(era => {

--- a/tests/systems/world-pressure-fairness.test.ts
+++ b/tests/systems/world-pressure-fairness.test.ts
@@ -137,6 +137,11 @@ describe('world pressure fairness (#529 MR3)', () => {
       // despite no measurable scheduling imbalance.
       expect(averageAiRate).toBeLessThanOrEqual(averageHumanRate * 1.6 + 1 / aiSamples);
     },
-    120_000,
+    // Widened from 120s (#608): under contention from concurrent Claude Code
+    // worktree agents on this dev machine, this simulation (3 seeds x 150
+    // turns) was observed taking up to 462.7s with no code regression. 600s
+    // gives headroom above that worst-observed value while still failing on
+    // a genuine hang or runaway simulation.
+    600_000,
   );
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,15 @@ export default defineConfig(({ mode }) => {
       // transform time (~17s cumulative) is inherent to 300+ test files and 8 workers
       // and is NOT reduced by this cache — that time is fixed by the suite size.
       cacheDir: resolve(__dirname, 'node_modules/.vite/vitest'),
+      // Cap worker count well below the machine's core count (#608). This dev machine
+      // routinely runs several Claude Code worktree agents in parallel, each invoking
+      // `yarn test` independently; with the default pool sizing (~8 workers each on a
+      // 10-core box), 2-3 concurrent runs oversubscribe CPU 2-3x and inflate individual
+      // test durations past their timeout budgets (observed: a 548s/16-timeout run with
+      // heavy contention, still 5 timeouts at ~213s with just one other partial run
+      // active). Capping to 4 leaves headroom for another agent's run without giving up
+      // meaningful parallelism for a solo run.
+      maxWorkers: 4,
     },
   };
 });


### PR DESCRIPTION
## Summary

Root cause for #608: this dev machine routinely runs several Claude Code worktree agents in parallel, each invoking `yarn test` independently. Vitest's default worker sizing oversubscribes CPU when runs overlap (verified: 200+ worktree dirs exist; caught a live agent running the exact same suspect test files concurrently during this investigation; load averages of 25/19/16 on a 10-core machine). A handful of new multi-city/era/seed simulation tests, left on vitest's 5s default timeout, were the first to fail under that contention — not a code regression.

- Cap `vite.config.ts`'s `test.maxWorkers` to 4 so a single run can't claim all cores.
- Widen timeouts (with measured-headroom comments citing observed durations) on the tests that actually failed during investigation: 4 in `pacing-reference-economy.test.ts`, 1 in `world-pressure-fairness.test.ts`, 2 in `pacing-production-budget.test.ts`.
- Split the suite into fast/slow tiers (`scripts/run-tests-by-tier.sh`, `yarn test:fast` / `yarn test:slow`) covering the 9 heavy files from the original #608 baseline. The local pre-push git hook and the Claude Code push-gate hook now run the fast tier only. CI's `yarn verify:push` is untouched and still runs the full suite as the required `test`/`build` merge gate (confirmed via branch protection) on isolated, contention-free hardware.
- Fix `scripts/run-with-mise.sh`'s worktree routing for the two new yarn scripts — its generic passthrough would have silently re-run them against the main worktree's package.json, which doesn't have them until merged.
- Document the timeout-hygiene convention and the tier split in `.claude/rules/hooks-and-tooling.md`, and correct two stale claims found while investigating (pre-push phases run sequentially, not in parallel; worker count is 4, not 8).

## Test plan

- [x] `yarn test:fast` — 401/410 files, 6666 tests, ~71s (excludes the 9 heavy files)
- [x] `yarn test:slow` — 9/9 files, 115 tests, ~40s
- [x] `yarn test` (full) — 410/410 files, 6781 tests + 3 skipped, clean
- [x] `bash tests/hooks/run.sh` — all 13 shell hook smoke tests pass, including new `--fast` assertions in `verify-before-push.test.sh`, `git-pre-push.test.sh`, `require-green-before-push.test.sh`
- [x] `yarn build` — passes

Note: the actual local git `pre-push` hook is resolved via `core.hooksPath` pointing at the main worktree's checkout, so this PR's hook changes only take full effect after merge (until then, local pushes redundantly run both the new fast tier via the Claude Code hook and the old full suite via the stale git hook — harmless, just slower).

🤖 Generated with [Claude Code](https://claude.com/claude-code)