### PR TITLE
fix(era13): record NetworkPlan history at resolution

### DIFF
--- a/docs/superpowers/plans/2026-07-21-network-plan-resolution-history.md
+++ b/docs/superpowers/plans/2026-07-21-network-plan-resolution-history.md
@@ -1,0 +1,87 @@
+# NetworkPlan Resolution History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record legendary-wonder NetworkPlan quest progress from explicit owner-turn resolution facts.
+
+**Architecture:** Add a typed resolution result to `network-plan-system`, call it before a civilization's city effects resolve, and pass its facts into a pure history append helper. Keep quest evaluation definition-driven and retain serializable history records.
+
+**Tech Stack:** TypeScript, Vitest.
+
+---
+
+### Task 1: Establish canonical resolution facts
+
+**Files:**
+- Modify: `src/systems/network-plan-system.ts`
+- Modify: `tests/systems/network-plan-system.test.ts`
+
+- [x] **Step 1: Write failing resolver tests**
+
+Add tests for an active `research-mesh` resolving once, a `survey-grid` resolving once with its source city preserved, and negative cases for `surgeResolutionTurn === state.turn` and active recovery.
+
+- [x] **Step 2: Run the focused tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-plan-system.test.ts`
+
+Expected: failure because no owner-turn resolution API exists.
+
+- [x] **Step 3: Implement the minimal typed resolver**
+
+Export `resolveStableNetworkPlansForOwnerTurn(state, civId)`. It must call existing invalid-plan cleanup, return its resulting immutable state plus one sorted fact per eligible active plan, and exclude Surge/recovery facts.
+
+- [x] **Step 4: Re-run the focused tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-plan-system.test.ts`
+
+Expected: pass.
+
+### Task 2: Append supplied facts and wire the turn lifecycle
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/legendary-wonder-history.ts`
+- Modify: `src/core/turn-manager.ts`
+- Modify: `tests/systems/legendary-wonder-history.test.ts`
+
+- [x] **Step 1: Write failing history tests**
+
+Replace the active-plan scan test with a supplied-resolution test that checks idempotency and host city preservation. Add a negative test proving an empty supplied list does not infer an active plan.
+
+- [x] **Step 2: Run the focused history test**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-history.test.ts`
+
+Expected: failure because the existing helper scans active plans.
+
+- [x] **Step 3: Implement typed history append and turn-manager wiring**
+
+Define a reusable serializable record type in `src/core/types.ts`. Change the history helper to append only its supplied facts and deduplicate by owner, plan, and turn. Call the owner-turn resolver after surge state advances and before city yield processing; append its returned facts in that same turn flow.
+
+- [x] **Step 4: Re-run focused system tests and rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/network-plan-system.ts src/systems/legendary-wonder-history.ts src/core/turn-manager.ts src/core/types.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/network-plan-system.test.ts tests/systems/legendary-wonder-history.test.ts
+```
+
+Expected: exit 0.
+
+### Task 3: Validate and publish the stacked MR
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run full verification**
+
+Run: `bash scripts/verify-before-push.sh --fast` and `bash scripts/run-with-mise.sh yarn build`.
+
+- [ ] **Step 2: Inspect and commit**
+
+Run: `git diff --check`, inspect `git diff origin/codex/issue-516-era13-launch-hardening...HEAD`, then commit the implementation, mirrored tests, and these design documents.
+
+- [ ] **Step 3: Push and create a draft PR targeting #661's branch**
+
+Run: `git push -u origin codex/network-plan-history-mr`, then create a draft PR with base `codex/issue-516-era13-launch-hardening`.

--- a/docs/superpowers/specs/2026-07-21-network-plan-resolution-history-design.md
+++ b/docs/superpowers/specs/2026-07-21-network-plan-resolution-history-design.md
@@ -1,0 +1,13 @@
+# NetworkPlan Resolution History Design
+
+## Goal
+
+Make Era 13 legendary-wonder NetworkPlan quests advance only from explicit, once-per-owner-turn resolution facts.
+
+## Decision
+
+`network-plan-system` will own a typed owner-turn resolver. It cleans invalid plans, identifies active constructive or Survey Grid plans that are actually resolving this owner turn, and returns immutable resolution facts. Recovery and Surge turns produce no Stable facts. The legendary-wonder history helper will only append supplied facts; it will no longer scan active plans.
+
+## Verification
+
+Tests prove ordinary active plans resolve once, invalid plans do not resolve, Surge and recovery do not resolve, and the history ledger preserves supplied owner/host facts without adding inferred records.

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -9,7 +9,7 @@ import { getCivAvailableResources } from '@/systems/resource-acquisition-system'
 import { applyCityMaturity } from '@/systems/city-maturity-system';
 import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
 import { processResearch, getTechById, getEffectiveTechCost } from '@/systems/tech-system';
-import { recordStableConstructivePlanResolutions } from '@/systems/legendary-wonder-history';
+import { appendLegendaryWonderNetworkPlanResolutions } from '@/systems/legendary-wonder-history';
 import {
   processPurposefulBarbarians,
 } from '@/systems/barbarian-system';
@@ -89,6 +89,7 @@ import {
   beginNetworkPlansForVictimTurn,
   isAutonomyActivated,
   resolveNetworkPlansForVictimTurnEnd,
+  resolveStableNetworkPlansForOwnerTurn,
 } from '@/systems/network-plan-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
@@ -186,6 +187,15 @@ export function processTurn(
     if (recoveringBeforeAdvance !== null && recoveringBeforeAdvance !== undefined
       && newState.autonomyByCiv?.[civId]?.surgeRecoveryUntilTurn === null) {
       bus.emit('network:audio-cue', { cue: 'recovery', viewerIds: [civId] });
+    }
+    const resolutionCountBefore = (newState.legendaryWonderHistory?.networkPlanResolutions ?? [])
+      .filter(record => record.civId === civId).length;
+    const ownerTurnResolution = resolveStableNetworkPlansForOwnerTurn(newState, civId);
+    newState = appendLegendaryWonderNetworkPlanResolutions(ownerTurnResolution.state, ownerTurnResolution.resolutions);
+    const resolutionCountAfter = (newState.legendaryWonderHistory?.networkPlanResolutions ?? [])
+      .filter(record => record.civId === civId).length;
+    if (resolutionCountBefore < 3 && resolutionCountAfter >= 3) {
+      bus.emit('network:audio-cue', { cue: 'constructive-resolution', viewerIds: [civId] });
     }
     if (!civ.isHuman) {
       const warningResult = beginNetworkPlansForVictimTurn(newState, civId);
@@ -466,15 +476,6 @@ export function processTurn(
         goldTransferred: event.goldTransferred,
         delayed: event.kind === 'exploit-delayed',
       });
-    }
-
-    const resolutionCountBefore = (newState.legendaryWonderHistory?.networkPlanResolutions ?? [])
-      .filter(record => record.civId === civId).length;
-    newState = recordStableConstructivePlanResolutions(newState, civId);
-    const resolutionCountAfter = (newState.legendaryWonderHistory?.networkPlanResolutions ?? [])
-      .filter(record => record.civId === civId).length;
-    if (resolutionCountBefore < 3 && resolutionCountAfter >= 3) {
-      bus.emit('network:audio-cue', { cue: 'constructive-resolution', viewerIds: [civId] });
     }
 
     // Process research

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -177,10 +177,19 @@ export interface LegendaryWonderDiscoveredSiteRecord {
   turn: number;
 }
 
+export interface LegendaryWonderNetworkPlanResolutionRecord {
+  civId: string;
+  planId: string;
+  definitionId: string;
+  cityId?: string;
+  stable: boolean;
+  turn: number;
+}
+
 export interface LegendaryWonderHistory {
   destroyedStrongholds: DestroyedStrongholdRecord[];
   discoveredSites: LegendaryWonderDiscoveredSiteRecord[];
-  networkPlanResolutions?: Array<{ civId: string; planId: string; definitionId: string; cityId?: string; stable: boolean; turn: number }>;
+  networkPlanResolutions?: LegendaryWonderNetworkPlanResolutionRecord[];
 }
 
 export type LegendaryWonderIntelKind = 'started' | 'completed' | 'host-location-known';

--- a/src/systems/legendary-wonder-history.ts
+++ b/src/systems/legendary-wonder-history.ts
@@ -2,8 +2,8 @@ import type {
   GameState,
   HexCoord,
   LegendaryWonderDiscoverySiteType,
+  LegendaryWonderNetworkPlanResolutionRecord,
 } from '@/core/types';
-import { isConstructiveSpecialistPlan } from './network-plan-definitions';
 
 export function recordLegendaryWonderDiscoverySite(
   state: GameState,
@@ -42,14 +42,18 @@ export function countLegendaryWonderDiscoverySites(
   ).length;
 }
 
-export function recordStableConstructivePlanResolutions(state: GameState, civId: string): GameState {
-  const autonomy = state.autonomyByCiv?.[civId];
-  if (!autonomy || autonomy.surgeRecoveryUntilTurn !== null && autonomy.surgeRecoveryUntilTurn > state.turn) return state;
+/** Appends facts emitted by the NetworkPlan owner-turn resolver; never scans plan state. */
+export function appendLegendaryWonderNetworkPlanResolutions(
+  state: GameState,
+  resolutions: readonly LegendaryWonderNetworkPlanResolutionRecord[],
+): GameState {
+  if (resolutions.length === 0) return state;
   const records = state.legendaryWonderHistory?.networkPlanResolutions ?? [];
-  const additions = Object.values(autonomy.plans)
-    .filter(plan => plan.status === 'active' && (isConstructiveSpecialistPlan(plan.definitionId) || plan.definitionId === 'survey-grid'))
-    .filter(plan => !records.some(record => record.civId === civId && record.planId === plan.id && record.turn === state.turn))
-    .map(plan => ({ civId, planId: plan.id, definitionId: plan.definitionId, cityId: plan.source?.kind === 'city' ? plan.source.cityId : undefined, stable: true, turn: state.turn }));
+  const additions = resolutions.filter(resolution => !records.some(record =>
+    record.civId === resolution.civId
+      && record.planId === resolution.planId
+      && record.turn === resolution.turn,
+  ));
   if (additions.length === 0) return state;
   return { ...state, legendaryWonderHistory: { destroyedStrongholds: state.legendaryWonderHistory?.destroyedStrongholds ?? [], discoveredSites: state.legendaryWonderHistory?.discoveredSites ?? [], networkPlanResolutions: [...records, ...additions] } };
 }

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -5,7 +5,7 @@ import type {
   NetworkPlanSource,
 } from '@/core/autonomy-state';
 import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
-import type { GameState } from '@/core/types';
+import type { GameState, LegendaryWonderNetworkPlanResolutionRecord } from '@/core/types';
 import { isAtWar } from '@/systems/diplomacy-system';
 import { hexDistance } from '@/systems/hex-utils';
 import { isAutonomyActivated as isAutonomyActivatedForCiv } from './autonomy-activation';
@@ -71,6 +71,13 @@ export interface NetworkTurnEndResult {
   state: GameState;
   creditsByOwner: Record<string, number>;
   events: NetworkEffectEvent[];
+}
+
+export type NetworkPlanResolutionRecord = LegendaryWonderNetworkPlanResolutionRecord;
+
+export interface NetworkPlanOwnerTurnResolutionResult {
+  state: GameState;
+  resolutions: NetworkPlanResolutionRecord[];
 }
 
 export interface NetworkPlanCleanupResult {
@@ -391,6 +398,37 @@ export function cancelInvalidNetworkPlans(state: GameState): NetworkPlanCleanupR
     cancelled.push({ planId: plan.id, reason: validation.reason });
   }
   return { state: nextState, cancelled };
+}
+
+/**
+ * Resolves the owner-turn fact for passive specialist plans before city yields
+ * consume their effects. These records are the canonical progression input for
+ * legendary-wonder quests; callers must not infer them from later state scans.
+ */
+export function resolveStableNetworkPlansForOwnerTurn(
+  state: GameState,
+  civId: string,
+): NetworkPlanOwnerTurnResolutionResult {
+  const nextState = cancelInvalidNetworkPlans(state).state;
+  const autonomy = nextState.autonomyByCiv?.[civId];
+  if (!autonomy || (autonomy.surgeRecoveryUntilTurn ?? 0) > nextState.turn) {
+    return { state: nextState, resolutions: [] };
+  }
+
+  const resolutions = Object.values(autonomy.plans)
+    .filter(plan => plan.status === 'active'
+      && (isConstructiveSpecialistPlan(plan.definitionId) || plan.definitionId === 'survey-grid')
+      && plan.surgeResolutionTurn !== nextState.turn)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map(plan => ({
+      civId,
+      planId: plan.id,
+      definitionId: plan.definitionId,
+      cityId: plan.source?.kind === 'city' ? plan.source.cityId : undefined,
+      stable: true,
+      turn: nextState.turn,
+    }));
+  return { state: nextState, resolutions };
 }
 
 export function beginNetworkPlansForVictimTurn(

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -62,6 +62,33 @@ function createWrappedGrasslandMap(width: number, height: number): GameState['ma
 }
 
 describe('processTurn', () => {
+  it('records a stable NetworkPlan resolution through the live owner-turn loop for player and AI owners', () => {
+    const state = createNewGame('rome', 'network-plan-history-turn-loop', 'small');
+    state.cities = {};
+    for (const [civId, position] of [['player', { q: 2, r: 2 }], ['ai-1', { q: 5, r: 2 }]] as const) {
+      const civ = state.civilizations[civId]!;
+      const city = foundCity(civId, position, state.map, state.idCounters);
+      city.buildings = ['network_operations_center'];
+      city.workedTiles = [];
+      city.productionQueue = [];
+      state.cities[city.id] = city;
+      civ.cities = [city.id];
+      civ.techState.completed = ['quantum-computing'];
+      state.autonomyByCiv![civId]!.plans[`${civId}-mesh`] = {
+        id: `${civId}-mesh`, ownerCivId: civId, definitionId: 'research-mesh',
+        source: { kind: 'city', cityId: city.id }, target: { kind: 'city', cityId: city.id },
+        status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+      };
+    }
+
+    const result = processTurn(state, new EventBus());
+
+    expect(result.legendaryWonderHistory?.networkPlanResolutions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ civId: 'player', planId: 'player-mesh', stable: true, turn: 1 }),
+      expect.objectContaining({ civId: 'ai-1', planId: 'ai-1-mesh', stable: true, turn: 1 }),
+    ]));
+  });
+
   it('applies Precision Gene Editing healing from a nearby Neural Rehabilitation Center during the owner turn', () => {
     const state = createNewGame('rome', 'precision-gene-healing', 'small');
     const civ = state.civilizations.player;

--- a/tests/systems/legendary-wonder-history.test.ts
+++ b/tests/systems/legendary-wonder-history.test.ts
@@ -1,34 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { recordStableConstructivePlanResolutions } from '@/systems/legendary-wonder-history';
+import { appendLegendaryWonderNetworkPlanResolutions } from '@/systems/legendary-wonder-history';
 
 describe('legendary-wonder history', () => {
-  it('records each active constructive plan once per stable owner turn', () => {
+  it('appends supplied owner-turn resolution facts once while preserving the host city', () => {
     const state = createNewGame('rome', 'wonder-history', 'small');
     const cityId = state.civilizations.player.cities[0]!;
-    state.autonomyByCiv!.player.plans.mesh = {
-      id: 'mesh', ownerCivId: 'player', definitionId: 'research-mesh',
-      source: { kind: 'city', cityId }, target: { kind: 'city', cityId },
-      status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
-    };
+    const resolution = { civId: 'player', planId: 'mesh', definitionId: 'research-mesh', cityId, stable: true, turn: state.turn };
 
-    const recorded = recordStableConstructivePlanResolutions(state, 'player');
+    const recorded = appendLegendaryWonderNetworkPlanResolutions(state, [resolution]);
     expect(recorded.legendaryWonderHistory?.networkPlanResolutions).toEqual([
-      expect.objectContaining({ civId: 'player', planId: 'mesh', definitionId: 'research-mesh', stable: true, turn: state.turn }),
+      resolution,
     ]);
-    expect(recordStableConstructivePlanResolutions(recorded, 'player')).toEqual(recorded);
+    expect(appendLegendaryWonderNetworkPlanResolutions(recorded, [resolution])).toEqual(recorded);
   });
 
-  it('does not count constructive plans during Surge recovery', () => {
-    const state = createNewGame('rome', 'wonder-history-recovery', 'small');
+  it('does not infer a resolution from an active plan when supplied no facts', () => {
+    const state = createNewGame('rome', 'wonder-history-no-inference', 'small');
     const cityId = state.civilizations.player.cities[0]!;
-    state.autonomyByCiv!.player.surgeRecoveryUntilTurn = state.turn + 1;
     state.autonomyByCiv!.player.plans.mesh = {
       id: 'mesh', ownerCivId: 'player', definitionId: 'research-mesh',
       source: { kind: 'city', cityId }, target: { kind: 'city', cityId },
       status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
     };
 
-    expect(recordStableConstructivePlanResolutions(state, 'player')).toBe(state);
+    expect(appendLegendaryWonderNetworkPlanResolutions(state, [])).toBe(state);
   });
 });

--- a/tests/systems/network-plan-system.test.ts
+++ b/tests/systems/network-plan-system.test.ts
@@ -8,6 +8,7 @@ import {
   previewNetworkPlan,
   cancelInvalidNetworkPlans,
   retargetNetworkPlan,
+  resolveStableNetworkPlansForOwnerTurn,
   validateNetworkPlanAssignment,
 } from '@/systems/network-plan-system';
 
@@ -78,6 +79,82 @@ function makeState(): GameState {
 }
 
 describe('network plan lifecycle', () => {
+  it('emits one explicit stable resolution for an active constructive plan on its owner turn', () => {
+    const state = makeState();
+    state.cities['city-player']!.buildings = ['network_operations_center'];
+    state.autonomyByCiv!.player.plans.mesh = {
+      id: 'mesh', ownerCivId: 'player', definitionId: 'research-mesh',
+      source: { kind: 'city', cityId: 'city-player' }, target: { kind: 'city', cityId: 'city-player' },
+      status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+    };
+
+    const result = resolveStableNetworkPlansForOwnerTurn(state, 'player');
+
+    expect(result.resolutions).toEqual([
+      { civId: 'player', planId: 'mesh', definitionId: 'research-mesh', cityId: 'city-player', stable: true, turn: state.turn },
+    ]);
+  });
+
+  it('does not emit stable resolutions during Surge or recovery', () => {
+    const state = makeState();
+    state.cities['city-player']!.buildings = ['space_center'];
+    state.autonomyByCiv!.player.plans.survey = {
+      id: 'survey', ownerCivId: 'player', definitionId: 'survey-grid',
+      source: { kind: 'city', cityId: 'city-player' }, target: { kind: 'city', cityId: 'city-player' },
+      linkedUnitIds: ['unit-cyber'], status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+      surgeResolutionTurn: state.turn,
+    };
+
+    expect(resolveStableNetworkPlansForOwnerTurn(state, 'player').resolutions).toEqual([]);
+
+    state.autonomyByCiv!.player.plans.survey.surgeResolutionTurn = null;
+    state.autonomyByCiv!.player.surgeRecoveryUntilTurn = state.turn + 1;
+    expect(resolveStableNetworkPlansForOwnerTurn(state, 'player').resolutions).toEqual([]);
+  });
+
+  it('emits a Survey Grid fact with its source city on an ordinary owner turn', () => {
+    const state = makeState();
+    state.cities['city-player']!.buildings = ['space_center'];
+    state.autonomyByCiv!.player.plans.survey = {
+      id: 'survey', ownerCivId: 'player', definitionId: 'survey-grid',
+      source: { kind: 'city', cityId: 'city-player' }, target: { kind: 'city', cityId: 'city-player' },
+      linkedUnitIds: ['unit-cyber'], status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+    };
+
+    expect(resolveStableNetworkPlansForOwnerTurn(state, 'player').resolutions).toEqual([
+      { civId: 'player', planId: 'survey', definitionId: 'survey-grid', cityId: 'city-player', stable: true, turn: state.turn },
+    ]);
+  });
+
+  it('cleans an invalid plan before it can emit a stable resolution', () => {
+    const state = makeState();
+    state.autonomyByCiv!.player.plans.mesh = {
+      id: 'mesh', ownerCivId: 'player', definitionId: 'research-mesh',
+      source: { kind: 'city', cityId: 'city-player' }, target: { kind: 'city', cityId: 'city-player' },
+      status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+    };
+
+    const result = resolveStableNetworkPlansForOwnerTurn(state, 'player');
+
+    expect(result.resolutions).toEqual([]);
+    expect(result.state.autonomyByCiv!.player.plans).not.toHaveProperty('mesh');
+  });
+
+  it('emits the same owner-turn fact for an AI civilization', () => {
+    const state = makeState();
+    state.cities['city-ai']!.buildings = ['network_operations_center'];
+    state.civilizations['ai-1']!.techState.completed = ['quantum-computing'];
+    state.autonomyByCiv!['ai-1'].plans.mesh = {
+      id: 'mesh', ownerCivId: 'ai-1', definitionId: 'research-mesh',
+      source: { kind: 'city', cityId: 'city-ai' }, target: { kind: 'city', cityId: 'city-ai' },
+      status: 'active', createdTurn: state.turn, nextResolutionTurn: state.turn, warnedTurn: null,
+    };
+
+    expect(resolveStableNetworkPlansForOwnerTurn(state, 'ai-1').resolutions).toEqual([
+      { civId: 'ai-1', planId: 'mesh', definitionId: 'research-mesh', cityId: 'city-ai', stable: true, turn: state.turn },
+    ]);
+  });
+
   it('uses the Autonomous Mobility Survey Grid Load in both validation and preview', () => {
     const state = makeState();
     state.cities['city-player']!.buildings = ['network_operations_center'];


### PR DESCRIPTION
## Summary

- Move legendary-wonder NetworkPlan progress from a late active-plan scan to typed owner-turn resolution facts.
- Clean invalid plans before producing facts; exclude Surge and active recovery.
- Preserve once-per-owner-turn history deduplication and wire player/AI owner turns before city yields.

## Stacking

Depends on #661; base is `codex/issue-516-era13-launch-hardening`.

## Validation

- `bash scripts/run-with-mise.sh yarn test` (424 files, 7,030 passed; 3 skipped)
- `bash scripts/verify-before-push.sh --fast`
- `bash scripts/run-with-mise.sh yarn build`
- targeted NetworkPlan/history/turn-manager tests and source-rule checks