### PR TITLE
fix(renderer): wire BUILDING_SPRITE_CATALOG into the city production badge (#658)

### DIFF
--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -73,9 +73,10 @@ Registered in `BUILDING_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.
 
 Live render surface (#658): the city production badge on the hex map
 (`drawCityProductionBadgePass` in `src/renderer/city-render-passes.ts`) draws the queued
-building's sprite via `spriteCache.getBuilding()`, falling back to the `PRODUCTION_ICONS`
-emoji while sprites load and for non-building queue items. City-panel thumbnail surfaces
-are a possible follow-up, not yet implemented — do not claim them in art prompts.
+building's sprite via `spriteCache.getBuilding()` — or the queued unit's sprite via
+`spriteCache.getUnit()` — falling back to the `PRODUCTION_ICONS` emoji while sprites load
+and for legendary-wonder queue items. City-panel thumbnail surfaces are a possible
+follow-up, not yet implemented — do not claim them in art prompts.
 
 | Building | Status | Category |
 |----------|--------|----------|

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -71,6 +71,12 @@ Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 ### Buildings — `src/renderer/sprites/buildings.tsx`
 Registered in `BUILDING_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 
+Live render surface (#658): the city production badge on the hex map
+(`drawCityProductionBadgePass` in `src/renderer/city-render-passes.ts`) draws the queued
+building's sprite via `spriteCache.getBuilding()`, falling back to the `PRODUCTION_ICONS`
+emoji while sprites load and for non-building queue items. City-panel thumbnail surfaces
+are a possible follow-up, not yet implemented — do not claim them in art prompts.
+
 | Building | Status | Category |
 |----------|--------|----------|
 | granary | ✅ sprite | food |

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -1,4 +1,4 @@
-import type { City, CrisisArchetype, HexCoord } from '@/core/types';
+import type { City, CrisisArchetype, HexCoord, UnitType } from '@/core/types';
 import { getOccupiedCityMood } from '@/systems/city-occupation-system';
 import { PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
 import type { LegendaryWonderMapEntry } from '@/systems/legendary-wonder-map-presentation';
@@ -430,15 +430,19 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
   if (!item.projection.isLive || !item.city || item.city.owner !== item.playerCivId) return;
   if (item.city.productionQueue.length === 0) return;
 
-  // #658: prefer the queued building's catalog sprite (loaded per-civ by initSprites);
-  // non-building queue heads (units, wonders) miss the building cache and fall through
-  // to the PRODUCTION_ICONS emoji, which also covers the not-yet-loaded window.
+  // #658: prefer the queued item's catalog sprite (loaded per-civ by initSprites),
+  // keyed by the city owner so hot-seat players each get their own palette. Buildings
+  // and units are separate cache namespaces, so at most one lookup hits. Unit sprites
+  // matter beyond looks: the old ⚔️ training emoji was the same glyph as the
+  // under-siege status badge on the opposite corner of the city. Wonders and
+  // not-yet-loaded sprites fall through to the PRODUCTION_ICONS emoji.
   const queueHead = item.city.productionQueue[0];
-  const buildingSprite = spriteCache.getBuilding(queueHead, item.city.owner);
-  if (buildingSprite) {
+  const spriteImage = spriteCache.getBuilding(queueHead, item.city.owner)
+    ?? spriteCache.getUnit(queueHead as UnitType, item.city.owner);
+  if (spriteImage) {
     const s = item.size * 0.32;
     ctx.drawImage(
-      buildingSprite,
+      spriteImage,
       item.screen.x - item.size * 0.48 - s / 2,
       item.screen.y - item.size * 0.42 - s / 2,
       s,

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -9,6 +9,7 @@ import {
 } from '@/renderer/city-map-presentation';
 import { getFamineBadgeMarkerImage } from '@/renderer/improvements/famine-badge-marker';
 import { getReligionBadgeMarkerImage } from '@/renderer/improvements/religion-badge-marker';
+import { spriteCache } from '@/renderer/sprites/sprite-loader';
 
 export interface CityRenderProjection {
   name: string;
@@ -427,6 +428,24 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
   if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'production');
   if (!item.projection.isLive || !item.city || item.city.owner !== item.playerCivId) return;
+  if (item.city.productionQueue.length === 0) return;
+
+  // #658: prefer the queued building's catalog sprite (loaded per-civ by initSprites);
+  // non-building queue heads (units, wonders) miss the building cache and fall through
+  // to the PRODUCTION_ICONS emoji, which also covers the not-yet-loaded window.
+  const queueHead = item.city.productionQueue[0];
+  const buildingSprite = spriteCache.getBuilding(queueHead, item.city.owner);
+  if (buildingSprite) {
+    const s = item.size * 0.32;
+    ctx.drawImage(
+      buildingSprite,
+      item.screen.x - item.size * 0.48 - s / 2,
+      item.screen.y - item.size * 0.42 - s / 2,
+      s,
+      s,
+    );
+    return;
+  }
 
   const buildIcon = getProductionBadgeIcon(item.city);
   if (!buildIcon) return;

--- a/tests/renderer/city-render-passes.test.ts
+++ b/tests/renderer/city-render-passes.test.ts
@@ -338,7 +338,7 @@ describe('city icon and badge text bounds', () => {
     getBuildingSpy.mockRestore();
   });
 
-  it('#658: keeps the emoji for a non-building queue head (units have no entry in the building sprite cache)', () => {
+  it('#658: keeps the emoji fallback while neither a building nor a unit sprite is cached yet', () => {
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
     const city = {
       id: 'city-1', owner: 'player', productionQueue: ['warrior'], idleProduction: null, unrestLevel: 0,
@@ -350,6 +350,44 @@ describe('city icon and badge text bounds', () => {
     expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(0);
     expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
     expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('⚔️');
+  });
+
+  it('#658 review: draws the queued unit sprite for a unit queue head, so training ⚔️ can never be mistaken for the under-siege ⚔️ badge', () => {
+    const fakeSprite = {} as HTMLImageElement;
+    const getUnitSpy = vi.spyOn(spriteCache, 'getUnit').mockReturnValue(fakeSprite);
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-1', owner: 'player', productionQueue: ['warrior'], idleProduction: null, unrestLevel: 0,
+    } as CityRenderItem['city'];
+    const item = makeItem({ city });
+
+    drawCityProductionBadgePass(ctx, item);
+
+    expect(getUnitSpy).toHaveBeenCalledWith('warrior', 'player');
+    expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(1);
+    expect((ctx as unknown as MockCtx).drawImageCalls[0]![0]).toBe(fakeSprite);
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(0);
+    getUnitSpy.mockRestore();
+  });
+
+  it('#658 review: hot seat — sprite lookup is keyed by the city owner, never a hardcoded player id', () => {
+    const fakeSprite = {} as HTMLImageElement;
+    const getBuildingSpy = vi.spyOn(spriteCache, 'getBuilding').mockReturnValue(fakeSprite);
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-9', owner: 'player-2', productionQueue: ['granary'], idleProduction: null, unrestLevel: 0,
+    } as CityRenderItem['city'];
+    const item = makeItem({
+      city,
+      playerCivId: 'player-2',
+      projection: { ...makeItem().projection, owner: 'player-2' },
+    });
+
+    drawCityProductionBadgePass(ctx, item);
+
+    expect(getBuildingSpy).toHaveBeenCalledWith('granary', 'player-2');
+    expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(1);
+    getBuildingSpy.mockRestore();
   });
 
   it('skips the world-pressure badge for landmark-only (non-live) render items', () => {

--- a/tests/renderer/city-render-passes.test.ts
+++ b/tests/renderer/city-render-passes.test.ts
@@ -17,6 +17,7 @@ import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-l
 import type { LegendaryWonderMapEntry } from '@/systems/legendary-wonder-map-presentation';
 import * as famineBadgeMarker from '@/renderer/improvements/famine-badge-marker';
 import * as religionBadgeMarker from '@/renderer/improvements/religion-badge-marker';
+import { spriteCache } from '@/renderer/sprites/sprite-loader';
 
 class MockCtx {
   fillTextCalls: Array<{ text: string; x: number; y: number; font: string; measuredWidth: number; maxWidth?: number }> = [];
@@ -301,6 +302,54 @@ describe('city icon and badge text bounds', () => {
     expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
     expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('⚠️');
     getFamineBadgeMarkerImageSpy.mockRestore();
+  });
+
+  it('#658: draws the queued building sprite (not the emoji) when the sprite is cached for the city owner', () => {
+    const fakeSprite = {} as HTMLImageElement;
+    const getBuildingSpy = vi.spyOn(spriteCache, 'getBuilding').mockReturnValue(fakeSprite);
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-1', owner: 'player', productionQueue: ['granary'], idleProduction: null, unrestLevel: 0,
+    } as CityRenderItem['city'];
+    const item = makeItem({ city });
+
+    drawCityProductionBadgePass(ctx, item);
+
+    expect(getBuildingSpy).toHaveBeenCalledWith('granary', 'player');
+    expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(1);
+    expect((ctx as unknown as MockCtx).drawImageCalls[0]![0]).toBe(fakeSprite);
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(0);
+    getBuildingSpy.mockRestore();
+  });
+
+  it('#658: falls back to the PRODUCTION_ICONS emoji while the building sprite is not yet cached', () => {
+    const getBuildingSpy = vi.spyOn(spriteCache, 'getBuilding').mockReturnValue(null);
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-1', owner: 'player', productionQueue: ['granary'], idleProduction: null, unrestLevel: 0,
+    } as CityRenderItem['city'];
+    const item = makeItem({ city });
+
+    drawCityProductionBadgePass(ctx, item);
+
+    expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(0);
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
+    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('🌾');
+    getBuildingSpy.mockRestore();
+  });
+
+  it('#658: keeps the emoji for a non-building queue head (units have no entry in the building sprite cache)', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-1', owner: 'player', productionQueue: ['warrior'], idleProduction: null, unrestLevel: 0,
+    } as CityRenderItem['city'];
+    const item = makeItem({ city });
+
+    drawCityProductionBadgePass(ctx, item);
+
+    expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(0);
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
+    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('⚔️');
   });
 
   it('skips the world-pressure badge for landmark-only (non-live) render items', () => {


### PR DESCRIPTION
## Summary

Issue #658 is confirmed real: all 116 `BUILDING_SPRITE_CATALOG` sprites were rasterized per-civ at startup by `initSprites` → `loadCiv`, but `spriteCache.getBuilding()` had zero call sites outside the loader unit test — the load cost was paid every game with no render benefit. (The v2 DOM overlay's `'building'` case in `sprite-overlay.ts` is equally dead: `sync` never receives a building-kind entity.)

## Fix — first live render surface

`drawCityProductionBadgePass` (the city's on-map production badge, drawn only for the viewing player's own cities) now draws the queued item's cached sprite, keyed by the **city owner** so hot-seat players each get their own palette:
- **Buildings** via `spriteCache.getBuilding()`, following the famine-badge image-with-fallback pattern.
- **Units** via `spriteCache.getUnit()` — added in second-pass review (see below).
- **Legendary wonders and not-yet-loaded sprites** fall through to the `PRODUCTION_ICONS` emoji — matching the terrain-tile/improvement-marker "fallback while loading" convention, so `PRODUCTION_ICONS` is intentionally kept, not replaced.

## Second-pass review

A full review across balance, fun, new-player ages (7–43), play styles, difficulty modes, AI usage, UI/UX, architecture, extensibility, data, SFX, saves, testing, and solo/hot-seat surfaced two real issues, both now fixed:

1. **Glyph collision (UX / young players):** unit queue heads originally fell back to the ⚔️ emoji — the *same glyph* as the under-siege status badge on the opposite corner of the same city. "Training a warrior" was indistinguishable from "under attack." Units already have cached per-civ sprites, so the badge now draws the actual unit sprite, unifying the visual language with buildings.
2. **Hot-seat coverage:** no regression pinned that the sprite lookup is keyed by the city owner rather than a hardcoded `'player'` (the #551 leak class). Added a `player-2` owner test.

Dimensions verified clean (no change needed): render-only, so no balance/difficulty/AI impact (AI never consumes this viewer-only badge); no state-shape change, so old saves need no migration and unknown/legacy queue ids fall back to emoji; no SFX implicated; direct `spriteCache` use matches `unit-renderer.ts`; new catalog sprites are picked up with zero wiring.

## Tests

- `tests/renderer/city-render-passes.test.ts`: building sprite drawn (and emoji suppressed) when cached; unit sprite drawn for a unit queue head; emoji fallback when nothing cached; hot-seat owner-keyed lookup. Each draw test fails without the corresponding branch.
- `yarn test`: 422 files, 7000 passed. `yarn build`: clean.

## Manual QA

Verified in the dev server: founded a city, queued a Workshop — the map badge renders the building sprite instead of the ⚒️ emoji. The unit path is the identical `drawImage` branch (same code, `getUnit` source) and is pinned by test.

## Docs

`docs/sprite-design-system.md` now names the one real render surface (building **and** unit sprites) so future art prompts (the #652 class of mistake) can't overclaim panel/chooser surfaces that don't exist yet.

## Follow-up candidates (not in scope)

- City-panel build-chooser/queue thumbnails (DOM surface; needs a canvas-thumbnail helper since cached images use revoked blob URLs).
- Feeding `kind: 'building'` entities to the v2 sprite overlay, or removing that dead case.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)