### PR TITLE
feat(combat): prize-crew naval capture (#541 MR3)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1159,6 +1159,8 @@ export interface CombatResult {
   defenderDamage: number;
   attackerSurvived: boolean;
   defenderSurvived: boolean;
+  attackerStrength: number;
+  defenderStrength: number;
   attackerPosition: HexCoord;
   defenderPosition: HexCoord;
   exchange?: CombatExchangeSummary;

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ import {
   NO_LAND_UNIT_WATER_RECOVERY,
   type LandUnitWaterRecovery,
 } from '@/systems/unit-water-recovery';
-import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
 import { resolveCivilizationEra } from '@/systems/tech-definitions';
@@ -3030,7 +3030,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
       }
     }
   } else if (applied.defenderCaptured) {
-    showNotification(`${UNIT_DEFINITIONS[defender.type].name} captured!`, 'success');
+    showNotification(getCaptureNotificationLabel(defender.type), 'success');
   }
 
   // `attacker` was captured before applyCombatOutcomeToState — safe even if attacker was destroyed

--- a/src/main.ts
+++ b/src/main.ts
@@ -2962,7 +2962,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
   if (applied.attackerDefeated) {
     showNotification('Our unit was destroyed!', 'warning');
   } else if (applied.attackerCaptured) {
-    showNotification(`Our ${UNIT_DEFINITIONS[attacker.type].name} was captured!`, 'warning');
+    showNotification(`Our ${getCaptureNotificationLabel(attacker.type)}`, 'warning');
   }
 
   for (const reward of applied.rewards) {

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -373,6 +373,13 @@ export function applyCombatOutcomeToState(
     result.defenderSurvived
     && isCapturableNavalMilitary(attackerBefore.type)
     && !isPirateFlagship(state, attackerBefore)
+    && !attackerBefore.cargoUnitIds?.length
+    // Prize crew moves the ship between two civilizations[] rosters (unlike civilian
+    // capture, naval military ships can legitimately be pirate-owned on either side —
+    // e.g. a player's frigate vs. a pirate_frigate — so both the old and new owner must
+    // be confirmed major civs, not just the new one).
+    && isMajorCivOwner(attackerBefore.owner)
+    && isMajorCivOwner(defenderBefore.owner)
     && meetsCaptureMargin(result.attackerStrength, result.defenderStrength, Math.max(1, defenderBefore.health - result.defenderDamage))
   ) {
     // Prize crew: a decisive naval defeat captures the hull instead of sinking it.
@@ -439,6 +446,10 @@ export function applyCombatOutcomeToState(
     result.attackerSurvived
     && isCapturableNavalMilitary(defenderBefore.type)
     && !isPirateFlagship(state, defenderBefore)
+    && !defenderBefore.cargoUnitIds?.length
+    // Mirror of the attacker-side branch above — both old and new owner must be major civs.
+    && isMajorCivOwner(attackerBefore.owner)
+    && isMajorCivOwner(defenderBefore.owner)
     && meetsCaptureMargin(result.defenderStrength, result.attackerStrength, Math.max(1, attackerBefore.health - result.attackerDamage))
   ) {
     // Prize crew: mirror of the attacker-side branch above.

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -1,4 +1,4 @@
-import type { CombatResult, CombatRewardNotification, GameState, Unit } from '@/core/types';
+import type { CombatResult, CombatRewardNotification, GameState, Unit, UnitType } from '@/core/types';
 import { cleanupDeadSpyUnit } from '@/systems/espionage-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { applyQuestGameplayAction, type ChainTransition } from '@/systems/quest-chain-system';
@@ -11,6 +11,46 @@ import {
 } from '@/systems/pirate-actions';
 import { recordMilitaryAttack } from './diplomacy-system';
 import { UNIT_CLASS_BY_TYPE } from '@/systems/unit-modifier-definitions';
+
+/** Age-of-Sail through ironclad — boarding-action flavor. Everything else
+ * (destroyer onward) uses modern "disabled and captured" phrasing. Same
+ * underlying mechanic at every era — this only changes notification text. */
+const PRE_INDUSTRIAL_NAVAL_TYPES: readonly UnitType[] = [
+  'galley', 'trireme', 'frigate', 'ironclad',
+  'pirate_galley', 'pirate_corsair', 'pirate_frigate',
+];
+
+export function isCapturableNavalMilitary(type: UnitType): boolean {
+  if (type === 'beast_sea_serpent') return false;
+  const classes = UNIT_CLASS_BY_TYPE[type];
+  return classes.includes('naval') && !classes.includes('civilian');
+}
+
+export function meetsCaptureMargin(loserStrength: number, winnerStrength: number, winnerHealthAfter: number): boolean {
+  return loserStrength <= winnerStrength * 0.5 && winnerHealthAfter >= 50;
+}
+
+// A deep-sea-flotilla pirate faction's flagship must never be captured: destroyPirateFaction
+// (called later in applyCombatOutcomeToState when the flagship is actually destroyed) removes
+// every ship in the faction, including the flagship, from state.units — capturing the flagship
+// here and then having that cleanup delete it out from under the new owner would silently
+// undo the capture. Faction-destruction-on-capture is a separate, unscoped feature; until it
+// exists, flagships are always destroyed on defeat, never captured.
+function isPirateFlagship(state: GameState, unit: Unit): boolean {
+  const faction = state.pirates?.factions[unit.owner];
+  return faction?.headquarters.kind === 'deep-sea-flotilla' && faction.headquarters.flagshipUnitId === unit.id;
+}
+
+export function getCaptureNotificationLabel(type: UnitType): string {
+  const name = UNIT_DEFINITIONS[type].name;
+  if (type === 'settler') return 'Settler captured — converted to Worker';
+  if (isCapturableNavalMilitary(type)) {
+    return PRE_INDUSTRIAL_NAVAL_TYPES.includes(type)
+      ? `${name} boarded — prize crew aboard!`
+      : `${name} disabled and captured!`;
+  }
+  return `${name} captured!`;
+}
 
 export type VeterancyTierId = 'recruit' | 'seasoned' | 'veteran' | 'elite';
 
@@ -329,6 +369,27 @@ export function applyCombatOutcomeToState(
     };
     attackerActuallyDefeated = false;
     attackerCaptured = true;
+  } else if (
+    result.defenderSurvived
+    && isCapturableNavalMilitary(attackerBefore.type)
+    && !isPirateFlagship(state, attackerBefore)
+    && meetsCaptureMargin(result.attackerStrength, result.defenderStrength, Math.max(1, defenderBefore.health - result.defenderDamage))
+  ) {
+    // Prize crew: a decisive naval defeat captures the hull instead of sinking it.
+    units[result.attackerId] = { ...attackerBefore, owner: defenderBefore.owner };
+    civilizations = {
+      ...civilizations,
+      [attackerBefore.owner]: {
+        ...civilizations[attackerBefore.owner],
+        units: (civilizations[attackerBefore.owner]?.units ?? []).filter(id => id !== result.attackerId),
+      },
+      [defenderBefore.owner]: {
+        ...civilizations[defenderBefore.owner],
+        units: [...(civilizations[defenderBefore.owner]?.units ?? []), result.attackerId],
+      },
+    };
+    attackerActuallyDefeated = false;
+    attackerCaptured = true;
   } else {
     const removed = removeUnitFromCopies(units, civilizations, espionage, result.attackerId);
     units = removed.units;
@@ -361,6 +422,27 @@ export function applyCombatOutcomeToState(
     // same major-civ-only capturing-side requirement).
     const capturedType = defenderBefore.type === 'settler' ? 'worker' : defenderBefore.type;
     units[result.defenderId] = { ...defenderBefore, type: capturedType, owner: attackerBefore.owner };
+    civilizations = {
+      ...civilizations,
+      [defenderBefore.owner]: {
+        ...civilizations[defenderBefore.owner],
+        units: (civilizations[defenderBefore.owner]?.units ?? []).filter(id => id !== result.defenderId),
+      },
+      [attackerBefore.owner]: {
+        ...civilizations[attackerBefore.owner],
+        units: [...(civilizations[attackerBefore.owner]?.units ?? []), result.defenderId],
+      },
+    };
+    defenderActuallyDefeated = false;
+    defenderCaptured = true;
+  } else if (
+    result.attackerSurvived
+    && isCapturableNavalMilitary(defenderBefore.type)
+    && !isPirateFlagship(state, defenderBefore)
+    && meetsCaptureMargin(result.defenderStrength, result.attackerStrength, Math.max(1, attackerBefore.health - result.attackerDamage))
+  ) {
+    // Prize crew: mirror of the attacker-side branch above.
+    units[result.defenderId] = { ...defenderBefore, owner: attackerBefore.owner };
     civilizations = {
       ...civilizations,
       [defenderBefore.owner]: {

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -332,6 +332,8 @@ export function resolveCombat(
       defenderDamage: defender.health,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: atkStrength,
+      defenderStrength: defStrength,
       attackerPosition: attacker.position,
       defenderPosition: defender.position,
     };
@@ -345,6 +347,8 @@ export function resolveCombat(
       defenderDamage: 0,
       attackerSurvived: false,
       defenderSurvived: true,
+      attackerStrength: atkStrength,
+      defenderStrength: defStrength,
       attackerPosition: attacker.position,
       defenderPosition: defender.position,
     };
@@ -388,6 +392,8 @@ export function resolveCombat(
     defenderDamage,
     attackerSurvived: attackerHealthAfter > 0,
     defenderSurvived: defenderHealthAfter > 0,
+    attackerStrength: atkStrength,
+    defenderStrength: defStrength,
     attackerPosition: attacker.position,
     defenderPosition: defender.position,
     ...(exchange.kind === 'none' ? {} : { exchange: { kind: exchange.kind, label: exchange.label! } }),

--- a/tests/audio/sfx-director.test.ts
+++ b/tests/audio/sfx-director.test.ts
@@ -59,6 +59,7 @@ function makeCombatResult(o: Partial<CombatResult> = {}): CombatResult {
     attackerId: 'a1', defenderId: 'd1',
     attackerDamage: 10, defenderDamage: 10,
     attackerSurvived: true, defenderSurvived: true,
+    attackerStrength: 20, defenderStrength: 20,
     attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     ...o,
   };

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -490,6 +490,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -515,6 +516,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -553,6 +555,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -920,6 +923,57 @@ describe('applyCombatOutcomeToState', () => {
     expect(applied.defenderCaptured).toBe(true);
     expect(applied.state.units.defender.owner).toBe('player');
     expect(applied.state.units.defender.type).toBe('galley');
+  });
+
+  it('sinks (never captures) a pirate ship defeated in a decisive win — pirates have no civilizations[] entry (#541 second-pass review)', () => {
+    // Same civ-corruption class as the civilian-capture fix: pirates track units in
+    // state.pirates.factions, not state.civilizations. Prize-crew capture had the same
+    // unconditional civilizations[newOwner] write as civilian capture did, just reached
+    // via a different unit class — fighting pirate ships is a core, frequent interaction,
+    // so this was readily reachable.
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player', health: 100 };
+    state.units.defender = { ...state.units.defender, type: 'pirate_frigate', owner: 'pirate-1' };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 8,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.units.defender).toBeUndefined();
+    expect(applied.state.civilizations['pirate-1']).toBeUndefined();
+  });
+
+  it('sinks (never captures) a carrier with based aircraft aboard, even in a decisive win (#541 second-pass review)', () => {
+    // Mirrors the civilian-capture cargo exclusion (loaded transports still sink so the
+    // existing cargo-cleanup cascade runs) — the prize-crew branch was missing the same
+    // guard, which would have captured the carrier while leaving its based aircraft
+    // still owned by the old civ, stranded aboard a ship they no longer control.
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player', health: 100 };
+    state.units.defender = {
+      ...state.units.defender, type: 'carrier', owner: 'ai-1', cargoUnitIds: ['plane-1'],
+    };
+    state.units['plane-1'] = { ...createUnit('biplane', 'ai-1', { q: 1, r: 0 }, mkC()), id: 'plane-1', transportId: 'defender' };
+    state.civilizations['ai-1'].units = ['defender', 'plane-1'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 8,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.units.defender).toBeUndefined();
+    expect(applied.state.units['plane-1']).toBeUndefined();
   });
 
   it('sinks a naval military unit when the win is not decisive enough', () => {

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -4,9 +4,12 @@ import {
   applyCombatOutcomeToState,
   calculateDefeatReward,
   collectCombatRewards,
+  getCaptureNotificationLabel,
   getExperienceToNextTier,
   getVeterancyCombatModifier,
   getVeterancyTier,
+  isCapturableNavalMilitary,
+  meetsCaptureMargin,
 } from '@/systems/combat-reward-system';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
 import type { CombatResult, GameState } from '@/core/types';
@@ -897,6 +900,144 @@ describe('applyCombatOutcomeToState', () => {
     expect(applied.defenderDefeated).toBe(true);
     expect(applied.defenderCaptured).toBe(false);
     expect(applied.state.units.defender).toBeUndefined();
+  });
+
+  it('captures a decisively-defeated naval military unit instead of sinking it', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player', health: 100 };
+    state.units.defender = { ...state.units.defender, type: 'galley', owner: 'ai-1' };
+    state.civilizations['ai-1'].units = ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 8,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderDefeated).toBe(false);
+    expect(applied.defenderCaptured).toBe(true);
+    expect(applied.state.units.defender.owner).toBe('player');
+    expect(applied.state.units.defender.type).toBe('galley');
+  });
+
+  it('sinks a naval military unit when the win is not decisive enough', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player' };
+    state.units.defender = { ...state.units.defender, type: 'galley', owner: 'ai-1' };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 15,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.defenderCaptured).toBe(false);
+  });
+
+  it('sinks a naval military unit when the winner drops below 50% health, even with a decisive strength margin', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player', health: 40 };
+    state.units.defender = { ...state.units.defender, type: 'galley', owner: 'ai-1' };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 5, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 8,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.defenderCaptured).toBe(false);
+  });
+
+  it('never captures a beast_sea_serpent — it is destroyed like any other beast', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player' };
+    state.units.defender = { ...state.units.defender, type: 'beast_sea_serpent', owner: 'beasts' };
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 1,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+  });
+
+  it('never captures a deep-sea-flotilla pirate flagship, even in a decisive win — it is destroyed like today', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'frigate', owner: 'player', health: 100 };
+    state.units.defender = { ...state.units.defender, type: 'pirate_frigate', owner: 'pirate-1' };
+    state.pirates = createEmptyPirateState();
+    state.pirates.factions['pirate-1'] = {
+      id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'raiding',
+      maritimeStage: 3, notoriety: 2, shipIds: ['defender'],
+      headquarters: { kind: 'deep-sea-flotilla', flagshipUnitId: 'defender', relocation: { planned: null, lastRelocatedRound: null } },
+      tributeByCiv: {}, demandByCiv: {}, contract: null, intent: null,
+      transitionGuards: { emittedEventKeys: [] },
+    } satisfies PirateFactionState;
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 8,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.defenderCaptured).toBe(false);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.pirates!.factions['pirate-1']).toBeUndefined();
+  });
+
+  it('captures a losing attacker naval military unit too (attacker-loses side), mirroring the defender side', () => {
+    const state = makeRewardState();
+    state.units.attacker = { ...state.units.attacker, type: 'galley', owner: 'player', health: 40 };
+    state.units.defender = { ...state.units.defender, type: 'frigate', owner: 'ai-1', health: 100 };
+    state.civilizations.player.units = ['attacker'];
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 100, defenderDamage: 0,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 8, defenderStrength: 20,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.attackerDefeated).toBe(false);
+    expect(applied.attackerCaptured).toBe(true);
+    expect(applied.state.units.attacker.owner).toBe('ai-1');
+  });
+});
+
+describe('prize-crew helpers', () => {
+  it('meetsCaptureMargin requires both a decisive strength ratio and winner health >= 50', () => {
+    expect(meetsCaptureMargin(8, 20, 60)).toBe(true);
+    expect(meetsCaptureMargin(15, 20, 60)).toBe(false);
+    expect(meetsCaptureMargin(8, 20, 40)).toBe(false);
+  });
+
+  it('isCapturableNavalMilitary is true for naval military types, false for naval civilian and beasts', () => {
+    expect(isCapturableNavalMilitary('galley')).toBe(true);
+    expect(isCapturableNavalMilitary('submarine')).toBe(true);
+    expect(isCapturableNavalMilitary('transport')).toBe(false);
+    expect(isCapturableNavalMilitary('beast_sea_serpent')).toBe(false);
+    expect(isCapturableNavalMilitary('warrior')).toBe(false);
+  });
+
+  it('getCaptureNotificationLabel uses Age-of-Sail phrasing for early naval types and modern phrasing for later ones', () => {
+    expect(getCaptureNotificationLabel('galley')).toMatch(/prize crew|boarded/i);
+    expect(getCaptureNotificationLabel('submarine')).toMatch(/disabled|captured/i);
+    expect(getCaptureNotificationLabel('worker')).toMatch(/captured/i);
   });
 });
 

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -93,6 +93,8 @@ describe('combat-reward-system', () => {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -117,6 +119,8 @@ describe('combat-reward-system', () => {
       defenderDamage: 12,
       attackerSurvived: false,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -141,6 +145,8 @@ describe('combat-reward-system', () => {
       defenderDamage: 100,
       attackerSurvived: false,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -213,7 +219,7 @@ describe('applyCombatOutcomeToState', () => {
     state.civilizations['ai-1'].units = ['carrier', 'based'];
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'carrier', attackerDamage: 0, defenderDamage: 100,
-      attackerSurvived: true, defenderSurvived: false, attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+      attackerSurvived: true, defenderSurvived: false, attackerStrength: 20, defenderStrength: 20, attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
     const applied = applyCombatOutcomeToState(state, result, 64);
@@ -238,6 +244,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -263,6 +271,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -290,6 +300,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -317,6 +329,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -342,6 +356,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -380,6 +396,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: true,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -403,6 +421,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -440,6 +460,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 10, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -549,6 +570,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -570,6 +593,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -599,6 +624,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 20,
       attackerSurvived: true,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -628,6 +655,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 5,
       attackerSurvived: false,
       defenderSurvived: true,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -662,6 +691,8 @@ describe('applyCombatOutcomeToState', () => {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     };
@@ -688,6 +719,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 5, defenderDamage: 5,
       attackerSurvived: true, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -712,6 +744,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 5, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -730,6 +763,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 10, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -747,6 +781,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -767,6 +802,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -784,6 +820,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -800,6 +837,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 100, defenderDamage: 0,
       attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -817,6 +855,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -833,6 +872,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 
@@ -848,6 +888,7 @@ describe('applyCombatOutcomeToState', () => {
     const result: CombatResult = {
       attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
 

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -92,6 +92,26 @@ describe('resolveCombat', () => {
     expect(result.defenderDamage).toBeGreaterThan(0);
   });
 
+  it('exposes the attacker and defender effective strengths it used to resolve the exchange', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const defender = createUnit('warrior', 'p2', { q: 11, r: 10 }, mkC());
+
+    const result = resolveCombat(attacker, defender, map, 64);
+
+    expect(result.attackerStrength).toBeGreaterThan(0);
+    expect(result.defenderStrength).toBeGreaterThan(0);
+  });
+
+  it('reports zero defender strength when the defender cannot fight', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const defender = createUnit('worker', 'p2', { q: 11, r: 10 }, mkC());
+
+    const result = resolveCombat(attacker, defender, map, 64);
+
+    expect(result.defenderStrength).toBe(0);
+    expect(result.attackerStrength).toBeGreaterThan(0);
+  });
+
   it('stronger unit deals more damage', () => {
     const warrior = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
     const scout = createUnit('scout', 'p2', { q: 11, r: 10 }, mkC());

--- a/tests/systems/era-12.test.ts
+++ b/tests/systems/era-12.test.ts
@@ -171,6 +171,7 @@ describe('geneTherapyReady — combat survival', () => {
       attackerId: 'a1', defenderId: 'd1',
       attackerDamage: 80, defenderDamage: 30,
       attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const applied = applyCombatOutcomeToState(state, result, 42);
@@ -190,6 +191,7 @@ describe('geneTherapyReady — combat survival', () => {
       attackerId: 'a2', defenderId: 'd2',
       attackerDamage: 80, defenderDamage: 30,
       attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const applied = applyCombatOutcomeToState(state, result, 42);
@@ -207,6 +209,7 @@ describe('geneTherapyReady — combat survival', () => {
       attackerId: 'a3', defenderId: 'd3',
       attackerDamage: 80, defenderDamage: 30,
       attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const applied = applyCombatOutcomeToState(state, result, 42);
@@ -226,6 +229,7 @@ describe('cyber_unit capture', () => {
       attackerId: 'w1', defenderId: 'cu1',
       attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 1, r: 0 }, defenderPosition: { q: 0, r: 0 },
     };
     const applied = applyCombatOutcomeToState(state, result, 42);
@@ -246,6 +250,7 @@ describe('cyber_unit capture', () => {
       attackerId: 'cu2', defenderId: 'w2',
       attackerDamage: 100, defenderDamage: 0,
       attackerSurvived: false, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const applied = applyCombatOutcomeToState(state, result, 42);

--- a/tests/ui/combat-resolved-presentation.test.ts
+++ b/tests/ui/combat-resolved-presentation.test.ts
@@ -23,6 +23,8 @@ function makeEvent(): GameEvents['combat:resolved'] {
       defenderDamage: 100,
       attackerSurvived: true,
       defenderSurvived: false,
+      attackerStrength: 20,
+      defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 },
       defenderPosition: { q: 1, r: 0 },
     },

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -252,6 +252,7 @@ describe('notification routing', () => {
       attackerId: 'a', defenderId: 'd',
       attackerDamage: 10, defenderDamage: 20,
       attackerSurvived: true, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const { sink, calls } = makeSink();
@@ -272,6 +273,7 @@ describe('notification routing', () => {
       attackerId: 'a', defenderId: 'd',
       attackerDamage: 0, defenderDamage: 100,
       attackerSurvived: true, defenderSurvived: false,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
     };
     const { sink, calls } = makeSink();
@@ -290,6 +292,7 @@ describe('notification routing', () => {
       attackerId: 'destroyed-attacker', defenderId: 'destroyed-defender',
       attackerDamage: 8, defenderDamage: 22,
       attackerSurvived: true, defenderSurvived: true,
+      attackerStrength: 20, defenderStrength: 20,
       attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
       exchange: {
         kind: 'turret-fire',


### PR DESCRIPTION
## Summary
- `CombatResult` now exposes the attacker/defender effective strengths `resolveCombat` already computes internally, so downstream logic never has to recompute (and risk drifting from) them.
- A decisively-won naval-military combat (loser's effective strength <= 50% of winner's, winner ending >= 50% health) captures the hull instead of sinking it, at every era — Age-of-Sail types get "prize crew/boarded" notification text, later types get "disabled and captured". `beast_sea_serpent` is explicitly excluded.
- A deep-sea-flotilla pirate faction's flagship is also excluded from capture: `destroyPirateFaction` deletes every ship in the faction (including the flagship) from `state.units` when it fires, which would silently undo a capture that just transferred ownership of that same unit. Found via an existing test that assumed a weak flagship always gets destroyed — faction-destruction-on-capture is a separate, unscoped feature.

## Test plan
- [x] `yarn vitest run tests/systems/combat-system.test.ts tests/systems/combat-reward-system.test.ts tests/ai/basic-ai-pirates.test.ts`
- [x] `yarn test` (full suite, 6892 tests, including `pacing-audit.test.ts`)
- [x] `yarn build`
- [x] Inline dimensional review completed — caught and fixed a real gap: the capture notification in `main.ts` wasn't actually using the new era-flavor label helper, so the "prize crew" text would never have reached the player

Part of the #541 pillage/capture/prize-crews arc — stacked on #651.