### PR TITLE
ci: refresh action pin metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,23 +20,23 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           advanced-security: false
           inputs: .github/workflows
-          version: v1.21.0
+          version: v1.26.1
 
   desktop-change-check:
     runs-on: ubuntu-latest
     outputs:
       desktop_changed: ${{ steps.desktop-changes.outputs.desktop_changed }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -67,7 +67,7 @@ jobs:
   web-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -236,7 +236,7 @@ jobs:
     needs: desktop-change-check
     if: github.ref == 'refs/heads/main' || needs.desktop-change-check.outputs.desktop_changed == 'true'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/docs/superpowers/plans/2026-07-20-ci-action-pin-maintenance.md
+++ b/docs/superpowers/plans/2026-07-20-ci-action-pin-maintenance.md
@@ -1,0 +1,78 @@
+# CI Action Pin Maintenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore a trustworthy passing security-analysis workflow without weakening action pinning.
+
+**Architecture:** Keep the existing immutable checkout release SHA and make every version comment identify the exact immutable release. Update the scanner action and scanner binary together from their official releases; do not change permissions or job logic.
+
+**Tech Stack:** GitHub Actions YAML, zizmor.
+
+---
+
+### Task 1: Correct action metadata and scanner version
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml:23-239`
+
+- [ ] **Step 1: Write a source-level failing check**
+
+Run:
+
+```bash
+rg -n 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4$|zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d|version: v1.21.0' .github/workflows/deploy.yml
+```
+
+Expected: eight checkout-comment matches plus the previous zizmor action and binary version.
+
+- [ ] **Step 2: Replace only the audited metadata**
+
+Change the eight checkout comments to `# v4.3.1`. Change zizmor-action to its official `v0.6.0` immutable SHA and set its requested binary version to `v1.26.1`. Preserve every workflow permission, trigger, and input.
+
+- [ ] **Step 3: Run the source-level check again**
+
+Run:
+
+```bash
+rg -n 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4$|zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d|version: v1.21.0' .github/workflows/deploy.yml
+```
+
+Expected: exit 1 with no output.
+
+- [ ] **Step 4: Inspect the intended diff and commit**
+
+Run:
+
+```bash
+git diff --check && git diff -- .github/workflows/deploy.yml
+git add .github/workflows/deploy.yml docs/superpowers/specs/2026-07-20-ci-action-pin-maintenance-design.md docs/superpowers/plans/2026-07-20-ci-action-pin-maintenance.md
+git commit -m "ci: refresh action pin metadata"
+```
+
+Expected: only the action pin comments, zizmor pin/version, and required design/plan documents are committed.
+
+### Task 2: Publish and obtain the authoritative scan
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the narrow repository workflow validation**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:hooks
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Push the branch and open a draft PR**
+
+Run:
+
+```bash
+git push -u origin codex/ci-action-pins
+gh pr create --draft --base main --head codex/ci-action-pins --title "ci: refresh action pin metadata" --body-file /tmp/ci-action-pins-pr.md
+```
+
+Expected: a draft PR whose security-analysis job is the authoritative verification.

--- a/docs/superpowers/specs/2026-07-20-ci-action-pin-maintenance-design.md
+++ b/docs/superpowers/specs/2026-07-20-ci-action-pin-maintenance-design.md
@@ -1,0 +1,13 @@
+# CI Action Pin Maintenance Design
+
+## Goal
+
+Clear the workflow scanner's false blocking findings while retaining immutable, verified GitHub Action pins.
+
+## Decision
+
+Keep the existing `actions/checkout` SHA because it is the official, signed `v4.3.1` release. Correct every adjacent version comment to `v4.3.1`, and update the pinned zizmor action and its scanner version to their current reviewed releases. No workflow permissions, triggers, credentials, or job behavior change.
+
+## Verification
+
+The workflow source must contain the exact current pins and exact version comments. The GitHub Actions security-analysis job is the final authoritative scanner run.


### PR DESCRIPTION
## Summary

- Correct immutable `actions/checkout` version comments to the verified `v4.3.1` release.
- Update the pinned zizmor action to `v0.6.0` and scanner to `v1.26.1`.
- Preserve workflow permissions, triggers, and job behavior.

## Why

The old `# v4` comments named a mutable tag while the workflow intentionally pinned the immutable `v4.3.1` SHA, producing blocking `ref-version-mismatch` findings.

## Validation

- `bash scripts/verify-before-push.sh --fast` — 413 test files passed; 6,885 tests passed; 3 skipped; hook tests passed; build passed
- `git diff --check`

GitHub security-analysis is the authoritative verification for the updated scanner.