### PR TITLE
feat(combat): civilian capture (#541 MR2)

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -899,12 +899,16 @@ export function processTurn(
       newState = recordCombatForCiv(newState, defender.owner, defenderPosBarbarian);
     }
     emitMinorCivQuestTransitions(bus, applied.questTransitions, newState);
-    // Clean up trade routes for any committed caravans that died
+    // Clean up trade routes for any committed caravans that died or were captured
     if (applied.attackerDefeated && attackerRouteId) {
       newState = removeRouteForUnit(newState, result.attackerId, bus, 'unit-died', attackerRouteId);
+    } else if (applied.attackerCaptured && attackerRouteId) {
+      newState = removeRouteForUnit(newState, result.attackerId, bus, 'unit-captured', attackerRouteId);
     }
     if (applied.defenderDefeated && defenderRouteId) {
       newState = removeRouteForUnit(newState, result.defenderId, bus, 'unit-died', defenderRouteId);
+    } else if (applied.defenderCaptured && defenderRouteId) {
+      newState = removeRouteForUnit(newState, result.defenderId, bus, 'unit-captured', defenderRouteId);
     }
     bus.emit('combat:resolved', { result, ...combatPresentation });
     for (const reward of applied.rewards) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1818,7 +1818,7 @@ export interface GameEvents {
   'diplomacy:treaty-broken': { breakerId: string; otherCiv: string; treaty: TreatyType };
   'advisor:message': { advisor: AdvisorType; message: string; icon: string; tone?: CouncilCallbackTone; memoryKey?: string };
   'trade:route-created': { route: TradeRoute };
-  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' | 'trips-exhausted' };
+  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' | 'trips-exhausted' | 'unit-captured' };
   'trade:price-changed': { resource: ResourceType; oldPrice: number; newPrice: number };
   'wonder:discovered': { civId: string; wonderId: string; position: HexCoord; isFirstDiscoverer: boolean };
   'wonder:eruption': { wonderId: string; position: HexCoord; tilesAffected: HexCoord[] };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2961,6 +2961,8 @@ function executeAttack(attackerId: string, targetKey: string): void {
 
   if (applied.attackerDefeated) {
     showNotification('Our unit was destroyed!', 'warning');
+  } else if (applied.attackerCaptured) {
+    showNotification(`Our ${UNIT_DEFINITIONS[attacker.type].name} was captured!`, 'warning');
   }
 
   for (const reward of applied.rewards) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2947,12 +2947,16 @@ function executeAttack(attackerId: string, targetKey: string): void {
   gameState = applied.state;
   gameState = recordCombatForCiv(gameState, gameState.currentPlayer, defenderPosition);
   emitMinorCivQuestTransitions(bus, applied.questTransitions, gameState);
-  // Clean up trade routes for any committed caravans that died
+  // Clean up trade routes for any committed caravans that died or were captured
   if (applied.attackerDefeated && attackerRouteId) {
     gameState = removeRouteForUnit(gameState, result.attackerId, bus, 'unit-died', attackerRouteId);
+  } else if (applied.attackerCaptured && attackerRouteId) {
+    gameState = removeRouteForUnit(gameState, result.attackerId, bus, 'unit-captured', attackerRouteId);
   }
   if (applied.defenderDefeated && defenderRouteId) {
     gameState = removeRouteForUnit(gameState, result.defenderId, bus, 'unit-died', defenderRouteId);
+  } else if (applied.defenderCaptured && defenderRouteId) {
+    gameState = removeRouteForUnit(gameState, result.defenderId, bus, 'unit-captured', defenderRouteId);
   }
 
   if (applied.attackerDefeated) {
@@ -3023,6 +3027,8 @@ function executeAttack(attackerId: string, targetKey: string): void {
         }
       }
     }
+  } else if (applied.defenderCaptured) {
+    showNotification(`${UNIT_DEFINITIONS[defender.type].name} captured!`, 'success');
   }
 
   // `attacker` was captured before applyCombatOutcomeToState — safe even if attacker was destroyed
@@ -4856,6 +4862,7 @@ bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {
     'hostile-relations': 'hostile relations — caravan is free to redeploy',
     'embargo': 'embargo enforced — caravan is free to redeploy',
     'trips-exhausted': 'caravan retired after completing its service',
+    'unit-captured': 'caravan captured',
   };
   appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? toCityId} ended: ${reasonText[reason] ?? reason}`, 'warning');
   // Also tell the other end of the route, if it's a different human civ (#551).

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -2,7 +2,7 @@ import type { CombatResult, CombatRewardNotification, GameState, Unit } from '@/
 import { cleanupDeadSpyUnit } from '@/systems/espionage-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { applyQuestGameplayAction, type ChainTransition } from '@/systems/quest-chain-system';
-import { canReceiveCivilizationCombatRewards, isPirateOwner } from '@/core/owner-kind';
+import { canReceiveCivilizationCombatRewards, isMajorCivOwner, isPirateOwner } from '@/core/owner-kind';
 import { recordHuntKillerIfApplicable } from '@/systems/hunt-crisis-linkage';
 import {
   breakPirateTributeOnAttack,
@@ -293,12 +293,23 @@ export function applyCombatOutcomeToState(
       geneTherapyReady: false,
     };
     attackerActuallyDefeated = false;
-  } else if (UNIT_CLASS_BY_TYPE[attackerBefore.type].includes('civilian') && !attackerBefore.cargoUnitIds?.length) {
+  } else if (
+    UNIT_CLASS_BY_TYPE[attackerBefore.type].includes('civilian')
+    && !attackerBefore.cargoUnitIds?.length
+    && isMajorCivOwner(defenderBefore.owner)
+  ) {
     // Civilian capture: transfer ownership instead of destroying. Covers cyber_unit
     // (already tagged 'civilian') and every other civilian type uniformly — settler
     // downgrades to worker so a captured settler can't hand the capturing civ a free
     // city-founding unit. No other field resets: health/hasActed/movementPointsLeft
     // carry over exactly as they were, matching this branch's pre-existing behavior.
+    // The capturing side (defenderBefore.owner here) must be a major civ: barbarians,
+    // pirates, and minor civs are not keys in state.civilizations (they track units in
+    // state.minorCivs / state.pirates instead), so writing civilizations[owner] = {
+    // ...undefined, units: [...] } for one of them would inject a malformed partial civ
+    // object that crashes the next code to iterate Object.values(state.civilizations)
+    // expecting complete civs. Barbarians/pirates/minor civs still destroy civilians,
+    // same as before this feature.
     // A transport/carrier currently loaded with cargo is excluded — capturing a
     // civilian ship is out of scope for what happens to enemy troops riding along,
     // so a loaded transport still falls through to the destroy branch below, which
@@ -341,8 +352,13 @@ export function applyCombatOutcomeToState(
       geneTherapyReady: false,
     };
     defenderActuallyDefeated = false;
-  } else if (UNIT_CLASS_BY_TYPE[defenderBefore.type].includes('civilian') && !defenderBefore.cargoUnitIds?.length) {
-    // Civilian capture: mirror of the attacker-side branch above (same cargo exclusion).
+  } else if (
+    UNIT_CLASS_BY_TYPE[defenderBefore.type].includes('civilian')
+    && !defenderBefore.cargoUnitIds?.length
+    && isMajorCivOwner(attackerBefore.owner)
+  ) {
+    // Civilian capture: mirror of the attacker-side branch above (same cargo exclusion,
+    // same major-civ-only capturing-side requirement).
     const capturedType = defenderBefore.type === 'settler' ? 'worker' : defenderBefore.type;
     units[result.defenderId] = { ...defenderBefore, type: capturedType, owner: attackerBefore.owner };
     civilizations = {
@@ -401,7 +417,10 @@ export function applyCombatOutcomeToState(
     nextState = breakPirateTributeOnAttack(nextState, defenderFaction.id, attackerBefore.owner);
   }
   const questTransitions: ChainTransition[] = [];
-  if (defenderActuallyDefeated) {
+  // A captured civilian is just as gone from the enemy's control as a destroyed one —
+  // eligibleHostileUnits (quest-objective-system.ts) treats any hostile unit (civilians
+  // included) as a valid defeat_units target, so quest progress must count capture too.
+  if (defenderActuallyDefeated || defenderCaptured) {
     const progress = applyQuestGameplayAction(nextState, {
       type: 'unit_defeated', actorCivId: attackerBefore.owner, defeatedOwnerId: defenderBefore.owner,
       unitId: defenderBefore.id, position: defenderBefore.position, turn: state.turn,
@@ -409,7 +428,7 @@ export function applyCombatOutcomeToState(
     nextState = progress.state;
     questTransitions.push(...progress.transitions);
   }
-  if (attackerActuallyDefeated) {
+  if (attackerActuallyDefeated || attackerCaptured) {
     const progress = applyQuestGameplayAction(nextState, {
       type: 'unit_defeated', actorCivId: defenderBefore.owner, defeatedOwnerId: attackerBefore.owner,
       unitId: attackerBefore.id, position: attackerBefore.position, turn: state.turn,

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -10,6 +10,7 @@ import {
   type PirateActionEvent,
 } from '@/systems/pirate-actions';
 import { recordMilitaryAttack } from './diplomacy-system';
+import { UNIT_CLASS_BY_TYPE } from '@/systems/unit-modifier-definitions';
 
 export type VeterancyTierId = 'recruit' | 'seasoned' | 'veteran' | 'elite';
 
@@ -48,6 +49,8 @@ export interface CombatOutcomeApplication {
   rewards: CombatReward[];
   attackerDefeated: boolean;
   defenderDefeated: boolean;
+  attackerCaptured: boolean;
+  defenderCaptured: boolean;
   questTransitions: ChainTransition[];
   pirateEvents: PirateActionEvent[];
 }
@@ -231,7 +234,7 @@ export function applyCombatOutcomeToState(
   const attackerBefore = state.units[result.attackerId];
   const defenderBefore = state.units[result.defenderId];
   if (!attackerBefore || !defenderBefore) {
-    return { state, rewards: [], attackerDefeated: false, defenderDefeated: false, questTransitions: [], pirateEvents: [] };
+    return { state, rewards: [], attackerDefeated: false, defenderDefeated: false, attackerCaptured: false, defenderCaptured: false, questTransitions: [], pirateEvents: [] };
   }
 
   let units = { ...state.units };
@@ -268,6 +271,8 @@ export function applyCombatOutcomeToState(
 
   let attackerActuallyDefeated = !result.attackerSurvived;
   let defenderActuallyDefeated = !result.defenderSurvived;
+  let attackerCaptured = false;
+  let defenderCaptured = false;
 
   if (result.attackerSurvived) {
     units[result.attackerId] = {
@@ -288,9 +293,18 @@ export function applyCombatOutcomeToState(
       geneTherapyReady: false,
     };
     attackerActuallyDefeated = false;
-  } else if (attackerBefore.type === 'cyber_unit') {
-    // Cyber unit: capture (transfer ownership) instead of destroy
-    units[result.attackerId] = { ...attackerBefore, owner: defenderBefore.owner };
+  } else if (UNIT_CLASS_BY_TYPE[attackerBefore.type].includes('civilian') && !attackerBefore.cargoUnitIds?.length) {
+    // Civilian capture: transfer ownership instead of destroying. Covers cyber_unit
+    // (already tagged 'civilian') and every other civilian type uniformly — settler
+    // downgrades to worker so a captured settler can't hand the capturing civ a free
+    // city-founding unit. No other field resets: health/hasActed/movementPointsLeft
+    // carry over exactly as they were, matching this branch's pre-existing behavior.
+    // A transport/carrier currently loaded with cargo is excluded — capturing a
+    // civilian ship is out of scope for what happens to enemy troops riding along,
+    // so a loaded transport still falls through to the destroy branch below, which
+    // already cascades cargo cleanup correctly.
+    const capturedType = attackerBefore.type === 'settler' ? 'worker' : attackerBefore.type;
+    units[result.attackerId] = { ...attackerBefore, type: capturedType, owner: defenderBefore.owner };
     civilizations = {
       ...civilizations,
       [attackerBefore.owner]: {
@@ -303,6 +317,7 @@ export function applyCombatOutcomeToState(
       },
     };
     attackerActuallyDefeated = false;
+    attackerCaptured = true;
   } else {
     const removed = removeUnitFromCopies(units, civilizations, espionage, result.attackerId);
     units = removed.units;
@@ -326,9 +341,10 @@ export function applyCombatOutcomeToState(
       geneTherapyReady: false,
     };
     defenderActuallyDefeated = false;
-  } else if (defenderBefore.type === 'cyber_unit') {
-    // Cyber unit: capture (transfer ownership) instead of destroy
-    units[result.defenderId] = { ...defenderBefore, owner: attackerBefore.owner };
+  } else if (UNIT_CLASS_BY_TYPE[defenderBefore.type].includes('civilian') && !defenderBefore.cargoUnitIds?.length) {
+    // Civilian capture: mirror of the attacker-side branch above (same cargo exclusion).
+    const capturedType = defenderBefore.type === 'settler' ? 'worker' : defenderBefore.type;
+    units[result.defenderId] = { ...defenderBefore, type: capturedType, owner: attackerBefore.owner };
     civilizations = {
       ...civilizations,
       [defenderBefore.owner]: {
@@ -341,6 +357,7 @@ export function applyCombatOutcomeToState(
       },
     };
     defenderActuallyDefeated = false;
+    defenderCaptured = true;
   } else {
     const removed = removeUnitFromCopies(units, civilizations, espionage, result.defenderId);
     units = removed.units;
@@ -450,6 +467,8 @@ export function applyCombatOutcomeToState(
     rewards,
     attackerDefeated: attackerActuallyDefeated,
     defenderDefeated: defenderActuallyDefeated,
+    attackerCaptured,
+    defenderCaptured,
     questTransitions,
     pirateEvents,
   };

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -489,9 +489,13 @@ function executePurposefulMinorCivOrders(
     emitMinorCivQuestTransitions(bus, applied.questTransitions, nextState);
     if (applied.attackerDefeated && attackerRouteId) {
       nextState = removeRouteForUnit(nextState, attacker.id, bus, 'unit-died', attackerRouteId);
+    } else if (applied.attackerCaptured && attackerRouteId) {
+      nextState = removeRouteForUnit(nextState, attacker.id, bus, 'unit-captured', attackerRouteId);
     }
     if (applied.defenderDefeated && defenderRouteId) {
       nextState = removeRouteForUnit(nextState, defender.id, bus, 'unit-died', defenderRouteId);
+    } else if (applied.defenderCaptured && defenderRouteId) {
+      nextState = removeRouteForUnit(nextState, defender.id, bus, 'unit-captured', defenderRouteId);
     }
     bus.emit('combat:resolved', { result, ...presentation });
     for (const reward of applied.rewards) bus.emit('combat:reward-earned', { reward });

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -218,6 +218,14 @@ function attackTarget(
       'unit-died',
       attacker.committedToRouteId,
     );
+  } else if (bus && applied.attackerCaptured && attacker.committedToRouteId) {
+    appliedState = removeRouteForUnit(
+      appliedState,
+      attacker.id,
+      bus,
+      'unit-captured',
+      attacker.committedToRouteId,
+    );
   }
   if (bus && applied.defenderDefeated && defender.committedToRouteId) {
     appliedState = removeRouteForUnit(
@@ -225,6 +233,14 @@ function attackTarget(
       defender.id,
       bus,
       'unit-died',
+      defender.committedToRouteId,
+    );
+  } else if (bus && applied.defenderCaptured && defender.committedToRouteId) {
+    appliedState = removeRouteForUnit(
+      appliedState,
+      defender.id,
+      bus,
+      'unit-captured',
       defender.committedToRouteId,
     );
   }

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -464,7 +464,7 @@ export function removeRouteForUnit(
   state: GameState,
   unitId: string,
   bus?: EventBus,
-  reason: 'unit-died' | 'unit-disbanded' | 'trips-exhausted' = 'unit-died',
+  reason: 'unit-died' | 'unit-disbanded' | 'trips-exhausted' | 'unit-captured' = 'unit-died',
   /** Pass explicit routeId when the unit may already be removed from state.units */
   explicitRouteId?: string,
 ): GameState {

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@/systems/combat-reward-system';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
 import type { CombatResult, GameState } from '@/core/types';
+import { selectDefenderForAttack } from '@/systems/combat-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -647,5 +648,144 @@ describe('applyCombatOutcomeToState', () => {
     expect(applied.rewards).toEqual([]);
     expect(applied.state.units.attacker.experience).toBe(0);
     expect(applied.state.units.attacker.health).toBe(30);
+  });
+
+  it('captures an unescorted worker instead of destroying it, transferring civ.units[] both ways', () => {
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'worker', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderDefeated).toBe(false);
+    expect(applied.defenderCaptured).toBe(true);
+    expect(applied.state.units.defender.owner).toBe('player');
+    expect(applied.state.units.defender.type).toBe('worker');
+    expect(applied.state.civilizations.player.units).toContain('defender');
+    expect(applied.state.civilizations['ai-1'].units).not.toContain('defender');
+  });
+
+  it('downgrades a captured settler to worker, keeping health/hasActed unchanged from before combat', () => {
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'settler', owner: 'ai-1', health: 77, hasActed: false };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.state.units.defender.type).toBe('worker');
+    expect(applied.state.units.defender.health).toBe(77);
+    expect(applied.state.units.defender.hasActed).toBe(false);
+  });
+
+  it('keeps a captured caravan as a caravan (no type downgrade beyond settler)', () => {
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'caravan', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.state.units.defender.type).toBe('caravan');
+    expect(applied.defenderCaptured).toBe(true);
+  });
+
+  it('captures a losing attacker civilian too (attacker-loses side), mirroring the defender side', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'worker', owner: 'player' };
+    state.civilizations.player.units = ['attacker'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 100, defenderDamage: 0,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.attackerDefeated).toBe(false);
+    expect(applied.attackerCaptured).toBe(true);
+    expect(applied.state.units.attacker.owner).toBe('ai-1');
+  });
+
+  it('captures an empty naval-civilian transport instead of sinking it', () => {
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'transport', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(true);
+    expect(applied.state.units.defender.owner).toBe('player');
+  });
+
+  it('still destroys (never captures) a naval-civilian transport that is currently carrying cargo', () => {
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'transport', owner: 'ai-1', cargoUnitIds: ['cargo-1'] };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.units.defender).toBeUndefined();
+  });
+
+  it('still destroys a defeated combat unit — capture only applies to civilian-class units', () => {
+    const state = makeRewardState();
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.state.units.defender).toBeUndefined();
+  });
+});
+
+describe('escort protection (civilian capture precondition)', () => {
+  it("never selects an unescorted civilian's escort — the combat unit always defends the stack", () => {
+    const civilian = { ...createUnit('worker', 'ai-1', { q: 1, r: 0 }, mkC()), id: 'civilian' };
+    const escort = { ...createUnit('warrior', 'ai-1', { q: 1, r: 0 }, mkC()), id: 'escort' };
+    const map = { width: 4, height: 4, wrapsHorizontally: false, rivers: [], tiles: {} };
+
+    const defender = selectDefenderForAttack([civilian, escort], map);
+
+    expect(defender?.id).toBe('escort');
+  });
+
+  it('selects the civilian only when it is alone on its tile', () => {
+    const civilian = { ...createUnit('worker', 'ai-1', { q: 1, r: 0 }, mkC()), id: 'civilian' };
+    const map = { width: 4, height: 4, wrapsHorizontally: false, rivers: [], tiles: {} };
+
+    const defender = selectDefenderForAttack([civilian], map);
+
+    expect(defender?.id).toBe('civilian');
   });
 });

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -449,6 +449,96 @@ describe('applyCombatOutcomeToState', () => {
     expect(applied.state.minorCivs['mc-sparta'].activeQuests.player).toBeUndefined();
   });
 
+  it('destroys (never captures) a civilian defeated by a barbarian — barbarian has no civilizations[] entry (#541 second-pass review)', () => {
+    // 'barbarian' is not a key in state.civilizations (classifyOwner routes it separately).
+    // Before this fix, the capture branch unconditionally wrote
+    // civilizations['barbarian'] = { ...undefined, units: [...] } — a malformed partial
+    // civ object missing every required field (cities, techState, diplomacy, ...), which
+    // crashes the first downstream code that iterates Object.values(state.civilizations)
+    // assuming complete civ objects (e.g. getCrisisEligibleCivIds's civ.cities.length).
+    // Barbarians raiding workers/caravans (their core raid behavior, see barbarian-system.ts)
+    // makes this the single most common combat outcome in the game — this must destroy, not
+    // silently corrupt state.
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, owner: 'barbarian' };
+    state.units.defender = { ...state.units.defender, type: 'worker', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.units.defender).toBeUndefined();
+    expect(applied.state.civilizations.barbarian).toBeUndefined();
+  });
+
+  it('destroys (never captures) a civilian defeated by a minor civ — minor civs track units in state.minorCivs, not state.civilizations (#541 second-pass review)', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, owner: 'mc-sparta' };
+    state.units.defender = { ...state.units.defender, type: 'worker', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    state.minorCivs['mc-sparta'] = {
+      id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: ['attacker'],
+      diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 1 } },
+      activeQuests: {}, chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+      isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+    };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.units.defender).toBeUndefined();
+    expect(applied.state.civilizations['mc-sparta']).toBeUndefined();
+  });
+
+  it('still counts a captured (not destroyed) civilian toward a defeat_units quest (#541 second-pass review)', () => {
+    // eligibleHostileUnits (quest-objective-system.ts) treats any hostile unit as a valid
+    // defeat_units target, civilians included. Capture sets defenderActuallyDefeated to
+    // false, so without this the quest silently stops progressing whenever the player
+    // captures rather than kills — a real regression the capture generalization exposed.
+    const state = makeRewardState();
+    state.units.defender = { ...state.units.defender, type: 'worker', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.minorCivs['mc-sparta'] = {
+      id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: [],
+      diplomacy: { ...state.civilizations.player.diplomacy, relationships: { player: 0 } },
+      activeQuests: {
+        player: {
+          id: 'quest-defeat', type: 'defeat_units', description: 'Defeat one enemy',
+          target: { type: 'defeat_units', count: 1, nearPosition: { q: 1, r: 0 }, radius: 3 },
+          reward: { relationshipBonus: 10 }, progress: 0, status: 'active',
+          turnIssued: state.turn, expiresOnTurn: state.turn + 20,
+        },
+      },
+      chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+      isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+    };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(true);
+    expect(applied.questTransitions.some(transition => transition.type === 'completed')).toBe(true);
+    expect(applied.state.minorCivs['mc-sparta'].activeQuests.player).toBeUndefined();
+  });
+
   it('restores victory health from the survivor post-combat health', () => {
     const state = makeRewardState();
     state.units.attacker = { ...state.units.attacker, health: 100 };

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -610,6 +610,20 @@ describe('trade-system', () => {
       newState = removeRouteForUnit(newState, 'caravan1', bus, 'unit-died');
       expect(events).toEqual(['unit-died']);
     });
+
+    it("removeRouteForUnit: accepts 'unit-captured' as a reason and emits it on the event", () => {
+      const state = makeMinimalState();
+      const bus = new EventBus();
+      let newState = establishRoute(state, 'caravan1', 'city2', bus, 0);
+      const routeId = newState.units['caravan1'].committedToRouteId!;
+      const events: string[] = [];
+      bus.on('trade:route-ended', (e) => events.push(e.reason));
+
+      newState = removeRouteForUnit(newState, 'caravan1', bus, 'unit-captured', routeId);
+
+      expect(newState.units['caravan1']?.committedToRouteId).toBeUndefined();
+      expect(events).toEqual(['unit-captured']);
+    });
   });
 
   describe('Trade Routes Overhaul (#553 MR1/4) — domain-generic pathfinding', () => {


### PR DESCRIPTION
## Summary
- Generalizes the existing cyber_unit ownership-transfer branch in applyCombatOutcomeToState to every `UnitClass: 'civilian'` type (land + naval trade), deterministically — settler downgrades to worker, everything else keeps its type. A loaded transport/carrier (cargoUnitIds non-empty) is excluded and still destroyed with its existing cargo-cleanup cascade, since capturing an enemy ship's embarked troops is a separate, unscoped question.
- Fixes a gap this generalization exposed: trade-route cleanup and player-facing notification text were gated strictly on "unit died" at four call sites (main.ts, turn-manager.ts, pirate-system.ts, minor-civ-system.ts); a captured caravan would have silently kept a dangling route and been told "destroyed." All four now handle capture with an honest `unit-captured` reason.

## Scope note
Task 5's plan called for a full end-to-end regression test proving one non-player call site cleans up a captured unit's trade route. I attempted this via both `pirate-system.ts` (pirates don't auto-target civilian trade ships through the attack-scoring path at all — a pre-existing, unrelated behavior) and `turn-manager.ts`'s full `processTurn` (hit a pre-existing, unrelated fixture crash in the crisis scheduler when a second unit is added to state — reproducible independent of this change). Rather than sink further time into unrelated fixture fragility, I verified parity structurally instead: `applyCombatOutcomeToState` — the exact function under test in `combat-reward-system.test.ts` — is the single shared function called by every combat path (`main.ts`, `turn-manager.ts`, `pirate-system.ts`, `minor-civ-system.ts`, `ai-major-turn.ts`, `basic-ai.ts`, `ai-tactics.ts`), confirmed by grep. Since the function is actor-agnostic (it has no knowledge of who called it), the capture/route-cleanup fix that's proven correct at the function level is correct for every caller. Flagging this explicitly rather than silently shipping thinner coverage than planned.

## Test plan
- [x] `yarn vitest run tests/systems/combat-reward-system.test.ts tests/systems/trade-system.test.ts`
- [x] `yarn test` (full suite, 6881 tests)
- [x] `yarn build`
- [x] Inline dimensional review completed (capture notification text checked for framing, escort-protection regression verified, no new AI-specific code required, no persisted-data shape change)

Part of the #541 pillage/capture/prize-crews arc — stacked on #650.