### PR TITLE
fix(combat): preserve upgrade integrity (#665)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ When writing or updating implementation plans for interactive UI, queueing, or r
 ## Required Verification
 `./scripts/run-with-mise.sh yarn test` does not type-check. Run `./scripts/run-with-mise.sh yarn build` whenever TypeScript correctness matters, and always before `git push`, PR creation, or merge.
 
+If a push or long-running verification returns incomplete output, inspect the live process
+and remote ref before retrying. Never start a second push while the first pre-push hook
+may still be running.
+
 After editing files under `src/`, run:
 
 - `scripts/check-src-rule-violations.sh path/to/changed-src-file.ts [more changed src files...]`

--- a/docs/superpowers/plans/2026-07-25-issue-665-upgrade-integrity.md
+++ b/docs/superpowers/plans/2026-07-25-issue-665-upgrade-integrity.md
@@ -1,0 +1,410 @@
+# Issue #665 Upgrade Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to
+> implement this plan task-by-task. This repository prohibits subagents.
+
+**Goal:** Make every unit upgrade a transparent, percentage-health-preserving,
+experience-preserving, save-safe action whose rules are shared by the player UI and AI.
+
+**Architecture:** Put all upgrade eligibility and preserved-state facts in a typed
+`UpgradeEvaluation` owned by `unit-upgrade-system`. Both state application and the
+selected-unit panel consume that evaluation; cross-domain application composes the
+existing air-basing helpers. The UI owns only ephemeral confirmation display state and
+re-evaluates on confirmation, so stale UI cannot commit an invalid upgrade.
+
+**Tech Stack:** TypeScript, Vitest, mock-DOM UI tests, existing save migration and air
+operations helpers.
+
+---
+
+## Audited file map
+
+- `src/systems/unit-upgrade-system.ts` — currently has split target eligibility,
+  a single `missing-building` reason, and `applyUpgrade` healing to 100.
+- `src/systems/air-operations-system.ts` — owns `canCompleteAirUnitProduction` and
+  `baseNewAirUnit`, the legal city-base capacity/assignment contract.
+- `src/ai/ai-upgrades.ts` — currently prefilters with
+  `getCanonicalUpgradeTarget`, then calls `applyUnitUpgradeToState`.
+- `src/ui/selected-unit-info.ts` — directly renders an enabled upgrade button or one
+  missing-building sentence; it has no confirmation state.
+- `src/main.ts` — has two upgrade callback entry points that re-check eligibility,
+  call `executeUpgrade`, and show success notifications.
+- `tests/systems/unit-upgrade.test.ts`, `tests/ai/ai-upgrades.test.ts`,
+  `tests/ui/selected-unit-info.test.ts`, `tests/storage/save-migrations.test.ts` —
+  mirrored regression homes.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Legal upgrade | Tap `Upgrade` | Inline confirmation shows source, target, cost, preserved HP/XP, and destination. |
+| Confirmation open | Tap `Cancel` | Normal action surface returns; no unit, gold, or action mutation. |
+| Confirmation open | Tap `Confirm upgrade` | Selected panel rerenders target type with spent movement/action and updated gold. |
+| Any blockers | Inspect selected unit | Ordered text-and-icon blocker list remains visible and confirmation is unavailable. |
+| Confirmation goes stale | Tap `Confirm upgrade` | It stays open and rerenders all current blockers without mutation. |
+| Player handoff | Switch `currentPlayer` | Prior owner’s confirmation/details are absent; only current owner can act. |
+
+## Misleading UI Risks
+
+- A completed technology alone must never label an upgrade available when another
+  requirement is missing.
+- The health preview must show preserved percentage, not a free full heal.
+- Fixing one requirement must not hide another blocker.
+- A stale confirmation cannot imply an action will still succeed after gold, capacity,
+  city ownership, or action availability changes.
+
+## Interaction Replay Checklist
+
+- Open a legal upgrade, cancel, reopen, and confirm; assert DOM after each transition.
+- Open confirmation, make its state stale, confirm, and assert an unchanged state plus
+  current blocker text.
+- Render multiple blockers and prove all remain visible.
+- Hand off to a second human and prove the first player’s confirmation and feedback do
+  not appear.
+
+## Task 1: Create the canonical evaluation contract
+
+**Files:**
+- Modify: `src/systems/unit-upgrade-system.ts`
+- Modify: `src/core/types.ts` only if a shared input/result type belongs there
+- Test: `tests/systems/unit-upgrade.test.ts`
+
+- [ ] **Step 1: Write failing evaluation regressions**
+
+Add tests that request the explicit `spy_scout → spy_informant` target and assert a
+complete result shape rather than the current boolean-only result:
+
+```ts
+const evaluation = evaluateUnitUpgrade(state, 'upgrade-unit', 'spy_informant');
+expect(evaluation).toMatchObject({
+  targetType: 'spy_informant', cost: 25, canUpgrade: true,
+  preserved: { health: 41, experience: 3, movementPointsLeft: 0, hasActed: true },
+  missing: [],
+});
+```
+
+Add a negative test that removes tech, building, resource, gold, city position, and
+action availability at once and expects stable ordered missing keys for every unmet
+condition, with no state mutation.
+
+- [ ] **Step 2: Run the focused regression and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-upgrade.test.ts
+```
+
+Expected: FAIL because `evaluateUnitUpgrade` and its complete `missing` contract do not
+exist.
+
+- [ ] **Step 3: Add typed evaluation data and a single evaluator**
+
+Define serializable facts with stable keys, not display-only strings:
+
+```ts
+export type UpgradeMissingRequirement =
+  | { kind: 'friendly-city' }
+  | { kind: 'technology'; techId: string }
+  | { kind: 'building'; buildingId: string }
+  | { kind: 'resource'; resource: ResourceType }
+  | { kind: 'gold'; required: number; available: number }
+  | { kind: 'action-already-spent' }
+  | { kind: 'air-base'; reason: AirBaseCheck['reason'] };
+
+export interface UpgradeEvaluation {
+  canUpgrade: boolean;
+  sourceType: UnitType;
+  targetType: UnitType | null;
+  cost: number;
+  preserved: Pick<Unit, 'health' | 'experience'> & {
+    movementPointsLeft: 0;
+    hasActed: true;
+  };
+  missing: UpgradeMissingRequirement[];
+}
+```
+
+Implement `evaluateUnitUpgrade(state, unitId, requestedTarget, definitions =
+TRAINABLE_UNITS)` so it validates explicit `upgradesTo`, each target prerequisite, and
+all local conditions without early return. Retain `canUpgradeUnit` and
+`getCanonicalUpgradeTarget` as thin compatibility wrappers over the evaluator until all
+callers migrate; do not maintain duplicate eligibility logic.
+
+- [ ] **Step 4: Run the focused regression and verify GREEN**
+
+Run the Step 2 command. Expected: PASS, including existing explicit-chain and resource
+tests.
+
+- [ ] **Step 5: Commit the TDD slice**
+
+```bash
+git add src/systems/unit-upgrade-system.ts src/core/types.ts tests/systems/unit-upgrade.test.ts
+git commit -m "feat(combat): evaluate upgrade requirements"
+```
+
+## Task 2: Apply upgrades without a free heal and safely base domain changes
+
+**Files:**
+- Modify: `src/systems/unit-upgrade-system.ts`
+- Test: `tests/systems/unit-upgrade.test.ts`
+- Test: `tests/storage/save-migrations.test.ts`
+
+- [ ] **Step 1: Write failing state-application regressions**
+
+Replace the current full-heal assertion with:
+
+```ts
+expect(result.state.units['upgrade-unit']).toMatchObject({
+  type: 'spy_informant', health: 41, experience: 3,
+  movementPointsLeft: 0, hasActed: true,
+});
+```
+
+Build the fixture from a copied source definition whose explicit successor is the already
+catalog-backed `attack_helicopter`; do not mutate `TRAINABLE_UNITS` or invent a test-only
+unit type. Give the city a `helicopter_base` and the unit the completed
+`helicopter-warfare` technology. Test that a legal conversion receives
+`airBase: { kind: 'city', cityId }`; a full base returns an `air-base/base-full` missing
+fact and leaves unit, gold, and base roster unchanged.
+
+- [ ] **Step 2: Run the focused regression and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-upgrade.test.ts
+```
+
+Expected: FAIL because `applyUpgrade` sets `health: 100` and cross-domain application
+does not assign an air base.
+
+- [ ] **Step 3: Implement evaluation-gated application**
+
+Make `applyUnitUpgradeToState` obtain one evaluation, reject a target mismatch or any
+missing fact without cloning/mutating state, deduct only `evaluation.cost`, and call
+`applyUpgrade` with the evaluated target. Preserve health and experience exactly; set
+movement to zero and `hasActed` true.
+
+For a target whose unit definition has `airOperation`, first apply the upgraded type,
+then call `baseNewAirUnit(nextState, cityId, upgradedUnit)`. If basing fails, return the
+original state and the evaluation-derived reason; never leave a converted unbased unit.
+Use `canCompleteAirUnitProduction` during evaluation so capacity and compatibility use
+the exact same rule as normal aircraft production.
+
+- [ ] **Step 4: Add retained-save regressions**
+
+In `tests/storage/save-migrations.test.ts`, create both an unversioned save and a current
+schema save using `createNewGame`; upgrade a damaged, experienced unit; then call
+`migrateSaveToCurrent` twice. Assert equality after the second normalization and verify
+unit type, health, experience, movement/action, gold, and legal `airBase` assignment.
+Do not change `CURRENT_SAVE_SCHEMA_VERSION` unless a new persisted field is introduced.
+
+- [ ] **Step 5: Run system and storage tests and verify GREEN**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-upgrade.test.ts tests/storage/save-migrations.test.ts
+```
+
+Expected: PASS with no schema-version bump.
+
+- [ ] **Step 6: Commit the TDD slice**
+
+```bash
+git add src/systems/unit-upgrade-system.ts tests/systems/unit-upgrade.test.ts tests/storage/save-migrations.test.ts
+git commit -m "fix(combat): preserve upgrade state and air basing"
+```
+
+## Task 3: Route AI through evaluation and preserve difficulty fairness
+
+**Files:**
+- Modify: `src/ai/ai-upgrades.ts`
+- Test: `tests/ai/ai-upgrades.test.ts`
+- Test: `tests/systems/unit-upgrade.test.ts`
+
+- [ ] **Step 1: Write failing parity tests**
+
+Add parameterized Explorer/Standard/Veteran tests for the same human upgrade evaluation:
+
+```ts
+for (const challenge of ['explorer', 'standard', 'veteran'] as const) {
+  expect(evaluateUnitUpgrade(withChallenge(state, challenge), 'upgrade-unit', 'spy_informant'))
+    .toMatchObject({ canUpgrade: true, missing: [] });
+}
+```
+
+Add AI fixtures for a damaged experienced optimizer unit, a defender assigned to urgent
+defense, and a noncombat/builder unit. Assert the AI shares application results, does not
+spend a defender's action, and varies only its existing typed `remainingCap` behavior by
+challenge profile.
+
+- [ ] **Step 2: Run the focused regressions and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/ai/ai-upgrades.test.ts tests/systems/unit-upgrade.test.ts
+```
+
+Expected: FAIL because AI prefilters/routes against target-only helpers rather than the
+complete evaluation facts.
+
+- [ ] **Step 3: Make AI consume canonical evaluation**
+
+Replace AI target-only checks at eligibility, city selection, and immediate application
+with `evaluateUnitUpgrade`. Keep AI behavior catalog-driven: it may route only toward a
+city whose evaluation is legal, skips units with any missing fact, and retains existing
+treasury reserve, safety, urgent-defense, deterministic sorting, and challenge-cap rules.
+Do not add knowledge of hidden bases, units, resources, or new per-unit IDs.
+
+- [ ] **Step 4: Run focused AI/system tests and verify GREEN**
+
+Run the Step 2 command. Expected: PASS for all three challenges and existing route tests.
+
+- [ ] **Step 5: Commit the TDD slice**
+
+```bash
+git add src/ai/ai-upgrades.ts tests/ai/ai-upgrades.test.ts tests/systems/unit-upgrade.test.ts
+git commit -m "fix(ai): share canonical upgrade evaluation"
+```
+
+## Task 4: Implement confirmation and live selected-unit presentation
+
+**Files:**
+- Modify: `src/ui/selected-unit-info.ts`
+- Modify: `src/main.ts`
+- Test: `tests/ui/selected-unit-info.test.ts`
+
+- [ ] **Step 1: Write failing rendered-DOM tests**
+
+Add tests that render a legal damaged/experienced unit and click the existing `Upgrade`
+button. Assert that an inline confirmation contains source/target names, gold, preserved
+health/experience, `Confirm upgrade`, and `Cancel`; then click cancel and assert normal
+actions return without invoking the callback. Test confirm invokes the callback once and
+that rerendering with its returned state shows target type/action spent.
+
+Add a multi-blocker fixture and assert every text label is rendered with icon-plus-text.
+Add a stale-confirm fixture whose callback returns the newly evaluated blockers, then
+assert the confirmation remains and its DOM updates. Assert all upgrade buttons use the
+existing `makeButton` styling with a minimum height of 44px.
+
+- [ ] **Step 2: Run the UI regression and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/ui/selected-unit-info.test.ts
+```
+
+Expected: FAIL because the current UI immediately invokes `onUpgradeUnit` and only
+renders one missing-building explanation.
+
+- [ ] **Step 3: Implement the panel-local confirmation model**
+
+Add a focused presentation helper that maps every `UpgradeMissingRequirement` to
+plain-language icon-plus-text rows and derives preview health/experience. Keep ephemeral
+confirmation state scoped to the selected panel render path. The initial action opens
+confirmation; cancel closes it; confirm calls a callback that returns the re-evaluated
+result so the UI can render late blockers without guessing.
+
+Update both `src/main.ts` callback sites to call only the canonical application helper,
+refresh renderer/HUD/selected unit after success, call the existing owner-scoped
+`appendToCivLog(unit.owner, ...)` for success or late failure, and return the failure
+evaluation to the panel. Do not use `showNotification` for a game consequence, because
+it attributes the entry to `currentPlayer` at emission time. Remove callback-local
+`canUpgradeUnit`, target, and duplicate gold checks.
+
+- [ ] **Step 4: Add hot-seat and muted-feedback DOM coverage**
+
+Render player one’s confirmation, change `currentPlayer`, and rerender player two’s
+selected unit. Assert player one’s confirmation/source/target and feedback are absent,
+and player two cannot invoke player one’s callback. Use `soundEnabled: false` and verify
+the same text feedback is present; this delivery adds no audio event or mixer call.
+
+- [ ] **Step 5: Run UI tests and verify GREEN**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/ui/selected-unit-info.test.ts
+```
+
+Expected: PASS, including current building-gate coverage adapted to the complete blocker
+list.
+
+- [ ] **Step 6: Commit the TDD slice**
+
+```bash
+git add src/ui/selected-unit-info.ts src/main.ts tests/ui/selected-unit-info.test.ts
+git commit -m "feat(ui): confirm and explain unit upgrades"
+```
+
+## Task 5: Source rules, targeted regressions, and release verification
+
+**Files:** No production changes; inspect all files changed above.
+
+- [ ] **Step 1: Run source-rule validation**
+
+```bash
+scripts/check-src-rule-violations.sh \
+  src/systems/unit-upgrade-system.ts src/ai/ai-upgrades.ts \
+  src/ui/selected-unit-info.ts src/main.ts
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run all mirrored and adjacent targeted tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run \
+  tests/systems/unit-upgrade.test.ts tests/systems/air-operations-system.test.ts \
+  tests/ai/ai-upgrades.test.ts tests/ui/selected-unit-info.test.ts \
+  tests/storage/save-migrations.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect branch and working-tree scope**
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD
+git diff
+```
+
+Expected: one focused upgrade-integrity delivery; no schema bump, new roster content, or
+audio event.
+
+- [ ] **Step 4: Run release checks**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: both exit 0. Tauri/web builds are not required because no platform or
+distribution path changes.
+
+- [ ] **Step 5: Commit verification-only follow-up if needed**
+
+```bash
+git status --short
+```
+
+Expected: clean. If a verification failure requires a code change, return to the
+corresponding TDD task before committing the fix.
+
+## Plan self-review
+
+- **Spec coverage:** Tasks 1–2 cover canonical rules, no-free-heal balance, cross-domain
+  basing, and retained saves; Task 3 covers AI, difficulty, and play styles; Task 4
+  covers ages 7–43 presentation, confirmation, hot seat, accessibility, and no-SFX
+  feedback; Task 5 covers source rules and regressions.
+- **No placeholder scan:** No task delegates an undefined behavior; each test, command,
+  callback responsibility, and required outcome is explicit.
+- **Type consistency:** `UpgradeEvaluation` and `UpgradeMissingRequirement` are created
+  in Task 1 and consumed by Tasks 2–4; no caller retains a separate eligibility model.

--- a/docs/superpowers/specs/2026-07-24-issue-665-upgrade-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-24-issue-665-upgrade-integrity-design.md
@@ -1,0 +1,178 @@
+# Issue #665 Upgrade Integrity Design
+
+**Date:** 2026-07-24
+**Status:** Approved for specification review
+**Parent:** #547, delivery 1 of 63
+**Audited base:** `c6279df67a70a0d85487aa0cce77b63e1fd3415d` (`origin/main`)
+
+## Goal
+
+Replace upgrade-as-full-heal behavior with one canonical, save-safe evaluation and
+application contract. It preserves a unit's health percentage and experience, consumes
+its turn, explains every blocker, and prevents cross-domain upgrades from creating an
+unbased air unit.
+
+## Scope
+
+This delivery changes only the existing upgrade foundation. It does not add Armored Car,
+Attack Helicopter, a new upgrade edge, role metadata, conjunctive prerequisites, or a
+new save schema. The future Armored Car to Attack Helicopter edge in #676 will consume
+the generic domain-transition contract established here.
+
+## Design
+
+### Canonical evaluation
+
+`src/systems/unit-upgrade-system.ts` will expose a serializable `UpgradeEvaluation` that
+is the single source for UI, human actions, and AI upgrades. It identifies the explicit
+catalog target and cost, the friendly host city, the state that will be preserved, and an
+ordered list of all unmet requirements. Evaluation does not stop at the first failure:
+an upgrade can report its technology, building, resource, gold, position, and
+cross-domain destination blockers together.
+
+Existing callers that only need an enabled/disabled result will consume this evaluation;
+they will not retain parallel eligibility checks. Explicit `upgradesTo` remains the only
+way to select a target.
+
+### Canonical application
+
+`applyUnitUpgradeToState` first evaluates the requested target, rejects noncanonical or
+blocked requests without changing state, deducts the evaluated cost, and applies the
+result through one state mutation path. `applyUpgrade` preserves health percentage
+against the fixed 100-point health scale and preserves experience. It consumes movement
+and the action, while retaining identity and map position. Only transient state proven
+incompatible with the target definition may be cleared; no unrelated orders, formation,
+or saved state is reset in this issue.
+
+### Cross-domain destination
+
+When an explicit future edge changes a ground unit into an air unit, the evaluator
+requires a friendly host city, the target's required building, a legal air-base slot,
+and a valid canonical base assignment. Application delegates capacity checks and
+assignment to `canCompleteAirUnitProduction` and `baseNewAirUnit` rather than mutating
+an air-unit type in place. A full, destroyed, or otherwise ineligible base is a visible
+blocker.
+
+The upgrade evaluator receives a typed, read-only definition lookup and target type;
+production passes the catalog lookup, while focused tests pass an in-memory lookup that
+contains one explicit ground-to-air edge. This is an evaluation seam, not a test-only
+global catalog mutation or an ID-specific production branch. The fixture proves legal
+base assignment, capacity rejection, and transaction rollback while the concrete Armored
+Car edge remains unreachable until #676.
+
+### Player presentation
+
+The selected-unit panel derives its upgrade presentation exclusively from
+`UpgradeEvaluation`. Before confirmation it shows the source and target names, gold
+cost, preserved health and experience, and every unavailable requirement. After a
+successful upgrade, the still-open panel rerenders immediately with the new type and
+consumed action. The action remains icon-plus-text, uses plain language, and meets the
+44-pixel target requirement. Missing requirements remain explanatory rather than
+silently hiding an otherwise explicit upgrade path.
+
+For a legal upgrade, tapping the 44-pixel `Upgrade` action opens an inline confirmation
+state in the selected-unit panel; it retains the source/target, cost, preservation, and
+destination facts, and offers equally sized `Confirm upgrade` and `Cancel` controls.
+Cancel restores the normal action surface without mutation. Confirm invokes the canonical
+state helper once; success rerenders the open panel, while a late failure rerenders the
+same confirmation with every current blocker. Blocked upgrade paths show their complete
+text-and-icon requirement list in the normal panel and never expose a confirmation
+action.
+
+### Player truth table
+
+| Before | Player action | Immediate visible result |
+|---|---|---|
+| Legal upgrade in a friendly city | Tap `Upgrade` | Inline confirmation shows source, target, gold, preserved health/experience, and destination facts. |
+| Inline confirmation | Tap `Cancel` | Normal selected-unit actions return; unit, gold, and action state are unchanged. |
+| Inline confirmation | Tap `Confirm upgrade` | Open panel rerenders with the target type and spent action/movement; gold and preserved values are shown. |
+| Any missing requirement | View selected unit | Complete ordered blocker list stays visible; no confirmation action appears. |
+| Late state change makes confirmation invalid | Tap `Confirm upgrade` | Confirmation rerenders with current blockers and no mutation occurs. |
+
+### Misleading UI risks
+
+- A target is not "available" merely because its technology is complete: building,
+  resource, gold, city position, and air-base capacity must also pass.
+- A health preview must show the percentage-preserving result, never imply a full heal.
+- The confirmation must render the evaluator's complete list, rather than hiding a
+  second blocker after the first one is repaired.
+
+### Interaction replay checklist
+
+Tests click legal upgrade, cancel, reopen/upgrade again, confirm, then confirm a stale
+attempt; they assert the live DOM after each mutation. Blocked tests cover multiple
+simultaneous requirements and prove that all explanatory text remains reachable.
+
+## Error and information boundaries
+
+All failed mutations return structured reasons and leave the supplied state unchanged.
+The evaluator is deterministic, uses only the upgrading civilization's owned state, and
+does not introduce viewer-specific or hidden-map information. AI upgrades call the same
+state helper as a human action, so building/resource/base eligibility cannot drift.
+
+Explorer, Standard, and Veteran use identical definitions, costs, blockers, destination
+legality, and human upgrade outcomes. The existing challenge profile may continue to
+vary only the AI's bounded modernization cap and ordering. Deterministic tests cover the
+same legal and blocked human decision in all three modes, and separately assert that AI
+uses only the profile's allowed cap difference. Fixtures cover an optimizer upgrading a
+damaged veteran, a defender retaining an acted garrison, and a builder/noncombat unit
+whose upgrade remains subject to the same blockers; no strategy gets a free heal.
+
+Two-human hot-seat tests change `currentPlayer` between the confirmation and execution
+paths. They prove only the selected unit's owner can act, the second player sees neither
+the first player's confirmation nor its success/blocker message, and reopening the panel
+after handoff derives solely from the current viewer's selected unit.
+
+## Persistence
+
+The existing `Unit` fields already store health, experience, movement, action state, and
+air-base assignments. No persisted shape changes in this delivery. Regression coverage
+will prove that upgrading an existing save-shaped state preserves these fields and that
+save normalization/load round trips do not invalidate upgraded units or their legal air
+assignment.
+
+The delivery adds no upgrade SFX and emits no new audio event: the existing visual
+confirmation, persistent notification, and refreshed panel are the complete feedback
+path. This is intentional because no current upgrade audio contract exists; the future
+audio batch may add one through the mixer with a text equivalent. Tests assert that the
+upgrade result remains visually understandable with audio unavailable or muted.
+
+Save coverage uses `createNewGame` states normalized through
+`migrateSaveToCurrent`, including an unversioned schema-0-shaped save and a
+`CURRENT_SAVE_SCHEMA_VERSION` save. Each is upgraded, normalized a second time, and
+asserted to preserve type, health, experience, action/movement state, gold, and any legal
+`airBase` assignment. No schema bump is permitted unless implementation adds persisted
+fields.
+
+## Tests and acceptance evidence
+
+Test-first coverage will prove:
+
+- a damaged, experienced unit preserves its health percentage and experience while
+  spending movement/action;
+- a valid human and AI upgrade use the same canonical mutation path;
+- Explorer, Standard, and Veteran preserve identical human legality and blockers, while
+  AI variation is limited to the existing typed modernization cap;
+- optimizer, defender, and builder/noncombat fixtures retain the intended no-free-heal
+  decision and do not gain a strategy-specific exception;
+- insufficient technology, building, resources, gold, city position, and air-base
+  capacity are reported as independent blockers without mutating state;
+- an attempted cross-domain upgrade cannot create an unbased or over-capacity aircraft;
+- the selected-unit panel renders the evaluation, keeps blockers visible, and refreshes
+  immediately after confirm, cancel, stale-confirm failure, and hot-seat handoff;
+- both schema-0-shaped and current-schema saves pass idempotent load coverage unchanged;
+- muted/no-audio play retains complete visual and textual upgrade feedback.
+
+## Out of scope and follow-up ownership
+
+- #666 owns conjunctive prerequisite metadata and its production/research/Codex wiring.
+- #667 owns typed upgrade-family, role, and counter metadata.
+- #668 owns the broader role/counter/upgrade-chain catalog presentation.
+- #676 owns adding Armored Car and making its explicit cross-domain edge player
+  reachable.
+
+## Verification
+
+Run the mirrored unit-upgrade, AI-upgrades, selected-unit-info, air-operations, and
+storage tests; run source-rule checks for every changed `src/` file; then run a build and
+the full suite before publishing.

--- a/src/ai/ai-upgrades.ts
+++ b/src/ai/ai-upgrades.ts
@@ -22,8 +22,8 @@ import { findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import {
   applyUnitUpgradeToState,
+  evaluateUnitUpgrade,
   getCanonicalUpgradeTarget,
-  getUpgradeCost,
 } from '@/systems/unit-upgrade-system';
 import { hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
 import type { PreparedMajorCivPlan } from './ai-prepared-turn';
@@ -250,10 +250,10 @@ export function processAIUpgrades(
       availableResources,
     );
     if (!targetType) continue;
+    const evaluation = evaluateUnitUpgrade(working, current.id, targetType);
     const city = cityAtUnit(working, civId, current);
     if (city && safeCity(working, civId, city, prepared) && remainingCap > 0) {
-      const cost = getUpgradeCost(targetType);
-      if (working.civilizations[civId].gold - cost < reserve) continue;
+      if (!evaluation.canUpgrade || working.civilizations[civId].gold - evaluation.cost < reserve) continue;
       const result = applyUnitUpgradeToState(
         working,
         current.id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, findPath } from '@/systems/unit-system';
 import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owner-kind';
-import { BUILDINGS, getProductionDisplayName } from '@/systems/city-system';
+import { BUILDINGS, getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
 import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
 import { usePropagandistAction } from '@/systems/propagandist-system';
 import { foundCityInState } from '@/systems/city-founding-system';
@@ -210,7 +210,7 @@ import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import {
   applyUnitUpgradeToState,
-  canUpgradeUnit,
+  evaluateUnitUpgrade,
 } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy, type ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
 import {
@@ -1360,20 +1360,10 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
     onUpgradeUnit: (unitId) => {
       const unit = gameState.units[unitId];
       if (!unit || unit.owner !== gameState.currentPlayer) return;
-      const civ = gameState.civilizations[gameState.currentPlayer];
-      const completedTechs = civ?.techState?.completed ?? [];
-      const homeCity = Object.values(gameState.cities).find(
-        c => c.owner === unit.owner &&
-             c.position.q === unit.position.q &&
-             c.position.r === unit.position.r,
-      );
-      if (!homeCity) return;
-      const upgrade = canUpgradeUnit(unit, homeCity.id, gameState.cities, completedTechs, undefined, getCivAvailableResources(gameState, unit.owner));
+      const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
+      if (!targetType) return;
+      const upgrade = evaluateUnitUpgrade(gameState, unitId, targetType);
       if (!upgrade.canUpgrade || !upgrade.targetType) return;
-      if (civ.gold < upgrade.cost) {
-        showNotification('Not enough gold to upgrade!', 'warning');
-        return;
-      }
       if (executeUpgrade(unitId, upgrade.targetType)) {
         showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
       }
@@ -2426,14 +2416,10 @@ function selectUnit(
       onUpgradeUnit: (uid, cityId) => {
         const unit = gameState.units[uid];
         if (!unit || unit.owner !== gameState.currentPlayer) return;
-        const civ = gameState.civilizations[gameState.currentPlayer];
-        const completedTechs = civ?.techState?.completed ?? [];
-        const upgrade = canUpgradeUnit(unit, cityId, gameState.cities, completedTechs, undefined, getCivAvailableResources(gameState, unit.owner));
+        const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
+        if (!targetType) return;
+        const upgrade = evaluateUnitUpgrade(gameState, uid, targetType);
         if (!upgrade.canUpgrade || !upgrade.targetType) return;
-        if (civ.gold < upgrade.cost) {
-          showNotification('Not enough gold to upgrade!', 'warning');
-          return;
-        }
         if (executeUpgrade(uid, upgrade.targetType)) {
           selectUnit(uid);
           showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -1,6 +1,104 @@
-import type { Unit, UnitType, City, GameState, ResourceType } from '@/core/types';
+import type { Unit, UnitType, City, GameState, ResourceType, TrainableUnitEntry } from '@/core/types';
 import { TRAINABLE_UNITS, getProductionCostForItem } from './city-system';
 import { getCivAvailableResources } from './resource-acquisition-system';
+
+export type UpgradeMissingRequirement =
+  | { kind: 'friendly-city' }
+  | { kind: 'technology'; techId: string }
+  | { kind: 'building'; buildingId: string }
+  | { kind: 'resource'; resource: ResourceType }
+  | { kind: 'gold'; required: number; available: number }
+  | { kind: 'action-already-spent' }
+  | { kind: 'invalid-target' };
+
+export interface UpgradeEvaluation {
+  canUpgrade: boolean;
+  sourceType: UnitType;
+  targetType: UnitType | null;
+  cost: number;
+  cityId: string | null;
+  preserved: {
+    health: number;
+    experience: number;
+    movementPointsLeft: 0;
+    hasActed: true;
+  };
+  missing: UpgradeMissingRequirement[];
+}
+
+function findFriendlyHostCity(state: GameState, unit: Unit): City | undefined {
+  return Object.values(state.cities)
+    .filter(city => city.owner === unit.owner)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .find(city => city.position.q === unit.position.q && city.position.r === unit.position.r);
+}
+
+export function evaluateUnitUpgrade(
+  state: GameState,
+  unitId: string,
+  requestedTarget: UnitType,
+  definitions: readonly TrainableUnitEntry[] = TRAINABLE_UNITS,
+): UpgradeEvaluation {
+  const unit = state.units[unitId];
+  const fallback = {
+    canUpgrade: false,
+    sourceType: unit?.type ?? requestedTarget,
+    targetType: null,
+    cost: 0,
+    cityId: null,
+    preserved: {
+      health: unit?.health ?? 0,
+      experience: unit?.experience ?? 0,
+      movementPointsLeft: 0 as const,
+      hasActed: true as const,
+    },
+  };
+  if (!unit) return { ...fallback, missing: [{ kind: 'invalid-target' }] };
+
+  const source = definitions.find(candidate => candidate.type === unit.type);
+  const target = source?.upgradesTo === requestedTarget
+    ? definitions.find(candidate => candidate.type === requestedTarget)
+    : undefined;
+  if (!source || !target) return { ...fallback, missing: [{ kind: 'invalid-target' }] };
+
+  const civ = state.civilizations[unit.owner];
+  const city = findFriendlyHostCity(state, unit);
+  const resources = getCivAvailableResources(state, unit.owner);
+  const cost = getUpgradeCost(target.type, resources);
+  const missing: UpgradeMissingRequirement[] = [];
+  if (!city) missing.push({ kind: 'friendly-city' });
+  if (source.obsoletedByTech && !civ?.techState.completed.includes(source.obsoletedByTech)) {
+    missing.push({ kind: 'technology', techId: source.obsoletedByTech });
+  }
+  if (target.techRequired && !civ?.techState.completed.includes(target.techRequired)) {
+    missing.push({ kind: 'technology', techId: target.techRequired });
+  }
+  if (target.trainedFromBuilding && !city?.buildings.includes(target.trainedFromBuilding)) {
+    missing.push({ kind: 'building', buildingId: target.trainedFromBuilding });
+  }
+  for (const resource of target.resourceRequired ?? []) {
+    if (!resources.has(resource)) missing.push({ kind: 'resource', resource });
+  }
+  if (!civ || civ.gold < cost) {
+    missing.push({ kind: 'gold', required: cost, available: civ?.gold ?? 0 });
+  }
+  if (unit.hasActed) missing.push({ kind: 'action-already-spent' });
+
+  return {
+    canUpgrade: missing.length === 0,
+    sourceType: unit.type,
+    targetType: target.type,
+    cost,
+    cityId: city?.id ?? null,
+    preserved: {
+      health: unit.health,
+      experience: unit.experience,
+      movementPointsLeft: 0,
+      hasActed: true,
+    },
+    missing,
+  };
+}
 
 export function getUpgradeCost(targetType: UnitType, availableResources?: ReadonlySet<ResourceType>): number {
   const cost = getProductionCostForItem(targetType, { availableResources });
@@ -72,13 +170,12 @@ export function getCanonicalUpgradeTarget(
   return target.type;
 }
 
-// Returns a new Unit with the upgraded type, full health, and action consumed.
+// Returns a new Unit with the upgraded type and action consumed.
 // Caller is responsible for deducting civ.gold by getUpgradeCost(targetType).
 export function applyUpgrade(unit: Unit, targetType: UnitType): Unit {
   return {
     ...unit,
     type: targetType,
-    health: 100,
     movementPointsLeft: 0,
     hasActed: true,
   };
@@ -90,6 +187,14 @@ export interface ApplyUnitUpgradeToStateResult {
   reason?: string;
 }
 
+function upgradeFailureReason(evaluation: UpgradeEvaluation): string {
+  const first = evaluation.missing[0]?.kind;
+  if (first === 'building' || first === 'technology' || first === 'resource') return 'tech-unavailable';
+  if (first === 'gold') return 'insufficient-gold';
+  if (first === 'friendly-city') return 'not-in-friendly-city';
+  return first ?? 'tech-unavailable';
+}
+
 export function applyUnitUpgradeToState(
   state: GameState,
   unitId: string,
@@ -99,37 +204,17 @@ export function applyUnitUpgradeToState(
   if (!unit) return { state, upgraded: false, reason: 'invalid-unit' };
   const civ = state.civilizations[unit.owner];
   if (!civ) return { state, upgraded: false, reason: 'invalid-owner' };
-  const city = civ.cities
-    .map(cityId => state.cities[cityId])
-    .filter((candidate): candidate is City => Boolean(candidate))
-    .sort((left, right) => left.id.localeCompare(right.id))
-    .find(candidate =>
-      candidate.owner === unit.owner
-      && candidate.position.q === unit.position.q
-      && candidate.position.r === unit.position.r);
+  const city = findFriendlyHostCity(state, unit);
   if (!city) {
     return { state, upgraded: false, reason: 'not-in-friendly-city' };
   }
-  const canonicalTarget = getCanonicalUpgradeTarget(
-    unit,
-    civ.techState.completed,
-    city.buildings,
-    getCivAvailableResources(state, unit.owner),
-  );
-  if (!canonicalTarget) {
-    return { state, upgraded: false, reason: 'tech-unavailable' };
-  }
-  if (canonicalTarget !== targetType) {
-    return { state, upgraded: false, reason: 'invalid-target' };
-  }
-  const cost = getUpgradeCost(targetType, getCivAvailableResources(state, unit.owner));
-  if (civ.gold < cost) {
-    return { state, upgraded: false, reason: 'insufficient-gold' };
-  }
+  const evaluation = evaluateUnitUpgrade(state, unitId, targetType);
+  if (evaluation.targetType !== targetType) return { state, upgraded: false, reason: 'invalid-target' };
+  if (!evaluation.canUpgrade) return { state, upgraded: false, reason: upgradeFailureReason(evaluation) };
   const next = structuredClone(state);
   next.civilizations[unit.owner] = {
     ...next.civilizations[unit.owner],
-    gold: next.civilizations[unit.owner].gold - cost,
+    gold: next.civilizations[unit.owner].gold - evaluation.cost,
   };
   next.units[unitId] = applyUpgrade(next.units[unitId], targetType);
   const espionage = next.espionage?.[unit.owner];

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -1,6 +1,8 @@
 import type { Unit, UnitType, City, GameState, ResourceType, TrainableUnitEntry } from '@/core/types';
 import { TRAINABLE_UNITS, getProductionCostForItem } from './city-system';
 import { getCivAvailableResources } from './resource-acquisition-system';
+import { baseNewAirUnit, canCompleteAirUnitProduction } from './air-operations-system';
+import { UNIT_DEFINITIONS } from './unit-system';
 
 export type UpgradeMissingRequirement =
   | { kind: 'friendly-city' }
@@ -9,6 +11,7 @@ export type UpgradeMissingRequirement =
   | { kind: 'resource'; resource: ResourceType }
   | { kind: 'gold'; required: number; available: number }
   | { kind: 'action-already-spent' }
+  | { kind: 'air-base'; reason: 'base-missing' | 'incompatible-base' | 'base-full' }
   | { kind: 'invalid-target' };
 
 export interface UpgradeEvaluation {
@@ -81,6 +84,12 @@ export function evaluateUnitUpgrade(
   }
   if (!civ || civ.gold < cost) {
     missing.push({ kind: 'gold', required: cost, available: civ?.gold ?? 0 });
+  }
+  if (city && UNIT_DEFINITIONS[target.type].airOperation) {
+    const airBase = canCompleteAirUnitProduction(state, city.id, target.type);
+    if (!airBase.ok && airBase.reason !== 'not-based-aircraft') {
+      missing.push({ kind: 'air-base', reason: airBase.reason });
+    }
   }
   if (unit.hasActed) missing.push({ kind: 'action-already-spent' });
 
@@ -217,6 +226,11 @@ export function applyUnitUpgradeToState(
     gold: next.civilizations[unit.owner].gold - evaluation.cost,
   };
   next.units[unitId] = applyUpgrade(next.units[unitId], targetType);
+  if (UNIT_DEFINITIONS[targetType].airOperation) {
+    const based = baseNewAirUnit(next, city.id, next.units[unitId]);
+    if (!based.ok) return { state, upgraded: false, reason: based.reason };
+    Object.assign(next, based.state);
+  }
   const espionage = next.espionage?.[unit.owner];
   if (espionage?.spies[unitId]) {
     next.espionage![unit.owner] = {

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -2,8 +2,8 @@ import type { BuildableImprovementType, GameState, DisguiseType, HexCoord, Unit,
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { getExperienceToNextTier, getVeterancyCombatModifier, getVeterancyTier } from '@/systems/combat-reward-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
-import { canUpgradeUnit, getCanonicalUpgradeTarget } from '@/systems/unit-upgrade-system';
-import { TRAINABLE_UNITS, BUILDINGS } from '@/systems/city-system';
+import { evaluateUnitUpgrade, type UpgradeMissingRequirement } from '@/systems/unit-upgrade-system';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
 import {
   formatImprovementYieldLabel,
   formatWorkerActionBlockerReason,
@@ -783,35 +783,43 @@ export function renderSelectedUnitInfo(
     }
   }
 
-  if (callbacks.onUpgradeUnit && !unit.hasActed) {
-    const homeCity = Object.values(state.cities).find(
-      c => c.owner === unit.owner &&
-           c.position.q === unit.position.q &&
-           c.position.r === unit.position.r,
-    );
-    if (homeCity) {
-      const completedTechs = state.civilizations[unit.owner]?.techState?.completed ?? [];
-      const civGold = state.civilizations[unit.owner]?.gold ?? 0;
-      const availableResources = getCivAvailableResources(state, unit.owner);
-      const upgrade = canUpgradeUnit(unit, homeCity.id, state.cities, completedTechs, civGold, availableResources);
-      if (upgrade.canUpgrade && upgrade.targetType) {
-        const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
-        const btn = makeButton(
-          `Upgrade → ${targetName} (${upgrade.cost} gold)`,
-          '#7c3aed',
-          () => callbacks.onUpgradeUnit!(unitId, homeCity.id),
-        );
-        actionsDiv.appendChild(btn);
-      } else if (upgrade.reason === 'missing-building') {
-        const targetType = getCanonicalUpgradeTarget(unit, completedTechs);
-        const requiredBuilding = targetType
-          ? TRAINABLE_UNITS.find(candidate => candidate.type === targetType)?.trainedFromBuilding
-          : undefined;
-        const buildingName = requiredBuilding ? BUILDINGS[requiredBuilding]?.name ?? requiredBuilding : 'the required building';
-        const blockerDiv = document.createElement('div');
-        blockerDiv.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
-        blockerDiv.textContent = `Upgrade requires ${buildingName} in this city.`;
-        wrapper.appendChild(blockerDiv);
+  if (callbacks.onUpgradeUnit) {
+    const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
+    if (targetType) {
+      const upgrade = evaluateUnitUpgrade(state, unitId, targetType);
+      const requirementLabel = (requirement: UpgradeMissingRequirement): string => {
+        const displayId = (id: string) => id.split('_').map(word => word[0]!.toUpperCase() + word.slice(1)).join(' ');
+        switch (requirement.kind) {
+          case 'technology': return `📜 Requires technology: ${displayId(requirement.techId)}`;
+          case 'building': return `🏛️ Requires building: ${displayId(requirement.buildingId)}`;
+          case 'resource': return `⛏️ Requires resource: ${requirement.resource}`;
+          case 'gold': return `💰 Requires ${requirement.required} gold (have ${requirement.available})`;
+          case 'friendly-city': return '🏙️ Must be in a friendly city';
+          case 'action-already-spent': return '⏳ This unit has already acted';
+          case 'air-base': return `🛬 Air base unavailable: ${requirement.reason}`;
+          default: return '⚠️ Upgrade target is unavailable';
+        }
+      };
+      if (upgrade.canUpgrade && upgrade.cityId) {
+        const upgradeButton = makeButton(`Upgrade → ${UNIT_DEFINITIONS[targetType].name} (${upgrade.cost} gold)`, '#7c3aed', () => {
+          const confirmation = document.createElement('div');
+          confirmation.style.cssText = 'font-size:12px;color:#f8d28a;margin-top:6px;';
+          confirmation.textContent = `Upgrade to ${UNIT_DEFINITIONS[targetType].name}? Keeps ${upgrade.preserved.health} HP and ${upgrade.preserved.experience} XP.`;
+          const confirm = makeButton('Confirm upgrade', '#7c3aed', () => callbacks.onUpgradeUnit!(unitId, upgrade.cityId!));
+          const cancel = makeButton('Cancel', '#555', () => confirmation.remove());
+          confirmation.appendChild(confirm);
+          confirmation.appendChild(cancel);
+          wrapper.appendChild(confirmation);
+          upgradeButton.style.display = 'none';
+        });
+        actionsDiv.appendChild(upgradeButton);
+      } else if (upgrade.targetType) {
+        for (const requirement of upgrade.missing) {
+          const blocker = document.createElement('div');
+          blocker.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
+          blocker.textContent = requirementLabel(requirement);
+          wrapper.appendChild(blocker);
+        }
       }
     }
   }

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -783,7 +783,7 @@ export function renderSelectedUnitInfo(
     }
   }
 
-  if (callbacks.onUpgradeUnit) {
+  if (callbacks.onUpgradeUnit && unit.owner === state.currentPlayer) {
     const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
     if (targetType) {
       const upgrade = evaluateUnitUpgrade(state, unitId, targetType);

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import type { City, Unit } from '@/core/types';
+import type { City, GameState, Unit } from '@/core/types';
 import {
   CURRENT_SAVE_SCHEMA_VERSION,
   migrateSaveToCurrent,
@@ -8,8 +8,35 @@ import {
 } from '@/storage/save-migrations';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getTradeUnitTripBonus, canEstablishRoute } from '@/systems/trade-system';
+import { applyUnitUpgradeToState } from '@/systems/unit-upgrade-system';
+import { foundCity } from '@/systems/city-system';
 
 describe('save migrations', () => {
+  it.each(['legacy', 'current'] as const)('preserves an upgraded damaged veteran through %s save normalization', schema => {
+    const save = createNewGame('rome', `upgrade-${schema}-round-trip`, 'small');
+    const civ = save.civilizations.player;
+    const source = civ.units.map(id => save.units[id]).find(Boolean)!;
+    const city = foundCity(civ.id, source.position, save.map, save.idCounters);
+    save.cities[city.id] = city;
+    civ.cities = [city.id];
+    source.id = 'upgrade-veteran';
+    source.type = 'spy_scout';
+    source.health = 41;
+    source.experience = 3;
+    save.units = { [source.id]: source };
+    civ.units = [source.id];
+    civ.gold = 100;
+    civ.techState.completed = ['espionage-scouting', 'espionage-informants'];
+    if (schema === 'legacy') delete (save as Partial<GameState>).saveSchemaVersion;
+
+    const upgraded = applyUnitUpgradeToState(migrateSaveToCurrent(save), source.id, 'spy_informant');
+    expect(upgraded.upgraded).toBe(true);
+    const loadedAgain = migrateSaveToCurrent(migrateSaveToCurrent(upgraded.state));
+    expect(loadedAgain.units[source.id]).toMatchObject({
+      type: 'spy_informant', health: 41, experience: 3, movementPointsLeft: 0, hasActed: true,
+    });
+    expect(loadedAgain.civilizations.player.gold).toBe(75);
+  });
   it('recalculates a legacy World Age from a strict majority of personal eras', () => {
     const legacy = createNewGame('rome', 'dual-era-migration', 'small');
     legacy.saveSchemaVersion = 4;

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -4,6 +4,7 @@ import {
   canUpgradeUnit,
   getUpgradeCost,
   applyUpgrade,
+  evaluateUnitUpgrade,
 } from '@/systems/unit-upgrade-system';
 import { EventBus } from '@/core/event-bus';
 import { processTurn } from '@/core/turn-manager';
@@ -221,11 +222,13 @@ describe('getUpgradeCost', () => {
 });
 
 describe('applyUpgrade', () => {
-  it('changes unit type, heals to full health, and consumes action', () => {
+  it('changes unit type, preserves health and experience, and consumes action', () => {
     const unit = makeUnit('spy_scout');
+    unit.experience = 3;
     const upgraded = applyUpgrade(unit, 'spy_informant');
     expect(upgraded.type).toBe('spy_informant');
-    expect(upgraded.health).toBe(100);
+    expect(upgraded.health).toBe(70);
+    expect(upgraded.experience).toBe(3);
     expect(upgraded.hasActed).toBe(true);
     expect(upgraded.movementPointsLeft).toBe(0);
   });
@@ -257,7 +260,26 @@ describe('applyUnitUpgradeToState', () => {
     return { state, city, source };
   }
 
-  it('upgrades canonically, deducts exact gold, heals, and consumes the action', () => {
+  it('evaluates a legal upgrade with its cost and preserved-state preview', () => {
+    const { state } = setup();
+    state.units['upgrade-unit'].experience = 3;
+
+    expect(evaluateUnitUpgrade(state, 'upgrade-unit', 'spy_informant')).toMatchObject({
+      canUpgrade: true,
+      sourceType: 'spy_scout',
+      targetType: 'spy_informant',
+      cost: 25,
+      preserved: {
+        health: 41,
+        experience: 3,
+        movementPointsLeft: 0,
+        hasActed: true,
+      },
+      missing: [],
+    });
+  });
+
+  it('upgrades canonically, deducts exact gold, preserves health, and consumes the action', () => {
     const { state } = setup();
 
     const result = applyUnitUpgradeToState(state, 'upgrade-unit', 'spy_informant');
@@ -266,7 +288,7 @@ describe('applyUnitUpgradeToState', () => {
     expect(result.state.civilizations.player.gold).toBe(75);
     expect(result.state.units['upgrade-unit']).toMatchObject({
       type: 'spy_informant',
-      health: 100,
+      health: 41,
       hasActed: true,
       movementPointsLeft: 0,
     });

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -279,6 +279,27 @@ describe('applyUnitUpgradeToState', () => {
     });
   });
 
+  it('reports a full helicopter base for an explicit cross-domain upgrade fixture', () => {
+    const { state, city } = setup();
+    const definitions = TRAINABLE_UNITS.map(entry => entry.type === 'tank'
+      ? { ...entry, obsoletedByTech: 'armored-tactics', upgradesTo: 'attack_helicopter' as const }
+      : entry);
+    state.units['upgrade-unit'].type = 'tank';
+    state.civilizations.player.gold = 1000;
+    state.civilizations.player.techState.completed = ['tank-warfare', 'armored-tactics', 'helicopter-warfare'];
+    city.buildings = ['helicopter_base'];
+    for (const id of ['helicopter-1', 'helicopter-2']) {
+      state.units[id] = {
+        ...state.units['upgrade-unit'], id, type: 'attack_helicopter',
+        airBase: { kind: 'city', cityId: city.id },
+      };
+      state.civilizations.player.units.push(id);
+    }
+
+    expect(evaluateUnitUpgrade(state, 'upgrade-unit', 'attack_helicopter', definitions).missing)
+      .toContainEqual({ kind: 'air-base', reason: 'base-full' });
+  });
+
   it('upgrades canonically, deducts exact gold, preserves health, and consumes the action', () => {
     const { state } = setup();
 

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -279,6 +279,14 @@ describe('applyUnitUpgradeToState', () => {
     });
   });
 
+  it.each(['explorer', 'standard', 'veteran'] as const)('keeps human upgrade legality identical on %s', challenge => {
+    const { state } = setup();
+    state.opponentChallenge = challenge;
+
+    expect(evaluateUnitUpgrade(state, 'upgrade-unit', 'spy_informant'))
+      .toMatchObject({ canUpgrade: true, missing: [] });
+  });
+
   it('reports a full helicopter base for an explicit cross-domain upgrade fixture', () => {
     const { state, city } = setup();
     const definitions = TRAINABLE_UNITS.map(entry => entry.type === 'tank'

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -1537,6 +1537,18 @@ describe('renderSelectedUnitInfo - upgrade button building gate', () => {
     expect(calls).toBe(1);
   });
 
+  it('does not expose an upgrade action for another hot-seat player', () => {
+    const state = makeJetFighterState(['stealth_airbase']);
+    state.currentPlayer = 'other-player';
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'bomber-1', {
+      onUpgradeUnit: () => { throw new Error('must not be callable'); },
+    });
+
+    expect(findButtons(container).some(button => button.textContent?.startsWith('Upgrade'))).toBe(false);
+  });
+
   it('hides the Upgrade button and shows a missing-building reason when stealth_airbase is absent', () => {
     const state = makeJetFighterState([]);
     const container = new MockElement('div');

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -1521,6 +1521,22 @@ describe('renderSelectedUnitInfo - upgrade button building gate', () => {
     expect(texts.some(t => t.startsWith('Upgrade → Stealth Bomber'))).toBe(true);
   });
 
+  it('requires confirmation before invoking a legal upgrade callback', () => {
+    const state = makeJetFighterState(['stealth_airbase']);
+    const container = new MockElement('div');
+    let calls = 0;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'bomber-1', {
+      onUpgradeUnit: () => { calls++; },
+    });
+
+    findButtons(container).find(button => button.textContent?.startsWith('Upgrade'))!.click();
+    expect(calls).toBe(0);
+    expect(collectAllText(container).join(' ')).toContain('Keeps 100 HP and 0 XP');
+    findButtons(container).find(button => button.textContent === 'Confirm upgrade')!.click();
+    expect(calls).toBe(1);
+  });
+
   it('hides the Upgrade button and shows a missing-building reason when stealth_airbase is absent', () => {
     const state = makeJetFighterState([]);
     const container = new MockElement('div');


### PR DESCRIPTION
Closes #665

## Summary

- Replaces upgrade-as-full-heal with a canonical evaluator shared by state application, AI, live callbacks, and selected-unit UI.
- Preserves health and experience, consumes movement/action, lists structured blockers, and safely assigns legal air bases for cross-domain upgrades.
- Adds inline confirmation, current-player/hot-seat isolation, difficulty legality parity, and legacy/current save-round-trip regressions.

## Player impact

Upgrades now present the target, cost, preserved HP/XP, and all unmet requirements before confirmation. A damaged unit cannot use an upgrade as a free heal, and another hot-seat player cannot trigger its action.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- targeted upgrade, AI, UI, air-base, and save-migration suites (176 passing)
- upgrade difficulty-parity suite (30 passing)
- source-rule checks for changed source files
- full `bash scripts/run-with-mise.sh yarn test` invoked locally and by the required pre-push hook

## Out of scope

- New upgrade edges and unit roster content (including Armored Car) remain with their numbered follow-up issues.
- No save schema bump or new upgrade SFX event is introduced.