### PR TITLE
test(e2e): establish canvas verification foundation (#660)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-660-canvas-verification.md
+++ b/docs/superpowers/plans/2026-07-23-issue-660-canvas-verification.md
@@ -1,0 +1,1609 @@
+# Issue #660 Canvas Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic, renderer-aware Canvas 2D verification while eliminating city-badge glyph and layout drift without exposing test controls in production builds.
+
+**Architecture:** Keep production additions narrow: a pure badge-presentation module, sprite metadata, viewer-safe renderer geometry queries, and an e2e runtime dynamically imported behind a literal Vite mode check. Keep fixture mutation and canvas interception in typed Playwright helpers, then migrate the existing browser specs and add one focused production-badge suite. Build-time and source-use sentinels keep the e2e seam and dormant v2 building catalog from becoming accidental production APIs.
+
+**Tech Stack:** TypeScript 5.9, Canvas 2D, Vite 8, Vitest 4, Playwright 1.59, Node.js scripts, Yarn 4.
+
+**Approved design:** `docs/superpowers/specs/2026-07-22-issue-660-canvas-verification-design.md`
+
+---
+
+## File Structure
+
+### Production source
+
+- Create `src/renderer/city-badge-presentation.ts`: semantic badge glyph registry, named slots, normalized bounds, and coexistence rules.
+- Modify `src/renderer/city-render-passes.ts`: consume the shared glyph/layout contract and use the generic production fallback.
+- Modify `src/renderer/city-renderer.ts`: export viewer-safe render-item geometry queries built from the live renderer projection.
+- Modify `src/renderer/sprites/sprite-loader.ts`: attach stable catalog metadata and expose the existing sprite-load promise to startup.
+- Create `src/testing/e2e-mode.ts`: pure exact-query predicate.
+- Create `src/testing/e2e-runtime.ts`: gated read-only readiness and renderer-geometry diagnostics.
+- Modify `src/main.ts`: literal e2e mode branch, canonical autosave entry, readiness reporting, and renderer-owned query closures.
+- Modify `src/vite-env.d.ts`: type the read-only e2e diagnostic only; do not add mutation or capture APIs.
+
+### Test harness and browser coverage
+
+- Create `tests/e2e/helpers/save-fixture.ts`: fresh-clone fixture loading, typed transforms, direct/UI installation, and valid production scenarios.
+- Create `tests/e2e/helpers/campaign-entry.ts`: direct and live-Continue campaign entry plus named readiness waits.
+- Create `tests/e2e/helpers/canvas-ops.ts`: dormant bounded capture probe, typed operations, filtering, frame synchronization, and freeze.
+- Create `tests/e2e/helpers/render-geometry.ts`: typed wrappers over renderer-owned visible-copy and badge-slot queries.
+- Create `tests/e2e/production-badges.spec.ts`: building, unit, and legendary-wonder Canvas assertions.
+- Create `tests/e2e/campaign-entry-smoke.spec.ts`: real Continue-button integration.
+- Modify `tests/e2e/issue-365-map-presentation.spec.ts`, `tests/e2e/issue-437-hud-alignment.spec.ts`, and `tests/e2e/issue-447-water-recovery.spec.ts`: remove copied fixture/entry/sleep/hex helpers.
+
+### Unit, architecture, and build tests
+
+- Create `tests/renderer/city-badge-presentation.test.ts`.
+- Modify `tests/renderer/city-render-passes.test.ts`, `tests/renderer/city-renderer.test.ts`, and `tests/renderer/camera.test.ts`.
+- Modify `tests/renderer/sprites/sprite-loader.test.ts` and `tests/renderer/sprites/sprite-catalog.test.ts`.
+- Create `tests/testing/e2e-mode.test.ts`, `tests/testing/e2e-runtime.test.ts`, `tests/e2e/helpers/save-fixture.test.ts`, and `tests/e2e/helpers/canvas-ops.test.ts`.
+- Create `tests/architecture/e2e-source-guard.test.ts` and `tests/architecture/v2-building-consumer.test.ts`.
+- Modify `tests/platform/playwright-config.test.ts`, `tests/main.integration.test.ts`, and `tests/systems/city-system.test.ts`.
+- Create `scripts/assert-no-e2e-runtime.mjs` and `tests/scripts/assert-no-e2e-runtime.test.ts`.
+- Modify `playwright.config.ts` and `package.json`.
+
+### Documentation
+
+- Create `docs/testing/canvas-render-verification.md`.
+- Modify `.claude/rules/ui-panels.md`.
+
+## Player Truth Table
+
+| Before | Action or transition | Internal result | Immediate visible result | Must remain reachable |
+|---|---|---|---|---|
+| Granary is active while its sprite loads | A sprite frame finishes loading | Cache gains the granary image; queue is unchanged | Map changes from `🏗️` to the granary sprite on a later frame | Granary name, icon, progress, order, and ETA in the city panel |
+| Warrior is active and the city is under siege | Renderer draws the city | No gameplay state changes | Production sprite or `🏗️` and separate `⚔️` status badge appear in disjoint slots | Full production catalog and existing queue controls |
+| Standing Stones is active | Renderer draws an intentionally unsprited item | No gameplay state changes | `🏗️` appears in the production slot | Existing legendary-wonder label and queue details |
+| Queue is empty with gold/science idle conversion | Renderer draws the city | No gameplay state changes | Existing idle glyph occupies the production/idle slot | Existing idle-production controls |
+| Modern solo autosave is installed | Player clicks real `Continue` | Canonical load/normalization enters the campaign | Save panel closes and canvas campaign is visible | New Game, exact save rows, imports, and legacy challenge flow |
+
+## Misleading UI Risks
+
+- `🏗️` means “city production is active but no catalog sprite is being drawn,” not the identity of the queued item. The city panel must continue to show the specific item identity and timing.
+- `sprites-ready` means every requested catalog image load fulfilled. It must not be reported after a rejected load, and campaign entry must remain usable with fallback art after that rejection.
+- A badge slot query means the city is actually rendered for the current viewer. Last-seen or hidden richer state must not be exposed as a live city result.
+- A captured `drawImage` is evidence only when it completed successfully and has matching stable sprite metadata; blob URLs and arbitrary image identity are not semantic evidence.
+- The v2 building catalog remains dormant. Existing assets resolving successfully must not be described as a live map or panel integration.
+
+## Interaction Replay Checklist
+
+- Click the real Continue button once and verify the campaign appears.
+- Reopen browser state in a fresh Playwright context and use direct entry; no prior runtime or capture state may leak.
+- Start, freeze, and start a second canvas capture; sequence/session state must reset.
+- Repeat HUD expand/collapse after helper migration to prove stale locators were not introduced.
+- Select a stacked unit, perform blocked recovery, then click the valid recovery tile using renderer-owned geometry.
+- Re-run the mobile/reduced-motion entry with viewport and media preferences set before navigation.
+
+## Queue and ETA Checklist
+
+- Active item remains the first visible item in the existing city panel.
+- Follow-up items remain in their existing order; this feature performs no queue mutation.
+- Existing progress and ETA text must remain visible and unchanged.
+- Existing reorder/remove behavior and invalid-item handling remain owned by the city panel and city system.
+- The renderer tests must snapshot the queue before and after every badge pass and prove presentation is state-pure.
+
+---
+
+### Task 1: Secure the e2e mode and production-bundle boundary
+
+**Files:**
+- Create: `src/testing/e2e-mode.ts`
+- Create: `tests/testing/e2e-mode.test.ts`
+- Create: `scripts/assert-no-e2e-runtime.mjs`
+- Create: `tests/scripts/assert-no-e2e-runtime.test.ts`
+- Modify: `playwright.config.ts`
+- Modify: `tests/platform/playwright-config.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write the failing exact-gate tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { isExactAutosaveE2ERequest } from '@/testing/e2e-mode';
+
+describe('isExactAutosaveE2ERequest', () => {
+  it.each([
+    ['production', '?e2e=autosave'],
+    ['development', '?e2e=autosave'],
+    ['tauri', '?e2e=autosave'],
+    ['e2e', ''],
+    ['e2e', '?e2e=true'],
+    ['e2e', '?e2e=autosave&state={}'],
+  ])('rejects mode %s and query %s', (mode, search) => {
+    expect(isExactAutosaveE2ERequest(mode, search)).toBe(false);
+  });
+
+  it('accepts only the literal e2e autosave request', () => {
+    expect(isExactAutosaveE2ERequest('e2e', '?e2e=autosave')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing module fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/testing/e2e-mode.test.ts`
+
+Expected: FAIL because `src/testing/e2e-mode.ts` does not exist.
+
+- [ ] **Step 3: Add the minimal pure gate**
+
+```ts
+export function isExactAutosaveE2ERequest(mode: string, search: string): boolean {
+  return mode === 'e2e' && search === '?e2e=autosave';
+}
+```
+
+- [ ] **Step 4: Write the bundle-sentinel script tests**
+
+```ts
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { assertNoE2ERuntime } from '../../scripts/assert-no-e2e-runtime.mjs';
+
+it('accepts emitted assets without the sentinel', () => {
+  const root = mkdtempSync(join(tmpdir(), 'cq-e2e-clean-'));
+  mkdirSync(join(root, 'assets'));
+  writeFileSync(join(root, 'assets', 'app.js'), 'console.log("ok")');
+  expect(() => assertNoE2ERuntime(root)).not.toThrow();
+});
+
+it('rejects a sentinel in emitted JavaScript or source maps', () => {
+  const root = mkdtempSync(join(tmpdir(), 'cq-e2e-leak-'));
+  mkdirSync(join(root, 'assets'));
+  writeFileSync(join(root, 'assets', 'app.js'), 'window.__CONQUESTORIA_E2E_DIAGNOSTICS__');
+  expect(() => assertNoE2ERuntime(root)).toThrow(/e2e runtime sentinel/i);
+});
+```
+
+- [ ] **Step 5: Implement the emitted-file scanner**
+
+```js
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const E2E_SENTINEL = '__CONQUESTORIA_E2E_DIAGNOSTICS__';
+
+export function assertNoE2ERuntime(root) {
+  const visit = path => {
+    for (const name of readdirSync(path)) {
+      const child = resolve(path, name);
+      if (statSync(child).isDirectory()) visit(child);
+      else if ((name.endsWith('.js') || name.endsWith('.map'))
+        && readFileSync(child, 'utf8').includes(E2E_SENTINEL)) {
+        throw new Error(`e2e runtime sentinel leaked into ${child}`);
+      }
+    }
+  };
+  visit(resolve(root));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  assertNoE2ERuntime(process.argv[2] ?? 'dist');
+}
+```
+
+- [ ] **Step 6: Put Playwright in e2e mode and chain both bundle checks**
+
+```ts
+export function resolvePlaywrightDevCommand(ci = process.env.CI): string {
+  return ci
+    ? 'yarn dev --mode e2e --host 127.0.0.1'
+    : './scripts/run-with-mise.sh yarn dev --mode e2e --host 127.0.0.1';
+}
+```
+
+```json
+{
+  "build": "tsc && vite build && node scripts/version-sw-cache.mjs && node scripts/assert-no-e2e-runtime.mjs dist",
+  "build:tauri": "tsc && vite build --mode tauri && node scripts/assert-no-e2e-runtime.mjs dist"
+}
+```
+
+Update `tests/platform/playwright-config.test.ts` to expect both commands with `--mode e2e`.
+
+- [ ] **Step 7: Run the focused tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/testing/e2e-mode.test.ts tests/scripts/assert-no-e2e-runtime.test.ts tests/platform/playwright-config.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/testing/e2e-mode.ts tests/testing/e2e-mode.test.ts scripts/assert-no-e2e-runtime.mjs tests/scripts/assert-no-e2e-runtime.test.ts playwright.config.ts tests/platform/playwright-config.test.ts package.json
+git commit -m "test(e2e): gate canvas diagnostics from production"
+```
+
+### Task 2: Centralize city-badge meanings and collision-free geometry
+
+**Files:**
+- Create: `src/renderer/city-badge-presentation.ts`
+- Create: `tests/renderer/city-badge-presentation.test.ts`
+- Modify: `src/renderer/city-render-passes.ts`
+- Modify: `tests/renderer/city-render-passes.test.ts`
+
+- [ ] **Step 1: Write failing glyph and coexistence tests**
+
+```ts
+import { Camera } from '@/renderer/camera';
+import {
+  CITY_BADGE_GLYPHS,
+  CITY_BADGE_GLYPH_COEXISTENCE,
+  CITY_BADGE_SLOT_COEXISTENCE,
+  getCityBadgeLayout,
+  type BadgeBounds,
+} from '@/renderer/city-badge-presentation';
+
+const intersects = (a: BadgeBounds, b: BadgeBounds) =>
+  a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+
+it('keeps simultaneous text meanings distinct', () => {
+  expect(CITY_BADGE_GLYPHS.production).toBe('🏗️');
+  expect(CITY_BADGE_GLYPHS.production).not.toBe(CITY_BADGE_GLYPHS.underSiege);
+  for (const [left, right] of CITY_BADGE_GLYPH_COEXISTENCE) {
+    expect(CITY_BADGE_GLYPHS[left], `${left}/${right}`)
+      .not.toBe(CITY_BADGE_GLYPHS[right]);
+  }
+});
+
+it('keeps every coexistent slot disjoint at normalized and camera zoom sizes', () => {
+  const camera = new Camera();
+  for (const size of [1, camera.hexSize * camera.minZoom, camera.hexSize * camera.maxZoom]) {
+    const layout = getCityBadgeLayout({ x: 0, y: 0 }, size);
+    for (const [left, right] of CITY_BADGE_SLOT_COEXISTENCE) {
+      expect(intersects(layout[left].bounds, layout[right].bounds), `${left}/${right}@${size}`)
+        .toBe(false);
+    }
+  }
+});
+
+it('does not classify production/idle or individual status meanings as coexistent', () => {
+  expect(CITY_BADGE_SLOT_COEXISTENCE).not.toContainEqual(['production', 'idle']);
+  expect(CITY_BADGE_GLYPH_COEXISTENCE).not.toContainEqual(['underSiege', 'unrest']);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing module fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/renderer/city-badge-presentation.test.ts`
+
+Expected: FAIL because the presentation module does not exist.
+
+- [ ] **Step 3: Implement the semantic registry and named layout**
+
+```ts
+export const CITY_BADGE_GLYPHS = {
+  underSiege: '⚔️',
+  breakawaySecession: '⛓',
+  breakawayEstablished: '👑',
+  occupationSevere: '☹',
+  occupation: '⚡',
+  unrestSevere: '🔥',
+  unrest: '⚡',
+  production: '🏗️',
+  idleGold: '💰',
+  idleScience: '🔬',
+  embeddedIntel: '🛡',
+  infiltratedIntel: '👁',
+  worldPressure: '⚠️',
+  loyaltyPressure: '🙏',
+} as const;
+
+export type CityBadgeSlot =
+  | 'status' | 'production' | 'idle' | 'leftIntel' | 'rightIntel'
+  | 'worldPressure' | 'loyaltyPressure' | 'religion';
+
+export type CityBadgeGlyphMeaning = keyof typeof CITY_BADGE_GLYPHS;
+
+export const CITY_BADGE_GLYPH_COEXISTENCE: ReadonlyArray<
+  readonly [CityBadgeGlyphMeaning, CityBadgeGlyphMeaning]
+> = [
+  ['production', 'underSiege'],
+  ['production', 'breakawaySecession'],
+  ['production', 'breakawayEstablished'],
+  ['production', 'occupationSevere'],
+  ['production', 'occupation'],
+  ['production', 'unrestSevere'],
+  ['production', 'unrest'],
+  ['production', 'worldPressure'],
+  ['production', 'loyaltyPressure'],
+];
+
+export const CITY_BADGE_SLOT_COEXISTENCE: ReadonlyArray<readonly [CityBadgeSlot, CityBadgeSlot]> = [
+  ['status', 'production'],
+  ['status', 'worldPressure'],
+  ['status', 'loyaltyPressure'],
+  ['production', 'worldPressure'],
+  ['production', 'religion'],
+  ['worldPressure', 'loyaltyPressure'],
+  ['worldPressure', 'religion'],
+  ['loyaltyPressure', 'religion'],
+];
+
+export function getCityBadgeLayout(screen: { x: number; y: number }, size: number) {
+  const bounds = (x: number, y: number, width: number, height: number): BadgeBounds => ({
+    x, y, width, height,
+    left: x, right: x + width, top: y, bottom: y + height,
+  });
+  const slot = (dx: number, dy: number, width = 0.28, height = 0.28) => {
+    const center = { x: screen.x + size * dx, y: screen.y + size * dy };
+    const x = center.x - size * width / 2;
+    const y = center.y - size * height / 2;
+    return {
+      center,
+      bounds: bounds(x, y, size * width, size * height),
+    };
+  };
+  return {
+    status: slot(0.62, -0.40),
+    production: slot(-0.62, -0.40, 0.32, 0.32),
+    idle: slot(-0.62, -0.40),
+    leftIntel: slot(-0.52, 0.04),
+    rightIntel: slot(0.52, 0.04),
+    worldPressure: slot(0, -0.70, 0.32, 0.32),
+    loyaltyPressure: slot(0.52, -0.70, 0.32, 0.32),
+    religion: slot(-0.52, -0.70, 0.32, 0.32),
+  } as const;
+}
+```
+
+```ts
+export interface BadgeBounds {
+  x: number; y: number; width: number; height: number;
+  left: number; right: number; top: number; bottom: number;
+}
+```
+
+- [ ] **Step 4: Refactor every affected pass to the registry/layout**
+
+```ts
+const layout = getCityBadgeLayout(item.screen, item.size);
+const { center } = layout.production;
+const queueHead = item.city.productionQueue[0];
+const spriteImage = spriteCache.getBuilding(queueHead, item.city.owner)
+  ?? spriteCache.getUnit(queueHead as UnitType, item.city.owner);
+if (spriteImage) {
+  const { x, y, width, height } = layout.production.bounds;
+  ctx.drawImage(spriteImage, x, y, width, height);
+  return;
+}
+drawFittedText(
+  ctx,
+  CITY_BADGE_GLYPHS.production,
+  center.x,
+  center.y,
+  layout.production.bounds.width,
+  item.size * 0.28,
+);
+```
+
+Apply `layout.status`, `layout.idle`, `layout.leftIntel`, `layout.rightIntel`,
+`layout.worldPressure`, `layout.loyaltyPressure`, and `layout.religion` in their
+respective passes. Preserve the existing mutually exclusive status selection and
+all visibility/ownership checks.
+
+- [ ] **Step 5: Update operations-log regressions**
+
+Add cases proving:
+
+```ts
+expect(fallback.fillTextCalls[0]?.text).toBe('🏗️');
+expect(cached.drawImageCalls).toHaveLength(1);
+expect(cached.fillTextCalls).toHaveLength(0);
+expect(wonder.fillTextCalls[0]?.text).toBe('🏗️');
+expect(state.city.productionQueue).toEqual(queueBefore);
+```
+
+Also retain the existing exact status, world-pressure, loyalty, religion, and idle assertions.
+
+- [ ] **Step 6: Run renderer tests and source checks**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/renderer/city-badge-presentation.test.ts tests/renderer/city-render-passes.test.ts tests/renderer/city-renderer.test.ts
+scripts/check-src-rule-violations.sh src/renderer/city-badge-presentation.ts src/renderer/city-render-passes.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/city-badge-presentation.ts src/renderer/city-render-passes.ts tests/renderer/city-badge-presentation.test.ts tests/renderer/city-render-passes.test.ts
+git commit -m "fix(renderer): separate city badge meanings and bounds"
+```
+
+### Task 3: Add stable sprite metadata and observable loading
+
+**Files:**
+- Modify: `src/renderer/sprites/sprite-loader.ts`
+- Modify: `tests/renderer/sprites/sprite-loader.test.ts`
+
+- [ ] **Step 1: Write failing metadata tests**
+
+```ts
+import {
+  getSpriteDiagnosticMetadata,
+  initSprites,
+  spriteCache,
+} from '@/renderer/sprites/sprite-loader';
+
+it('attaches stable building catalog metadata before load completion', async () => {
+  const promise = initSprites({ civ: '#336699' });
+  const created = imageConstructorSpy.mock.results[0]?.value as HTMLImageElement;
+  expect(getSpriteDiagnosticMetadata(created)).toMatchObject({
+    kind: 'building',
+    itemId: expect.any(String),
+    civilization: 'civ',
+  });
+  resolveAllImages();
+  await promise;
+});
+
+it('identifies unit motion and neutral landmarks without state data', async () => {
+  const loading = initSprites({ civ: '#336699' });
+  resolveAllImages();
+  await loading;
+  const unit = spriteCache.getUnitMotion('warrior', 'civ', 'move-a');
+  const landmark = spriteCache.getLandmark('pirate-headquarters');
+  expect(getSpriteDiagnosticMetadata(unit!)).toEqual({
+    kind: 'unit',
+    itemId: 'warrior',
+    civilization: 'civ',
+    motion: 'move-a',
+  });
+  expect(getSpriteDiagnosticMetadata(landmark!)).toEqual({
+    kind: 'landmark',
+    itemId: 'pirate-headquarters',
+    civilization: 'neutral',
+  });
+});
+
+it('rejects when a catalog image fails instead of reporting sprites ready', async () => {
+  const loading = initSprites({ civ: '#336699' });
+  rejectOneImage();
+  await expect(loading).rejects.toThrow('SVG image load failed');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/renderer/sprites/sprite-loader.test.ts`
+
+Expected: FAIL because diagnostic metadata access is absent.
+
+- [ ] **Step 3: Attach metadata when each image is created**
+
+```ts
+export interface SpriteDiagnosticMetadata {
+  kind: 'unit' | 'building' | 'landmark';
+  itemId: string;
+  civilization: string;
+  motion?: UnitSpriteMotion;
+}
+
+export const SPRITE_DIAGNOSTIC_METADATA_KEY = 'conquestoria.spriteDiagnostic';
+const diagnosticMetadataSymbol = Symbol.for(SPRITE_DIAGNOSTIC_METADATA_KEY);
+
+export function getSpriteDiagnosticMetadata(
+  image: CanvasImageSource,
+): Readonly<SpriteDiagnosticMetadata> | null {
+  if (!(image instanceof HTMLImageElement)) return null;
+  return (image as unknown as Record<
+    symbol,
+    Readonly<SpriteDiagnosticMetadata> | undefined
+  >)[diagnosticMetadataSymbol] ?? null;
+}
+
+function svgStringToImage(
+  svgString: string,
+  size: number,
+  metadata: SpriteDiagnosticMetadata,
+): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const img = new Image(size, size);
+    Object.defineProperty(img, diagnosticMetadataSymbol, {
+      value: Object.freeze({ ...metadata }),
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+    img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('SVG image load failed')); };
+    img.src = url;
+  });
+}
+```
+
+Pass `{ kind, itemId, civilization, motion }` at each unit, building, pirate,
+and landmark call site. Do not attach URLs, owner state, visibility, or game data.
+
+- [ ] **Step 4: Run tests and source checks**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/renderer/sprites/sprite-loader.test.ts
+scripts/check-src-rule-violations.sh src/renderer/sprites/sprite-loader.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/sprites/sprite-loader.ts tests/renderer/sprites/sprite-loader.test.ts
+git commit -m "test(renderer): identify catalog image draws"
+```
+
+### Task 4: Expose viewer-safe renderer geometry
+
+**Files:**
+- Modify: `src/renderer/city-renderer.ts`
+- Modify: `tests/renderer/city-renderer.test.ts`
+- Modify: `tests/renderer/camera.test.ts`
+
+- [ ] **Step 1: Write failing geometry tests**
+
+```ts
+it('returns every visible wrapped copy through production projection', () => {
+  const results = getVisibleHexViewportCopies(state, camera, state.currentPlayer, city.position);
+  expect(results).not.toHaveLength(0);
+  for (const result of results) {
+    expect(camera.screenToHex(result.x, result.y)).toEqual(city.position);
+  }
+});
+
+it('returns a named badge slot only for a live city rendered to the viewer', () => {
+  expect(getVisibleCityBadgeSlots(state, camera, state.currentPlayer, city.id, 'production'))
+    .not.toHaveLength(0);
+  expect(getVisibleCityBadgeSlots(state, camera, state.currentPlayer, hiddenCity.id, 'production'))
+    .toEqual([]);
+});
+```
+
+Include one horizontal-wrap case with a viewport that makes two copies visible.
+
+- [ ] **Step 2: Run focused tests and verify missing exports fail**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/renderer/city-renderer.test.ts tests/renderer/camera.test.ts`
+
+Expected: FAIL because the query functions are not exported.
+
+- [ ] **Step 3: Reuse the live projection and transforms**
+
+```ts
+export function getVisibleHexViewportCopies(
+  state: GameState,
+  camera: Camera,
+  viewerId: string,
+  coord: HexCoord,
+): Array<{ x: number; y: number }> {
+  if (!state.civilizations[viewerId]?.visibility) return [];
+  const coords = state.map.wrapsHorizontally
+    ? getHorizontalWrapRenderCoords(coord, state.map.width, camera)
+    : [coord];
+  return coords
+    .filter(copy => camera.isHexVisible(copy))
+    .map(copy => {
+      const world = hexToPixel(copy, camera.hexSize);
+      return camera.worldToScreen(world.x, world.y);
+    });
+}
+
+export function getVisibleCityBadgeSlots(
+  state: GameState,
+  camera: Camera,
+  viewerId: string,
+  cityId: string,
+  slot: CityBadgeSlot,
+) {
+  return createCityRenderItems(state, camera, viewerId, {})
+    .filter(item => item.projection.isLive && item.city?.id === cityId)
+    .map(item => getCityBadgeLayout(item.screen, item.size)[slot]);
+}
+```
+
+Keep `createCityRenderItems` private; return serialized coordinates/bounds only.
+
+- [ ] **Step 4: Run tests and source checks**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/renderer/city-renderer.test.ts tests/renderer/camera.test.ts
+scripts/check-src-rule-violations.sh src/renderer/city-renderer.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/city-renderer.ts tests/renderer/city-renderer.test.ts tests/renderer/camera.test.ts
+git commit -m "test(renderer): expose viewer-safe canvas geometry"
+```
+
+### Task 5: Add the read-only direct-entry runtime and readiness phases
+
+**Files:**
+- Create: `src/testing/e2e-runtime.ts`
+- Create: `tests/testing/e2e-runtime.test.ts`
+- Modify: `src/main.ts`
+- Modify: `src/vite-env.d.ts`
+- Modify: `tests/main.integration.test.ts`
+
+- [ ] **Step 1: Write failing runtime contract tests**
+
+```ts
+it('rejects missing challenge and hot-seat autosaves before entry', async () => {
+  await expect(startE2ERuntime(deps({ state: withoutChallenge })))
+    .rejects.toThrow(/opponent challenge/i);
+  await expect(startE2ERuntime(deps({ state: hotSeatState })))
+    .rejects.toThrow(/hot-seat/i);
+  expect(enterCampaign).not.toHaveBeenCalled();
+});
+
+it('exposes only frozen readiness and serialized geometry queries', async () => {
+  const runtime = await startE2ERuntime(deps({ state: soloState }));
+  expect(Object.isFrozen(runtime)).toBe(true);
+  expect(Object.keys(runtime).sort()).toEqual([
+    'errors', 'getCityBadgeSlots', 'getVisibleHexCopies', 'readiness',
+  ]);
+  expect(runtime).not.toHaveProperty('gameState');
+  expect(runtime).not.toHaveProperty('camera');
+  expect(runtime).not.toHaveProperty('renderLoop');
+});
+
+it('records sprite rejection without blocking campaign readiness', async () => {
+  const runtime = await startE2ERuntime(deps({ spritePromise: Promise.reject(new Error('bad sprite')) }));
+  expect(runtime.readiness()).toContain('campaign-ready');
+  await Promise.resolve();
+  expect(runtime.readiness()).not.toContain('sprites-ready');
+  expect(runtime.errors()).toContainEqual(expect.stringContaining('bad sprite'));
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing runtime fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/testing/e2e-runtime.test.ts`
+
+Expected: FAIL because `src/testing/e2e-runtime.ts` does not exist.
+
+- [ ] **Step 3: Implement the dependency-injected runtime**
+
+```ts
+export interface E2ERuntimeDependencies {
+  loadAutosave: () => Promise<LoadedSaveEntry | undefined>;
+  enterSoloCampaign: (state: GameState) => Promise<void>;
+  getVisibleHexCopies: (coord: HexCoord) => ViewportPoint[];
+  getCityBadgeSlots: (cityId: string, slot: CityBadgeSlot) => BadgeSlotResult[];
+}
+
+export async function startE2ERuntime(deps: E2ERuntimeDependencies) {
+  const loaded = await deps.loadAutosave();
+  if (!loaded) throw new Error('E2E direct entry requires an installed autosave.');
+  const state = loaded.state;
+  if (!isOpponentChallenge(state.opponentChallenge)) {
+    throw new Error('E2E autosave requires a valid opponent challenge.');
+  }
+  if (state.hotSeat) throw new Error('E2E direct entry does not bypass hot-seat handoff.');
+
+  const phases = new Set<string>();
+  const errors: string[] = [];
+  const sprites = deps.enterSoloCampaign(state);
+  phases.add('campaign-ready');
+  void sprites.then(
+    () => phases.add('sprites-ready'),
+    error => errors.push(String(error)),
+  );
+
+  return Object.freeze({
+    readiness: () => Object.freeze([...phases]),
+    errors: () => Object.freeze([...errors]),
+    getVisibleHexCopies: deps.getVisibleHexCopies,
+    getCityBadgeSlots: deps.getCityBadgeSlots,
+  });
+}
+```
+
+- [ ] **Step 4: Retain sprite readiness and mark campaign readiness after startup**
+
+Change `startGame()` to return the non-blocking sprite promise:
+
+```ts
+function startGame(): Promise<void> {
+  const spritesReady = initSprites(civColors);
+  void spritesReady.catch(() => {});
+  renderLoop.start();
+  return spritesReady;
+}
+```
+
+Return that promise from the existing solo branches while leaving hot-seat handoff
+as a deferred `null` result:
+
+```ts
+function enterCampaign(
+  state: GameState,
+  message: string,
+  persistBeforeReady = false,
+): Promise<void> | null {
+  document.getElementById('save-panel')?.remove();
+  gameState = state;
+  migrateLegacySave();
+  if (gameState.gameOver) {
+    const spritesReady = startGame();
+    handleVictoryIfNeeded();
+    return spritesReady;
+  }
+  if (!gameState.hotSeat) {
+    const spritesReady = startGame();
+    showNotification(message, 'info');
+    return spritesReady;
+  }
+  // Existing handoff controller and persistence code remain unchanged.
+  return null;
+}
+
+function enterCampaignForE2E(state: GameState): Promise<void> {
+  if (state.hotSeat) throw new Error('E2E direct entry does not bypass hot-seat handoff.');
+  const spritesReady = enterCampaign(state, `Welcome back! Turn ${state.turn}`);
+  if (!spritesReady) throw new Error('E2E direct entry requires a solo campaign.');
+  return spritesReady;
+}
+```
+
+Because `startGame()` remains synchronous until its returned promise is observed,
+`campaign-ready` is set only after `renderLoop.setGameState`, camera centering,
+and `renderLoop.start()` have occurred. Normal UI callbacks may ignore the return.
+
+- [ ] **Step 5: Add the literal mode/query branch in `init()`**
+
+```ts
+if (import.meta.env.MODE === 'e2e') {
+  const { isExactAutosaveE2ERequest } = await import('@/testing/e2e-mode');
+  if (isExactAutosaveE2ERequest(import.meta.env.MODE, window.location.search)) {
+    const { installE2ERuntime } = await import('@/testing/e2e-runtime');
+    await installE2ERuntime({
+      loadAutosave: loadMostRecentAutoSaveEntry,
+      enterSoloCampaign: state => enterCampaignForE2E(state),
+      getVisibleHexCopies: coord => getVisibleHexViewportCopies(
+        gameState, renderLoop.camera, gameState.currentPlayer, coord,
+      ),
+      getCityBadgeSlots: (cityId, slot) => getVisibleCityBadgeSlots(
+        gameState, renderLoop.camera, gameState.currentPlayer, cityId, slot,
+      ),
+    });
+    return;
+  }
+}
+await showStartSavePanel();
+```
+
+`installE2ERuntime` assigns only `window.__CONQUESTORIA_E2E_DIAGNOSTICS__`.
+Do not add state payloads, storage writes, capture controls, renderer objects, or
+arbitrary callbacks to that object.
+
+- [ ] **Step 6: Add source-wiring assertions**
+
+In `tests/main.integration.test.ts`, assert:
+
+```ts
+expect(main).toContain("if (import.meta.env.MODE === 'e2e')");
+expect(main).toContain("await import('@/testing/e2e-runtime')");
+expect(main.indexOf("import.meta.env.MODE === 'e2e'"))
+  .toBeLessThan(main.indexOf('await showStartSavePanel()'));
+expect(main).not.toContain('window.gameState');
+expect(main).not.toContain('window.renderLoop');
+```
+
+- [ ] **Step 7: Run focused tests, build, and source checks**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/testing/e2e-mode.test.ts tests/testing/e2e-runtime.test.ts tests/main.integration.test.ts
+scripts/check-src-rule-violations.sh src/testing/e2e-mode.ts src/testing/e2e-runtime.ts src/main.ts
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn build:tauri
+```
+
+Expected: all PASS; both builds finish with no e2e sentinel in `dist`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/testing/e2e-runtime.ts tests/testing/e2e-runtime.test.ts src/main.ts src/vite-env.d.ts tests/main.integration.test.ts
+git commit -m "test(e2e): enter autosaves through a gated runtime"
+```
+
+### Task 6: Build independent, valid save scenarios
+
+**Files:**
+- Create: `tests/e2e/helpers/save-fixture.ts`
+- Create: `tests/e2e/helpers/save-fixture.test.ts`
+
+- [ ] **Step 1: Write failing clone, ownership, and scenario tests**
+
+```ts
+it('returns independent clones and derives the city from currentPlayer', () => {
+  const first = createScenarioState('building');
+  const second = createScenarioState('building');
+  expect(first).not.toBe(second);
+  expect(first.cities[selectedCityId(first)].owner).toBe(first.currentPlayer);
+  first.turn = 999;
+  expect(second.turn).not.toBe(999);
+});
+
+it('creates valid building and unit queue heads', () => {
+  expect(selectedCity(createScenarioState('building')).productionQueue[0]).toBe('granary');
+  expect(selectedCity(createScenarioState('unit')).productionQueue[0]).toBe('warrior');
+});
+
+it('uses canonical legendary-wonder transitions', () => {
+  const state = createScenarioState('legendary');
+  const city = selectedCity(state);
+  const project = Object.values(state.legendaryWonderProjects ?? {}).find(candidate =>
+    candidate.cityId === city.id && candidate.wonderId === 'standing-stones');
+  expect(city.productionQueue[0]).toBe('legendary:standing-stones');
+  expect(project?.phase).toBe('building');
+});
+
+it('fails when a requested definition or viewer-owned visible city is absent', () => {
+  expect(() => transformScenario(baseWithoutGranary, 'building')).toThrow(/granary/i);
+  expect(() => transformScenario(baseWithoutVisibleOwnedCity, 'unit')).toThrow(/visible city/i);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing helper fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/e2e/helpers/save-fixture.test.ts`
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 3: Implement fresh clone and typed transforms**
+
+```ts
+const BASE_FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as GameState;
+
+export type ProductionScenario = 'building' | 'unit' | 'legendary';
+
+export function createBaseFixture(): GameState {
+  return structuredClone(BASE_FIXTURE);
+}
+
+export function findVisibleOwnedCity(state: GameState): City {
+  const visibility = state.civilizations[state.currentPlayer]?.visibility;
+  const city = Object.values(state.cities).find(candidate =>
+    candidate.owner === state.currentPlayer
+    && visibility
+    && getVisibility(visibility, candidate.position) === 'visible');
+  if (!city) throw new Error('Fixture requires a visible city owned by currentPlayer.');
+  return city;
+}
+
+export function createScenarioState(scenario: ProductionScenario): GameState {
+  const state = createBaseFixture();
+  state.opponentChallenge = 'standard';
+  const city = findVisibleOwnedCity(state);
+  if (scenario === 'building') setValidatedQueueHead(state, city, 'granary');
+  if (scenario === 'unit') setValidatedQueueHead(state, city, 'warrior');
+  if (scenario === 'legendary') configureStandingStones(state, city);
+  return state;
+}
+```
+
+```ts
+function configureStandingStones(initial: GameState, city: City): GameState {
+  const state = structuredClone(initial);
+  const civ = state.civilizations[state.currentPlayer];
+  civ.techState.completed = [
+    ...new Set([...civ.techState.completed, 'animism', 'mud-brick', 'gathering']),
+  ];
+  state.marketplace.purchasedResources = [
+    ...(state.marketplace.purchasedResources ?? []),
+    { civId: state.currentPlayer, resource: 'stone', expiresOnTurn: state.turn + 10 },
+  ];
+  const village = Object.values(state.tribalVillages ?? {})[0];
+  if (!village) throw new Error('Standing Stones fixture requires an existing village.');
+  state.legendaryWonderHistory ??= { destroyedStrongholds: [], discoveredSites: [] };
+  state.legendaryWonderHistory.discoveredSites.push({
+    civId: state.currentPlayer,
+    siteId: village.id,
+    siteType: 'tribal-village',
+    position: village.position,
+    turn: state.turn,
+  });
+  let next = initializeLegendaryWonderProjectsForCity(state, state.currentPlayer, city.id);
+  const ready = Object.values(next.legendaryWonderProjects ?? {}).find(project =>
+    project.cityId === city.id && project.wonderId === 'standing-stones');
+  if (ready?.phase !== 'ready_to_build') {
+    throw new Error('Standing Stones fixture did not reach ready_to_build.');
+  }
+  next = startLegendaryWonderBuild(next, state.currentPlayer, city.id, 'standing-stones');
+  const building = Object.values(next.legendaryWonderProjects ?? {}).find(project =>
+    project.cityId === city.id && project.wonderId === 'standing-stones');
+  if (building?.phase !== 'building'
+    || next.cities[city.id]?.productionQueue[0] !== 'legendary:standing-stones') {
+    throw new Error('Standing Stones fixture did not enter its canonical build state.');
+  }
+  return next;
+}
+```
+
+- [ ] **Step 4: Add the browser installer**
+
+```ts
+export async function installAutosave(page: Page, state: GameState): Promise<void> {
+  await page.addInitScript(serialized => {
+    localStorage.setItem('conquestoria-autosave', serialized);
+  }, JSON.stringify(state));
+}
+```
+
+- [ ] **Step 5: Run the helper tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/e2e/helpers/save-fixture.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/e2e/helpers/save-fixture.ts tests/e2e/helpers/save-fixture.test.ts
+git commit -m "test(e2e): build valid production save scenarios"
+```
+
+### Task 7: Implement bounded Canvas operation capture
+
+**Files:**
+- Create: `tests/e2e/helpers/canvas-ops.ts`
+- Create: `tests/e2e/helpers/canvas-ops.test.ts`
+
+- [ ] **Step 1: Write failing parser and normalization tests**
+
+```ts
+it.each([
+  [[image, 1, 2], { dx: 1, dy: 2 }],
+  [[image, 1, 2, 3, 4], { dx: 1, dy: 2, dw: 3, dh: 4 }],
+  [[image, 1, 2, 3, 4, 5, 6, 7, 8], { sx: 1, sy: 2, sw: 3, sh: 4, dx: 5, dy: 6, dw: 7, dh: 8 }],
+])('parses drawImage overload %j', (args, expected) => {
+  expect(parseDrawImage(args)).toMatchObject(expected);
+});
+
+it('transforms every image corner through CTM, DPR scale, and canvas offset', () => {
+  expect(normalizeImageBounds({
+    rect: { x: 1, y: 2, width: 3, height: 4 },
+    transform: { a: 2, b: 1, c: 0.5, d: 3, e: 7, f: 11 },
+    backing: { width: 200, height: 100 },
+    css: { x: 10, y: 20, width: 100, height: 50 },
+  }).polygon).toHaveLength(4);
+});
+
+it('freezes, overflows, and resets by capture session', () => {
+  const recorder = createOperationRecorder({ maxOperations: 2 });
+  recorder.start(filter);
+  recorder.record(op1);
+  recorder.record(op2);
+  recorder.record(op3);
+  expect(recorder.snapshot()).toMatchObject({ overflowed: true, operations: [op1, op2] });
+  recorder.freeze();
+  recorder.record(op4);
+  expect(recorder.snapshot().operations).toHaveLength(2);
+  recorder.start(filter);
+  expect(recorder.snapshot()).toMatchObject({ overflowed: false, operations: [] });
+});
+```
+
+- [ ] **Step 2: Run and verify the helper is missing**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/e2e/helpers/canvas-ops.test.ts`
+
+Expected: FAIL because `canvas-ops.ts` does not exist.
+
+- [ ] **Step 3: Implement serializable operation types and pure helpers**
+
+```ts
+export type CapturedCanvasOperation = CapturedTextOperation | CapturedImageOperation;
+
+export interface CapturedOperationBase {
+  sessionId: number;
+  sequence: number;
+  canvasId: string;
+  transform: MatrixSnapshot;
+  backing: { width: number; height: number };
+  cssRect: RectSnapshot;
+}
+
+export interface CapturedTextOperation extends CapturedOperationBase {
+  kind: 'fillText';
+  text: string;
+  raw: { x: number; y: number; maxWidth?: number };
+  anchor: { x: number; y: number };
+  font: string;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+}
+
+export interface CapturedImageOperation extends CapturedOperationBase {
+  kind: 'drawImage';
+  rawDestination: RectSnapshot;
+  source?: RectSnapshot;
+  polygon: ViewportPoint[];
+  bounds: RectSnapshot;
+  sprite: SpriteDiagnosticMetadata | null;
+}
+```
+
+Implement `parseDrawImage`, matrix application, all-four-corner bounds,
+backing-to-CSS scaling, filters, maximum buffer, overflow, freeze, and reset as
+pure functions/classes so Vitest can cover them without launching a browser.
+
+- [ ] **Step 4: Install dormant native-method wrappers**
+
+```ts
+export async function installCanvasCapture(page: Page): Promise<void> {
+  await page.addInitScript(({ maxOperations }) => {
+    const originalFillText = CanvasRenderingContext2D.prototype.fillText;
+    const originalDrawImage = CanvasRenderingContext2D.prototype.drawImage;
+    const capture = createBrowserRecorder(maxOperations);
+
+    CanvasRenderingContext2D.prototype.fillText = function (...args) {
+      let prepared;
+      try { prepared = capture.prepareText(this, args); }
+      catch (error) { capture.instrumentationError(error); }
+      const result = Reflect.apply(originalFillText, this, args);
+      if (prepared) capture.commit(prepared);
+      return result;
+    };
+
+    CanvasRenderingContext2D.prototype.drawImage = function (...args) {
+      let prepared;
+      try { prepared = capture.prepareImage(this, args); }
+      catch (error) { capture.instrumentationError(error); }
+      const result = Reflect.apply(originalDrawImage, this, args);
+      if (prepared) capture.commit(prepared);
+      return result;
+    };
+  }, { maxOperations: 500 });
+}
+```
+
+The browser-side implementation reads the non-enumerable value from
+`image[Symbol.for('conquestoria.spriteDiagnostic')]`. It contains only the
+approved catalog fields and is installed before the image load promise resolves.
+
+- [ ] **Step 5: Add capture lifecycle and two-frame synchronization**
+
+```ts
+export async function captureCompleteFrame(
+  page: Page,
+  filter: CaptureFilter,
+): Promise<CaptureSnapshot> {
+  await page.evaluate(value => window.__CQ_CANVAS_CAPTURE__.start(value), filter);
+  await page.evaluate(() => new Promise<void>(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+  const snapshot = await page.evaluate(() => window.__CQ_CANVAS_CAPTURE__.freeze());
+  if (snapshot.overflowed) throw new Error('Canvas capture overflowed its bounded buffer.');
+  if (snapshot.instrumentationErrors.length) {
+    throw new Error(snapshot.instrumentationErrors.join('\n'));
+  }
+  return snapshot;
+}
+```
+
+The Playwright-owned `__CQ_CANVAS_CAPTURE__` global is installed only by
+`page.addInitScript`; never declare or create it in `src/**`.
+
+- [ ] **Step 6: Test native parity explicitly**
+
+Add tests with fake native methods that return a sentinel or throw. Assert the
+wrapper returns the same sentinel, rethrows the exact error object, commits only
+after success, and still delegates unknown argument shapes.
+
+- [ ] **Step 7: Run focused tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/e2e/helpers/canvas-ops.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/e2e/helpers/canvas-ops.ts tests/e2e/helpers/canvas-ops.test.ts
+git commit -m "test(e2e): capture bounded canvas operations"
+```
+
+### Task 8: Share campaign entry and renderer geometry across browser specs
+
+**Files:**
+- Create: `tests/e2e/helpers/campaign-entry.ts`
+- Create: `tests/e2e/helpers/render-geometry.ts`
+- Create: `tests/e2e/campaign-entry-smoke.spec.ts`
+- Modify: `tests/e2e/issue-365-map-presentation.spec.ts`
+- Modify: `tests/e2e/issue-437-hud-alignment.spec.ts`
+- Modify: `tests/e2e/issue-447-water-recovery.spec.ts`
+- Create: `tests/architecture/e2e-source-guard.test.ts`
+
+- [ ] **Step 1: Write the source guard before refactoring**
+
+```ts
+it('keeps renderer math and fixed bootstrap sleeps out of e2e specs', () => {
+  const sources = e2eSpecSources();
+  for (const [path, source] of sources) {
+    expect(source, path).not.toMatch(/function pointyHexPixel/);
+    expect(source, path).not.toContain('waitForTimeout(');
+    expect(source, path).not.toMatch(/Math\.sqrt\(3\).*48/);
+  }
+});
+```
+
+- [ ] **Step 2: Run the guard and verify it fails on issues 365 and 447**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/architecture/e2e-source-guard.test.ts`
+
+Expected: FAIL, naming the copied helpers and sleeps.
+
+- [ ] **Step 3: Implement direct and UI campaign entry**
+
+```ts
+export type CampaignEntryMode = 'direct' | 'ui';
+export type ReadinessPhase = 'campaign-ready' | 'sprites-ready';
+
+export async function enterInstalledCampaign(
+  page: Page,
+  options: { mode: CampaignEntryMode; waitFor: ReadinessPhase },
+): Promise<void> {
+  if (options.mode === 'direct') {
+    await page.goto('/?e2e=autosave');
+    await waitForReadiness(page, options.waitFor);
+    return;
+  }
+  await page.goto('/');
+  const button = page.getByRole('button', { name: 'Continue', exact: true });
+  await button.click();
+  await expect(button).toBeHidden();
+  await expect(page.locator('#game-canvas')).toBeVisible();
+}
+```
+
+`waitForReadiness` uses `expect.poll` over the read-only runtime and includes
+`errors()` in its failure message. It never chooses a legacy challenge and never
+accepts a hot-seat handoff.
+
+- [ ] **Step 4: Implement geometry wrappers**
+
+```ts
+export async function visibleHexCopyNearest(
+  page: Page,
+  coord: HexCoord,
+  anchor: ViewportPoint,
+): Promise<ViewportPoint> {
+  const copies = await page.evaluate(
+    value => window.__CONQUESTORIA_E2E_DIAGNOSTICS__!.getVisibleHexCopies(value),
+    coord,
+  );
+  if (!copies.length) throw new Error(`No visible wrapped copy for ${coord.q},${coord.r}`);
+  return copies.reduce((best, candidate) =>
+    distance(candidate, anchor) < distance(best, anchor) ? candidate : best);
+}
+
+export async function visibleCityBadgeSlots(
+  page: Page,
+  cityId: string,
+  slot: CityBadgeSlot,
+) {
+  const results = await page.evaluate(
+    value => window.__CONQUESTORIA_E2E_DIAGNOSTICS__!
+      .getCityBadgeSlots(value.cityId, value.slot),
+    { cityId, slot },
+  );
+  if (!results.length) throw new Error(`City ${cityId} is not rendered for the current viewer.`);
+  return results;
+}
+```
+
+- [ ] **Step 5: Add a real Continue smoke test**
+
+```ts
+test('modern solo autosave still enters through the real Continue button', async ({ page }) => {
+  await installAutosave(page, createScenarioState('building'));
+  await enterInstalledCampaign(page, { mode: 'ui', waitFor: 'campaign-ready' });
+  await expect(page.getByRole('button', { name: 'Continue', exact: true })).toBeHidden();
+  await expect(page.locator('#game-canvas')).toBeVisible();
+});
+```
+
+- [ ] **Step 6: Refactor issues 365, 437, and 447**
+
+Use `createBaseFixture`/scenario transforms, `installAutosave`,
+`enterInstalledCampaign`, `visibleHexCopyNearest`, and the shared Canvas capture.
+In issue 447, click the renderer-owned destination point directly instead of
+adding a locally calculated delta. Set viewport and reduced motion before
+`page.goto`.
+
+Keep issue 365's v2 assertion and improve its failure message:
+
+```ts
+await expect(
+  page.locator('#building-sprites > *'),
+  'v2 building sprites are intentionally dormant; update #660 observability before activating a consumer',
+).toHaveCount(0);
+```
+
+- [ ] **Step 7: Run refactored browser specs and the source guard**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/architecture/e2e-source-guard.test.ts
+bash scripts/run-with-mise.sh yarn playwright test tests/e2e/campaign-entry-smoke.spec.ts tests/e2e/issue-365-map-presentation.spec.ts tests/e2e/issue-437-hud-alignment.spec.ts tests/e2e/issue-447-water-recovery.spec.ts
+```
+
+Expected: PASS with no fixed bootstrap sleep or local renderer math.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/e2e/helpers/campaign-entry.ts tests/e2e/helpers/render-geometry.ts tests/e2e/campaign-entry-smoke.spec.ts tests/e2e/issue-365-map-presentation.spec.ts tests/e2e/issue-437-hud-alignment.spec.ts tests/e2e/issue-447-water-recovery.spec.ts tests/architecture/e2e-source-guard.test.ts
+git commit -m "test(e2e): share deterministic campaign geometry"
+```
+
+### Task 9: Verify building, unit, and wonder production in a real browser
+
+**Files:**
+- Create: `tests/e2e/production-badges.spec.ts`
+
+- [ ] **Step 1: Write the building image assertion**
+
+```ts
+test('building production draws the identified catalog sprite in its slot', async ({ page }) => {
+  const state = createScenarioState('building');
+  const city = findVisibleOwnedCity(state);
+  await installCanvasCapture(page);
+  await installAutosave(page, state);
+  await enterInstalledCampaign(page, { mode: 'direct', waitFor: 'sprites-ready' });
+  const slots = await visibleCityBadgeSlots(page, city.id, 'production');
+  const capture = await captureCompleteFrame(page, {
+    canvasIds: ['game-canvas'],
+    kinds: ['drawImage', 'fillText'],
+    sprite: { kind: 'building', itemId: 'granary', civilization: city.owner },
+    textValues: ['🏗️'],
+  });
+  const image = capture.operations.find(isMatchingBuilding('granary', city.owner));
+  expect(image).toBeDefined();
+  expect(slots.some(slot => rectsIntersect(image!.bounds, slot.bounds))).toBe(true);
+  expect(capture.operations.some(isTextInSlots('🏗️', slots))).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run the single test and verify the integrated contract**
+
+Run: `bash scripts/run-with-mise.sh yarn playwright test tests/e2e/production-badges.spec.ts --grep "building production"`
+
+Expected: PASS. A failure must identify one of the already implemented contracts:
+sprite readiness, stable metadata, bounded capture, or renderer-owned slot
+geometry. Correct that contract in its owning file and rerun its Task 3, 4, 5,
+or 7 unit suite before rerunning this browser assertion.
+
+- [ ] **Step 3: Add the unit image assertion**
+
+```ts
+test('unit production draws the identified catalog sprite in its slot', async ({ page }) => {
+  const state = createScenarioState('unit');
+  const city = findVisibleOwnedCity(state);
+  await installCanvasCapture(page);
+  await installAutosave(page, state);
+  await enterInstalledCampaign(page, { mode: 'direct', waitFor: 'sprites-ready' });
+  const slots = await visibleCityBadgeSlots(page, city.id, 'production');
+  const capture = await captureCompleteFrame(page, {
+    canvasIds: ['game-canvas'],
+    kinds: ['drawImage', 'fillText'],
+    sprite: {
+      kind: 'unit',
+      itemId: 'warrior',
+      civilization: city.owner,
+      motion: 'idle',
+    },
+    textValues: ['🏗️'],
+  });
+  const image = capture.operations.find(isMatchingUnit('warrior', city.owner, 'idle'));
+  expect(image).toBeDefined();
+  expect(slots.some(slot => rectsIntersect(image!.bounds, slot.bounds))).toBe(true);
+  expect(capture.operations.some(isTextInSlots('🏗️', slots))).toBe(false);
+});
+```
+
+- [ ] **Step 4: Add the legendary-wonder fallback assertion**
+
+```ts
+const state = createScenarioState('legendary');
+// Enter after campaign-ready; the item is intentionally unsprited.
+expect(capture.operations.some(isTextInSlots('🏗️', slots))).toBe(true);
+expect(capture.operations.some(operation =>
+  operation.kind === 'drawImage'
+  && operation.sprite?.itemId === 'legendary:standing-stones')).toBe(false);
+```
+
+- [ ] **Step 5: Run the complete production-badge spec**
+
+Run: `bash scripts/run-with-mise.sh yarn playwright test tests/e2e/production-badges.spec.ts`
+
+Expected: PASS for all three scenarios.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/e2e/production-badges.spec.ts
+git commit -m "test(e2e): verify city production canvas badges"
+```
+
+### Task 10: Lock live catalogs and dormant v2 boundaries
+
+**Files:**
+- Modify: `tests/renderer/sprites/sprite-catalog.test.ts`
+- Modify: `tests/systems/city-system.test.ts`
+- Create: `tests/architecture/v2-building-consumer.test.ts`
+
+- [ ] **Step 1: Write exact live-catalog relationship tests**
+
+```ts
+it('covers every canonical building and only the five retained extras', () => {
+  const buildings = new Set(Object.keys(BUILDINGS));
+  const sprites = new Set(Object.keys(BUILDING_SPRITE_CATALOG));
+  for (const id of buildings) expect(sprites.has(id), `missing sprite: ${id}`).toBe(true);
+  expect([...sprites].filter(id => !buildings.has(id)).sort()).toEqual([
+    'colosseum',
+    'great_library',
+    'lighthouse',
+    'pyramids',
+    'wright-flyer',
+  ]);
+});
+
+it('keeps canonical buildings inside the broader production-icon catalog', () => {
+  for (const id of Object.keys(BUILDINGS)) {
+    expect(PRODUCTION_ICONS[id], `missing production icon: ${id}`).toBeTruthy();
+  }
+});
+```
+
+Add an assertion that each retained extra renders a non-empty sprite. Add an
+adjacent source comment for each extra in `sprite-catalog.ts` only if an existing
+comment does not already explain why it is not a canonical building ID.
+
+- [ ] **Step 2: Write the failing v2 source-use architecture test**
+
+```ts
+it('keeps getBuildingSpriteV2 limited to its definition and dormant overlay branch', () => {
+  expect(findIdentifierConsumers('src', 'getBuildingSpriteV2', {
+    exclude: ['**/*.svg.ts'],
+  }).sort()).toEqual([
+    'src/renderer/sprite-overlay.ts',
+    'src/renderer/sprites/v2/index.ts',
+  ]);
+});
+```
+
+Failure text must direct a future implementer to update #660 catalog consistency
+and Canvas/DOM observability before adding a panel, preview, or renderer consumer.
+
+- [ ] **Step 3: Run the catalog and architecture tests**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/renderer/sprites/sprite-catalog.test.ts tests/systems/city-system.test.ts tests/renderer/sprites/v2/index.test.ts tests/architecture/v2-building-consumer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/renderer/sprites/sprite-catalog.test.ts tests/systems/city-system.test.ts tests/architecture/v2-building-consumer.test.ts src/renderer/sprites/sprite-catalog.ts
+git commit -m "test(renderer): guard live and dormant building catalogs"
+```
+
+### Task 11: Document the Canvas verification contract
+
+**Files:**
+- Create: `docs/testing/canvas-render-verification.md`
+- Modify: `.claude/rules/ui-panels.md`
+
+- [ ] **Step 1: Add the maintainer guide**
+
+The guide must contain these concrete sections and commands:
+
+```md
+# Canvas Render Verification
+
+## Choose the smallest proof
+- Operations-log unit test for every Canvas render change.
+- Playwright capture only for startup, real sprite loading, camera composition, or Canvas/DOM integration.
+
+## Shared helpers
+- `save-fixture.ts`: fresh clones and named scenarios.
+- `campaign-entry.ts`: `direct` and `ui` entry plus readiness phases.
+- `canvas-ops.ts`: install, start, two-frame wait, freeze, assert no overflow.
+- `render-geometry.ts`: visible wrapped copies and named city-badge slots.
+
+## Adding a sprite assertion
+1. Add stable metadata at image construction.
+2. Add an operations-log test.
+3. Filter a bounded capture by canvas, operation, and sprite metadata.
+4. Compare normalized bounds with a renderer-owned slot.
+
+## Dormant v2 building boundary
+`getBuildingSpriteV2` is serialized asset support, not a live surface. Update the
+catalog and observability contracts before adding a consumer.
+
+## Operational browser constraints
+Screenshots are debugging evidence only. Browser tree omissions, timeouts, and
+downscaling are not substitutes for repository assertions.
+```
+
+- [ ] **Step 2: Add the scoped renderer rule and link**
+
+Append to `.claude/rules/ui-panels.md`:
+
+```md
+## Canvas Verification
+- Canvas behavior is invisible to DOM-only assertions.
+- Every Canvas rendering change requires an operations-log unit regression.
+- Use browser coverage when behavior depends on startup, sprite loading, camera composition, or Canvas/DOM integration.
+- Browser assertions must use the shared bounded operation capture and renderer-owned coordinate helpers.
+- Screenshots are QA evidence, not regression coverage.
+- Treat external browser-tool quirks as operational context, not repository defects.
+
+See `docs/testing/canvas-render-verification.md`.
+```
+
+- [ ] **Step 3: Run hook and link checks**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:hooks
+test -f docs/testing/canvas-render-verification.md
+rg -n "docs/testing/canvas-render-verification.md" .claude/rules/ui-panels.md
+```
+
+Expected: PASS and one live documentation link.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/testing/canvas-render-verification.md .claude/rules/ui-panels.md
+git commit -m "docs: define canvas render verification"
+```
+
+### Task 12: Complete end-to-end verification and review
+
+**Files:**
+- Review all files changed by Tasks 1–11.
+
+- [ ] **Step 1: Run source-rule validation for every changed source file**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh \
+  src/main.ts \
+  src/renderer/city-badge-presentation.ts \
+  src/renderer/city-render-passes.ts \
+  src/renderer/city-renderer.ts \
+  src/renderer/sprites/sprite-loader.ts \
+  src/testing/e2e-mode.ts \
+  src/testing/e2e-runtime.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run all focused unit suites**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run \
+  tests/testing/e2e-mode.test.ts \
+  tests/testing/e2e-runtime.test.ts \
+  tests/e2e/helpers/save-fixture.test.ts \
+  tests/e2e/helpers/canvas-ops.test.ts \
+  tests/renderer/city-badge-presentation.test.ts \
+  tests/renderer/city-render-passes.test.ts \
+  tests/renderer/city-renderer.test.ts \
+  tests/renderer/camera.test.ts \
+  tests/renderer/sprites/sprite-loader.test.ts \
+  tests/renderer/sprites/sprite-catalog.test.ts \
+  tests/renderer/sprites/v2/index.test.ts \
+  tests/systems/city-system.test.ts \
+  tests/platform/playwright-config.test.ts \
+  tests/main.integration.test.ts \
+  tests/scripts/assert-no-e2e-runtime.test.ts \
+  tests/architecture/e2e-source-guard.test.ts \
+  tests/architecture/v2-building-consumer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run focused browser coverage**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn playwright test \
+  tests/e2e/production-badges.spec.ts \
+  tests/e2e/campaign-entry-smoke.spec.ts \
+  tests/e2e/issue-365-map-presentation.spec.ts \
+  tests/e2e/issue-437-hud-alignment.spec.ts \
+  tests/e2e/issue-447-water-recovery.spec.ts
+```
+
+Expected: PASS on desktop and the embedded mobile/reduced-motion cases.
+
+- [ ] **Step 4: Run hook, full browser, build, and full unit verification**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:hooks
+bash scripts/run-with-mise.sh yarn test:web-smoke
+bash scripts/run-with-mise.sh yarn build
+node scripts/assert-no-e2e-runtime.mjs dist
+bash scripts/run-with-mise.sh yarn build:tauri
+node scripts/assert-no-e2e-runtime.mjs dist
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: every command exits 0. The web build retains `/conquestoria/` asset
+paths and the Tauri build retains relative asset paths.
+
+- [ ] **Step 5: Inspect desktop/mobile bounds and both diffs**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+git diff --check
+git diff --stat
+git diff
+git status --short --branch
+```
+
+Review that:
+
+- production/religion and status/loyalty bounds are disjoint at supported sizes;
+- no queue/menu icon, name, order, progress, ETA, or action changed;
+- only the map fallback and overlapping anchors visibly changed;
+- no e2e state/capture API exists in normal bundles;
+- no `pointyHexPixel`, fixed bootstrap sleep, or copied fixture installer remains;
+- v2 building assets and lookups remain intact and dormant.
+
+Expected: no whitespace errors and no unexplained uncommitted delta.
+
+- [ ] **Step 6: Commit any verification-only corrections**
+
+If verification required changes, rerun the narrow failing command first, then
+the affected matrix rows. Stage the reviewed paths printed by
+`git status --short` one by one, then commit only those corrections:
+
+```bash
+git commit -m "test(e2e): complete canvas verification coverage"
+```
+
+Do not commit generated `dist/`, screenshots, traces, or Playwright reports.

--- a/docs/superpowers/plans/2026-07-23-issue-660-canvas-verification.md
+++ b/docs/superpowers/plans/2026-07-23-issue-660-canvas-verification.md
@@ -86,6 +86,20 @@
 - Existing reorder/remove behavior and invalid-item handling remain owned by the city panel and city system.
 - The renderer tests must snapshot the queue before and after every badge pass and prove presentation is state-pure.
 
+## Cross-Cutting Regression Matrix
+
+| Concern | Proof required by this plan |
+|---|---|
+| Balance, pacing, and new mechanics | Renderer tests deep-compare gameplay state before/after badge passes; the committed diff contains no definition, economy, combat, movement, research, crisis, AI-scoring, or turn-processing change. |
+| Fun, ages, and play styles | Simultaneous meanings are distinct and non-overlapping; the production browser test opens the real city panel and verifies the specific name and turns remaining remain readable. Full catalog and queue interaction tests stay green. |
+| Difficulty | Runtime tests accept `explorer`, `standard`, and `veteran` unchanged; identical visible state produces identical badge operations across the three values. |
+| Computer players | AI/rival queue items do not render as player production badges. No `src/ai/**` file changes, and sprite preloading exposes catalog identity only—not AI state. |
+| Solo and hot seat | Direct entry covers solo saves only. Unit/integration tests switch hot-seat `currentPlayer`, preserve handoff, and prove production visibility follows the active seat. |
+| UI, UX, and reduced motion | Desktop and mobile bounds, reduced motion before navigation, DOM production identity, viewer privacy, and no color/audio-only meaning. |
+| Architecture and extensibility | Typed registry/slots, shared loader metadata, viewer-safe serialized geometry, bounded Playwright-owned capture, literal tree-shaken mode gate, and v2 consumer sentinel. |
+| Data and saved games | Relationship-based catalog assertions, fresh fixture clones, valid canonical wonder transition, no save schema change, normalized load path, and no write/mutation on rejected direct entry. |
+| SFX | New presentation/testing modules import no audio/SFX modules; render and readiness transitions call no audio, notification, event-bus, or state mutation function. Existing `startGame()` remains the sole campaign audio startup path. |
+
 ---
 
 ### Task 1: Secure the e2e mode and production-bundle boundary
@@ -364,6 +378,12 @@ export interface BadgeBounds {
 - [ ] **Step 4: Refactor every affected pass to the registry/layout**
 
 ```ts
+export function getProductionBadgeIcon(
+  city: { productionQueue: string[] },
+): string | null {
+  return city.productionQueue.length > 0 ? CITY_BADGE_GLYPHS.production : null;
+}
+
 const layout = getCityBadgeLayout(item.screen, item.size);
 const { center } = layout.production;
 const queueHead = item.city.productionQueue[0];
@@ -376,7 +396,7 @@ if (spriteImage) {
 }
 drawFittedText(
   ctx,
-  CITY_BADGE_GLYPHS.production,
+  getProductionBadgeIcon(item.city)!,
   center.x,
   center.y,
   layout.production.bounds.width,
@@ -394,6 +414,9 @@ all visibility/ownership checks.
 Add cases proving:
 
 ```ts
+expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🏗️');
+expect(getProductionBadgeIcon({ productionQueue: ['warrior'] })).toBe('🏗️');
+expect(getProductionBadgeIcon({ productionQueue: [] })).toBeNull();
 expect(fallback.fillTextCalls[0]?.text).toBe('🏗️');
 expect(cached.drawImageCalls).toHaveLength(1);
 expect(cached.fillTextCalls).toHaveLength(0);
@@ -401,7 +424,10 @@ expect(wonder.fillTextCalls[0]?.text).toBe('🏗️');
 expect(state.city.productionQueue).toEqual(queueBefore);
 ```
 
-Also retain the existing exact status, world-pressure, loyalty, religion, and idle assertions.
+Deep-compare the complete input `CityRenderItem` before and after every badge pass.
+Retain the existing exact status, world-pressure, loyalty, religion, and idle
+assertions. `PRODUCTION_ICONS`, `PRODUCTION_ICON_FALLBACK`, and
+`getProductionIconForItem()` remain untouched for the DOM city panel.
 
 - [ ] **Step 6: Run renderer tests and source checks**
 
@@ -431,15 +457,21 @@ git commit -m "fix(renderer): separate city badge meanings and bounds"
 
 ```ts
 import {
-  getSpriteDiagnosticMetadata,
   initSprites,
+  SPRITE_DIAGNOSTIC_METADATA_KEY,
   spriteCache,
+  type SpriteDiagnosticMetadata,
 } from '@/renderer/sprites/sprite-loader';
+
+const readMetadata = (image: HTMLImageElement) =>
+  (image as unknown as Record<symbol, Readonly<SpriteDiagnosticMetadata> | undefined>)[
+    Symbol.for(SPRITE_DIAGNOSTIC_METADATA_KEY)
+  ];
 
 it('attaches stable building catalog metadata before load completion', async () => {
   const promise = initSprites({ civ: '#336699' });
   const created = imageConstructorSpy.mock.results[0]?.value as HTMLImageElement;
-  expect(getSpriteDiagnosticMetadata(created)).toMatchObject({
+  expect(readMetadata(created)).toMatchObject({
     kind: 'building',
     itemId: expect.any(String),
     civilization: 'civ',
@@ -454,13 +486,13 @@ it('identifies unit motion and neutral landmarks without state data', async () =
   await loading;
   const unit = spriteCache.getUnitMotion('warrior', 'civ', 'move-a');
   const landmark = spriteCache.getLandmark('pirate-headquarters');
-  expect(getSpriteDiagnosticMetadata(unit!)).toEqual({
+  expect(readMetadata(unit!)).toEqual({
     kind: 'unit',
     itemId: 'warrior',
     civilization: 'civ',
     motion: 'move-a',
   });
-  expect(getSpriteDiagnosticMetadata(landmark!)).toEqual({
+  expect(readMetadata(landmark!)).toEqual({
     kind: 'landmark',
     itemId: 'pirate-headquarters',
     civilization: 'neutral',
@@ -492,16 +524,6 @@ export interface SpriteDiagnosticMetadata {
 
 export const SPRITE_DIAGNOSTIC_METADATA_KEY = 'conquestoria.spriteDiagnostic';
 const diagnosticMetadataSymbol = Symbol.for(SPRITE_DIAGNOSTIC_METADATA_KEY);
-
-export function getSpriteDiagnosticMetadata(
-  image: CanvasImageSource,
-): Readonly<SpriteDiagnosticMetadata> | null {
-  if (!(image instanceof HTMLImageElement)) return null;
-  return (image as unknown as Record<
-    symbol,
-    Readonly<SpriteDiagnosticMetadata> | undefined
-  >)[diagnosticMetadataSymbol] ?? null;
-}
 
 function svgStringToImage(
   svgString: string,
@@ -560,7 +582,10 @@ it('returns every visible wrapped copy through production projection', () => {
   const results = getVisibleHexViewportCopies(state, camera, state.currentPlayer, city.position);
   expect(results).not.toHaveLength(0);
   for (const result of results) {
-    expect(camera.screenToHex(result.x, result.y)).toEqual(city.position);
+    expect(wrapHexCoord(
+      camera.screenToHex(result.x, result.y),
+      state.map.width,
+    )).toEqual(city.position);
   }
 });
 
@@ -569,6 +594,30 @@ it('returns a named badge slot only for a live city rendered to the viewer', () 
     .not.toHaveLength(0);
   expect(getVisibleCityBadgeSlots(state, camera, state.currentPlayer, hiddenCity.id, 'production'))
     .toEqual([]);
+});
+
+it.each(['explorer', 'standard', 'veteran'] as const)(
+  'keeps city presentation independent of %s difficulty',
+  challenge => {
+    const challenged = { ...state, opponentChallenge: challenge };
+    expect(collectCityOperations(challenged, camera, challenged.currentPlayer))
+      .toEqual(collectCityOperations(state, camera, state.currentPlayer));
+  },
+);
+
+it('keeps rival AI production private', () => {
+  const rivalCity = { ...city, owner: 'ai-1', productionQueue: ['warrior'] };
+  const rivalState = {
+    ...state,
+    cities: { ...state.cities, [rivalCity.id]: rivalCity },
+  };
+  expect(collectProductionOperations(rivalState, camera, state.currentPlayer, rivalCity.id))
+    .toEqual([]);
+});
+
+it('switches hot-seat production visibility with currentPlayer', () => {
+  expect(visibleProductionCityIds(hotSeatState, camera, 'player-1')).toEqual(['city-p1']);
+  expect(visibleProductionCityIds(hotSeatState, camera, 'player-2')).toEqual(['city-p2']);
 });
 ```
 
@@ -647,11 +696,32 @@ git commit -m "test(renderer): expose viewer-safe canvas geometry"
 
 ```ts
 it('rejects missing challenge and hot-seat autosaves before entry', async () => {
+  const hotSeatBefore = structuredClone(hotSeatState);
   await expect(startE2ERuntime(deps({ state: withoutChallenge })))
     .rejects.toThrow(/opponent challenge/i);
   await expect(startE2ERuntime(deps({ state: hotSeatState })))
     .rejects.toThrow(/hot-seat/i);
   expect(enterCampaign).not.toHaveBeenCalled();
+  expect(storageWriter).not.toHaveBeenCalled();
+  expect(hotSeatState).toEqual(hotSeatBefore);
+});
+
+it.each(['explorer', 'standard', 'veteran'] as const)(
+  'accepts %s without resolving or rewriting it',
+  async challenge => {
+    const state = { ...soloState, opponentChallenge: challenge };
+    await startE2ERuntime(deps({ state }));
+    expect(enterCampaign).toHaveBeenCalledWith(
+      expect.objectContaining({ opponentChallenge: challenge }),
+    );
+  },
+);
+
+it('rejects an unknown challenge without entering or writing', async () => {
+  const state = { ...soloState, opponentChallenge: 'impossible' as never };
+  await expect(startE2ERuntime(deps({ state }))).rejects.toThrow(/valid opponent challenge/i);
+  expect(enterCampaign).not.toHaveBeenCalled();
+  expect(storageWriter).not.toHaveBeenCalled();
 });
 
 it('exposes only frozen readiness and serialized geometry queries', async () => {
@@ -911,10 +981,14 @@ function configureStandingStones(initial: GameState, city: City): GameState {
   civ.techState.completed = [
     ...new Set([...civ.techState.completed, 'animism', 'mud-brick', 'gathering']),
   ];
-  state.marketplace.purchasedResources = [
-    ...(state.marketplace.purchasedResources ?? []),
-    { civId: state.currentPlayer, resource: 'stone', expiresOnTurn: state.turn + 10 },
-  ];
+  if (!state.marketplace) throw new Error('Standing Stones fixture requires marketplace state.');
+  state.marketplace = {
+    ...state.marketplace,
+    purchasedResources: [
+      ...(state.marketplace.purchasedResources ?? []),
+      { civId: state.currentPlayer, resource: 'stone', expiresOnTurn: state.turn + 10 },
+    ],
+  };
   const village = Object.values(state.tribalVillages ?? {})[0];
   if (!village) throw new Error('Standing Stones fixture requires an existing village.');
   state.legendaryWonderHistory ??= { destroyedStrongholds: [], discoveredSites: [] };
@@ -1053,36 +1127,107 @@ pure functions/classes so Vitest can cover them without launching a browser.
 - [ ] **Step 4: Install dormant native-method wrappers**
 
 ```ts
+export function installBrowserCanvasProbe(config: {
+  maxOperations: number;
+  metadataKey: string;
+}): void {
+  // All recorder, filter, overload, matrix, and normalization helpers are
+  // declared inside this function. Playwright serializes this function body;
+  // it cannot close over imports or module-local helpers.
+  const createBrowserRecorder = (maxOperations: number) => {
+    const state = {
+      active: false,
+      sessionId: 0,
+      sequence: 0,
+      overflowed: false,
+      operations: [] as CapturedCanvasOperation[],
+      instrumentationErrors: [] as string[],
+      filter: null as CaptureFilter | null,
+    };
+    return {
+      start(filter: CaptureFilter) {
+        state.active = true;
+        state.sessionId += 1;
+        state.sequence = 0;
+        state.overflowed = false;
+        state.operations = [];
+        state.instrumentationErrors = [];
+        state.filter = structuredClone(filter);
+      },
+      freeze() {
+        state.active = false;
+        return structuredClone(state);
+      },
+      prepareText(context: CanvasRenderingContext2D, args: unknown[]) {
+        return prepareBrowserTextOperation(context, args, state, config);
+      },
+      prepareImage(context: CanvasRenderingContext2D, args: unknown[]) {
+        return prepareBrowserImageOperation(context, args, state, config);
+      },
+      instrumentationError(error: unknown) {
+        state.instrumentationErrors.push(String(error));
+      },
+      commit(operation: CapturedCanvasOperation) {
+        if (!state.active || !matchesBrowserFilter(operation, state.filter)) return;
+        if (state.operations.length >= maxOperations) {
+          state.overflowed = true;
+          state.active = false;
+          return;
+        }
+        state.operations.push({ ...operation, sequence: state.sequence++ });
+      },
+    };
+  };
+
+  // Define prepareBrowserTextOperation, prepareBrowserImageOperation, and
+  // matchesBrowserFilter above createBrowserRecorder in the real function body
+  // using the pure algorithms from Step 3. They may reference only parameters,
+  // local declarations, and browser globals.
+  const capture = createBrowserRecorder(config.maxOperations);
+  const originalFillText = CanvasRenderingContext2D.prototype.fillText;
+  const originalDrawImage = CanvasRenderingContext2D.prototype.drawImage;
+
+  CanvasRenderingContext2D.prototype.fillText = function (...args) {
+    let prepared;
+    try { prepared = capture.prepareText(this, args); }
+    catch (error) { capture.instrumentationError(error); }
+    const result = Reflect.apply(originalFillText, this, args);
+    if (prepared) capture.commit(prepared);
+    return result;
+  };
+
+  CanvasRenderingContext2D.prototype.drawImage = function (...args) {
+    let prepared;
+    try { prepared = capture.prepareImage(this, args); }
+    catch (error) { capture.instrumentationError(error); }
+    const result = Reflect.apply(originalDrawImage, this, args);
+    if (prepared) capture.commit(prepared);
+    return result;
+  };
+
+  Object.defineProperty(window, '__CQ_CANVAS_CAPTURE__', {
+    value: Object.freeze({ start: capture.start, freeze: capture.freeze }),
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+}
+
 export async function installCanvasCapture(page: Page): Promise<void> {
-  await page.addInitScript(({ maxOperations }) => {
-    const originalFillText = CanvasRenderingContext2D.prototype.fillText;
-    const originalDrawImage = CanvasRenderingContext2D.prototype.drawImage;
-    const capture = createBrowserRecorder(maxOperations);
-
-    CanvasRenderingContext2D.prototype.fillText = function (...args) {
-      let prepared;
-      try { prepared = capture.prepareText(this, args); }
-      catch (error) { capture.instrumentationError(error); }
-      const result = Reflect.apply(originalFillText, this, args);
-      if (prepared) capture.commit(prepared);
-      return result;
-    };
-
-    CanvasRenderingContext2D.prototype.drawImage = function (...args) {
-      let prepared;
-      try { prepared = capture.prepareImage(this, args); }
-      catch (error) { capture.instrumentationError(error); }
-      const result = Reflect.apply(originalDrawImage, this, args);
-      if (prepared) capture.commit(prepared);
-      return result;
-    };
-  }, { maxOperations: 500 });
+  await page.addInitScript(installBrowserCanvasProbe, {
+    maxOperations: 500,
+    metadataKey: 'conquestoria.spriteDiagnostic',
+  });
 }
 ```
 
 The browser-side implementation reads the non-enumerable value from
 `image[Symbol.for('conquestoria.spriteDiagnostic')]`. It contains only the
 approved catalog fields and is installed before the image load promise resolves.
+Add a unit test that invokes `installBrowserCanvasProbe.toString()` in an isolated
+browser-like VM with only the approved Canvas/window globals; it must install and
+capture successfully. This fails if the function accidentally closes over a
+module import such as `createBrowserRecorder`.
 
 - [ ] **Step 5: Add capture lifecycle and two-frame synchronization**
 
@@ -1148,6 +1293,20 @@ it('keeps renderer math and fixed bootstrap sleeps out of e2e specs', () => {
     expect(source, path).not.toMatch(/Math\.sqrt\(3\).*48/);
   }
 });
+
+it('keeps badge and e2e support out of gameplay, AI, audio, and save schemas', () => {
+  const presentation = readSource('src/renderer/city-badge-presentation.ts');
+  const runtime = readSource('src/testing/e2e-runtime.ts');
+  for (const [path, source] of [
+    ['city-badge-presentation.ts', presentation],
+    ['e2e-runtime.ts', runtime],
+  ] as const) {
+    expect(source, path).not.toMatch(/@\/(ai|audio|core\/event-bus|systems\/economy)/);
+    expect(source, path).not.toMatch(/SFX|EventBus|showNotification/);
+  }
+  expect(runtime).not.toMatch(/autoSave|rewriteLoadedSaveEntry|localStorage|indexedDB/);
+});
+
 ```
 
 - [ ] **Step 2: Run the guard and verify it fails on issues 365 and 447**
@@ -1286,6 +1445,17 @@ test('building production draws the identified catalog sprite in its slot', asyn
   expect(image).toBeDefined();
   expect(slots.some(slot => rectsIntersect(image!.bounds, slot.bounds))).toBe(true);
   expect(capture.operations.some(isTextInSlots('🏗️', slots))).toBe(false);
+
+  const cityCenter = await visibleHexCopyNearest(
+    page,
+    city.position,
+    slots[0]!.center,
+  );
+  await page.mouse.click(cityCenter.x, cityCenter.y);
+  const panel = page.locator('#city-panel');
+  await expect(panel).toBeVisible();
+  await expect(panel).toContainText('Granary');
+  await expect(panel).toContainText('turns remaining');
 });
 ```
 
@@ -1532,6 +1702,12 @@ bash scripts/run-with-mise.sh yarn test --run \
   tests/systems/city-system.test.ts \
   tests/platform/playwright-config.test.ts \
   tests/main.integration.test.ts \
+  tests/ui/city-panel.test.ts \
+  tests/ui/campaign-entry-flow.test.ts \
+  tests/ui/turn-handoff.test.ts \
+  tests/storage/save-manager.test.ts \
+  tests/core/hotseat-events.test.ts \
+  tests/integration/hot-seat-unit-persistence.test.ts \
   tests/scripts/assert-no-e2e-runtime.test.ts \
   tests/architecture/e2e-source-guard.test.ts \
   tests/architecture/v2-building-consumer.test.ts
@@ -1590,6 +1766,10 @@ Review that:
 - production/religion and status/loyalty bounds are disjoint at supported sizes;
 - no queue/menu icon, name, order, progress, ETA, or action changed;
 - only the map fallback and overlapping anchors visibly changed;
+- `explorer`, `standard`, and `veteran` presentation is identical for identical visible state;
+- AI scoring/turn code, balance definitions, gameplay systems, and save schemas are absent from the source diff;
+- hot-seat production visibility follows `currentPlayer`, while direct entry still rejects handoff bypass;
+- no new audio/SFX/event dependency or color/audio-only meaning was introduced;
 - no e2e state/capture API exists in normal bundles;
 - no `pointyHexPixel`, fixed bootstrap sleep, or copied fixture installer remains;
 - v2 building assets and lookups remain intact and dormant.

--- a/docs/superpowers/specs/2026-07-22-issue-660-canvas-verification-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-660-canvas-verification-design.md
@@ -1,0 +1,369 @@
+# Issue #660 Canvas Verification Design
+
+**Date:** 2026-07-22
+
+**Issue:** [#660 — Harden fragile browser-driven verification of canvas render changes](https://github.com/a1flecke/conquestoria/issues/660)
+
+**Status:** Approved and reviewed design; implementation not started
+
+## Goal
+
+Make Canvas 2D render changes verifiable through deterministic unit and browser tests without replaying the full new-game flow or relying on screenshots and raw canvas coordinates.
+
+The design also closes the drift paths that allowed production and status badges to share a glyph or overlap geometrically, while preserving the intentionally dormant v2 building-sprite catalog for its planned future use.
+
+## Root Cause
+
+The renderer has no shared, renderer-aware browser-test boundary.
+
+- Canvas output is invisible to DOM queries. The existing browser probe captures selected `fillText` calls, but production badges now use `drawImage`.
+- Fixture installation, legacy campaign entry, and coordinate conversion are copied between e2e specs.
+- The copied coordinate helper uses hex size `48`, while the live `Camera` uses `32`; the test geometry has already drifted from production geometry.
+- The sole save fixture contains a city producing a granary, but no browser test can identify the corresponding sprite draw.
+- City badge meanings and production fallback glyphs are independently authored. A cached warrior sprite avoids the `⚔️` collision, but the loading fallback still uses `⚔️`, so the collision remains possible before sprite loading completes.
+- Badge anchors are independently authored. The production/religion pair and status/loyalty pair occupy overlapping upper-corner bounds at current sizes even though comments claim the badges do not collide.
+- `initSprites()` is deliberately non-blocking in `startGame()`. A browser test that merely waits for campaign entry can therefore observe either the text fallback or the final sprite depending on timing.
+- The render loop draws continuously. An always-on, unfiltered operation recorder would grow without bound and collect unrelated terrain, unit, and animation operations.
+- The issue-365 design history explains why v2 buildings are dormant, but current catalog tests do not encode that boundary or force future integration to update the live consistency/observability contract.
+
+Browser-tool timeouts, downscaled screenshots, intermittent page-tree reads, and missing accessibility nodes for canvas entities are environmental constraints. They are context for the design, not repository defects to repair.
+
+## Scope
+
+### In scope
+
+- Shared Playwright helpers for fixture loading, deterministic campaign entry, canvas-operation capture, and hex coordinate conversion.
+- Canonical production-badge scenarios for a building, unit, and legendary wonder.
+- An e2e-mode-only direct campaign-entry seam that reuses production normalization and startup behavior.
+- Explicit game-ready, sprite-ready, and rendered-frame synchronization without fixed sleeps.
+- Bounded, filterable browser assertions for `fillText` and `drawImage` operations.
+- Stable metadata that lets a captured image operation identify its sprite kind, item ID, and civilization.
+- Unit operations-log coverage as the required first line for canvas render changes.
+- Collision-safe city production fallbacks, shared badge layout, and anti-drift coverage for live badge meanings and bounds.
+- Consistency tests for the live building catalogs.
+- Documentation of the canvas-testing convention and known browser-tool constraints.
+- A sentinel that fails when v2 building entities become live, forcing this contract to be revisited.
+
+### Out of scope
+
+- Implementing v2 building entities or choosing their eventual player-visible surface.
+- Removing the v2 building assets, lookup, overlay layer, or `SpriteEntity.kind === 'building'` support.
+- A screenshot-diff or full visual-regression pipeline.
+- Repairing external browser-automation behavior.
+- Re-centering the camera on viewport resize. That is useful UX work but independent of render observability and should be handled separately.
+
+## Non-Negotiable Invariants
+
+- Normal web and Tauri builds expose no e2e state-entry or diagnostic API.
+- The e2e path accepts no JSON or state payload from the URL or a callable global; it may only enter the autosave already installed in the isolated browser context.
+- The live Continue/save-panel path remains wired and retains at least one browser integration test.
+- Fixture transforms derive the active civilization and city from `state.currentPlayer`; they never hardcode `player` or `cities[0]`.
+- Tests never mutate the shared parsed fixture object. Every scenario starts from a fresh structured clone.
+- Capturing canvas operations never changes the result or exception behavior of the native canvas method.
+- Production-menu icons, names, queue ordering, progress, and ETA behavior remain unchanged. Only the temporary map fallback and overlapping badge anchors change visibly.
+
+## Architecture
+
+### 1. Shared e2e harness
+
+Create focused modules under `tests/e2e/helpers/`:
+
+- `save-fixture.ts` reads the canonical fixture once, returns a fresh structured clone for every test, applies a typed scenario transform, and installs the result before navigation.
+- `campaign-entry.ts` supports explicit `direct` and `ui` entry modes and waits for named readiness phases.
+- `canvas-ops.ts` installs dormant canvas probes before application code runs, controls bounded capture sessions, and exposes typed operation queries.
+- `render-geometry.ts` asks the e2e runtime for visible screen positions for a canonical hex and rendered bounds for a named city-badge slot. It contains no layout formula or renderer constant.
+
+Issue-365, issue-437, and issue-447 specs move to these helpers. They must not retain local copies of fixture installation, campaign continuation, fixed sleeps, or pointy-hex math. A focused campaign-entry smoke test continues through the real Continue button so extracting the harness does not leave the player path covered only by isolated unit tests.
+
+### 2. E2E-only campaign-entry bridge
+
+Playwright starts Vite with `--mode e2e`; ordinary `yarn dev`, web builds, and Tauri builds do not use that mode. Direct entry requires both conditions:
+
+- `import.meta.env.MODE === 'e2e'`;
+- the URL contains the exact opt-in query `?e2e=autosave`.
+
+`main.ts` uses a direct `import.meta.env.MODE === 'e2e'` branch so Vite/Rollup can eliminate the dynamic import from other modes; a pure helper validates the exact query inside that branch. The runtime accepts no state argument. It may only load the autosave already installed by `page.addInitScript` in Playwright's isolated browser context.
+
+The bridge must reuse the canonical load path:
+
+1. `init()` creates the normal UI and loads settings.
+2. The e2e runtime calls `loadMostRecentAutoSaveEntry()`, which performs production save normalization.
+3. It rejects a missing/invalid opponent challenge or a hot-seat save with a diagnostic; direct entry never chooses a migration value or bypasses the private turn-handoff veil.
+4. It calls the same `enterCampaign()` boundary as the live save-panel callbacks.
+5. If either e2e gate is absent, initialization continues to `showStartSavePanel()` unchanged.
+
+Implement the pure gate in `src/testing/e2e-mode.ts` and the dynamically loaded runtime in `src/testing/e2e-runtime.ts`, with mirrored unit tests. `main.ts` passes the runtime only the closures it needs for canonical autosave entry, readiness observation, and renderer-owned coordinate queries.
+
+The runtime exposes one frozen, read-only diagnostic object only in e2e mode. It reports readiness/errors and delegates visible-hex and named city-badge-slot geometry queries to the live renderer. Badge geometry is returned only for city render items visible to the current viewer. The runtime does not expose `gameState`, `renderLoop`, `camera`, mutation functions, storage writers, canvas-capture controls, or an arbitrary state loader. Canvas capture is a separate Playwright-owned global installed solely by `page.addInitScript`; it is not production-source functionality.
+
+Normal web and Tauri builds must not contain the diagnostic global's sentinel name. Add one `scripts/assert-no-e2e-runtime.mjs` check over emitted JavaScript and source maps and invoke it from both `build` and `build:tauri` after Vite emits `dist`. Script-level tests prove it fails on a synthetic leaked sentinel and passes without one. Unit coverage separately proves the mode/query predicate rejects `production`, ordinary `development`, missing-query, and wrong-query cases.
+
+### 3. Readiness and sprite loading
+
+The e2e runtime exposes monotonic readiness states:
+
+- `campaign-ready`: normalized state has entered `enterCampaign()`, the renderer owns that state, the camera has been centered, and the render loop has scheduled rendering;
+- `sprites-ready`: the `initSprites()` promise for all civilizations has fulfilled;
+
+Production remains non-blocking: the game renders its fallback while sprites load. The implementation retains the `initSprites()` promise so e2e diagnostics can observe completion without delaying player startup. A sprite-load rejection records a diagnostic error and leaves the production fallback visible; it must not prevent campaign entry. Tests expecting `drawImage` require successful `sprites-ready` and fail with the recorded loader error instead of racing the fallback.
+
+After the required state, the capture helper waits through two successive `requestAnimationFrame` callbacks, then freezes the session. Because the game render loop continuously requeues itself, this guarantees at least one complete render opportunity without exposing or modifying its private tick. All helpers use condition-based waits; the existing `waitForTimeout(500)` calls are removed.
+
+### 4. Canvas operation capture
+
+The browser helper patches `CanvasRenderingContext2D.prototype.fillText` and `drawImage` through `page.addInitScript`, before the application creates its rendering context.
+
+The patch is dormant by default. A capture session:
+
+1. clears previous operations and overflow state;
+2. selects canvas IDs, operation kinds, text values, and/or sprite metadata of interest;
+3. enables capture;
+4. waits for a complete frame after the required readiness phase;
+5. freezes capture before returning operations.
+
+The buffer has a fixed maximum. Reaching it sets `overflowed: true` and stops recording; assertions fail with an overflow diagnostic rather than silently dropping evidence. Tests assert presence or absence within a captured frame, not an exact total across the continuously running render loop.
+
+Captured operations use a discriminated union:
+
+- shared fields: capture-session ID, sequence, canvas ID, current transform, canvas backing dimensions, and CSS bounding rectangle;
+- text operation: text, raw and viewport-normalized anchor position, optional maximum width, font, alignment, and baseline;
+- image operation: raw destination rectangle, viewport-normalized destination polygon/bounds, source rectangle when supplied, and sprite metadata when the source is a catalog image.
+
+Viewport normalization applies `ctx.getTransform()` and the backing-store-to-CSS scale, then offsets by the canvas bounding rectangle. This keeps assertions correct under device-pixel ratio, camera zoom, canvas resizing, and future canvas transforms. Image bounds transform all four destination corners rather than assuming scale-only matrices. Text assertions use the normalized anchor and the renderer-owned semantic slot bounds; the browser helper does not guess an emoji's platform-dependent ink box.
+
+The probe delegates with `Reflect.apply()` using the original argument list, thereby preserving the two `fillText` forms and all three standard `drawImage` overloads. Instrumentation parsing is isolated so its own failure records a diagnostic but cannot block the native call. An unknown argument shape is recorded and still delegates unchanged. A prepared operation is committed to the buffer only after the native call succeeds, so failed draws are not reported as rendered. Native return values and thrown errors are preserved exactly.
+
+Catalog images receive stable diagnostic metadata when created by the sprite loader:
+
+- sprite kind: `unit`, `building`, or `landmark`;
+- canonical item ID;
+- civilization or neutral palette identity;
+- motion where applicable.
+
+Metadata is attached to the in-memory `HTMLImageElement` before its load promise resolves. It contains catalog identity only—no game-state or player-secret data. The e2e assertion identifies the production draw from metadata plus its normalized destination near the expected city. It must not depend on a revoked blob URL, opaque object identity across the page boundary, or screenshot pixels.
+
+### 5. Fixture strategy
+
+Keep the existing crowded-map save as the canonical base fixture. A common transform applied to a fresh clone adds a valid `opponentChallenge: 'standard'` for direct-entry scenarios without rewriting or mutating the shared legacy source object. This preserves the fixture's usefulness for the separately tested legacy migration path.
+
+Create small, typed scenario builders rather than copying the full save:
+
+- current-player city producing `granary`;
+- current-player city producing `warrior`;
+- current-player city validly building `legendary:standing-stones`, which intentionally uses the map construction glyph.
+
+The builder selects a visible city owned by `state.currentPlayer` by ID/predicate, never by `civilization.cities[0]`. Building and unit scenarios validate their definitions before replacing only the queue head and progress required by the test.
+
+The legendary-wonder scenario must be internally valid, not merely a stray queue string. Its builder adds `animism` and `mud-brick`, adds the stone reveal technology `gathering`, grants a non-expired marketplace stone source, and records discovery of one existing fixture village for the current player. It then initializes the city's project through `initializeLegendaryWonderProjectsForCity()`, asserts the project reached `ready_to_build`, transitions it through `startLegendaryWonderBuild()`, and asserts both the `building` project phase and `legendary:standing-stones` queue head before serialization. If the canonical helpers reject the scenario, fixture setup fails rather than bypassing wonder invariants.
+
+This keeps scenarios reviewable while still exercising a real normalized save through the live renderer.
+
+This is an intentional, approved deviation from issue #660's example of separate `city-producing-building.json` and `city-producing-unit.json` files. The named builders are the canonical fixtures and avoid duplicating a roughly 15,000-line save; their output and invariants are directly unit-tested.
+
+### 6. Coordinate ownership
+
+Tests must not maintain pointy-hex constants or layout formulas.
+
+The read-only e2e diagnostic accepts a canonical hex coordinate and returns every visible wrapped copy as viewport CSS coordinates. Inside the renderer closure it composes the production `getHorizontalWrapRenderCoords()`, `hexToPixel()`, and `Camera.worldToScreen()` behavior. A second query accepts a visible city ID and semantic badge slot and composes the same city render-item projection with `getCityBadgeLayout()`. Tests do not receive camera internals and do not reimplement either transform.
+
+Tests that click relative to an already-located DOM sprite may continue to use that sprite as an anchor, but the destination comes from the shared visible-copy query. The helper chooses the copy nearest the anchor when horizontal wrapping produces multiple results. No literal `32`, `48`, `sqrt(3)`, `1.5`, camera offset, or zoom formula belongs in e2e specs.
+
+## Badge Anti-Drift Contract
+
+Production catalog emojis are useful labels in menus and cannot be globally unique; multiple units and buildings intentionally share symbols. The anti-drift rule therefore applies to simultaneous city-map badge meanings, not to every catalog label.
+
+Introduce `src/renderer/city-badge-presentation.ts`, a pure city-badge presentation module with two responsibilities:
+
+- semantic glyph fallbacks for under siege, breakaway, occupation, unrest, idle production, world pressure, loyalty pressure, intel, and production;
+- named layout slots and bounds for status, production/idle, left/right intel, world pressure, loyalty pressure, and religion.
+
+Status meanings are mutually exclusive because the status pass selects one branch. Production and idle are mutually exclusive because idle production requires an empty queue. The collision test uses an explicit coexistence matrix so intentional reuse inside mutually exclusive meanings is allowed while simultaneously visible meanings remain distinguishable.
+
+The city production pass follows this decision table:
+
+| Queue head | Sprite ready | Rendered badge |
+|---|---:|---|
+| Building | Yes | Building sprite |
+| Trainable unit | Yes | Unit sprite |
+| Building or unit | No | `🏗️`, the generic city-map production/loading glyph |
+| Legendary wonder or other intentionally unsprited item | Not applicable | Construction glyph |
+
+`PRODUCTION_ICONS` and `getProductionIconForItem()` remain unchanged for the city panel, chooser, and queue. The map renderer no longer uses an item's catalog emoji as its sprite-loading fallback; it uses the single `🏗️` production meaning. Thus a player retains the specific icon and name in the panel while the map shows an unambiguous temporary construction state.
+
+The generic production glyph must not equal any glyph belonging to a semantically distinct badge that can coexist with production. Separately, the layout resolver must produce non-overlapping bounds for every coexistence combination. Anchors and bounds are expressed as linear factors of `item.size`, so disjointness is proven in normalized space and checked at sizes derived from a real `Camera` instance's minimum and maximum zoom. Image-backed famine/religion badges participate in the bounds test even though they do not participate in glyph uniqueness.
+
+Tests must prove:
+
+- `production !== underSiege`, which fails with the original `⚔️` production fallback;
+- all pairs marked as coexistent have distinct semantic glyphs when both are text-backed;
+- all coexistent badge bounds are disjoint, including production/religion and status/loyalty;
+- mutually exclusive meanings such as production/idle and the individual status branches are not falsely rejected;
+- catalog glyph reuse outside simultaneous city-map badge categories remains allowed;
+- cached building and unit sprites suppress their text fallback;
+- uncached building and unit sprites use the collision-safe production fallback;
+- intentionally unsprited wonders still render the production construction glyph.
+
+## Player-Visible Behavior and UX
+
+| Situation | City panel/queue | Strategic-map result |
+|---|---|---|
+| Granary queued, sprite loading | Specific granary icon, name, progress, order, and ETA remain unchanged | Temporary `🏗️` in the production slot |
+| Granary sprite ready | Unchanged | Granary sprite replaces `🏗️` on a later frame |
+| Warrior queued while city is under siege | Specific warrior icon and queue details remain unchanged | Warrior sprite or `🏗️` in production slot; distinct `⚔️` in status slot; bounds do not overlap |
+| Legendary Standing Stones queued | Existing legendary-wonder name/icon and queue details remain unchanged | `🏗️` in production slot |
+| Queue empty with idle conversion | Existing idle-production UI remains unchanged | Existing gold/science idle badge in the mutually exclusive production slot |
+
+There is no queue mutation, new action, panel filtering, or recommendation surface in this change. Existing active item, follow-up order, progress, ETA text, and lower-ranked catalog reachability must remain unchanged. Unit tests verify the state is not mutated by badge presentation, while existing city-panel queue interaction regressions remain green.
+
+Rendering must continue to key sprite lookup and visibility to `state.currentPlayer` and the actual city owner. The new registry/layout helper is presentation-only and receives already viewer-safe `CityRenderItem` data; it must not read richer state or introduce a new privacy path.
+
+## Building Catalog Contract
+
+The live production path currently depends on:
+
+- `BUILDINGS` for canonical building definitions;
+- `PRODUCTION_ICONS` through `getProductionIconForItem()` for city-panel and queue labels;
+- `BUILDING_SPRITE_CATALOG` for Canvas image generation and production badges.
+
+Existing tests already prove that every `BUILDINGS` key has a production icon and v1 sprite. Consolidate or extend that coverage instead of duplicating it, and add the missing exact-set assertions:
+
+- `Object.keys(BUILDINGS)` is a subset of `Object.keys(PRODUCTION_ICONS)`; additional production-icon keys are expected because that catalog also contains trainable units and non-building production items.
+- `Object.keys(BUILDING_SPRITE_CATALOG)` equals `Object.keys(BUILDINGS)` plus the named retained building-scale asset allowlist: `pyramids`, `colosseum`, `great_library`, `lighthouse`, and `wright-flyer`.
+- Every allowlisted extra resolves to a non-empty sprite and carries a comment explaining that it is not a canonical `BUILDINGS` ID.
+
+The current audited counts are 158 canonical buildings, 229 production icons, and 163 v1 building-sprite entries. Tests assert relationships and named IDs, not the counts, so legitimate catalog growth does not require updating arbitrary totals.
+
+### Dormant v2 building sentinel
+
+The v2 building sprite catalog is preserved for planned future integration. Issue #365 deliberately removed full-size building entities from the strategic map, so #660 must not revive them indirectly.
+
+The sentinel has two parts:
+
+1. The existing functional e2e assertion that `#building-sprites` has no children after a real campaign render receives an actionable failure message.
+2. A narrow source-usage architecture test allows the v2 building lookup only in its defining module and the intentionally dormant `SpriteOverlay` lookup branch. Existing v2 unit tests continue to verify that serialized building assets resolve. A new panel/preview source import fails until the integration updates #660's catalog and observability contract.
+
+Together they detect both ways planned integration can become live: feeding the existing strategic-map `building` entity path or consuming the v2 lookup from a new surface. The failure message documents that:
+
+- v2 building assets and lookups exist;
+- no live renderer currently emits building entities;
+- when a planned surface starts emitting them, the implementer must update the catalog-consistency boundary and canvas/DOM observability coverage introduced by #660.
+
+The architecture test scans TypeScript source under `src/**` only for the exact `getBuildingSpriteV2` identifier, excluding generated `*.svg.ts` assets; it does not scan documentation, fixtures, build output, or arbitrary file contents. It is a deliberate temporary boundary test and should be removed or rewritten when the planned integration lands.
+
+This sentinel is preferable to a duplicate tracking issue because the v2 overlay plan and the later issue-365 strategic-map decision already document the intended work and its revised presentation boundary.
+
+This is the approved replacement for issue #660's proposed three-way catalog equality test. Treating a deliberately partial, dormant v2 asset set as live would either fail permanently or require a broad allowlist that hides real drift. Live catalogs receive exact relationship tests now; v2 receives a tripwire that forces those relationships to be redesigned when it gains a real consumer.
+
+## Test Strategy
+
+### Unit tests: first line
+
+Operations-log renderer tests remain mandatory for every canvas-render change. The production-badge suite covers the complete decision table without a browser and asserts draw ordering, sprite lookup ownership, draw operation type, and fallback behavior.
+
+Additional unit coverage verifies:
+
+- badge-glyph coexistence and layout-bound collision rules, including negative/mutually-exclusive cases;
+- live building-catalog subset and exact-extra relationships without duplicating existing coverage;
+- sprite diagnostic metadata for building, unit motion, and neutral landmark images;
+- fixture builders return independent states, derive ownership from `currentPlayer`, reject missing definitions, and produce a consistent legendary-wonder project/queue pair;
+- Playwright config resolves both CI and local dev-server commands with `--mode e2e`;
+- e2e mode/query gating rejects normal development, production, Tauri, missing-query, and wrong-query inputs, and direct entry rejects hot-seat state;
+- renderer-owned visible-copy coordinate queries agree with `Camera.screenToHex()` for non-wrapped and horizontally wrapped cases, while badge-slot queries reject cities not rendered for the current viewer;
+- a narrow e2e-source guard rejects reintroduced local `pointyHexPixel` helpers and the removed `waitForTimeout(500)` bootstrap pattern;
+- capture overload parsing, transform/DPR normalization, filtering, overflow, freeze, return values, and native error propagation;
+- the dormant-v2 source-use allowlist.
+
+### Browser integration tests
+
+One focused production-badge spec uses the shared harness and transformed canonical fixture to prove:
+
+- building production emits a metadata-identified building `drawImage` operation;
+- unit production emits a metadata-identified unit `drawImage` operation;
+- legendary-wonder production emits the expected construction `fillText` operation;
+- each image operation's normalized bounds intersect, and each text operation's normalized anchor lies within, the expected production slot for a visible copy of the selected city;
+- building/unit sprite frames do not emit a production fallback at that slot, while the wonder frame does not emit a catalog sprite for its queue item;
+- the game is entered without save-panel or migration-dialog interaction.
+
+One separate browser smoke test installs the modernized clone, clicks the real Continue button, and proves the live save-panel callback still reaches the game. Legacy challenge choice, cancel/focus restoration, persistence failure/retry, and import ordering remain covered by the existing campaign-entry and prompt interaction tests.
+
+The existing issue-365, issue-437, and issue-447 browser behavior remains covered after helper extraction. Issue-365 retains the functional v2 building sentinel. Mobile/reduced-motion tests set their viewport/media preferences before navigation, use direct entry, and wait for readiness before making final layout assertions; they never depend on desktop coordinates.
+
+Screenshots may remain as debugging artifacts, but no acceptance criterion depends on visual comparison.
+
+## Failure Handling
+
+- Fixture transforms fail before navigation when the selected city, queue item, or canonical definition is missing.
+- Direct entry fails before `enterCampaign()` when the e2e mode/query gate, autosave, opponent challenge, or solo-campaign precondition is missing; the diagnostic names the failed precondition.
+- Campaign entry waits identify the missing readiness phase and include any recorded startup/sprite error rather than sleeping for a fixed interval.
+- Canvas capture reports unsupported overloads and buffer overflow explicitly while still delegating to the browser implementation.
+- Sprite loading failures remain visible to players through the collision-safe text fallback. Browser tests requiring image operations fail deterministically at `sprites-ready` with the loader error; they do not accept a timing-dependent fallback.
+- Catalog tests identify the missing or unexpected IDs and the catalog responsible.
+- The v2 sentinel failure tells the implementer which #660 contracts must be extended when building entities become live.
+
+## Documentation
+
+Add a `Canvas verification` section to `.claude/rules/ui-panels.md`, whose existing path scope covers renderer changes, with these requirements:
+
+1. Canvas-rendered behavior is invisible to DOM assertions.
+2. Every canvas render change ships with a unit operations-log regression.
+3. Browser coverage is required when the behavior depends on real startup, sprite loading, camera integration, or canvas/DOM composition.
+4. Browser canvas assertions use shared operation capture and production coordinate conversion.
+5. Manual screenshots are QA evidence, not regression coverage.
+6. External browser-tool quirks are documented as operational context and are not repository fix targets.
+
+Add `docs/testing/canvas-render-verification.md` as the user-facing maintainer guide. It documents helper APIs, readiness phases, capture lifecycle and bounds, fixture-builder conventions, how to add a new sprite assertion, the dormant-v2 sentinel, and the browser-tool behaviors from issue #660. Link the guide from the new section in `.claude/rules/ui-panels.md`; because that existing rule is already indexed for both Claude and Codex renderer work, no new rule-file index entry is needed.
+
+## Implementation Boundaries
+
+Keep production changes small and independently testable:
+
+- the exact-query predicate is a pure helper, while `main.ts` keeps the mode comparison literal for reliable dead-code elimination;
+- the e2e runtime is dynamically imported behind the compile-time mode gate;
+- readiness observation wraps the existing non-blocking sprite promise without delaying normal startup;
+- canvas capture and fixture builders remain under `tests/e2e/helpers/`; only readiness, canonical entry, and viewer-safe renderer geometry queries live in the gated source runtime;
+- badge glyph/layout computation is a pure renderer presentation helper consumed by every affected city badge pass;
+- sprite metadata is assigned at image construction, not inferred later from cache keys or blob URLs;
+- no gameplay state shape or save schema changes are introduced.
+
+Do not expose `renderLoop`, `camera`, `gameState`, or sprite-cache mutation through `window`. The e2e diagnostic returns serialized snapshots/results only.
+
+## Verification Matrix
+
+Implementation is not complete until all applicable checks pass:
+
+- `scripts/check-src-rule-violations.sh` for every changed `src/` file;
+- mirrored unit tests for renderer, sprite loader, campaign entry, Vite/e2e gating, and any changed UI helper;
+- `bash scripts/run-with-mise.sh yarn test:hooks` after changing `.claude/rules/**` or related hook coverage;
+- the focused production-badge Playwright spec;
+- the refactored issue-365, issue-437, and issue-447 specs plus the live Continue smoke test;
+- `bash scripts/run-with-mise.sh yarn test:web-smoke` for the full browser suite;
+- `bash scripts/run-with-mise.sh yarn build` and an assertion that the normal web bundle contains no e2e diagnostic sentinel;
+- `bash scripts/run-with-mise.sh yarn build:tauri` and the same absence assertion for the Tauri frontend;
+- `bash scripts/run-with-mise.sh yarn test` for the complete Vitest and hook suite.
+
+Because the design changes renderer output, final review must inspect both `origin/main...HEAD` and the uncommitted delta and must compare the implemented badge bounds at desktop and mobile city sizes. Screenshot inspection may supplement, but cannot replace, operations assertions.
+
+## Acceptance Criteria
+
+- Shared e2e helpers replace copied fixture, continuation, capture, and coordinate code.
+- No e2e spec contains a fixed sleep, duplicated pointy-hex math, hardcoded renderer hex size, camera offset, zoom formula, or wrap formula.
+- Browser capture is opt-in, filtered, bounded, transform/DPR-aware, and records both text and image operations without changing native behavior.
+- Production sprite draws can be identified by stable, non-sensitive metadata and normalized viewport bounds.
+- Building, unit, and internally consistent wonder scenarios start from independent clones of one canonical fixture.
+- Direct campaign entry requires e2e mode, the exact query, and a solo save; it cannot bypass hot-seat handoff, and normal web/Tauri bundles expose no diagnostic or state-entry API.
+- At least one browser test continues through the real Continue button.
+- Game, sprite, and rendered-frame readiness replace timing sleeps; image tests fail deterministically on sprite-load errors.
+- Unit and browser tests cover the production-badge decision table.
+- The production fallback cannot collide with any simultaneous city-map badge glyph.
+- Simultaneous city badges have non-overlapping bounds at supported sizes, including production/religion and status/loyalty.
+- Specific production icons remain visible in the city panel while the temporary map fallback is generic.
+- Live building catalogs have subset/exact-extra consistency coverage with the five named retained assets.
+- V2 building assets remain intact and out of scope.
+- The functional and source-use v2 sentinels fail with actionable guidance when building rendering becomes live.
+- The canvas-testing convention and browser-tool constraints are documented.
+- Targeted, browser, web-build, Tauri-build, hook, and full-suite verification is green.
+
+## Related Design History
+
+- `docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md` records the planned v2 building integration.
+- `docs/superpowers/specs/2026-06-12-issue-365-strategic-map-presentation-design.md` supersedes map-level building piles and preserves full-size building sprites for a future close-up surface such as panels, previews, or catalogs.

--- a/docs/superpowers/specs/2026-07-22-issue-660-canvas-verification-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-660-canvas-verification-design.md
@@ -217,6 +217,25 @@ There is no queue mutation, new action, panel filtering, or recommendation surfa
 
 Rendering must continue to key sprite lookup and visibility to `state.currentPlayer` and the actual city owner. The new registry/layout helper is presentation-only and receives already viewer-safe `CityRenderItem` data; it must not read richer state or introduce a new privacy path.
 
+## Cross-Cutting Gameplay and Audience Contract
+
+Issue #660 changes verification and map presentation, not simulation. The implementation must make that neutrality explicit instead of relying on the absence of intended gameplay work.
+
+| Dimension | Required contract |
+|---|---|
+| Balance and pacing | No yield, cost, ETA, combat, movement, research, crisis, or difficulty value changes. Badge rendering does not mutate the queue, progress, city, civilization, or turn state. |
+| Fun and new mechanics | No new action, reward, penalty, resource, rule, or decision is introduced. The benefit is faster visual comprehension and fewer misleading badge collisions. |
+| Ages and comprehension | A specific text name, icon, progress, and ETA remain available in the DOM city panel; the small Canvas badge is only a glanceable supplement. Meaning never depends on color or sound alone. Distinct simultaneous glyphs and disjoint bounds reduce ambiguity for early readers without removing detail for experienced players. |
+| Play styles | Completionist, military, builder, wonder, and idle-production play remain behaviorally identical. Full production browsing, queue ordering, and lower-ranked item reachability are unchanged. |
+| Difficulty modes | `explorer`, `standard`, and `veteran` all render through the same badge and sprite path. The e2e bridge accepts every valid built-in challenge and rejects missing or invalid values; it does not resolve, rewrite, or rebalance difficulty. |
+| Computer players | AI production, scoring, research, and turn scheduling are untouched. Rival/AI queue contents remain private because the production badge is still restricted to a city owned by `state.currentPlayer`; loading sprites for all civilizations does not make AI choices observable. |
+| Solo and hot seat | Direct e2e entry is solo-only. The live UI path retains hot-seat handoff and privacy. Renderer tests switch `currentPlayer` between hot-seat seats and prove that only the active seat's city production is presented. |
+| SFX and reduced motion | Badge drawing and sprite readiness are silent presentation updates; they emit no SFX, music, notification, or gameplay event. Existing campaign-entry audio starts through the unchanged `startGame()` path. Reduced-motion behavior remains controlled by the existing renderer/overlay setting. |
+| Saved games | No save field, schema version, migration, or serialized metadata changes. Direct entry consumes the normalized `LoadedSaveEntry.state` returned by the existing storage path. A rejected direct entry does not rewrite storage or mutate the loaded state. |
+| Extensibility | New badge meanings require one typed registry entry, one named slot/coexistence decision, and operations-log coverage. New catalog sprites inherit metadata at the shared loader boundary. No ID-specific renderer branch is added for granary, warrior, or Standing Stones. |
+
+The target audience range cannot be proven by a numeric age test. The enforceable proxy is redundant readable detail, non-color/non-audio-only meaning, mobile/reduced-motion coverage, and deterministic tests for simultaneous meanings. Manual playtesting may supplement those contracts but must not replace them.
+
 ## Building Catalog Contract
 
 The live production path currently depends on:
@@ -268,7 +287,10 @@ Additional unit coverage verifies:
 - fixture builders return independent states, derive ownership from `currentPlayer`, reject missing definitions, and produce a consistent legendary-wonder project/queue pair;
 - Playwright config resolves both CI and local dev-server commands with `--mode e2e`;
 - e2e mode/query gating rejects normal development, production, Tauri, missing-query, and wrong-query inputs, and direct entry rejects hot-seat state;
+- direct entry accepts each valid built-in challenge without changing it, while rejected direct entry leaves the supplied state and storage dependencies untouched;
 - renderer-owned visible-copy coordinate queries agree with `Camera.screenToHex()` for non-wrapped and horizontally wrapped cases, while badge-slot queries reject cities not rendered for the current viewer;
+- hot-seat viewer switching shows production only for the active seat, AI/rival production remains private, and all three challenge values produce identical presentation operations for identical visible state;
+- badge passes are state-pure and silent: no gameplay event, notification, audio, or SFX dependency is introduced;
 - a narrow e2e-source guard rejects reintroduced local `pointyHexPixel` helpers and the removed `waitForTimeout(500)` bootstrap pattern;
 - capture overload parsing, transform/DPR normalization, filtering, overflow, freeze, return values, and native error propagation;
 - the dormant-v2 source-use allowlist.
@@ -283,6 +305,7 @@ One focused production-badge spec uses the shared harness and transformed canoni
 - each image operation's normalized bounds intersect, and each text operation's normalized anchor lies within, the expected production slot for a visible copy of the selected city;
 - building/unit sprite frames do not emit a production fallback at that slot, while the wonder frame does not emit a catalog sprite for its queue item;
 - the game is entered without save-panel or migration-dialog interaction.
+- the real city panel still exposes the queued item's specific name and turns remaining, so the generic loading badge is never the only source of production identity.
 
 One separate browser smoke test installs the modernized clone, clicks the real Continue button, and proves the live save-panel callback still reaches the game. Legacy challenge choice, cancel/focus restoration, persistence failure/retry, and import ordering remain covered by the existing campaign-entry and prompt interaction tests.
 
@@ -357,6 +380,10 @@ Because the design changes renderer output, final review must inspect both `orig
 - The production fallback cannot collide with any simultaneous city-map badge glyph.
 - Simultaneous city badges have non-overlapping bounds at supported sizes, including production/religion and status/loyalty.
 - Specific production icons remain visible in the city panel while the temporary map fallback is generic.
+- The same presentation result is produced at explorer, standard, and veteran difficulty for identical visible state, without changing AI or balance data.
+- AI/rival production remains private, and hot-seat viewer switching follows `state.currentPlayer` without bypassing handoff.
+- Badge rendering and sprite readiness emit no gameplay event or SFX and mutate no saved/gameplay state.
+- Existing saves need no schema or migration change; invalid or hot-seat direct entry performs no storage write.
 - Live building catalogs have subset/exact-extra consistency coverage with the five named retained assets.
 - V2 building assets remain intact and out of scope.
 - The functional and source-use v2 sentinels fail with actionable guidance when building rendering becomes live.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "packageManager": "yarn@4.17.0",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && node scripts/version-sw-cache.mjs",
-    "build:tauri": "tsc && vite build --mode tauri",
+    "build": "tsc && vite build && node scripts/version-sw-cache.mjs && node scripts/assert-no-e2e-runtime.mjs dist",
+    "build:tauri": "tsc && vite build --mode tauri && node scripts/assert-no-e2e-runtime.mjs dist",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 export function resolvePlaywrightDevCommand(ci = process.env.CI): string {
   return ci
-    ? 'yarn dev --host 127.0.0.1'
-    : './scripts/run-with-mise.sh yarn dev --host 127.0.0.1';
+    ? 'yarn dev --mode e2e --host 127.0.0.1'
+    : './scripts/run-with-mise.sh yarn dev --mode e2e --host 127.0.0.1';
 }
 
 export default defineConfig({

--- a/scripts/assert-no-e2e-runtime.mjs
+++ b/scripts/assert-no-e2e-runtime.mjs
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const E2E_SENTINEL = '__CONQUESTORIA_E2E_DIAGNOSTICS__';
+
+/**
+ * Reject e2e-only diagnostics leaking into normal distributable JavaScript or
+ * source maps. Source maps are included because a public production artifact
+ * must not retain the diagnostic API even when its minified bundle does not.
+ */
+export function assertNoE2ERuntime(root) {
+  const visit = path => {
+    for (const name of readdirSync(path)) {
+      const child = resolve(path, name);
+      if (statSync(child).isDirectory()) {
+        visit(child);
+        continue;
+      }
+      if (!name.endsWith('.js') && !name.endsWith('.map')) continue;
+      if (readFileSync(child, 'utf8').includes(E2E_SENTINEL)) {
+        throw new Error(`e2e runtime sentinel leaked into ${child}`);
+      }
+    }
+  };
+  visit(resolve(root));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  assertNoE2ERuntime(process.argv[2] ?? 'dist');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,10 @@ import { resolveOpponentChallenge, setPendingOpponentChallenge, resolveChallenge
 import { processTurn } from '@/core/turn-manager';
 import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
 import { RenderLoop } from '@/renderer/render-loop';
+import {
+  getVisibleCityBadgeSlots,
+  getVisibleHexViewportCopies,
+} from '@/renderer/city-renderer';
 import { initSprites } from '@/renderer/sprites/sprite-loader';
 import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
 import { preloadFamineBadgeMarker } from '@/renderer/improvements/famine-badge-marker';
@@ -4929,6 +4933,31 @@ async function init(): Promise<void> {
   createUI();
   persistedSettings = await loadSettings();
 
+  if (import.meta.env.MODE === 'e2e') {
+    const { isExactAutosaveE2ERequest } = await import('@/testing/e2e-mode');
+    if (isExactAutosaveE2ERequest(import.meta.env.MODE, window.location.search)) {
+      const { installE2ERuntime } = await import('@/testing/e2e-runtime');
+      await installE2ERuntime({
+        loadAutosave: loadMostRecentAutoSaveEntry,
+        enterSoloCampaign: state => enterCampaignForE2E(state),
+        getVisibleHexCopies: coord => getVisibleHexViewportCopies(
+          gameState,
+          renderLoop.camera,
+          gameState.currentPlayer,
+          coord,
+        ),
+        getCityBadgeSlots: (cityId, slot) => getVisibleCityBadgeSlots(
+          gameState,
+          renderLoop.camera,
+          gameState.currentPlayer,
+          cityId,
+          slot,
+        ),
+      });
+      return;
+    }
+  }
+
   await showStartSavePanel();
 }
 
@@ -4936,19 +4965,19 @@ function enterCampaign(
   state: GameState,
   message: string,
   persistBeforeReady: boolean = false,
-): void {
+): Promise<void> | null {
   document.getElementById('save-panel')?.remove();
   gameState = state;
   migrateLegacySave();
   if (gameState.gameOver) {
-    startGame();
+    const spritesReady = startGame();
     handleVictoryIfNeeded();
-    return;
+    return spritesReady;
   }
   if (!gameState.hotSeat) {
-    startGame();
+    const spritesReady = startGame();
     showNotification(message, 'info');
-    return;
+    return spritesReady;
   }
 
   audio.setMasterVolume(0);
@@ -4992,7 +5021,7 @@ function enterCampaign(
     },
   );
 
-  if (!persistBeforeReady) return;
+  if (!persistBeforeReady) return null;
   const persist = async (): Promise<void> => {
     try {
       await autoSave(gameState);
@@ -5011,6 +5040,14 @@ function enterCampaign(
     }
   };
   void persist();
+  return null;
+}
+
+function enterCampaignForE2E(state: GameState): Promise<void> {
+  if (state.hotSeat) throw new Error('E2E direct entry does not bypass hot-seat handoff.');
+  const spritesReady = enterCampaign(state, `Welcome back! Turn ${state.turn}`);
+  if (!spritesReady) throw new Error('E2E direct entry requires a solo campaign.');
+  return spritesReady;
 }
 
 async function showStartSavePanel(): Promise<void> {
@@ -5266,7 +5303,7 @@ function showGameModeSelection(): void {
   });
 }
 
-function startGame(): void {
+function startGame(): Promise<void> {
   // Initialize treasury drawer once
   if (!drawer) {
     drawer = createTreasuryDrawer();
@@ -5278,7 +5315,8 @@ function startGame(): void {
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {
     civColors[civId] = civ.color;
   }
-  initSprites(civColors);
+  const spritesReady = initSprites(civColors);
+  void spritesReady.catch(() => {});
   preloadOutpostMarker().catch(() => {});
   preloadFamineBadgeMarker().catch(() => {});
   preloadReligionBadgeMarker().catch(() => {});
@@ -5375,6 +5413,7 @@ function startGame(): void {
 
   // Start render loop
   renderLoop.start();
+  return spritesReady;
 }
 
 init();

--- a/src/renderer/city-badge-presentation.ts
+++ b/src/renderer/city-badge-presentation.ts
@@ -1,0 +1,124 @@
+/** Semantic glyphs used only for simultaneous strategic-map city badges. */
+export const CITY_BADGE_GLYPHS = {
+  underSiege: '⚔️',
+  breakawaySecession: '⛓',
+  breakawayEstablished: '👑',
+  occupationSevere: '☹',
+  occupation: '⚡',
+  unrestSevere: '🔥',
+  unrest: '⚡',
+  production: '🏗️',
+  idleGold: '💰',
+  idleScience: '🔬',
+  embeddedIntel: '🛡',
+  infiltratedIntel: '👁',
+  worldPressure: '⚠️',
+  loyaltyPressure: '🙏',
+} as const;
+
+export type CityBadgeGlyphMeaning = keyof typeof CITY_BADGE_GLYPHS;
+
+export type CityBadgeSlot =
+  | 'status'
+  | 'production'
+  | 'idle'
+  | 'leftIntel'
+  | 'rightIntel'
+  | 'worldPressure'
+  | 'loyaltyPressure'
+  | 'religion';
+
+export interface BadgeBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export interface CityBadgeSlotLayout {
+  center: { x: number; y: number };
+  bounds: BadgeBounds;
+}
+
+export type CityBadgeLayout = Record<CityBadgeSlot, CityBadgeSlotLayout>;
+
+/** Pairs whose text glyphs must remain distinguishable when both can appear. */
+export const CITY_BADGE_GLYPH_COEXISTENCE: ReadonlyArray<
+  readonly [CityBadgeGlyphMeaning, CityBadgeGlyphMeaning]
+> = [
+  ['production', 'underSiege'],
+  ['production', 'breakawaySecession'],
+  ['production', 'breakawayEstablished'],
+  ['production', 'occupationSevere'],
+  ['production', 'occupation'],
+  ['production', 'unrestSevere'],
+  ['production', 'unrest'],
+  ['production', 'worldPressure'],
+  ['production', 'loyaltyPressure'],
+];
+
+/** Pairs whose rendered bounds must not intersect. */
+export const CITY_BADGE_SLOT_COEXISTENCE: ReadonlyArray<
+  readonly [CityBadgeSlot, CityBadgeSlot]
+> = [
+  ['status', 'production'],
+  ['status', 'worldPressure'],
+  ['status', 'loyaltyPressure'],
+  ['production', 'worldPressure'],
+  ['production', 'religion'],
+  ['worldPressure', 'loyaltyPressure'],
+  ['worldPressure', 'religion'],
+  ['loyaltyPressure', 'religion'],
+];
+
+function createSlot(
+  screen: { x: number; y: number },
+  size: number,
+  dx: number,
+  dy: number,
+  width = 0.28,
+  height = 0.28,
+): CityBadgeSlotLayout {
+  const center = { x: screen.x + size * dx, y: screen.y + size * dy };
+  const boundsWidth = size * width;
+  const boundsHeight = size * height;
+  const x = center.x - boundsWidth / 2;
+  const y = center.y - boundsHeight / 2;
+  return {
+    center,
+    bounds: {
+      x,
+      y,
+      width: boundsWidth,
+      height: boundsHeight,
+      left: x,
+      right: x + boundsWidth,
+      top: y,
+      bottom: y + boundsHeight,
+    },
+  };
+}
+
+/**
+ * Resolves all city-badge positions from one scale-aware coordinate system.
+ * Production and idle intentionally share a slot because they cannot coexist.
+ */
+export function getCityBadgeLayout(
+  screen: { x: number; y: number },
+  size: number,
+): CityBadgeLayout {
+  return {
+    status: createSlot(screen, size, 0.62, -0.4),
+    production: createSlot(screen, size, -0.62, -0.4, 0.32, 0.32),
+    idle: createSlot(screen, size, -0.62, -0.4),
+    leftIntel: createSlot(screen, size, -0.52, 0.04),
+    rightIntel: createSlot(screen, size, 0.52, 0.04),
+    worldPressure: createSlot(screen, size, 0, -0.9, 0.32, 0.32),
+    loyaltyPressure: createSlot(screen, size, 0.52, -0.9, 0.32, 0.32),
+    religion: createSlot(screen, size, -0.85, -0.9, 0.32, 0.32),
+  };
+}

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -1,6 +1,5 @@
 import type { City, CrisisArchetype, HexCoord, UnitType } from '@/core/types';
 import { getOccupiedCityMood } from '@/systems/city-occupation-system';
-import { PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
 import type { LegendaryWonderMapEntry } from '@/systems/legendary-wonder-map-presentation';
 import { drawLegendaryWonderLandmarkGlyph } from '@/renderer/wonders/legendary-wonder-renderer';
 import {
@@ -10,6 +9,10 @@ import {
 import { getFamineBadgeMarkerImage } from '@/renderer/improvements/famine-badge-marker';
 import { getReligionBadgeMarkerImage } from '@/renderer/improvements/religion-badge-marker';
 import { spriteCache } from '@/renderer/sprites/sprite-loader';
+import {
+  CITY_BADGE_GLYPHS,
+  getCityBadgeLayout,
+} from '@/renderer/city-badge-presentation';
 
 export interface CityRenderProjection {
   name: string;
@@ -70,9 +73,7 @@ export type CityRenderPass = {
 };
 
 export function getProductionBadgeIcon(city: { productionQueue: string[] }): string | null {
-  if (city.productionQueue.length === 0) return null;
-  const id = city.productionQueue[0];
-  return PRODUCTION_ICONS[id] ?? PRODUCTION_ICON_FALLBACK;
+  return city.productionQueue.length > 0 ? CITY_BADGE_GLYPHS.production : null;
 }
 
 const TIER_STRUCTURE_COUNTS = {
@@ -401,15 +402,23 @@ export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: Cit
   // '⚔️' matches the city panel's own "Under siege" label icon (#522) for consistency
   // between the map badge and the panel status line.
   const statusText = item.breakaway
-    ? item.breakaway.status === 'secession' ? '⛓' : '👑'
+    ? item.breakaway.status === 'secession'
+      ? CITY_BADGE_GLYPHS.breakawaySecession
+      : CITY_BADGE_GLYPHS.breakawayCapital
     : item.presentation.underSiege
-      ? '⚔️'
+      ? CITY_BADGE_GLYPHS.underSiege
       : item.city.occupation
-        ? getOccupiedCityMood(item.city) === 2 ? '☹' : '⚡'
+        ? getOccupiedCityMood(item.city) === 2
+          ? CITY_BADGE_GLYPHS.occupationSevere
+          : CITY_BADGE_GLYPHS.occupation
         : item.city.unrestLevel > 0
-          ? item.city.unrestLevel === 2 ? '🔥' : '⚡'
+          ? item.city.unrestLevel === 2
+            ? CITY_BADGE_GLYPHS.unrestSevere
+            : CITY_BADGE_GLYPHS.unrest
           : null;
   if (!statusText) return;
+
+  const { center, bounds } = getCityBadgeLayout(item.screen, item.size).status;
 
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -417,9 +426,9 @@ export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: Cit
   drawFittedText(
     ctx,
     statusText,
-    item.screen.x + item.size * 0.48,
-    item.screen.y - item.size * 0.42,
-    item.size * 0.28,
+    center.x,
+    center.y,
+    bounds.width,
     item.size * 0.28,
   );
 }
@@ -433,20 +442,20 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
   // #658: prefer the queued item's catalog sprite (loaded per-civ by initSprites),
   // keyed by the city owner so hot-seat players each get their own palette. Buildings
   // and units are separate cache namespaces, so at most one lookup hits. Unit sprites
-  // matter beyond looks: the old ⚔️ training emoji was the same glyph as the
+  // matter beyond looks: an old training emoji shared a glyph with the
   // under-siege status badge on the opposite corner of the city. Wonders and
-  // not-yet-loaded sprites fall through to the PRODUCTION_ICONS emoji.
+  // not-yet-loaded sprites fall through to the neutral construction marker.
   const queueHead = item.city.productionQueue[0];
+  const { center, bounds } = getCityBadgeLayout(item.screen, item.size).production;
   const spriteImage = spriteCache.getBuilding(queueHead, item.city.owner)
     ?? spriteCache.getUnit(queueHead as UnitType, item.city.owner);
   if (spriteImage) {
-    const s = item.size * 0.32;
     ctx.drawImage(
       spriteImage,
-      item.screen.x - item.size * 0.48 - s / 2,
-      item.screen.y - item.size * 0.42 - s / 2,
-      s,
-      s,
+      bounds.x,
+      bounds.y,
+      bounds.width,
+      bounds.height,
     );
     return;
   }
@@ -459,8 +468,8 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
   drawFittedText(
     ctx,
     buildIcon,
-    item.screen.x - item.size * 0.48,
-    item.screen.y - item.size * 0.42,
+    center.x,
+    center.y,
     item.size * 0.28,
     item.size * 0.28,
   );
@@ -479,15 +488,18 @@ export function drawCityIdleBadgePass(ctx: CanvasRenderingContext2D, item: CityR
     return;
   }
 
-  const idleIcon = item.city.idleProduction === 'gold' ? '💰' : '🔬';
+  const idleIcon = item.city.idleProduction === 'gold'
+    ? CITY_BADGE_GLYPHS.idleGold
+    : CITY_BADGE_GLYPHS.idleScience;
+  const { center, bounds } = getCityBadgeLayout(item.screen, item.size).idle;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillStyle = '#fff';
   drawFittedText(
     ctx,
     idleIcon,
-    item.screen.x - item.size * 0.48,
-    item.screen.y - item.size * 0.42,
+    center.x,
+    center.y,
     item.size * 0.28,
     item.size * 0.28,
   );
@@ -498,18 +510,19 @@ export function drawCityIntelBadgePass(ctx: CanvasRenderingContext2D, item: City
   markPass(ctx, 'intel');
   if (!item.projection.isLive || item.lowZoom) return;
 
+  const layout = getCityBadgeLayout(item.screen, item.size);
   const badges = [
     item.intel.hasEmbeddedSpy
-      ? { text: '🛡', x: item.screen.x - item.size * 0.5 }
+      ? { text: CITY_BADGE_GLYPHS.embeddedIntel, slot: layout.leftIntel }
       : null,
     item.intel.hasInfiltratedSpy
-      ? { text: '👁', x: item.screen.x + item.size * 0.5 }
+      ? { text: CITY_BADGE_GLYPHS.infiltratedIntel, slot: layout.rightIntel }
       : null,
-  ].filter((badge): badge is { text: string; x: number } => badge !== null);
-  const y = item.screen.y + item.size * 0.04;
+  ].filter((badge): badge is { text: string; slot: typeof layout.leftIntel } => badge !== null);
   for (const badge of badges) {
+    const { center, bounds } = badge.slot;
     ctx.beginPath();
-    ctx.arc(badge.x, y, item.size * 0.14, 0, Math.PI * 2);
+    ctx.arc(center.x, center.y, bounds.width / 2, 0, Math.PI * 2);
     ctx.fillStyle = 'rgba(20,24,30,0.86)';
     ctx.fill();
     ctx.textAlign = 'center';
@@ -517,16 +530,16 @@ export function drawCityIntelBadgePass(ctx: CanvasRenderingContext2D, item: City
     drawFittedText(
       ctx,
       badge.text,
-      badge.x,
-      y,
-      item.size * 0.28,
+      center.x,
+      center.y,
+      bounds.width,
       item.size * 0.2,
     );
   }
 }
 
-// Reuses drawCityIntelBadgePass's dark-circle "intel" style, at top-center so it never
-// collides with the corner status/production/idle/spy badges. One glyph for every
+// Reuses drawCityIntelBadgePass's dark-circle "intel" style. Its dedicated shared
+// layout slot never collides with the other city indicators. One glyph for every
 // archetype (matches city-panel's existing '⚠️' crisis convention) -- this is player
 // intel about a rival's crisis, not the rival's own detailed diagnosis.
 export function drawCityWorldPressureBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
@@ -534,8 +547,7 @@ export function drawCityWorldPressureBadgePass(ctx: CanvasRenderingContext2D, it
   markPass(ctx, 'world-pressure');
   if (!item.projection.isLive || !item.city || !item.worldPressureCrisis) return;
 
-  const x = item.screen.x;
-  const y = item.screen.y - item.size * 0.58;
+  const { center, bounds } = getCityBadgeLayout(item.screen, item.size).worldPressure;
 
   // #594 MR7: famine gets bespoke badge art; every other archetype (outbreak,
   // catastrophe, hunt) keeps the generic ⚠️ glyph -- the badge fires for ANY active
@@ -544,33 +556,30 @@ export function drawCityWorldPressureBadgePass(ctx: CanvasRenderingContext2D, it
   if (item.worldPressureCrisis === 'famine') {
     const famineImg = getFamineBadgeMarkerImage();
     if (famineImg) {
-      const s = item.size * 0.32;
-      ctx.drawImage(famineImg, x - s / 2, y - s / 2, s, s);
+      ctx.drawImage(famineImg, bounds.x, bounds.y, bounds.width, bounds.height);
       return;
     }
   }
 
   ctx.beginPath();
-  ctx.arc(x, y, item.size * 0.14, 0, Math.PI * 2);
+  ctx.arc(center.x, center.y, bounds.width / 2, 0, Math.PI * 2);
   ctx.fillStyle = 'rgba(20,24,30,0.86)';
   ctx.fill();
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  drawFittedText(ctx, '⚠️', x, y, item.size * 0.28, item.size * 0.2);
+  drawFittedText(ctx, CITY_BADGE_GLYPHS.worldPressure, center.x, center.y, bounds.width, item.size * 0.2);
 }
 
-// #593 MR6: same dark-circle badge style, offset to the upper-right of the
-// world-pressure badge (which sits top-center) so the two never collide when a city
-// happens to have both a world-pressure crisis and active loyalty pressure.
+// #593 MR6: same dark-circle badge style. The shared layout keeps this signal distinct
+// from world pressure when a city has both conditions.
 export function drawCityLoyaltyPressureBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
   if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'loyalty-pressure');
   if (!item.projection.isLive || !item.city || !item.loyaltyPressure) return;
 
-  const x = item.screen.x + item.size * 0.5;
-  const y = item.screen.y - item.size * 0.58;
+  const { center, bounds } = getCityBadgeLayout(item.screen, item.size).loyaltyPressure;
   ctx.beginPath();
-  ctx.arc(x, y, item.size * 0.14, 0, Math.PI * 2);
+  ctx.arc(center.x, center.y, bounds.width / 2, 0, Math.PI * 2);
   ctx.fillStyle = 'rgba(20,24,30,0.86)';
   ctx.fill();
   ctx.textAlign = 'center';
@@ -580,13 +589,11 @@ export function drawCityLoyaltyPressureBadgePass(ctx: CanvasRenderingContext2D, 
   // cross/crescent/etc.) was used in an earlier draft and would have broken this
   // project's "invented faiths, never real-world religions" convention (see
   // religion-definitions.ts NAME_CANDIDATES doc comment).
-  drawFittedText(ctx, '🙏', x, y, item.size * 0.28, item.size * 0.2);
+  drawFittedText(ctx, CITY_BADGE_GLYPHS.loyaltyPressure, center.x, center.y, bounds.width, item.size * 0.2);
 }
 
-// #594 MR7: offset to the upper-left of the world-pressure badge (top-center) --
-// mirrors the loyalty-pressure badge's upper-right offset above -- so a city that
-// simultaneously has a world-pressure crisis, loyalty pressure, and a religion badge
-// never has more than two badges sharing the same spot.
+// #594 MR7: the shared layout assigns faith a dedicated slot, distinct from production,
+// status, world pressure, and loyalty indicators.
 export function drawCityReligionBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
   if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'religion-badge');
@@ -594,10 +601,8 @@ export function drawCityReligionBadgePass(ctx: CanvasRenderingContext2D, item: C
 
   const img = getReligionBadgeMarkerImage(item.religionBadge.isOwnFaith);
   if (!img) return;
-  const x = item.screen.x - item.size * 0.5;
-  const y = item.screen.y - item.size * 0.58;
-  const s = item.size * 0.32;
-  ctx.drawImage(img, x - s / 2, y - s / 2, s, s);
+  const { bounds } = getCityBadgeLayout(item.screen, item.size).religion;
+  ctx.drawImage(img, bounds.x, bounds.y, bounds.width, bounds.height);
 }
 
 export const CITY_RENDER_PASSES: CityRenderPass[] = [

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -404,7 +404,7 @@ export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: Cit
   const statusText = item.breakaway
     ? item.breakaway.status === 'secession'
       ? CITY_BADGE_GLYPHS.breakawaySecession
-      : CITY_BADGE_GLYPHS.breakawayCapital
+      : CITY_BADGE_GLYPHS.breakawayEstablished
     : item.presentation.underSiege
       ? CITY_BADGE_GLYPHS.underSiege
       : item.city.occupation
@@ -511,14 +511,13 @@ export function drawCityIntelBadgePass(ctx: CanvasRenderingContext2D, item: City
   if (!item.projection.isLive || item.lowZoom) return;
 
   const layout = getCityBadgeLayout(item.screen, item.size);
-  const badges = [
-    item.intel.hasEmbeddedSpy
-      ? { text: CITY_BADGE_GLYPHS.embeddedIntel, slot: layout.leftIntel }
-      : null,
-    item.intel.hasInfiltratedSpy
-      ? { text: CITY_BADGE_GLYPHS.infiltratedIntel, slot: layout.rightIntel }
-      : null,
-  ].filter((badge): badge is { text: string; slot: typeof layout.leftIntel } => badge !== null);
+  const badges: Array<{ text: string; slot: typeof layout.leftIntel }> = [];
+  if (item.intel.hasEmbeddedSpy) {
+    badges.push({ text: CITY_BADGE_GLYPHS.embeddedIntel, slot: layout.leftIntel });
+  }
+  if (item.intel.hasInfiltratedSpy) {
+    badges.push({ text: CITY_BADGE_GLYPHS.infiltratedIntel, slot: layout.rightIntel });
+  }
   for (const badge of badges) {
     const { center, bounds } = badge.slot;
     ctx.beginPath();

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -21,6 +21,11 @@ import {
   buildLiveCityMapPresentation,
   buildStaleCityMapPresentation,
 } from '@/renderer/city-map-presentation';
+import {
+  getCityBadgeLayout,
+  type CityBadgeSlot,
+  type CityBadgeSlotLayout,
+} from '@/renderer/city-badge-presentation';
 
 export { getProductionBadgeIcon } from '@/renderer/city-render-passes';
 
@@ -69,6 +74,46 @@ export function getCityRenderData(state: GameState): CityRenderInfo[] {
         : undefined,
     };
   });
+}
+
+/**
+ * Returns the on-screen centers of every visible render copy of one canonical
+ * hex. The query uses the same horizontal-wrap and camera transforms as the
+ * live renderer, but exposes no game-state or camera references.
+ */
+export function getVisibleHexViewportCopies(
+  state: GameState,
+  camera: Camera,
+  viewerId: string,
+  coord: HexCoord,
+): Array<{ x: number; y: number }> {
+  if (!state.civilizations[viewerId]?.visibility) return [];
+  const renderCoords = state.map.wrapsHorizontally
+    ? getHorizontalWrapRenderCoords(coord, state.map.width, camera)
+    : [coord];
+  return renderCoords
+    .filter(copy => camera.isHexVisible(copy))
+    .map(copy => {
+      const pixel = hexToPixel(copy, camera.hexSize);
+      return camera.worldToScreen(pixel.x, pixel.y);
+    });
+}
+
+/**
+ * Returns the badge geometry for visible, live city render copies. This keeps
+ * visual checks viewer-scoped and prevents fogged snapshots from exposing live
+ * city state to diagnostic callers.
+ */
+export function getVisibleCityBadgeSlots(
+  state: GameState,
+  camera: Camera,
+  viewerId: string,
+  cityId: string,
+  slot: CityBadgeSlot,
+): CityBadgeSlotLayout[] {
+  return createCityRenderItems(state, camera, viewerId, {})
+    .filter(item => item.projection.isLive && item.city?.id === cityId)
+    .map(item => getCityBadgeLayout(item.screen, item.size)[slot]);
 }
 
 export function drawCities(

--- a/src/renderer/sprites/sprite-loader.ts
+++ b/src/renderer/sprites/sprite-loader.ts
@@ -41,6 +41,10 @@ function attachSpriteDiagnosticMetadata(
   return image;
 }
 
+export function getSpriteDiagnosticMetadata(image: HTMLImageElement): SpriteDiagnosticMetadata | undefined {
+  return (image as DiagnosticImage)[SPRITE_DIAGNOSTIC_METADATA];
+}
+
 function svgStringToImage(
   svgString: string,
   size: number,

--- a/src/renderer/sprites/sprite-loader.ts
+++ b/src/renderer/sprites/sprite-loader.ts
@@ -15,11 +15,41 @@ const PIRATE_HULL_SET = new Set<string>(PIRATE_HULL_TYPES);
 
 const UNIT_MOTIONS: UnitSpriteMotion[] = ['idle', 'move-a', 'move-b'];
 
-function svgStringToImage(svgString: string, size: number): Promise<HTMLImageElement> {
+export const SPRITE_DIAGNOSTIC_METADATA = Symbol.for('conquestoria.spriteDiagnostic');
+
+export interface SpriteDiagnosticMetadata {
+  kind: 'unit' | 'building' | 'landmark';
+  itemId: string;
+  civilization: string;
+  motion?: UnitSpriteMotion;
+}
+
+type DiagnosticImage = HTMLImageElement & {
+  [SPRITE_DIAGNOSTIC_METADATA]?: SpriteDiagnosticMetadata;
+};
+
+function attachSpriteDiagnosticMetadata(
+  image: HTMLImageElement,
+  metadata: SpriteDiagnosticMetadata,
+): HTMLImageElement {
+  Object.defineProperty(image as DiagnosticImage, SPRITE_DIAGNOSTIC_METADATA, {
+    value: Object.freeze({ ...metadata }),
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return image;
+}
+
+function svgStringToImage(
+  svgString: string,
+  size: number,
+  metadata: SpriteDiagnosticMetadata,
+): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const blob = new Blob([svgString], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);
-    const img = new Image(size, size);
+    const img = attachSpriteDiagnosticMetadata(new Image(size, size), metadata);
     img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
     img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('SVG image load failed')); };
     img.src = url;
@@ -40,7 +70,9 @@ class SpriteCache {
       UNIT_MOTIONS.map(async (motion) => {
         const svg = fn({ palette, svgOnly: true, motion });
         if (!svg) return;
-        const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE);
+        const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE, {
+          kind: 'unit', itemId: type, civilization: civId, motion,
+        });
         this.units.set(`${type}:${civId}:${motion}`, img);
         if (motion === 'idle') {
           this.units.set(`${type}:${civId}`, img);
@@ -51,7 +83,9 @@ class SpriteCache {
     const buildingWork = Object.entries(BUILDING_SPRITE_CATALOG).map(async ([id, fn]) => {
       const svg = fn({ palette, svgOnly: true });
       if (!svg) return;
-      const img = await svgStringToImage(svg, BUILDING_SPRITE_SIZE);
+      const img = await svgStringToImage(svg, BUILDING_SPRITE_SIZE, {
+        kind: 'building', itemId: id, civilization: civId,
+      });
       this.buildings.set(`${id}:${civId}`, img);
     });
 
@@ -61,12 +95,16 @@ class SpriteCache {
   async loadPirates(): Promise<void> {
     const unitWork = PIRATE_HULL_TYPES.flatMap(type => UNIT_MOTIONS.map(async motion => {
       const svg = UNIT_SPRITE_CATALOG[type]({ palette: PIRATE_PALETTE, svgOnly: true, motion });
-      const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE);
+      const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE, {
+        kind: 'unit', itemId: type, civilization: PIRATE_OWNER_FAMILY, motion,
+      });
       this.units.set(`${type}:${PIRATE_OWNER_FAMILY}:${motion}`, img);
       if (motion === 'idle') this.units.set(`${type}:${PIRATE_OWNER_FAMILY}`, img);
     }));
     const landmarkWork = Object.entries(PIRATE_HEADQUARTERS_SPRITE_CATALOG).map(async ([id, render]) => {
-      const img = await svgStringToImage(render({ svgOnly: true }), LANDMARK_SPRITE_SIZE);
+      const img = await svgStringToImage(render({ svgOnly: true }), LANDMARK_SPRITE_SIZE, {
+        kind: 'landmark', itemId: id, civilization: PIRATE_OWNER_FAMILY,
+      });
       this.landmarks.set(id, img);
     });
     await Promise.all([...unitWork, ...landmarkWork]);

--- a/src/testing/e2e-mode.ts
+++ b/src/testing/e2e-mode.ts
@@ -1,0 +1,8 @@
+/**
+ * The direct browser-test entry point is deliberately narrower than a normal
+ * development build: it is compiled only for Vite's e2e mode and needs this
+ * exact opt-in query. Keeping this pure makes the security boundary testable.
+ */
+export function isExactAutosaveE2ERequest(mode: string, search: string): boolean {
+  return mode === 'e2e' && search === '?e2e=autosave';
+}

--- a/src/testing/e2e-runtime.ts
+++ b/src/testing/e2e-runtime.ts
@@ -1,0 +1,62 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { isOpponentChallenge } from '@/core/opponent-challenge';
+import type { LoadedSaveEntry } from '@/storage/save-manager';
+import type { CityBadgeSlot, CityBadgeSlotLayout } from '@/renderer/city-badge-presentation';
+
+export interface ViewportPoint {
+  x: number;
+  y: number;
+}
+
+export interface E2ERuntimeDependencies {
+  loadAutosave: () => Promise<LoadedSaveEntry | undefined>;
+  enterSoloCampaign: (state: GameState) => Promise<void>;
+  getVisibleHexCopies: (coord: HexCoord) => ViewportPoint[];
+  getCityBadgeSlots: (cityId: string, slot: CityBadgeSlot) => CityBadgeSlotLayout[];
+}
+
+export interface E2EDiagnostics {
+  readiness: () => readonly string[];
+  errors: () => readonly string[];
+  getVisibleHexCopies: (coord: HexCoord) => ViewportPoint[];
+  getCityBadgeSlots: (cityId: string, slot: CityBadgeSlot) => CityBadgeSlotLayout[];
+}
+
+/**
+ * Enters an already-installed solo autosave without resolving difficulty,
+ * mutating persistence, or exposing mutable runtime objects to browser tests.
+ */
+export async function startE2ERuntime(deps: E2ERuntimeDependencies): Promise<E2EDiagnostics> {
+  const loaded = await deps.loadAutosave();
+  if (!loaded) throw new Error('E2E direct entry requires an installed autosave.');
+
+  const state = loaded.state;
+  if (!isOpponentChallenge(state.opponentChallenge)) {
+    throw new Error('E2E autosave requires a valid opponent challenge.');
+  }
+  if (state.hotSeat) {
+    throw new Error('E2E direct entry does not bypass hot-seat handoff.');
+  }
+
+  const phases = new Set<string>();
+  const errors: string[] = [];
+  const spritesReady = deps.enterSoloCampaign(state);
+  phases.add('campaign-ready');
+  void spritesReady.then(
+    () => phases.add('sprites-ready'),
+    error => errors.push(error instanceof Error ? error.message : String(error)),
+  );
+
+  return Object.freeze({
+    readiness: () => Object.freeze([...phases]),
+    errors: () => Object.freeze([...errors]),
+    getVisibleHexCopies: deps.getVisibleHexCopies,
+    getCityBadgeSlots: deps.getCityBadgeSlots,
+  });
+}
+
+export async function installE2ERuntime(deps: E2ERuntimeDependencies): Promise<E2EDiagnostics> {
+  const runtime = await startE2ERuntime(deps);
+  window.__CONQUESTORIA_E2E_DIAGNOSTICS__ = runtime;
+  return runtime;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,3 +7,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  __CONQUESTORIA_E2E_DIAGNOSTICS__?: import('@/testing/e2e-runtime').E2EDiagnostics;
+}

--- a/tests/e2e/helpers/canvas-ops.ts
+++ b/tests/e2e/helpers/canvas-ops.ts
@@ -1,0 +1,98 @@
+export interface RectSnapshot { x: number; y: number; width: number; height: number; }
+export interface MatrixSnapshot { a: number; b: number; c: number; d: number; e: number; f: number; }
+export interface ViewportPoint { x: number; y: number; }
+
+export interface ParsedDrawImage {
+  sx?: number;
+  sy?: number;
+  sw?: number;
+  sh?: number;
+  dx: number;
+  dy: number;
+  dw?: number;
+  dh?: number;
+}
+
+export function parseDrawImage(args: unknown[]): ParsedDrawImage {
+  const values = args.slice(1).map(value => Number(value));
+  if (values.length === 2) return { dx: values[0]!, dy: values[1]! };
+  if (values.length === 4) return { dx: values[0]!, dy: values[1]!, dw: values[2]!, dh: values[3]! };
+  if (values.length === 8) {
+    return {
+      sx: values[0]!, sy: values[1]!, sw: values[2]!, sh: values[3]!,
+      dx: values[4]!, dy: values[5]!, dw: values[6]!, dh: values[7]!,
+    };
+  }
+  throw new Error(`Unsupported drawImage overload with ${values.length} numeric arguments.`);
+}
+
+function transformPoint(point: ViewportPoint, matrix: MatrixSnapshot): ViewportPoint {
+  return {
+    x: matrix.a * point.x + matrix.c * point.y + matrix.e,
+    y: matrix.b * point.x + matrix.d * point.y + matrix.f,
+  };
+}
+
+export function normalizeImageBounds(input: {
+  rect: RectSnapshot;
+  transform: MatrixSnapshot;
+  backing: { width: number; height: number };
+  css: RectSnapshot;
+}): { polygon: ViewportPoint[]; bounds: RectSnapshot } {
+  const { rect, transform, backing, css } = input;
+  const scaleX = css.width / backing.width;
+  const scaleY = css.height / backing.height;
+  const corners = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height },
+  ];
+  const polygon = corners.map(corner => {
+    const transformed = transformPoint(corner, transform);
+    return { x: css.x + transformed.x * scaleX, y: css.y + transformed.y * scaleY };
+  });
+  const xs = polygon.map(point => point.x);
+  const ys = polygon.map(point => point.y);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  return { polygon, bounds: { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y } };
+}
+
+export type RecorderOperation = { kind: string; canvasId: string; [key: string]: unknown };
+export type CaptureFilter = { canvasId?: string };
+
+export function createOperationRecorder({ maxOperations }: { maxOperations: number }) {
+  let active = false;
+  let sessionId = 0;
+  let overflowed = false;
+  let filter: CaptureFilter = {};
+  let operations: RecorderOperation[] = [];
+
+  const matches = (operation: RecorderOperation): boolean => (
+    !filter.canvasId || operation.canvasId === filter.canvasId
+  );
+
+  return {
+    start(nextFilter: CaptureFilter): void {
+      active = true;
+      sessionId += 1;
+      overflowed = false;
+      operations = [];
+      filter = structuredClone(nextFilter);
+    },
+    record(operation: RecorderOperation): void {
+      if (!active || !matches(operation)) return;
+      if (operations.length >= maxOperations) {
+        overflowed = true;
+        active = false;
+        return;
+      }
+      operations.push(structuredClone(operation));
+    },
+    freeze(): void { active = false; },
+    snapshot(): { sessionId: number; overflowed: boolean; operations: RecorderOperation[] } {
+      return { sessionId, overflowed, operations: structuredClone(operations) };
+    },
+  };
+}

--- a/tests/e2e/helpers/save-fixture.ts
+++ b/tests/e2e/helpers/save-fixture.ts
@@ -85,7 +85,7 @@ function configureStandingStones(initial: GameState, cityId: string): GameState 
 }
 
 export function createScenarioState(scenario: ProductionScenario): GameState {
-  let state = normalizeLoadedState(createBaseFixture());
+  let state: GameState = normalizeLoadedState(createBaseFixture());
   state.opponentChallenge = 'standard';
   const city = findVisibleOwnedCity(state);
   if (scenario === 'building') setValidatedQueueHead(state, city, 'granary');

--- a/tests/e2e/helpers/save-fixture.ts
+++ b/tests/e2e/helpers/save-fixture.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Page } from '@playwright/test';
+import type { City, GameState } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import {
+  initializeLegendaryWonderProjectsForCity,
+  startLegendaryWonderBuild,
+} from '@/systems/legendary-wonder-system';
+import { normalizeLoadedState } from '@/storage/save-manager';
+
+const FIXTURE_PATH = join(__dirname, '..', '..', 'fixtures', 'issue-365-crowded-map-save.json');
+const BASE_FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as GameState;
+
+export type ProductionScenario = 'building' | 'unit' | 'legendary';
+
+export function createBaseFixture(): GameState {
+  return structuredClone(BASE_FIXTURE);
+}
+
+export function findVisibleOwnedCity(state: GameState): City {
+  const visibility = state.civilizations[state.currentPlayer]?.visibility;
+  const city = Object.values(state.cities).find(candidate => (
+    candidate.owner === state.currentPlayer
+    && visibility !== undefined
+    && getVisibility(visibility, candidate.position) === 'visible'
+  ));
+  if (!city) throw new Error('Fixture requires a visible city owned by currentPlayer.');
+  return city;
+}
+
+function setValidatedQueueHead(state: GameState, city: City, itemId: 'granary' | 'warrior'): void {
+  if (itemId === 'granary' && !BUILDINGS.granary) {
+    throw new Error('Fixture requires the granary definition.');
+  }
+  if (itemId === 'warrior' && !TRAINABLE_UNITS.some(unit => unit.type === 'warrior')) {
+    throw new Error('Fixture requires the warrior definition.');
+  }
+  state.cities[city.id] = { ...city, productionQueue: [itemId], productionProgress: 0 };
+}
+
+function configureStandingStones(initial: GameState, cityId: string): GameState {
+  let state = structuredClone(initial);
+  const civ = state.civilizations[state.currentPlayer];
+  civ.techState.completed = [...new Set([
+    ...civ.techState.completed,
+    'animism',
+    'mud-brick',
+    'gathering',
+  ])];
+  if (!state.marketplace) throw new Error('Standing Stones fixture requires marketplace state.');
+  state.marketplace = {
+    ...state.marketplace,
+    purchasedResources: [
+      ...(state.marketplace.purchasedResources ?? []),
+      { civId: state.currentPlayer, resource: 'stone', expiresOnTurn: state.turn + 10 },
+    ],
+  };
+  const village = Object.values(state.tribalVillages ?? {})[0];
+  if (!village) throw new Error('Standing Stones fixture requires an existing village.');
+  state.legendaryWonderHistory ??= { destroyedStrongholds: [], discoveredSites: [] };
+  state.legendaryWonderHistory.discoveredSites.push({
+    civId: state.currentPlayer,
+    siteId: village.id,
+    siteType: 'tribal-village',
+    position: village.position,
+    turn: state.turn,
+  });
+  state = initializeLegendaryWonderProjectsForCity(state, state.currentPlayer, cityId);
+  const ready = Object.values(state.legendaryWonderProjects ?? {}).find(project => (
+    project.cityId === cityId && project.wonderId === 'standing-stones'
+  ));
+  if (ready?.phase !== 'ready_to_build') {
+    throw new Error('Standing Stones fixture did not reach ready_to_build.');
+  }
+  state = startLegendaryWonderBuild(state, state.currentPlayer, cityId, 'standing-stones');
+  const project = Object.values(state.legendaryWonderProjects ?? {}).find(candidate => (
+    candidate.cityId === cityId && candidate.wonderId === 'standing-stones'
+  ));
+  if (project?.phase !== 'building' || state.cities[cityId]?.productionQueue[0] !== 'legendary:standing-stones') {
+    throw new Error('Standing Stones fixture did not enter its canonical build state.');
+  }
+  return state;
+}
+
+export function createScenarioState(scenario: ProductionScenario): GameState {
+  let state = normalizeLoadedState(createBaseFixture());
+  state.opponentChallenge = 'standard';
+  const city = findVisibleOwnedCity(state);
+  if (scenario === 'building') setValidatedQueueHead(state, city, 'granary');
+  if (scenario === 'unit') setValidatedQueueHead(state, city, 'warrior');
+  if (scenario === 'legendary') state = configureStandingStones(state, city.id);
+  return state;
+}
+
+export async function installAutosave(page: Page, state: GameState): Promise<void> {
+  await page.addInitScript(serialized => {
+    localStorage.setItem('conquestoria-autosave', serialized);
+  }, JSON.stringify(state));
+}

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -29,6 +29,17 @@ describe('campaign entry wiring', () => {
       .toBeLessThan(entry.indexOf('if (!gameState.hotSeat)'));
     expect(entry).toContain('handleVictoryIfNeeded()');
   });
+
+  it('gates direct E2E autosave entry before the save-panel UI and exposes no mutable runtime globals', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main).toContain("if (import.meta.env.MODE === 'e2e')");
+    expect(main).toContain("await import('@/testing/e2e-runtime')");
+    expect(main.indexOf("import.meta.env.MODE === 'e2e'"))
+      .toBeLessThan(main.indexOf('await showStartSavePanel()'));
+    expect(main).not.toContain('window.gameState');
+    expect(main).not.toContain('window.renderLoop');
+  });
 });
 
 describe('player combat wiring', () => {

--- a/tests/platform/playwright-config.test.ts
+++ b/tests/platform/playwright-config.test.ts
@@ -7,13 +7,13 @@ describe('playwright config', () => {
       ? playwrightConfig.webServer[0]
       : playwrightConfig.webServer;
 
-    expect(resolvePlaywrightDevCommand('true')).toBe('yarn dev --host 127.0.0.1');
+    expect(resolvePlaywrightDevCommand('true')).toBe('yarn dev --mode e2e --host 127.0.0.1');
     expect(resolvePlaywrightDevCommand('true')).not.toContain('run-with-mise');
     expect(webServer?.command).toBe(resolvePlaywrightDevCommand());
   });
 
   it('uses the worktree-aware wrapper for local browser tests', () => {
     expect(resolvePlaywrightDevCommand(''))
-      .toBe('./scripts/run-with-mise.sh yarn dev --host 127.0.0.1');
+      .toBe('./scripts/run-with-mise.sh yarn dev --mode e2e --host 127.0.0.1');
   });
 });

--- a/tests/renderer/city-badge-presentation.test.ts
+++ b/tests/renderer/city-badge-presentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { Camera } from '@/renderer/camera';
+import {
+  CITY_BADGE_GLYPHS,
+  CITY_BADGE_GLYPH_COEXISTENCE,
+  CITY_BADGE_SLOT_COEXISTENCE,
+  getCityBadgeLayout,
+  type BadgeBounds,
+} from '@/renderer/city-badge-presentation';
+
+function intersects(left: BadgeBounds, right: BadgeBounds): boolean {
+  return left.left < right.right
+    && left.right > right.left
+    && left.top < right.bottom
+    && left.bottom > right.top;
+}
+
+describe('city badge presentation', () => {
+  it('uses a construction fallback distinct from every coexistent text badge', () => {
+    expect(CITY_BADGE_GLYPHS.production).toBe('🏗️');
+    for (const [left, right] of CITY_BADGE_GLYPH_COEXISTENCE) {
+      expect(CITY_BADGE_GLYPHS[left], `${left}/${right}`)
+        .not.toBe(CITY_BADGE_GLYPHS[right]);
+    }
+  });
+
+  it('keeps every coexistent city badge bound disjoint at supported zoom sizes', () => {
+    const camera = new Camera();
+    for (const size of [1, camera.hexSize * camera.minZoom, camera.hexSize * camera.maxZoom]) {
+      const layout = getCityBadgeLayout({ x: 0, y: 0 }, size);
+      for (const [left, right] of CITY_BADGE_SLOT_COEXISTENCE) {
+        expect(intersects(layout[left].bounds, layout[right].bounds), `${left}/${right} @ ${size}`)
+          .toBe(false);
+      }
+    }
+  });
+
+  it('does not treat intentionally exclusive badges as a collision pair', () => {
+    expect(CITY_BADGE_SLOT_COEXISTENCE).not.toContainEqual(['production', 'idle']);
+    expect(CITY_BADGE_GLYPH_COEXISTENCE).not.toContainEqual(['underSiege', 'unrest']);
+  });
+});

--- a/tests/renderer/city-render-passes.test.ts
+++ b/tests/renderer/city-render-passes.test.ts
@@ -11,6 +11,7 @@ import {
   drawCityLoyaltyPressureBadgePass,
   drawCityReligionBadgePass,
   fitCityBannerLabel,
+  getProductionBadgeIcon,
   type CityRenderItem,
 } from '@/renderer/city-render-passes';
 import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
@@ -187,6 +188,12 @@ describe('drawCityLabelPass', () => {
 });
 
 describe('city icon and badge text bounds', () => {
+  it('uses construction only as the map production fallback', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🏗️');
+    expect(getProductionBadgeIcon({ productionQueue: ['warrior'] })).toBe('🏗️');
+    expect(getProductionBadgeIcon({ productionQueue: [] })).toBeNull();
+  });
+
   it('fits minor-civ, status, production, idle, and intel glyphs to their containers', () => {
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
     const city = {
@@ -322,7 +329,7 @@ describe('city icon and badge text bounds', () => {
     getBuildingSpy.mockRestore();
   });
 
-  it('#658: falls back to the PRODUCTION_ICONS emoji while the building sprite is not yet cached', () => {
+  it('falls back to the generic construction badge while the building sprite is not yet cached', () => {
     const getBuildingSpy = vi.spyOn(spriteCache, 'getBuilding').mockReturnValue(null);
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
     const city = {
@@ -334,11 +341,11 @@ describe('city icon and badge text bounds', () => {
 
     expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(0);
     expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
-    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('🌾');
+    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('🏗️');
     getBuildingSpy.mockRestore();
   });
 
-  it('#658: keeps the emoji fallback while neither a building nor a unit sprite is cached yet', () => {
+  it('uses the generic construction fallback while neither a building nor unit sprite is cached', () => {
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
     const city = {
       id: 'city-1', owner: 'player', productionQueue: ['warrior'], idleProduction: null, unrestLevel: 0,
@@ -349,7 +356,7 @@ describe('city icon and badge text bounds', () => {
 
     expect((ctx as unknown as MockCtx).drawImageCalls).toHaveLength(0);
     expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(1);
-    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('⚔️');
+    expect((ctx as unknown as MockCtx).fillTextCalls[0]!.text).toBe('🏗️');
   });
 
   it('#658 review: draws the queued unit sprite for a unit queue head, so training ⚔️ can never be mistaken for the under-siege ⚔️ badge', () => {

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -691,7 +691,7 @@ describe('drawCities — explicit city render pass contract', () => {
 });
 
 describe('drawCities — bottom-right build badge', () => {
-  it('draws the production icon for a player-owned city with a non-empty queue', () => {
+  it('draws the neutral construction badge for a player-owned city with a non-empty queue', () => {
     const state = createNewGame(undefined, 'badge-build-render');
     const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
     const city = foundCity('player', settler.position, state.map, state.idCounters);
@@ -704,7 +704,7 @@ describe('drawCities — bottom-right build badge', () => {
     drawCities(ctx, state, makeCamera(), 'player');
 
     const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
-    expect(texts).toContain('⚔️');
+    expect(texts).toContain('🏗️');
   });
 
   it('does NOT draw the production icon for an enemy-owned visible city', () => {
@@ -793,15 +793,15 @@ describe('drawCities — bottom-right build badge', () => {
 });
 
 describe('getProductionBadgeIcon', () => {
-  it('returns the matching icon when productionQueue[0] is a known building', () => {
-    expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🌾');
+  it('returns construction for a queued building', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🏗️');
   });
 
-  it('returns the matching icon when productionQueue[0] is a known unit', () => {
-    expect(getProductionBadgeIcon({ productionQueue: ['warrior'] })).toBe('⚔️');
+  it('returns construction for a queued unit', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['warrior'] })).toBe('🏗️');
   });
 
-  it('returns the fallback icon when productionQueue[0] is unknown (e.g. legendary wonder)', () => {
+  it('returns construction for other queued content such as a legendary wonder', () => {
     expect(getProductionBadgeIcon({ productionQueue: ['some-legendary-wonder-id'] })).toBe('🏗️');
   });
 

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { Camera } from '@/renderer/camera';
-import { drawCities, getCityRenderData, getProductionBadgeIcon } from '@/renderer/city-renderer';
+import {
+  drawCities,
+  getCityRenderData,
+  getProductionBadgeIcon,
+  getVisibleCityBadgeSlots,
+  getVisibleHexViewportCopies,
+} from '@/renderer/city-renderer';
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { hexKey, hexToPixel } from '@/systems/hex-utils';
@@ -262,6 +268,45 @@ describe('city renderer', () => {
 
     const labels = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
     expect(labels).toContain(`${city.name} (${city.population})`);
+  });
+
+  it('returns every visible wrapped hex copy through the live viewport transform', () => {
+    const state = createNewGame(undefined, 'wrapped-geometry');
+    state.map.wrapsHorizontally = true;
+    state.map.width = 5;
+    const city = foundCity('player', { q: 0, r: 0 }, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles['0,0'] = 'visible';
+    const camera = {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: (coord: { q: number; r: number }) => coord.q === 0 || coord.q === 5,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+
+    expect(getVisibleHexViewportCopies(state, camera, 'player', city.position))
+      .toEqual([hexToPixel({ q: 0, r: 0 }, 48), hexToPixel({ q: 5, r: 0 }, 48)]);
+  });
+
+  it('returns a named badge slot only for a live city rendered to the viewer', () => {
+    const state = createNewGame(undefined, 'city-badge-geometry');
+    const settler = Object.values(state.units).find(unit => unit.owner === 'player' && unit.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map, state.idCounters);
+    city.productionQueue = ['granary'];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+    const hiddenCity = foundCity('ai-1', { q: city.position.q + 1, r: city.position.r }, state.map, state.idCounters);
+    hiddenCity.productionQueue = ['warrior'];
+    state.cities[hiddenCity.id] = hiddenCity;
+    state.civilizations['ai-1'].cities.push(hiddenCity.id);
+    state.civilizations.player.visibility.tiles[hexKey(hiddenCity.position)] = 'fog';
+
+    const visible = getVisibleCityBadgeSlots(state, makeCamera(), 'player', city.id, 'production');
+    expect(visible).not.toHaveLength(0);
+    expect(visible[0]!.bounds.width).toBeGreaterThan(0);
+    expect(getVisibleCityBadgeSlots(state, makeCamera(), 'player', hiddenCity.id, 'production')).toEqual([]);
   });
 
   it('draws legendary landmark layer before city label and production badges remain above it', () => {

--- a/tests/renderer/sprites/sprite-loader.test.ts
+++ b/tests/renderer/sprites/sprite-loader.test.ts
@@ -14,6 +14,7 @@ Object.defineProperty(HTMLImageElement.prototype, 'src', {
 
 import {
   SPRITE_DIAGNOSTIC_METADATA,
+  getSpriteDiagnosticMetadata,
   spriteCache,
   initSprites,
 } from '@/renderer/sprites/sprite-loader';
@@ -83,16 +84,16 @@ describe('SpriteCache after initSprites', () => {
     const building = spriteCache.getBuilding('granary', 'player')!;
     const landmark = spriteCache.getLandmark('pirate_enclave_stage_1')!;
 
-    expect(unit[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+    expect(getSpriteDiagnosticMetadata(unit)).toEqual({
       kind: 'unit', itemId: 'warrior', civilization: 'player', motion: 'idle',
     });
-    expect(building[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+    expect(getSpriteDiagnosticMetadata(building)).toEqual({
       kind: 'building', itemId: 'granary', civilization: 'player',
     });
-    expect(landmark[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+    expect(getSpriteDiagnosticMetadata(landmark)).toEqual({
       kind: 'landmark', itemId: 'pirate_enclave_stage_1', civilization: 'pirates',
     });
     expect(Object.keys(unit)).not.toContain(String(SPRITE_DIAGNOSTIC_METADATA));
-    expect(Object.isFrozen(unit[SPRITE_DIAGNOSTIC_METADATA])).toBe(true);
+    expect(Object.isFrozen(getSpriteDiagnosticMetadata(unit))).toBe(true);
   });
 });

--- a/tests/renderer/sprites/sprite-loader.test.ts
+++ b/tests/renderer/sprites/sprite-loader.test.ts
@@ -12,7 +12,11 @@ Object.defineProperty(HTMLImageElement.prototype, 'src', {
   configurable: true,
 });
 
-import { spriteCache, initSprites } from '@/renderer/sprites/sprite-loader';
+import {
+  SPRITE_DIAGNOSTIC_METADATA,
+  spriteCache,
+  initSprites,
+} from '@/renderer/sprites/sprite-loader';
 
 describe('SpriteCache before initSprites', () => {
   it('getUnit returns null before any load', () => {
@@ -72,5 +76,23 @@ describe('SpriteCache after initSprites', () => {
     expect(spriteCache.getLandmark('pirate_enclave_stage_1')).toBeInstanceOf(HTMLImageElement);
     expect(spriteCache.getLandmark('pirate_flotilla_stage_5')).toBeInstanceOf(HTMLImageElement);
     expect(spriteCache.getLandmark('missing')).toBeNull();
+  });
+
+  it('attaches immutable, non-enumerable diagnostic provenance to cached sprites', () => {
+    const unit = spriteCache.getUnit('warrior', 'player')!;
+    const building = spriteCache.getBuilding('granary', 'player')!;
+    const landmark = spriteCache.getLandmark('pirate_enclave_stage_1')!;
+
+    expect(unit[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+      kind: 'unit', itemId: 'warrior', civilization: 'player', motion: 'idle',
+    });
+    expect(building[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+      kind: 'building', itemId: 'granary', civilization: 'player',
+    });
+    expect(landmark[SPRITE_DIAGNOSTIC_METADATA]).toEqual({
+      kind: 'landmark', itemId: 'pirate_enclave_stage_1', civilization: 'pirates',
+    });
+    expect(Object.keys(unit)).not.toContain(String(SPRITE_DIAGNOSTIC_METADATA));
+    expect(Object.isFrozen(unit[SPRITE_DIAGNOSTIC_METADATA])).toBe(true);
   });
 });

--- a/tests/scripts/assert-no-e2e-runtime.test.ts
+++ b/tests/scripts/assert-no-e2e-runtime.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertNoE2ERuntime } from '../../scripts/assert-no-e2e-runtime.mjs';
+
+const tempDirs: string[] = [];
+
+function createDist(): string {
+  const root = mkdtempSync(join(tmpdir(), 'cq-e2e-runtime-'));
+  tempDirs.push(root);
+  mkdirSync(join(root, 'assets'));
+  return root;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('assertNoE2ERuntime', () => {
+  it('accepts emitted assets without the e2e sentinel', () => {
+    const root = createDist();
+    writeFileSync(join(root, 'assets', 'app.js'), 'console.log("ok");');
+
+    expect(() => assertNoE2ERuntime(root)).not.toThrow();
+  });
+
+  it('rejects the e2e sentinel in emitted JavaScript', () => {
+    const root = createDist();
+    writeFileSync(join(root, 'assets', 'app.js'), 'window.__CONQUESTORIA_E2E_DIAGNOSTICS__;');
+
+    expect(() => assertNoE2ERuntime(root)).toThrow(/e2e runtime sentinel/i);
+  });
+
+  it('rejects the e2e sentinel in source maps', () => {
+    const root = createDist();
+    writeFileSync(join(root, 'assets', 'app.js.map'), '__CONQUESTORIA_E2E_DIAGNOSTICS__');
+
+    expect(() => assertNoE2ERuntime(root)).toThrow(/app\.js\.map/);
+  });
+});

--- a/tests/scripts/assert-no-e2e-runtime.test.ts
+++ b/tests/scripts/assert-no-e2e-runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+// @ts-expect-error JavaScript CLI module has no declaration file.
 import { assertNoE2ERuntime } from '../../scripts/assert-no-e2e-runtime.mjs';
 
 const tempDirs: string[] = [];

--- a/tests/testing/canvas-ops.test.ts
+++ b/tests/testing/canvas-ops.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createOperationRecorder,
+  normalizeImageBounds,
+  parseDrawImage,
+} from '../e2e/helpers/canvas-ops';
+
+describe('Canvas operation helpers', () => {
+  it.each([
+    [[{}, 1, 2], { dx: 1, dy: 2 }],
+    [[{}, 1, 2, 3, 4], { dx: 1, dy: 2, dw: 3, dh: 4 }],
+    [[{}, 1, 2, 3, 4, 5, 6, 7, 8], { sx: 1, sy: 2, sw: 3, sh: 4, dx: 5, dy: 6, dw: 7, dh: 8 }],
+  ])('parses drawImage overload %#', (args, expected) => {
+    expect(parseDrawImage(args)).toMatchObject(expected);
+  });
+
+  it('transforms every image corner through CTM, DPR scale, and canvas offset', () => {
+    const result = normalizeImageBounds({
+      rect: { x: 1, y: 2, width: 3, height: 4 },
+      transform: { a: 2, b: 1, c: 0.5, d: 3, e: 7, f: 11 },
+      backing: { width: 200, height: 100 },
+      css: { x: 10, y: 20, width: 100, height: 50 },
+    });
+    expect(result.polygon).toHaveLength(4);
+    expect(result.bounds).toMatchObject({ x: expect.any(Number), width: expect.any(Number) });
+  });
+
+  it('freezes, overflows, and resets by capture session', () => {
+    const recorder = createOperationRecorder({ maxOperations: 2 });
+    const filter = { canvasId: 'game-canvas' };
+    const operation = { kind: 'fillText' as const, canvasId: 'game-canvas', text: '🏗️' };
+    recorder.start(filter);
+    recorder.record(operation);
+    recorder.record(operation);
+    recorder.record(operation);
+    expect(recorder.snapshot()).toMatchObject({ overflowed: true, operations: [operation, operation] });
+    recorder.freeze();
+    recorder.record(operation);
+    expect(recorder.snapshot().operations).toHaveLength(2);
+    recorder.start(filter);
+    expect(recorder.snapshot()).toMatchObject({ overflowed: false, operations: [] });
+  });
+});

--- a/tests/testing/e2e-mode.test.ts
+++ b/tests/testing/e2e-mode.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isExactAutosaveE2ERequest } from '@/testing/e2e-mode';
+
+describe('isExactAutosaveE2ERequest', () => {
+  it.each([
+    ['production', '?e2e=autosave'],
+    ['development', '?e2e=autosave'],
+    ['tauri', '?e2e=autosave'],
+    ['e2e', ''],
+    ['e2e', '?e2e=true'],
+    ['e2e', '?e2e=autosave&state={}'],
+  ])('rejects mode %s and query %s', (mode, search) => {
+    expect(isExactAutosaveE2ERequest(mode, search)).toBe(false);
+  });
+
+  it('accepts only the literal e2e autosave request', () => {
+    expect(isExactAutosaveE2ERequest('e2e', '?e2e=autosave')).toBe(true);
+  });
+});

--- a/tests/testing/e2e-runtime.test.ts
+++ b/tests/testing/e2e-runtime.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { normalizeLoadedState } from '@/storage/save-manager';
+import {
+  startE2ERuntime,
+  type E2ERuntimeDependencies,
+} from '@/testing/e2e-runtime';
+
+function dependencies(
+  state = createNewGame(undefined, 'e2e-runtime'),
+  spritePromise: Promise<void> = Promise.resolve(),
+): E2ERuntimeDependencies & { enterSoloCampaign: ReturnType<typeof vi.fn> } {
+  const enterSoloCampaign = vi.fn(() => spritePromise);
+  return {
+    loadAutosave: vi.fn(async () => ({
+      state: normalizeLoadedState(state),
+      source: { id: 'autosave:e2e-runtime:1', kind: 'autosave' as const },
+    })),
+    enterSoloCampaign,
+    getVisibleHexCopies: vi.fn(() => [{ x: 10, y: 20 }]),
+    getCityBadgeSlots: vi.fn(() => []),
+  };
+}
+
+describe('startE2ERuntime', () => {
+  it('rejects missing challenge and hot-seat autosaves before entry', async () => {
+    const withoutChallenge = createNewGame(undefined, 'e2e-runtime-missing-challenge');
+    delete withoutChallenge.opponentChallenge;
+    const invalidChallengeDeps = dependencies(withoutChallenge);
+    await expect(startE2ERuntime(invalidChallengeDeps)).rejects.toThrow(/opponent challenge/i);
+    expect(invalidChallengeDeps.enterSoloCampaign).not.toHaveBeenCalled();
+
+    const hotSeatState = createNewGame(undefined, 'e2e-runtime-hot-seat');
+    hotSeatState.hotSeat = { playerCount: 2, mapSize: 'small', players: [] };
+    const hotSeatBefore = structuredClone(hotSeatState);
+    const hotSeatDeps = dependencies(hotSeatState);
+    await expect(startE2ERuntime(hotSeatDeps)).rejects.toThrow(/hot-seat/i);
+    expect(hotSeatDeps.enterSoloCampaign).not.toHaveBeenCalled();
+    expect(hotSeatState).toEqual(hotSeatBefore);
+  });
+
+  it.each(['explorer', 'standard', 'veteran'] as const)(
+    'accepts %s without resolving or rewriting it',
+    async opponentChallenge => {
+      const state = createNewGame(undefined, `e2e-runtime-${opponentChallenge}`);
+      state.opponentChallenge = opponentChallenge;
+      const deps = dependencies(state);
+
+      await startE2ERuntime(deps);
+
+      expect(deps.enterSoloCampaign).toHaveBeenCalledWith(
+        expect.objectContaining({ opponentChallenge }),
+      );
+    },
+  );
+
+  it('rejects an unknown challenge without entering', async () => {
+    const state = createNewGame(undefined, 'e2e-runtime-unknown-challenge');
+    state.opponentChallenge = 'impossible' as never;
+    const deps = dependencies(state);
+
+    await expect(startE2ERuntime(deps)).rejects.toThrow(/valid opponent challenge/i);
+    expect(deps.enterSoloCampaign).not.toHaveBeenCalled();
+  });
+
+  it('exposes only frozen readiness and serialized geometry queries', async () => {
+    const deps = dependencies();
+    const runtime = await startE2ERuntime(deps);
+
+    expect(Object.isFrozen(runtime)).toBe(true);
+    expect(Object.keys(runtime).sort()).toEqual([
+      'errors', 'getCityBadgeSlots', 'getVisibleHexCopies', 'readiness',
+    ]);
+    expect(runtime.getVisibleHexCopies({ q: 0, r: 0 })).toEqual([{ x: 10, y: 20 }]);
+    expect(runtime).not.toHaveProperty('gameState');
+    expect(runtime).not.toHaveProperty('camera');
+    expect(runtime).not.toHaveProperty('renderLoop');
+  });
+
+  it('records sprite rejection without blocking campaign readiness', async () => {
+    const deps = dependencies(
+      createNewGame(undefined, 'e2e-runtime-sprite-rejection'),
+      Promise.reject(new Error('bad sprite')),
+    );
+    const runtime = await startE2ERuntime(deps);
+
+    expect(runtime.readiness()).toContain('campaign-ready');
+    await Promise.resolve();
+    expect(runtime.readiness()).not.toContain('sprites-ready');
+    expect(runtime.errors()).toContainEqual(expect.stringContaining('bad sprite'));
+  });
+});

--- a/tests/testing/e2e-save-fixture.test.ts
+++ b/tests/testing/e2e-save-fixture.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createScenarioState,
+  findVisibleOwnedCity,
+} from '../e2e/helpers/save-fixture';
+
+describe('E2E save scenarios', () => {
+  it('returns independent clones and derives the city from currentPlayer', () => {
+    const first = createScenarioState('building');
+    const second = createScenarioState('building');
+    const city = findVisibleOwnedCity(first);
+
+    expect(first).not.toBe(second);
+    expect(city.owner).toBe(first.currentPlayer);
+    first.turn = 999;
+    expect(second.turn).not.toBe(999);
+  });
+
+  it('creates valid building and unit queue heads', () => {
+    expect(findVisibleOwnedCity(createScenarioState('building')).productionQueue[0]).toBe('granary');
+    expect(findVisibleOwnedCity(createScenarioState('unit')).productionQueue[0]).toBe('warrior');
+  });
+
+  it('uses canonical legendary-wonder transitions', () => {
+    const state = createScenarioState('legendary');
+    const city = findVisibleOwnedCity(state);
+    const project = Object.values(state.legendaryWonderProjects ?? {}).find(candidate => (
+      candidate.cityId === city.id && candidate.wonderId === 'standing-stones'
+    ));
+
+    expect(city.productionQueue[0]).toBe('legendary:standing-stones');
+    expect(project?.phase).toBe('building');
+  });
+});


### PR DESCRIPTION
Refs #660

## Summary

- Gates E2E-only diagnostics from production and Tauri bundles, with a source sentinel.
- Unifies city badge semantics/layout, provides neutral construction fallbacks, viewer-safe geometry, and immutable sprite provenance.
- Adds direct autosave E2E entry that accepts valid solo difficulty modes, rejects invalid/hot-seat saves, and exposes only frozen readiness/geometry diagnostics.
- Adds independent valid building, unit, and Standing Stones save scenarios plus a bounded, pure Canvas operation-capture core.

## Current scope

This is intentionally a draft: browser-side Canvas method wrappers, migrated Playwright specifications, rendered evidence assertions, and the final architecture/documentation sweep remain to be implemented.

## Validation

- `bash scripts/run-with-mise.sh yarn test`
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn build:tauri`
- focused renderer, sprite, runtime, save-fixture, and capture-core suites