### PR TITLE
feat(combat): AI/barbarian pillage + difficulty scaling (#541 MR4)

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -102,6 +102,8 @@ import { applyAIResearch } from './ai-research';
 import { processAIResourceMarketplace } from './ai-resource-marketplace';
 import { getCrisisRestoreAssignments } from './ai-crisis-response';
 import { applyWorkerAction, getWorkerChargesRemaining } from '@/systems/worker-action-system';
+import { applyPillageToState, canPillageTile } from '@/systems/pillage-system';
+import { isAtWar } from '@/systems/diplomacy-system';
 import { getAvailableWorkerActions, getKnownTileResourceForWorkerAction } from '@/systems/improvement-system';
 import { chooseRoadBuilderUnit } from '@/systems/road-network';
 import { canBuildRoad } from '@/systems/road-system';
@@ -686,6 +688,26 @@ function processAITurnInternal(
       const result = applyWorkerAction(newState, current.id, actions[0]!);
       if (result.ok) newState = result.state;
     }
+  }
+  civ = newState.civilizations[civId];
+
+  // #541: pillage is discretionary, not a passive combat side effect (unlike civilian/
+  // prize-crew capture, which is automatic inside applyCombatOutcomeToState regardless of
+  // actor) — an AI combat unit standing on a pillageable enemy tile must actively choose to
+  // spend its action burning it. Administrative for the same reason as the worker loops
+  // above: no AIStrategicPlan role covers this. Only pillages civs already at war — never
+  // auto-declares a new war just to pillage, which stays the player's own explicit choice.
+  const combatUnitsForPillage = civ.units
+    .map(id => newState.units[id])
+    .filter((unit): unit is Unit => Boolean(unit) && !unit.hasActed && UNIT_DEFINITIONS[unit.type].strength > 0);
+  for (const unit of combatUnitsForPillage) {
+    const current = newState.units[unit.id];
+    if (!current || current.hasActed) continue;
+    const tile = newState.map.tiles[hexKey(current.position)];
+    if (!tile || !tile.owner || !isAtWar(civ.diplomacy, tile.owner)) continue;
+    if (!canPillageTile(tile, civId)) continue;
+    const result = applyPillageToState(newState, current.id);
+    if (result.ok) newState = result.state;
   }
   civ = newState.civilizations[civId];
 

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -704,7 +704,8 @@ function processAITurnInternal(
     const current = newState.units[unit.id];
     if (!current || current.hasActed) continue;
     const tile = newState.map.tiles[hexKey(current.position)];
-    if (!tile || !tile.owner || !isAtWar(civ.diplomacy, tile.owner)) continue;
+    if (!tile) continue;
+    if (tile.owner && !isAtWar(civ.diplomacy, tile.owner)) continue;
     if (!canPillageTile(tile, civId)) continue;
     const result = applyPillageToState(newState, current.id);
     if (result.ok) newState = result.state;

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -24,10 +24,11 @@ export interface OpponentChallengeProfile {
   crisisResponseDelayTurns: number;   // crisis age before the AI acts
   crisisRemedyGoldMultiplier: number; // treasury needed as multiple of remedy cost
   crisisDispatchWeight: number;       // multiplier on dispatch objective score
-  // #541: scales how eagerly barbarian/pirate raid plans prefer a pillage-capable
-  // resource-tile raid target over a plain unit-raid target. Player-side pillage
-  // rules are identical at every difficulty — only barbarian/pirate/AI frequency
-  // changes.
+  // #541: scales how eagerly a barbarian camp's raid plan (barbarian-system.ts)
+  // prefers a pillage-capable resource-tile raid target over a plain unit-raid
+  // target. Pirates use a separate plunder/blockade targeting model and don't
+  // consume this field. Player-side pillage rules are identical at every
+  // difficulty — only barbarian raid-target frequency changes.
   pillageAggressivenessMultiplier: number;
 }
 

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -24,6 +24,11 @@ export interface OpponentChallengeProfile {
   crisisResponseDelayTurns: number;   // crisis age before the AI acts
   crisisRemedyGoldMultiplier: number; // treasury needed as multiple of remedy cost
   crisisDispatchWeight: number;       // multiplier on dispatch objective score
+  // #541: scales how eagerly barbarian/pirate raid plans prefer a pillage-capable
+  // resource-tile raid target over a plain unit-raid target. Player-side pillage
+  // rules are identical at every difficulty — only barbarian/pirate/AI frequency
+  // changes.
+  pillageAggressivenessMultiplier: number;
 }
 
 export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChallengeProfile> = {
@@ -45,6 +50,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisResponseDelayTurns: 4,
     crisisRemedyGoldMultiplier: 3.0,
     crisisDispatchWeight: 0.5,
+    pillageAggressivenessMultiplier: 0.5,
   },
   standard: {
     mobilizationRounds: 1,
@@ -64,6 +70,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisResponseDelayTurns: 2,
     crisisRemedyGoldMultiplier: 2.0,
     crisisDispatchWeight: 1.0,
+    pillageAggressivenessMultiplier: 1.0,
   },
   veteran: {
     mobilizationRounds: 0,
@@ -83,6 +90,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisResponseDelayTurns: 0,
     crisisRemedyGoldMultiplier: 1.2,
     crisisDispatchWeight: 1.5,
+    pillageAggressivenessMultiplier: 1.3,
   },
 };
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -22,6 +22,7 @@ import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system'
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { applyPillageToState } from '@/systems/pillage-system';
 import {
   PIRATE_OWNER,
   processIndependentThreatPressure,
@@ -870,6 +871,12 @@ export function processTurn(
     if (unit) {
       executeUnitMove(newState, order.unitId, order.toCoord, { actor: 'world', bus });
     }
+  }
+
+  // Barbarian pillage-on-arrival
+  for (const order of barbResult.pillageOrders) {
+    const result = applyPillageToState(newState, order.unitId);
+    if (result.ok) newState = result.state;
   }
 
   // Barbarian attacks

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -865,18 +865,26 @@ export function processTurn(
     bus.emit('barbarian:spawned', { campId: spawn.campId, unitId: raider.id });
   }
 
+  // Barbarian pillage-on-arrival. Must run BEFORE moves: an arriving raider's plan
+  // transitions to 'withdrawing' in the same processPurposefulBarbarians call that
+  // queues its pillageOrder, which also queues a withdrawal moveOrder for that same
+  // unit this turn (#541 second-pass review — the original order had moves first,
+  // so the raider stepped away from the resource tile before applyPillageToState
+  // re-derived the tile from the unit's now-stale position, silently pillaging
+  // nothing). Pillaging first sets movementPointsLeft to 0, so the queued
+  // withdrawal move correctly fails validation and simply doesn't fire this turn —
+  // the raider retreats next turn instead.
+  for (const order of barbResult.pillageOrders) {
+    const result = applyPillageToState(newState, order.unitId);
+    if (result.ok) newState = result.state;
+  }
+
   // Move barbarian units
   for (const order of barbResult.moveOrders) {
     const unit = newState.units[order.unitId];
     if (unit) {
       executeUnitMove(newState, order.unitId, order.toCoord, { actor: 'world', bus });
     }
-  }
-
-  // Barbarian pillage-on-arrival
-  for (const order of barbResult.pillageOrders) {
-    const result = applyPillageToState(newState, order.unitId);
-    if (result.ok) newState = result.state;
   }
 
   // Barbarian attacks

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -149,12 +149,18 @@ export interface BarbarianCityAttackOrder {
   damage: number;
 }
 
+export interface BarbarianPillageOrder {
+  unitId: string;
+  tileKey: string;
+}
+
 export interface BarbarianProcessResult {
   updatedCamps: BarbarianCamp[];
   spawnedUnits: Array<{ campId: string; position: HexCoord; unitType?: UnitType }>;
   moveOrders: BarbarianMoveOrder[];
   attackOrders: BarbarianAttackOrder[];
   cityAttackOrders: BarbarianCityAttackOrder[];
+  pillageOrders: BarbarianPillageOrder[];
 }
 
 export const BARBARIAN_ROSTER_BY_ERA: Array<{
@@ -335,6 +341,7 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
   const moveOrders: BarbarianMoveOrder[] = [];
   const attackOrders: BarbarianAttackOrder[] = [];
   const cityAttackOrders: BarbarianCityAttackOrder[] = [];
+  const pillageOrders: BarbarianPillageOrder[] = [];
   const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
 
   for (const camp of camps) {
@@ -404,7 +411,7 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
       );
     }
 
-    if (!plan) {
+    const tryRaidUnitPlan = (): typeof plan => {
       const raidUnit = sensedUnits
         .filter(unit => unit.type === 'worker' || unit.type === 'caravan')
         .sort((a, b) => {
@@ -413,19 +420,19 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
             || barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
             || a.id.localeCompare(b.id);
         })[0];
-      if (raidUnit) {
-        plan = makeBarbarianPlan(
-          state,
-          camp,
-          { kind: 'unit', id: raidUnit.id, lastKnownPosition: { ...raidUnit.position } },
-          'raid',
-          'opportunistic-raid',
-          assignedIds,
-        );
-      }
-    }
+      return raidUnit
+        ? makeBarbarianPlan(
+            state,
+            camp,
+            { kind: 'unit', id: raidUnit.id, lastKnownPosition: { ...raidUnit.position } },
+            'raid',
+            'opportunistic-raid',
+            assignedIds,
+          )
+        : null;
+    };
 
-    if (!plan) {
+    const tryRaidResourcePlan = (): typeof plan => {
       const resource = Object.values(state.map.tiles)
         .filter(tile =>
           Boolean(tile.resource)
@@ -437,16 +444,25 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
         .sort((a, b) =>
           barbarianDistance(state, camp.position, a.coord) - barbarianDistance(state, camp.position, b.coord)
           || hexKey(a.coord).localeCompare(hexKey(b.coord)))[0];
-      if (resource?.resource) {
-        plan = makeBarbarianPlan(
-          state,
-          camp,
-          { kind: 'resource', resource: resource.resource as ResourceType, position: { ...resource.coord } },
-          'raid',
-          'opportunistic-raid',
-          assignedIds,
-        );
-      }
+      return resource?.resource
+        ? makeBarbarianPlan(
+            state,
+            camp,
+            { kind: 'resource', resource: resource.resource as ResourceType, position: { ...resource.coord } },
+            'raid',
+            'opportunistic-raid',
+            assignedIds,
+          )
+        : null;
+    };
+
+    // #541: higher-difficulty barbarians prioritize pillage-capable resource-tile
+    // raids over chasing a lone worker/caravan; player-side pillage rules never
+    // change by difficulty — only this raid-target preference does.
+    if (!plan) {
+      plan = profile.pillageAggressivenessMultiplier > 1
+        ? (tryRaidResourcePlan() ?? tryRaidUnitPlan())
+        : (tryRaidUnitPlan() ?? tryRaidResourcePlan());
     }
 
     if (!plan) {
@@ -485,6 +501,12 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
 
     const targetPosition = planTargetPosition(state, plan);
     const resourceTarget = plan.target.kind === 'resource' ? plan.target : null;
+    const arrivedRaider = resourceTarget !== null
+      ? assigned.find(unit => hexKey(unit.position) === hexKey(resourceTarget.position) && !unit.hasActed)
+      : undefined;
+    if (arrivedRaider && resourceTarget) {
+      pillageOrders.push({ unitId: arrivedRaider.id, tileKey: hexKey(resourceTarget.position) });
+    }
     const completedResourceRaid = resourceTarget !== null
       && plan.createdTurn < state.turn
       && assigned.some(unit => hexKey(unit.position) === hexKey(resourceTarget.position));
@@ -546,6 +568,7 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
     moveOrders,
     attackOrders,
     cityAttackOrders,
+    pillageOrders,
     opponentAI,
   };
 }
@@ -592,7 +615,7 @@ export function processBarbarians(
 
   // --- Barbarian unit movement and attack ---
   if (!barbarianUnits || barbarianUnits.length === 0) {
-    return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
+    return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders, pillageOrders: [] };
   }
 
   // Build a set of all occupied positions (for collision avoidance)
@@ -704,5 +727,5 @@ export function processBarbarians(
     }
   }
 
-  return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
+  return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders, pillageOrders: [] };
 }

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -441,6 +441,41 @@ describe('AI attack targeting', () => {
     expect(state.units[attacker.id]?.position).toEqual({ q: 0, r: 0 });
   });
 
