### PR TITLE
feat(production): support conjunctive technology prerequisites (#666)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-issue-666-conjunctive-prerequisites.md
+++ b/docs/superpowers/plans/2026-07-25-issue-666-conjunctive-prerequisites.md
@@ -1,0 +1,165 @@
+# Issue #666 Conjunctive Prerequisites Implementation Plan
+
+> **For agentic workers:** Execute this plan inline. Do not delegate: repository policy
+> requires explicit user approval for any subagent, and the user requested inline work.
+
+**Goal:** Add one canonical, explainable conjunctive-tech prerequisite contract for
+trainable units and buildings without changing existing save semantics or difficulty rules.
+
+**Architecture:** Keep legacy `techRequired` readable while adding optional
+`requiredTechs`. A pure `production-prerequisites` helper returns stable ordered
+required/satisfied/missing facts, and city production, upgrades, AI, and presentation
+delegate to it. Static definition metadata remains non-persisted; existing queue
+revalidation removes an old queued item that has become ineligible and records its
+existing `no-longer-available` reason.
+
+**Tech Stack:** TypeScript, Vitest, DOM tests, Vite.
+
+---
+
+## Inline review resolution
+
+- **Balance/fun/difficulty:** This changes eligibility explanation, not unit strength,
+  costs, combat, rewards, or Explorer/Standard/Veteran legality. Every difficulty uses
+  the same helper and catalog.
+- **Ages 7–43 and play styles:** The default explanation says `Requires A + B` with
+  individual done/missing facts. The catalog remains browseable; no player must infer
+  a missing gate from a vanished option.
+- **AI:** AI production and research use definition data and the shared helper only;
+  no opponent state or map scan is introduced.
+- **Hot seat:** City production evaluates the displayed city's owner; the research
+  inspector evaluates its displayed civilization. No prerequisite, queue, hint,
+  notification, or sound state is stored per viewer. There is no SFX event because
+  eligibility itself has no mutation.
+- **Saves:** `requiredTechs` lives in static definitions. Existing saved queues use the
+  established revalidation path: an entry made newly ineligible is removed with an
+  explicit `no-longer-available` reason. No schema increment or migration is warranted.
+
+## Player Truth Table
+
+| State | City catalog result | Upgrade result | Visible explanation |
+|---|---|---|---|
+| All required techs complete | Actionable | Eligible if other gates pass | No prerequisite blocker |
+| One of two techs complete | Locked, still browseable | Ineligible | `Requires A + B`; A done, B missing |
+| Neither complete | Locked, still browseable | Ineligible | Both requirements missing |
+| Legacy single-tech definition | Existing behavior | Existing behavior | One requirement fact |
+| Old queued item after a definition adds a second gate | Removed with existing explicit reason | N/A | Existing `no-longer-available` save-compat path |
+
+## Misleading UI Risks
+
+- A partially complete conjunction must never be represented as `Available now`.
+- A resource-locked item is not a tech-locked item; both blockers remain distinct.
+- A focused locked section must not hide the complete production catalog behind a
+  recommendation-only surface.
+- The displayed city's owner determines city-production facts; the displayed
+  civilization determines research facts. Neither surface may read another hot-seat
+  player's completed-tech list.
+
+## Interaction Replay Checklist
+
+1. Open a city with one required technology complete; inspect the locked item.
+2. Complete the second technology, rerender the same city panel, and see the item become
+   actionable without reopening a different player’s panel.
+3. Attempt an upgrade with one requirement missing; see every missing fact.
+4. Switch `currentPlayer` in a two-human state and verify the same definition evaluates
+   from the new viewer’s own technologies.
+
+## Task 1: Define and test the pure prerequisite contract
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Create: `src/systems/production-prerequisites.ts`
+- Test: `tests/systems/production-prerequisites.test.ts`
+
+1. Write failing tests for legacy-only, conjunction complete, A-only, B-only, duplicate,
+   empty, and unknown prerequisite IDs. Assert ordered output:
+
+   ```ts
+   expect(evaluateProductionPrerequisites(
+     { techRequired: 'alpha', requiredTechs: ['beta'] },
+     new Set(['alpha']),
+   )).toEqual({ required: ['alpha', 'beta'], satisfied: ['alpha'], missing: ['beta'] });
+   ```
+
+2. Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/production-prerequisites.test.ts`
+   and confirm the test fails because the helper does not exist.
+3. Add `requiredTechs?: string[]` to `Building` and `TrainableUnitEntry`. Implement a
+   pure helper with `getRequiredTechIds(definition)` and
+   `evaluateProductionPrerequisites(definition, completedTechs)`. Legacy `techRequired`
+   is first, duplicates are removed, and result order is deterministic.
+4. Rerun the focused test and commit the green contract.
+
+## Task 2: Route production and upgrades through the helper
+
+**Files:**
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/systems/unit-upgrade-system.ts`
+- Test: `tests/systems/city-system.test.ts`
+- Test: `tests/systems/unit-upgrade.test.ts`
+
+1. Write failing production tests for a synthetic two-tech unit/building that is absent
+   with one prerequisite and eligible with both. Add an upgrade test whose returned
+   `missing` facts contain the incomplete second technology.
+2. Verify red with the two mirrored test files.
+3. Replace local `techRequired` checks in `getTrainableUnitsForCiv`,
+   `getAvailableBuildings`, and `evaluateUnitUpgrade` with the helper. Preserve
+   obsolescence/resource/coastal/building/air-base checks and the existing old-save
+   queue fallback.
+4. Rerun both focused suites and commit.
+
+## Task 3: Make AI and unlock metadata conjunction-aware
+
+**Files:**
+- Modify: `src/ai/ai-research.ts`
+- Modify: `src/systems/tech-definitions.ts` or its existing consistency seam
+- Modify: `tests/systems/tech-unlocks-consistency.test.ts`
+- Test: `tests/ai/ai-research.test.ts`
+
+1. Write red tests proving a partially completed gate supplies no production candidate
+   and that research planning can value the remaining prerequisite without claiming the
+   unit is already enabled.
+2. Change unlock-consistency coverage so each declared prerequisite recognizes an item,
+   while a full-catalog validator rejects empty, duplicate, unknown, or unreachable
+   required IDs.
+3. Keep tech `unlocksUnits`/`unlocksBuildings` as discoverability metadata; do not
+   duplicate every conjunction into a second eligibility rule.
+4. Rerun the focused AI and consistency suites and commit.
+
+## Task 4: Render partial gates without hiding the catalog
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/ui/tech-panel.ts`
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/ui/tech-panel.test.ts`
+
+1. Write red DOM tests for `Requires A + B`, individual done/missing states, and a
+   two-human `currentPlayer` switch. Include a negative assertion that an A-only item
+   is not labeled available.
+2. Derive locked prerequisite presentation from the shared evaluator. Preserve the
+   existing resource-locked presentation, and add a tested `Show all` path if the
+   focused locked section truncates items.
+3. Have tech-panel unlock copy use the same requirement facts so it never promises a
+   conjunction after only one tech completes.
+4. Rerun focused UI tests and commit.
+
+## Task 5: Save, parity, and completion verification
+
+**Files:**
+- Modify: `tests/storage/save-migrations.test.ts` only if a current fixture proves the
+  queue compatibility path; no schema version change.
+- Test: `tests/systems/city-system.test.ts`, `tests/systems/unit-upgrade.test.ts`,
+  `tests/ai/ai-production.test.ts`, `tests/ai/ai-research.test.ts`,
+  `tests/ui/city-panel.test.ts`, `tests/ui/tech-panel.test.ts`,
+  `tests/systems/tech-unlocks-consistency.test.ts`.
+
+1. Add a regression showing an old queue item made ineligible by a newly added
+   conjunction is removed through the existing explicit save-compatibility path.
+2. Add Explorer/Standard/Veteran legality parity and two-human hot-seat coverage where
+   the relevant harnesses exist; requirements must depend only on the acting civ’s
+   completed technologies.
+3. Run `scripts/check-src-rule-violations.sh` for every changed `src/` file, all
+   mirrored focused tests in one command, `git diff --check`, and inspect both diff
+   stats and full source diff.
+4. Before delivery run `bash scripts/run-with-mise.sh yarn build` and
+   `bash scripts/run-with-mise.sh yarn test`.

--- a/src/ai/ai-research.ts
+++ b/src/ai/ai-research.ts
@@ -70,12 +70,14 @@ interface SearchTarget {
   depth: number;
   pathCost: number;
   preliminary: number;
+  completedAfterPath: ReadonlySet<string>;
 }
 
 function descendantsWithinLimit(
   frontier: Tech,
   techs: readonly Tech[],
   completed: ReadonlySet<string>,
+  knownTechIds: ReadonlySet<string>,
 ): SearchTarget[] {
   const byId = new Map(techs.map(tech => [tech.id, tech]));
   const targets: SearchTarget[] = [];
@@ -92,7 +94,8 @@ function descendantsWithinLimit(
     const previousDepth = bestDepth.get(current.tech.id);
     if (previousDepth !== undefined && previousDepth <= current.depth) continue;
     bestDepth.set(current.tech.id, current.depth);
-    const capabilities = evaluateAITechCapabilities(current.tech);
+    const completedAfterPath = new Set([...completed, ...current.pathIds]);
+    const capabilities = evaluateAITechCapabilities(current.tech, completedAfterPath, knownTechIds);
     const preliminary = capabilities.militaryPowerSpike
       + capabilities.economicSupport
       + capabilities.eraProgress
@@ -104,6 +107,7 @@ function descendantsWithinLimit(
       depth: current.depth,
       pathCost: current.pathCost,
       preliminary,
+      completedAfterPath,
     });
     if (current.depth === 4) continue;
     for (const child of techs
@@ -144,6 +148,7 @@ export function planAIResearch(
   context: AIResearchPlanningContext,
 ): AIResearchDecision | null {
   const techs = context.techs ?? TECH_TREE;
+  const knownTechIds = new Set(techs.map(tech => tech.id));
   const completed = new Set(context.techState.completed);
   const frontier = techs
     .filter(tech =>
@@ -155,14 +160,14 @@ export function planAIResearch(
   if (frontier.length === 0) return null;
 
   const searchTargets = frontier
-    .flatMap(tech => descendantsWithinLimit(tech, techs, completed))
+    .flatMap(tech => descendantsWithinLimit(tech, techs, completed, knownTechIds))
     .sort((left, right) =>
       right.preliminary - left.preliminary
       || left.frontier.id.localeCompare(right.frontier.id)
       || left.target.id.localeCompare(right.target.id))
     .slice(0, 24);
   const evaluated = searchTargets.map(entry => {
-    const capabilities = evaluateAITechCapabilities(entry.target);
+    const capabilities = evaluateAITechCapabilities(entry.target, entry.completedAfterPath, knownTechIds);
     const roleCount = Object.values(capabilities.rolesUnlocked)
       .reduce((sum, value) => sum + (value ?? 0), 0);
     const modernizationFit = context.modernizationDemand / 25

--- a/src/ai/ai-tech-evaluation.ts
+++ b/src/ai/ai-tech-evaluation.ts
@@ -6,6 +6,7 @@ import type {
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { evaluateProductionPrerequisites } from '@/systems/production-prerequisites';
 import { getAIStrategicRoles } from './ai-unit-roles';
 
 export interface AITechCapabilities {
@@ -20,13 +21,30 @@ export interface AITechCapabilities {
   situationality: number;
 }
 
-export function evaluateAITechCapabilities(tech: Tech): AITechCapabilities {
+export function evaluateAITechCapabilities(
+  tech: Tech,
+  completedTechs?: ReadonlySet<string>,
+  knownTechIds?: ReadonlySet<string>,
+): AITechCapabilities {
   const rolesUnlocked: Partial<Record<AIStrategicRole, number>> = {};
   let militaryPowerSpike = 0;
-  for (const type of tech.unlocksUnits ?? []) {
+  const isAvailableAfterResearch = (definition: typeof TRAINABLE_UNITS[number] | typeof BUILDINGS[string]): boolean =>
+    !completedTechs || !evaluateProductionPrerequisites(definition, completedTechs).missing
+      .some(techId => !knownTechIds || knownTechIds.has(techId));
+  const unitTypes = new Set(tech.unlocksUnits ?? []);
+  if (completedTechs) {
+    for (const unit of TRAINABLE_UNITS) {
+      if (evaluateProductionPrerequisites(unit, completedTechs).required.includes(tech.id)
+        && isAvailableAfterResearch(unit)) {
+        unitTypes.add(unit.type);
+      }
+    }
+  }
+  for (const type of unitTypes) {
     const catalogEntry = TRAINABLE_UNITS.find(unit => unit.type === type);
     const definition = UNIT_DEFINITIONS[type];
     if (!catalogEntry || !definition) continue;
+    if (!isAvailableAfterResearch(catalogEntry)) continue;
     for (const role of getAIStrategicRoles(type)) {
       rolesUnlocked[role] = (rolesUnlocked[role] ?? 0) + 1;
     }
@@ -34,8 +52,19 @@ export function evaluateAITechCapabilities(tech: Tech): AITechCapabilities {
   }
 
   const buildingYieldValue: AITechCapabilities['buildingYieldValue'] = {};
-  for (const buildingId of tech.unlocksBuildings ?? []) {
-    const yields = BUILDINGS[buildingId]?.yields;
+  const buildingIds = new Set(tech.unlocksBuildings ?? []);
+  if (completedTechs) {
+    for (const building of Object.values(BUILDINGS)) {
+      if (evaluateProductionPrerequisites(building, completedTechs).required.includes(tech.id)
+        && isAvailableAfterResearch(building)) {
+        buildingIds.add(building.id);
+      }
+    }
+  }
+  for (const buildingId of buildingIds) {
+    const building = BUILDINGS[buildingId];
+    if (building && !isAvailableAfterResearch(building)) continue;
+    const yields = building?.yields;
     if (!yields) continue;
     for (const key of ['food', 'production', 'gold', 'science'] as const) {
       buildingYieldValue[key] = (buildingYieldValue[key] ?? 0) + yields[key];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -479,6 +479,8 @@ export interface Building {
   productionCost: number;
   description: string;
   techRequired?: string | null;
+  /** Additional technologies required alongside the legacy single-tech gate. */
+  requiredTechs?: string[];
   coastalRequired?: boolean;
   pacing?: PacingMetadata;
   resourceRequired?: ResourceType[];
@@ -895,6 +897,8 @@ export interface TrainableUnitEntry {
   name: string;
   cost: number;
   techRequired?: string;
+  /** Additional technologies required alongside the legacy single-tech gate. */
+  requiredTechs?: string[];
   obsoletedByTech?: string;
   upgradesTo?: UnitType;
   civTypeRequired?: string;  // only available/shown for this civ

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -11,6 +11,7 @@ import {
   getLegendaryWonderProductionCost,
   getLegendaryWonderQueueItemMetadata,
 } from './legendary-wonder-production';
+import { evaluateProductionPrerequisites } from './production-prerequisites';
 
 export const CITY_NAMES = DEFAULT_CITY_NAMES;
 
@@ -1721,7 +1722,7 @@ export function getTrainableUnitsForCiv(
       .map(u => u.replacesUnit!),
   );
   return TRAINABLE_UNITS.filter(u => {
-    if (u.techRequired && !completedTechs.includes(u.techRequired)) return false;
+    if (evaluateProductionPrerequisites(u, completedTechs).missing.length > 0) return false;
     if (u.obsoletedByTech && completedTechs.includes(u.obsoletedByTech)) return false;
     if (u.civTypeRequired && u.civTypeRequired !== civType) return false;
     if (replacedForCiv.has(u.type)) return false;
@@ -1827,7 +1828,7 @@ export function getAvailableBuildings(
   const coastal = isCityCoastal(city, map);
   return Object.values(BUILDINGS).filter(b => {
     if (city.buildings.includes(b.id)) return false;
-    if (b.techRequired && !completedTechs.includes(b.techRequired)) return false;
+    if (evaluateProductionPrerequisites(b, completedTechs).missing.length > 0) return false;
     if (isBuildingObsolete(b, completedTechs)) return false;
     if (b.coastalRequired && !coastal) return false;
     if (availableResources !== undefined && b.resourceRequired?.length) {

--- a/src/systems/production-prerequisites.ts
+++ b/src/systems/production-prerequisites.ts
@@ -1,0 +1,61 @@
+export interface ProductionPrerequisiteDefinition {
+  techRequired?: string | null;
+  requiredTechs?: readonly string[];
+}
+
+export interface ProductionPrerequisiteEvaluation {
+  required: string[];
+  satisfied: string[];
+  missing: string[];
+}
+
+export function getRequiredTechIds(definition: ProductionPrerequisiteDefinition): string[] {
+  const required = [
+    ...(definition.techRequired ? [definition.techRequired] : []),
+    ...(definition.requiredTechs ?? []),
+  ];
+  return [...new Set(required)];
+}
+
+export function evaluateProductionPrerequisites(
+  definition: ProductionPrerequisiteDefinition,
+  completedTechs: readonly string[] | ReadonlySet<string>,
+): ProductionPrerequisiteEvaluation {
+  const completed = completedTechs instanceof Set ? completedTechs : new Set(completedTechs);
+  const required = getRequiredTechIds(definition);
+  const satisfied = required.filter(techId => completed.has(techId));
+  return {
+    required,
+    satisfied,
+    missing: required.filter(techId => !completed.has(techId)),
+  };
+}
+
+export function validateProductionPrerequisiteDefinitions(
+  definitions: Iterable<ProductionPrerequisiteDefinition & { id: string }>,
+  knownTechIds: ReadonlySet<string>,
+  reachableTechIds: ReadonlySet<string> = knownTechIds,
+): string[] {
+  const errors: string[] = [];
+  for (const definition of definitions) {
+    if (definition.requiredTechs?.length === 0) {
+      errors.push(`${definition.id}: requiredTechs must not be empty`);
+    }
+    const declared = [
+      ...(definition.techRequired ? [definition.techRequired] : []),
+      ...(definition.requiredTechs ?? []),
+    ];
+    const seen = new Set<string>();
+    for (const techId of declared) {
+      if (seen.has(techId)) {
+        errors.push(`${definition.id}: duplicate prerequisite ${techId}`);
+      } else if (!knownTechIds.has(techId)) {
+        errors.push(`${definition.id}: unknown prerequisite ${techId}`);
+      } else if (!reachableTechIds.has(techId)) {
+        errors.push(`${definition.id}: unreachable prerequisite ${techId}`);
+      }
+      seen.add(techId);
+    }
+  }
+  return errors;
+}

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -3,6 +3,7 @@ import { TRAINABLE_UNITS, getProductionCostForItem } from './city-system';
 import { getCivAvailableResources } from './resource-acquisition-system';
 import { baseNewAirUnit, canCompleteAirUnitProduction } from './air-operations-system';
 import { UNIT_DEFINITIONS } from './unit-system';
+import { evaluateProductionPrerequisites } from './production-prerequisites';
 
 export type UpgradeMissingRequirement =
   | { kind: 'friendly-city' }
@@ -73,8 +74,8 @@ export function evaluateUnitUpgrade(
   if (source.obsoletedByTech && !civ?.techState.completed.includes(source.obsoletedByTech)) {
     missing.push({ kind: 'technology', techId: source.obsoletedByTech });
   }
-  if (target.techRequired && !civ?.techState.completed.includes(target.techRequired)) {
-    missing.push({ kind: 'technology', techId: target.techRequired });
+  for (const techId of evaluateProductionPrerequisites(target, civ?.techState.completed ?? []).missing) {
+    missing.push({ kind: 'technology', techId });
   }
   if (target.trainedFromBuilding && !city?.buildings.includes(target.trainedFromBuilding)) {
     missing.push({ kind: 'building', buildingId: target.trainedFromBuilding });
@@ -158,7 +159,7 @@ export function getCanonicalUpgradeTarget(
     candidate.type === currentEntry.upgradesTo);
   if (
     !target
-    || (target.techRequired && !completedTechs.includes(target.techRequired))
+    || evaluateProductionPrerequisites(target, completedTechs).missing.length > 0
     || (
       target.obsoletedByTech
       && completedTechs.includes(target.obsoletedByTech)

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -52,7 +52,8 @@ import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/c
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { getCityTechYields } from '@/systems/tech-yield-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
-import { resolveCivilizationEra } from '@/systems/tech-definitions';
+import { TECH_TREE, resolveCivilizationEra } from '@/systems/tech-definitions';
+import { evaluateProductionPrerequisites } from '@/systems/production-prerequisites';
 import { createCityWorkSection } from './city-grid';
 import { createCityDistrictsTab } from './city-districts';
 import {
@@ -611,7 +612,7 @@ export function createCityPanel(
     ? availableUnits.filter(u => hasAITradeRole(u.type))
     : [];
 
-  // Locked items: tech met + resource NOT met (tech-missing items stay hidden entirely)
+  // Locked items retain explanatory resource and partial-conjunction states.
   const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined, cityFollowsOwnFaith(state, city));
   const lockedUnits = allTechUnlockedUnits.filter(u => !availableUnits.some(a => a.type === u.type));
 
@@ -619,18 +620,58 @@ export function createCityPanel(
     .filter(b => !b.nationalProject);
   const lockedBuildings = allTechUnlockedBuildings.filter(b => !availableBuildings.some(a => a.id === b.id));
 
-  const lockedItems: Array<{ id: string; name: string; missingResources: ResourceType[] }> = [
+  const partialPrerequisiteUnits = TRAINABLE_UNITS.filter(unit => {
+    const prerequisites = evaluateProductionPrerequisites(unit, completedTechs);
+    return prerequisites.required.length > 1
+      && prerequisites.missing.length > 0
+      && !availableUnits.some(available => available.type === unit.type)
+      && !lockedUnits.some(locked => locked.type === unit.type)
+      && (!unit.civTypeRequired || unit.civTypeRequired === currentCiv.civType);
+  });
+
+  const partialPrerequisiteBuildings = Object.values(BUILDINGS).filter(building => {
+    const prerequisites = evaluateProductionPrerequisites(building, completedTechs);
+    return prerequisites.required.length > 1
+      && prerequisites.missing.length > 0
+      && !building.nationalProject
+      && !city.buildings.includes(building.id)
+      && !availableBuildings.some(available => available.id === building.id)
+      && !lockedBuildings.some(locked => locked.id === building.id);
+  });
+
+  const lockedItems: Array<{ id: string; name: string; missingResources: ResourceType[]; requiredTechs: string[] }> = [
     ...lockedUnits.map(u => ({
       id: u.type,
       name: u.name,
       missingResources: (u.resourceRequired ?? []).filter(r => !playerResources.has(r)),
+      requiredTechs: [],
     })),
     ...lockedBuildings.map(b => ({
       id: b.id,
       name: b.name,
       missingResources: (b.resourceRequired ?? []).filter(r => !playerResources.has(r)),
+      requiredTechs: [],
+    })),
+    ...partialPrerequisiteUnits.map(unit => ({
+      id: unit.type,
+      name: unit.name,
+      missingResources: [],
+      requiredTechs: evaluateProductionPrerequisites(unit, completedTechs).required,
+    })),
+    ...partialPrerequisiteBuildings.map(building => ({
+      id: building.id,
+      name: building.name,
+      missingResources: [],
+      requiredTechs: evaluateProductionPrerequisites(building, completedTechs).required,
     })),
   ];
+
+  const prerequisiteChecklist = (techIds: readonly string[]): string => techIds
+    .map(techId => {
+      const name = TECH_TREE.find(tech => tech.id === techId)?.name ?? techId;
+      return completedTechs.includes(techId) ? `${name} ✓` : name;
+    })
+    .join(' + ');
 
   const IMPROVEMENT_LABELS: Record<string, string> = { mine: 'Mine', pasture: 'Pasture', quarry: 'Quarry', plantation: 'Plantation', camp: 'Camp', oil_well: 'Oil Well' };
 
@@ -1106,7 +1147,9 @@ export function createCityPanel(
     const nameEl = panel.querySelector(`[data-locked-name="${item.id}"]`);
     if (nameEl) nameEl.textContent = item.name;
     const reasonEl = panel.querySelector(`[data-locked-reason="${item.id}"]`);
-    if (reasonEl) reasonEl.textContent = item.missingResources.map(r => buildLockedItemReason(r, completedTechs)).join('\n\n');
+    if (reasonEl) reasonEl.textContent = item.requiredTechs.length > 0
+      ? `Requires: ${prerequisiteChecklist(item.requiredTechs)}`
+      : item.missingResources.map(r => buildLockedItemReason(r, completedTechs)).join('\n\n');
   }
 
   city.productionQueue.forEach((itemId, index) => {
@@ -1401,7 +1444,9 @@ export function createCityPanel(
       const nameEl = panel.querySelector(`[data-locked-name-extra="${item.id}"]`);
       if (nameEl) nameEl.textContent = item.name;
       const reasonEl = panel.querySelector(`[data-locked-reason-extra="${item.id}"]`);
-      if (reasonEl) reasonEl.textContent = item.missingResources.map(r => buildLockedItemReason(r, completedTechs)).join('\n\n');
+      if (reasonEl) reasonEl.textContent = item.requiredTechs.length > 0
+        ? `Requires: ${prerequisiteChecklist(item.requiredTechs)}`
+        : item.missingResources.map(r => buildLockedItemReason(r, completedTechs)).join('\n\n');
     }
     btn.remove();
   });

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -1,5 +1,5 @@
 import type { GameState, Tech, TechTrack } from '@/core/types';
-import { BUILDINGS } from '@/systems/city-system';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import {
@@ -12,16 +12,37 @@ import {
 import { TECH_TREE, getEffectiveTechCost } from '@/systems/tech-system';
 import { getEraAdvancementFraction, getEraAdvancementTechs, resolveCivilizationEra } from '@/systems/tech-definitions';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { evaluateProductionPrerequisites } from '@/systems/production-prerequisites';
 
-function getUnlockLines(tech: Tech): string[] {
+function getUnlockLines(tech: Tech, completedTechs?: readonly string[]): string[] {
   const lines = [...tech.unlocks];
+  const completedAfterResearch = completedTechs
+    ? new Set([...completedTechs, tech.id])
+    : undefined;
   for (const unitType of tech.unlocksUnits ?? []) {
     const def = UNIT_DEFINITIONS[unitType];
-    if (def) lines.push(def.name);
+    const entry = TRAINABLE_UNITS.find(unit => unit.type === unitType);
+    const prerequisites = completedAfterResearch && entry
+      ? evaluateProductionPrerequisites(entry, completedAfterResearch)
+      : undefined;
+    const prerequisiteLabel = prerequisites?.missing.length && completedAfterResearch
+      ? prerequisites.required.map(techId => `${getTechName(techId)}${completedAfterResearch.has(techId) ? ' ✓' : ''}`).join(' + ')
+      : null;
+    if (def) lines.push(prerequisiteLabel
+      ? `${def.name} (requires ${prerequisiteLabel})`
+      : def.name);
   }
   for (const buildingId of tech.unlocksBuildings ?? []) {
     const building = BUILDINGS[buildingId];
-    if (building) lines.push(building.name);
+    const prerequisites = completedAfterResearch && building
+      ? evaluateProductionPrerequisites(building, completedAfterResearch)
+      : undefined;
+    const prerequisiteLabel = prerequisites?.missing.length && completedAfterResearch
+      ? prerequisites.required.map(techId => `${getTechName(techId)}${completedAfterResearch.has(techId) ? ' ✓' : ''}`).join(' + ')
+      : null;
+    if (building) lines.push(prerequisiteLabel
+      ? `${building.name} (requires ${prerequisiteLabel})`
+      : building.name);
   }
   return lines;
 }
@@ -311,7 +332,7 @@ function renderInspector(
   inspector.appendChild(meta);
 
   const unlocks = document.createElement('div');
-  unlocks.textContent = getUnlockLines(selectedNode.tech).join(', ') || 'New options for your empire';
+  unlocks.textContent = getUnlockLines(selectedNode.tech, civ.techState.completed).join(', ') || 'New options for your empire';
   unlocks.style.cssText = 'font-size:12px;line-height:1.35;margin-bottom:10px;';
   inspector.appendChild(unlocks);
 

--- a/tests/ai/ai-production.test.ts
+++ b/tests/ai/ai-production.test.ts
@@ -104,6 +104,25 @@ function makeCoastal(state: GameState, cityId = 'city-a'): void {
 }
 
 describe('AI strategic production', () => {
+  it('does not generate a partially unlocked conjunctive unit candidate', () => {
+    const state = setupState(['archery']);
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const candidates = generateAIProductionCandidates(
+        state,
+        'ai-1',
+        'city-a',
+        [demand('ranged')],
+        aggressive,
+      );
+      expect(candidates.map(candidate => candidate.itemId)).not.toContain('archer');
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
   it('prioritizes a defensive espionage building only for a live detected city threat', () => {
     const state = setupState(['cold-war-networks', 'writing']);
     state.cities['city-a'].buildings = Object.keys(BUILDINGS)

--- a/tests/ai/ai-research.test.ts
+++ b/tests/ai/ai-research.test.ts
@@ -11,6 +11,7 @@ import type {
   TechTrack,
 } from '@/core/types';
 import { createTechState } from '@/systems/tech-system';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
 import { prepareMajorCivStrategicPlan } from '@/ai/ai-prepared-turn';
 
 const neutral: PersonalityTraits = {
@@ -56,6 +57,28 @@ function context(
 }
 
 describe('AI strategic research planning', () => {
+  it('values the final conjunctive prerequisite without claiming the first tech already enables the unit', () => {
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const result = planAIResearch(context([
+        tech('archery', 'military'),
+        tech('bronze-working', 'military'),
+      ], {
+        techState: { ...createTechState(), completed: ['archery'] },
+        forceDemands: [{
+          role: 'ranged', desired: 1, assigned: 0, missing: 1, priority: 100, sourcePlanIds: ['primary'],
+        }],
+      }));
+
+      expect(result?.frontierTechId).toBe('bronze-working');
+      expect(result?.scoreComponents.activePlanFit).toBeGreaterThan(0);
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
   it('chooses the available prerequisite toward a modern frontline unit', () => {
     const result = planAIResearch(context([
       tech('economy-now', 'economy', [], { unlocksBuildings: ['marketplace'] }),

--- a/tests/ai/ai-tech-evaluation.test.ts
+++ b/tests/ai/ai-tech-evaluation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { evaluateAITechCapabilities } from '@/ai/ai-tech-evaluation';
 import type { Tech } from '@/core/types';
 import { TECH_TREE } from '@/systems/tech-definitions';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
 
 describe('structured AI technology capabilities', () => {
   it('derives military roles and building yields from typed catalogs', () => {
@@ -37,5 +38,36 @@ describe('structured AI technology capabilities', () => {
       (capabilities.rolesUnlocked.frontline ?? 0) > 0
       || (capabilities.rolesUnlocked['air-combat'] ?? 0) > 0,
     )).toBe(true);
+  });
+
+  it('does not claim a role is unlocked until every conjunctive unit gate is complete', () => {
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const archery = TECH_TREE.find(tech => tech.id === 'archery')!;
+      expect(evaluateAITechCapabilities(archery, new Set(['archery'])).rolesUnlocked.ranged)
+        .toBeUndefined();
+      expect(evaluateAITechCapabilities(archery, new Set(['archery', 'bronze-working'])).rolesUnlocked.ranged)
+        .toBeGreaterThan(0);
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
+  it('credits the final conjunctive technology when it completes an earlier unit unlock', () => {
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const bronzeWorking = TECH_TREE.find(tech => tech.id === 'bronze-working')!;
+      expect(evaluateAITechCapabilities(
+        bronzeWorking,
+        new Set(['archery', 'bronze-working']),
+        new Set(['archery', 'bronze-working']),
+      ).rolesUnlocked.ranged).toBeGreaterThan(0);
+    } finally {
+      archer.requiredTechs = original;
+    }
   });
 });

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -256,6 +256,21 @@ describe('isCityCoastal', () => {
 });
 
 describe('getAvailableBuildings', () => {
+  it('does not offer a building until every conjunctive technology is complete', () => {
+    const map = generateMap(30, 30, 'conjunctive-building-tech-gate');
+    const landTile = Object.values(map.tiles).find(tile => tile.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const library = BUILDINGS.library;
+    const original = library.requiredTechs;
+    library.requiredTechs = ['mathematics'];
+    try {
+      expect(getAvailableBuildings(city, ['writing'], map).some(building => building.id === 'library')).toBe(false);
+      expect(getAvailableBuildings(city, ['writing', 'mathematics'], map).some(building => building.id === 'library')).toBe(true);
+    } finally {
+      library.requiredTechs = original;
+    }
+  });
+
   it('returns buildings the city can build', () => {
     const map = generateMap(30, 30, 'city-test');
     const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
@@ -420,6 +435,39 @@ describe('#443 — building obsolescence data', () => {
 });
 
 describe('MR8 — naval roster gating', () => {
+  it('does not offer a unit until every conjunctive technology is complete', () => {
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      expect(getTrainableUnitsForCiv(['archery']).some(unit => unit.type === 'archer')).toBe(false);
+      expect(getTrainableUnitsForCiv(['archery', 'bronze-working']).some(unit => unit.type === 'archer')).toBe(true);
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
+  it('dequeues a saved production item that a newly added conjunction makes ineligible', () => {
+    const map = generateMap(10, 10, 'conjunctive-queue-save-compat');
+    const landTile = Object.values(map.tiles).find(tile => tile.terrain === 'grassland' || tile.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      productionQueue: ['archer'],
+    };
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const result = processCity(city, map, 2, 3, undefined, ['archery']);
+      expect(result.city.productionQueue).not.toContain('archer');
+      expect(result.droppedProductionItems).toEqual([
+        { itemId: 'archer', itemKind: 'unit', reason: 'no-longer-available' },
+      ]);
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
   it('trireme is trainable through era 5 and obsoletes at frigate-construction', () => {
     expect(getTrainableUnitsForCiv(['triremes']).some(u => u.type === 'trireme')).toBe(true);
     expect(getTrainableUnitsForCiv(['triremes', 'frigate-construction']).some(u => u.type === 'trireme')).toBe(false);

--- a/tests/systems/production-prerequisites.test.ts
+++ b/tests/systems/production-prerequisites.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateProductionPrerequisites,
+  getRequiredTechIds,
+  validateProductionPrerequisiteDefinitions,
+} from '@/systems/production-prerequisites';
+
+describe('production prerequisites', () => {
+  it('treats the legacy single-tech gate as one ordered requirement', () => {
+    expect(evaluateProductionPrerequisites(
+      { techRequired: 'bronze-working' },
+      ['bronze-working'],
+    )).toEqual({
+      required: ['bronze-working'],
+      satisfied: ['bronze-working'],
+      missing: [],
+    });
+  });
+
+  it('requires every conjunctive technology and preserves definition order', () => {
+    const definition = { techRequired: 'bronze-working', requiredTechs: ['iron-forging', 'engineering'] };
+
+    expect(getRequiredTechIds(definition)).toEqual([
+      'bronze-working',
+      'iron-forging',
+      'engineering',
+    ]);
+    expect(evaluateProductionPrerequisites(definition, ['bronze-working', 'engineering'])).toEqual({
+      required: ['bronze-working', 'iron-forging', 'engineering'],
+      satisfied: ['bronze-working', 'engineering'],
+      missing: ['iron-forging'],
+    });
+  });
+
+  it.each([
+    ['legacy gate only', ['bronze-working'], ['bronze-working'], ['iron-forging']],
+    ['additional gate only', ['iron-forging'], ['iron-forging'], ['bronze-working']],
+  ])('keeps %s incomplete until both gates are complete', (_label, completed, satisfied, missing) => {
+    expect(evaluateProductionPrerequisites(
+      { techRequired: 'bronze-working', requiredTechs: ['iron-forging'] },
+      completed,
+    )).toMatchObject({
+      required: ['bronze-working', 'iron-forging'],
+      satisfied,
+      missing,
+    });
+  });
+
+  it('reports distinct catalog-definition errors for empty, duplicate, and unknown gates', () => {
+    expect(validateProductionPrerequisiteDefinitions(
+      [
+        { id: 'empty', requiredTechs: [] },
+        { id: 'duplicate', techRequired: 'alpha', requiredTechs: ['alpha'] },
+        { id: 'unknown', requiredTechs: ['omega'] },
+        { id: 'unreachable', requiredTechs: ['beta'] },
+      ],
+      new Set(['alpha', 'beta']),
+      new Set(['alpha']),
+    )).toEqual([
+      'empty: requiredTechs must not be empty',
+      'duplicate: duplicate prerequisite alpha',
+      'unknown: unknown prerequisite omega',
+      'unreachable: unreachable prerequisite beta',
+    ]);
+  });
+});

--- a/tests/systems/tech-unlocks-consistency.test.ts
+++ b/tests/systems/tech-unlocks-consistency.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
+import { validateProductionPrerequisiteDefinitions } from '@/systems/production-prerequisites';
 
 describe('tech.unlocks copy matches gameplay gating', () => {
   it('every "Unlock <Name> building" claim corresponds to a building gated by that tech', () => {
@@ -65,6 +66,26 @@ describe('tech.unlocks must contain only effect text', () => {
 });
 
 describe('tech structured unlock arrays', () => {
+  it('has only known, non-duplicated production prerequisites across the full catalog', () => {
+    const knownTechIds = new Set(TECH_TREE.map(tech => tech.id));
+    const reachableTechIds = new Set(TECH_TREE
+      .filter(tech => tech.prerequisites.length === 0)
+      .map(tech => tech.id));
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const tech of TECH_TREE) {
+        if (reachableTechIds.has(tech.id) || !tech.prerequisites.every(id => reachableTechIds.has(id))) continue;
+        reachableTechIds.add(tech.id);
+        changed = true;
+      }
+    }
+    expect(validateProductionPrerequisiteDefinitions([
+      ...TRAINABLE_UNITS.map(unit => ({ ...unit, id: unit.type })),
+      ...Object.values(BUILDINGS),
+    ], knownTechIds, reachableTechIds)).toEqual([]);
+  });
+
   it('never exposes pirate hulls through technology unlocks', () => {
     const unlockedUnits = new Set(TECH_TREE.flatMap(tech => tech.unlocksUnits ?? []));
     for (const hull of PIRATE_HULL_TYPES) expect(unlockedUnits.has(hull), hull).toBe(false);

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -287,6 +287,19 @@ describe('applyUnitUpgradeToState', () => {
       .toMatchObject({ canUpgrade: true, missing: [] });
   });
 
+  it('reports every missing conjunctive target technology', () => {
+    const { state } = setup();
+    const target = TRAINABLE_UNITS.find(entry => entry.type === 'spy_informant')!;
+    const original = target.requiredTechs;
+    target.requiredTechs = ['disguise'];
+    try {
+      expect(evaluateUnitUpgrade(state, 'upgrade-unit', 'spy_informant').missing)
+        .toContainEqual({ kind: 'technology', techId: 'disguise' });
+    } finally {
+      target.requiredTechs = original;
+    }
+  });
+
   it('reports a full helicopter base for an explicit cross-domain upgrade fixture', () => {
     const { state, city } = setup();
     const definitions = TRAINABLE_UNITS.map(entry => entry.type === 'tank'

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createCityPanel } from '@/ui/city-panel';
 import { SESSION_SHOWN_TIPS } from '@/ui/advisor-system';
 import { createUnit } from '@/systems/unit-system';
-import { BUILDINGS } from '@/systems/city-system';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { hexKey } from '@/systems/hex-utils';
 import { TECH_TREE } from '@/systems/tech-definitions';
@@ -24,6 +24,66 @@ function clickElement(element: Element | null | undefined): void {
 }
 
 describe('city-panel national projects', () => {
+  it('keeps a partially satisfied conjunctive unit gate visible with every ordered technology state', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed = ['archery'];
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const panel = createCityPanel(container, city, state, {
+        onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+      });
+      expect(collectText(panel)).toContain('Archer');
+      expect(collectText(panel)).toContain('Requires: Archery ✓ + Bronze Working');
+      expect(panel.querySelector('[data-item-id="archer"]')).toBeNull();
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
+  it('uses the current hot-seat city owner\'s prerequisites without leaking another human\'s research', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations['player-2'] = {
+      ...structuredClone(state.civilizations.player),
+      id: 'player-2', isHuman: true,
+      techState: { ...state.civilizations.player.techState, completed: ['archery'] },
+    };
+    state.civilizations.player.techState.completed = ['archery', 'bronze-working'];
+    city.owner = 'player-2';
+    state.currentPlayer = 'player-2';
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const panel = createCityPanel(container, city, state, {
+        onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+      });
+      expect(collectText(panel)).toContain('Requires: Archery ✓ + Bronze Working');
+      expect(panel.querySelector('[data-item-id="archer"]')).toBeNull();
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
+  it('keeps a conjunctively gated building reachable in the explanatory catalog', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed = ['writing'];
+    const library = BUILDINGS.library;
+    const original = library.requiredTechs;
+    library.requiredTechs = ['mathematics'];
+    try {
+      const panel = createCityPanel(container, city, state, {
+        onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+      });
+      expect(collectText(panel)).toContain('Library');
+      expect(collectText(panel)).toContain('Requires: Writing ✓ + Mathematics');
+      expect(panel.querySelector('[data-item-id="library"]')).toBeNull();
+    } finally {
+      library.requiredTechs = original;
+    }
+  });
+
   it('uses the city owner research for hot-seat building availability', () => {
     const { container, city, state } = makeWonderPanelFixture();
     state.civilizations['player-2'] = {

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
-import { foundCity } from '@/systems/city-system';
+import { foundCity, TRAINABLE_UNITS } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
 import { enqueueResearch } from '@/systems/planning-system';
 import { startResearch, TECH_TREE } from '@/systems/tech-system';
@@ -12,6 +12,23 @@ import { createTechPanel, formatTechNodeEta } from '@/ui/tech-panel';
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
 describe('tech-panel', () => {
+  it('explains an unlocked unit\'s remaining conjunctive technology in the inspector', () => {
+    const state = createNewGame(undefined, 'tech-conjunctive-inspector');
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const panel = createTechPanel(document.body, state, {
+        onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
+      });
+      panel.querySelector<HTMLButtonElement>('[data-zoom="all"]')!.click();
+      panel.querySelector<HTMLButtonElement>('[data-tech-id="archery"]')!.click();
+      expect(panel.textContent).toContain('Archer (requires Archery ✓ + Bronze Working)');
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
   it('groups techs by readable tracks and emphasizes current / next relevant research', () => {
     const state = createNewGame(undefined, 'tech-panel-test');
     const firstAvailable = state.civilizations.player.techState.completed.length === 0

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -14,6 +14,8 @@ const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1
 describe('tech-panel', () => {
   it('explains an unlocked unit\'s remaining conjunctive technology in the inspector', () => {
     const state = createNewGame(undefined, 'tech-conjunctive-inspector');
+    state.civilizations.player.techState.completed = ['stone-weapons'];
+    state.civilizations.player.techState.currentResearch = 'archery';
     const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
     const original = archer.requiredTechs;
     archer.requiredTechs = ['bronze-working'];
@@ -21,8 +23,7 @@ describe('tech-panel', () => {
       const panel = createTechPanel(document.body, state, {
         onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
       });
-      panel.querySelector<HTMLButtonElement>('[data-zoom="all"]')!.click();
-      panel.querySelector<HTMLButtonElement>('[data-tech-id="archery"]')!.click();
+      expect(panel.querySelector('[data-tech-id="archery"]')).toBeTruthy();
       expect(panel.textContent).toContain('Archer (requires Archery ✓ + Bronze Working)');
     } finally {
       archer.requiredTechs = original;


### PR DESCRIPTION
Closes #666

## Summary

- Adds ordered `requiredTechs` metadata plus one canonical evaluator for legacy and multi-tech production gates.
- Wires the evaluator through human/AI production, upgrades, AI research capability scoring, city locked-item explanations, and research unlock copy.
- Keeps a blocked unit or building discoverable with an accessible `Requires: A ✓ + B` explanation, validates catalog prerequisite data, and preserves the existing save-queue revalidation policy.

## Inline review

- Balance, difficulty modes, and existing game pacing are unchanged until a catalog entry opts into the new metadata; no combat, cost, SFX, or save-schema changes.
- The UI uses an ordered text checklist rather than color alone; coverage includes normal solo play, AI use, saved queues, and two-human hot-seat ownership isolation.
- The canonical helper keeps future prerequisite extensions data-driven and avoids UI-only or AI-only eligibility rules.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` — 431 files passed; 7,090 tests passed; 3 skipped; hooks passed
- focused production, upgrade, AI production/research, city/tech UI, hot-seat, save-queue, and catalog-integrity suites
- `scripts/check-src-rule-violations.sh` for every changed source file
- `git diff --check`