+  it('pillages an enemy improved tile it is already at war with, using its action (#541)', () => {
+    const state = createNewGame(undefined, 'ai-pillage-at-war', 'small');
+    const raider = createUnit('warrior', 'ai-1', { q: 3, r: 3 }, mkC());
+    raider.id = 'raider';
+    state.units = { [raider.id]: raider };
+    state.civilizations['ai-1'].units = [raider.id];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.map.tiles['3,3'] = {
+      ...state.map.tiles['3,3'],
+      owner: 'player', improvement: 'farm', improvementTurnsLeft: 0,
+    };
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.units[raider.id].hasActed).toBe(true);
+    expect(result.map.tiles['3,3'].improvement).toBe('none');
+  });
+
+  it('does not pillage a tile owned by a civ it is not at war with (#541)', () => {
+    const state = createNewGame(undefined, 'ai-no-pillage-at-peace', 'small');
+    const raider = createUnit('warrior', 'ai-1', { q: 3, r: 3 }, mkC());
+    raider.id = 'raider';
+    state.units = { [raider.id]: raider };
+    state.civilizations['ai-1'].units = [raider.id];
+    state.map.tiles['3,3'] = {
+      ...state.map.tiles['3,3'],
+      owner: 'player', improvement: 'farm', improvementTurnsLeft: 0,
+    };
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.map.tiles['3,3'].improvement).toBe('farm');
+  });
+
   it('does not make AI units opportunistically attack minor-civ units', () => {
     const state = createNewGame(undefined, 'ai-minor-neutral-range', 'small');
     const attacker = createUnit('warrior', 'ai-1', { q: 0, r: 0 }, mkC());

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -476,6 +476,27 @@ describe('AI attack targeting', () => {
     expect(result.map.tiles['3,3'].improvement).toBe('farm');
   });
 
+  it('pillages a null-owner (unclaimed) improved tile without needing a war check (#541 second-pass review)', () => {
+    // canPillageTile treats null-owner tiles as pillageable (no diplomatic owner to be at
+    // war with), same as the player's own Pillage action -- the AI loop's original
+    // `!tile.owner` guard rejected null-owner tiles outright, an inconsistency between what
+    // the player could pillage and what the AI would even attempt.
+    const state = createNewGame(undefined, 'ai-pillage-unclaimed', 'small');
+    const raider = createUnit('warrior', 'ai-1', { q: 3, r: 3 }, mkC());
+    raider.id = 'raider';
+    state.units = { [raider.id]: raider };
+    state.civilizations['ai-1'].units = [raider.id];
+    state.map.tiles['3,3'] = {
+      ...state.map.tiles['3,3'],
+      owner: null, improvement: 'farm', improvementTurnsLeft: 0,
+    };
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.units[raider.id].hasActed).toBe(true);
+    expect(result.map.tiles['3,3'].improvement).toBe('none');
+  });
+
   it('does not make AI units opportunistically attack minor-civ units', () => {
     const state = createNewGame(undefined, 'ai-minor-neutral-range', 'small');
     const attacker = createUnit('warrior', 'ai-1', { q: 0, r: 0 }, mkC());

--- a/tests/core/opponent-challenge.test.ts
+++ b/tests/core/opponent-challenge.test.ts
@@ -139,6 +139,12 @@ describe('crisis profile knobs', () => {
       crisisCooldownTurns: 5, crisisGraceMaxEra: 1, crisisGraceMinTurns: 10, crisisSeverityMultiplier: 1.3 });
   });
 
+  it('scales barbarian/pirate pillage aggressiveness across all three difficulty tiers (#541)', () => {
+    expect(OPPONENT_CHALLENGE_PROFILES.explorer.pillageAggressivenessMultiplier).toBe(0.5);
+    expect(OPPONENT_CHALLENGE_PROFILES.standard.pillageAggressivenessMultiplier).toBe(1.0);
+    expect(OPPONENT_CHALLENGE_PROFILES.veteran.pillageAggressivenessMultiplier).toBe(1.3);
+  });
+
   it('getChallengeProfileForCiv resolves the per-civ profile', () => {
     expect(getChallengeProfileForCiv(stateWith('veteran', 'explorer'), 'c1').crisisCooldownTurns).toBe(5);
   });

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -355,6 +355,66 @@ describe('processPurposefulBarbarians', () => {
     expect(result.cityAttackOrders).toHaveLength(0);
     expect(result.moveOrders).toHaveLength(0);
   });
+
+  it('pillages a resource tile on arrival instead of leaving it untouched (#541)', () => {
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 7, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.map.tiles['7,5'] = {
+      ...state.map.tiles['7,5'],
+      resource: 'iron',
+      improvement: 'mine',
+      improvementTurnsLeft: 0,
+      owner: 'player',
+    };
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.pillageOrders).toContainEqual({ unitId: 'raider', tileKey: '7,5' });
+  });
+
+  it('prioritizes a resource-raid target over a unit-raid target on veteran (multiplier > 1) (#541)', () => {
+    const state = purposefulState();
+    state.opponentChallenge = 'veteran';
+    const raider = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const worker = createUnit('worker', 'player', { q: 6, r: 5 }, state.idCounters);
+    worker.id = 'worker';
+    state.units = { raider, worker };
+    state.civilizations.player.units = ['worker'];
+    state.map.tiles['8,5'] = {
+      ...state.map.tiles['8,5'],
+      resource: 'iron', improvement: 'mine', improvementTurnsLeft: 0, owner: 'player',
+    };
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.opponentAI.barbarianCamps['camp-a']).toMatchObject({
+      target: { kind: 'resource' },
+    });
+  });
+
+  it('prioritizes a unit-raid target over a resource-raid target on explorer (multiplier <= 1) (#541)', () => {
+    const state = purposefulState();
+    state.opponentChallenge = 'explorer';
+    const raider = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const worker = createUnit('worker', 'player', { q: 6, r: 5 }, state.idCounters);
+    worker.id = 'worker';
+    state.units = { raider, worker };
+    state.civilizations.player.units = ['worker'];
+    state.map.tiles['8,5'] = {
+      ...state.map.tiles['8,5'],
+      resource: 'iron', improvement: 'mine', improvementTurnsLeft: 0, owner: 'player',
+    };
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.opponentAI.barbarianCamps['camp-a']).toMatchObject({
+      target: { kind: 'unit', id: 'worker' },
+    });
+  });
 });
 
 describe('barbarian camp evolution', () => {

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -13,6 +13,8 @@ import { checkCampEvolution } from '@/systems/minor-civ-system';
 import { createNewGame } from '@/core/game-state';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { createUnit } from '@/systems/unit-system';
+import { applyPillageToState } from '@/systems/pillage-system';
+import { executeUnitMove } from '@/systems/unit-movement-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -372,6 +374,99 @@ describe('processPurposefulBarbarians', () => {
     const result = processPurposefulBarbarians(state);
 
     expect(result.pillageOrders).toContainEqual({ unitId: 'raider', tileKey: '7,5' });
+  });
+
+  it('also queues a same-turn withdrawal move for a raider that arrives on a pre-existing (not freshly-created) plan (#541 second-pass review)', () => {
+    // The first pillage-on-arrival test above accidentally avoided this: with no
+    // pre-existing plan, the plan is created fresh THIS turn (createdTurn === state.turn),
+    // so completedResourceRaid's `plan.createdTurn < state.turn` check is false and the
+    // withdrawal transition never fires in the same call. A raider that has been walking
+    // toward the tile for several turns (the realistic case) arrives with an
+    // ALREADY-EXISTING plan, so completedResourceRaid IS true this turn, the plan flips to
+    // 'withdrawing', and the same unit gets a moveOrder queued in the very same call that
+    // queued its pillageOrder — turn-manager.ts must apply pillage before move, or the
+    // raider steps off the tile before applyPillageToState ever runs.
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 7, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.map.tiles['7,5'] = {
+      ...state.map.tiles['7,5'],
+      resource: 'iron',
+      improvement: 'mine',
+      improvementTurnsLeft: 0,
+      owner: 'player',
+    };
+    state.opponentAI = {
+      barbarianCamps: {
+        'camp-a': {
+          objective: 'raid',
+          target: { kind: 'resource', resource: 'iron', position: { q: 7, r: 5 } },
+          phase: 'raiding',
+          commitment: 1,
+          createdTurn: state.turn - 3,
+          lastProgressTurn: state.turn - 1,
+          expiresAfterTurn: state.turn + 10,
+          assignedUnitIds: ['raider'],
+        },
+      },
+      barbarianHomeCampByUnitId: { raider: 'camp-a' },
+    } as never;
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.pillageOrders).toContainEqual({ unitId: 'raider', tileKey: '7,5' });
+    expect(result.moveOrders.some(order => order.unitId === 'raider')).toBe(true);
+    expect(result.opponentAI.barbarianCamps['camp-a']).toMatchObject({ phase: 'withdrawing' });
+  });
+
+  it('pillages the tile even though a same-turn withdrawal move is also queued, because pillage applies first (#541 second-pass review)', () => {
+    // Proves the actual fix at the level turn-manager.ts consumes these orders: applying
+    // the queued pillageOrder before the queued moveOrder still burns the tile (and the
+    // subsequent move — now blocked by 0 movementPointsLeft — correctly fails validation
+    // instead of silently relocating the "arrived" raider first).
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 7, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.map.tiles['7,5'] = {
+      ...state.map.tiles['7,5'],
+      resource: 'iron',
+      improvement: 'mine',
+      improvementTurnsLeft: 0,
+      owner: 'player',
+    };
+    state.opponentAI = {
+      barbarianCamps: {
+        'camp-a': {
+          objective: 'raid',
+          target: { kind: 'resource', resource: 'iron', position: { q: 7, r: 5 } },
+          phase: 'raiding',
+          commitment: 1,
+          createdTurn: state.turn - 3,
+          lastProgressTurn: state.turn - 1,
+          expiresAfterTurn: state.turn + 10,
+          assignedUnitIds: ['raider'],
+        },
+      },
+      barbarianHomeCampByUnitId: { raider: 'camp-a' },
+    } as never;
+
+    const result = processPurposefulBarbarians(state);
+    const pillageOrder = result.pillageOrders.find(order => order.unitId === 'raider')!;
+    const moveOrder = result.moveOrders.find(order => order.unitId === 'raider')!;
+    expect(pillageOrder).toBeDefined();
+    expect(moveOrder).toBeDefined();
+
+    // Simulate turn-manager.ts's fixed order: pillage first, then attempt the move.
+    const pillaged = applyPillageToState(state, pillageOrder.unitId);
+    expect(pillaged.ok).toBe(true);
+    expect(pillaged.state.map.tiles['7,5'].improvement).toBe('none');
+    expect(pillaged.state.units.raider.movementPointsLeft).toBe(0);
+
+    const moveResult = executeUnitMove(pillaged.state, moveOrder.unitId, moveOrder.toCoord, { actor: 'world' });
+    expect(moveResult.ok).toBe(false);
+    expect(pillaged.state.units.raider.position).toEqual({ q: 7, r: 5 });
   });
 
   it('prioritizes a resource-raid target over a unit-raid target on veteran (multiplier > 1) (#541)', () => {


### PR DESCRIPTION
## Summary
- Closes an existing dead end: barbarian raid plans already navigate to improved resource tiles (`barbarian-system.ts`) but did nothing on arrival — they now pillage, reusing MR1's `pillage-system.ts` helper verbatim, wired in via `turn-manager.ts`.
- New `pillageAggressivenessMultiplier` difficulty field (0.5/1.0/1.3) controls whether a barbarian camp prioritizes a resource-raid target over a unit-raid target when both are available — above 1.0 (veteran), resource-tile raids come first; at or below 1.0 (explorer/standard), today's unit-first priority is unchanged.
- AI civs gain a new discretionary pillage decision in their turn processing (unlike capture, which was already automatic as a passive side effect of the shared combat helper) — AI only pillages civs it's already at war with, never auto-declaring a new war to do so.

## Test plan
- [x] `yarn vitest run tests/systems/barbarian-system.test.ts tests/ai/basic-ai.test.ts tests/core/opponent-challenge.test.ts`
- [x] `yarn test` (full suite, 6898 tests)
- [x] `yarn build`
- [x] Inline dimensional review completed — verified `applyPillageToState` is called from exactly 3 independent sites (player UI, barbarian turn processing, AI turn processing) with zero duplicated logic; verified the barbarian priority-reorder diff touches only the intended unit-raid/resource-raid ordering block (city-raid fallback, camp-defense, and withdrawal logic are byte-for-byte unchanged); verified no save migration needed for the new difficulty field

Closes #541. Final MR of the pillage/capture/prize-crews arc (#650, #651, #653, this one).