### PR TITLE
fix(ui): resolve research, unit, diplomacy, and map viewport regressions

### DIFF
--- a/docs/superpowers/plans/2026-07-25-issue-735-736-738-fixes.md
+++ b/docs/superpowers/plans/2026-07-25-issue-735-736-738-fixes.md
@@ -1,0 +1,18 @@
+# Implementation plan: #735, #736, #738 and diplomacy eligibility
+
+1. Add regression tests for each root cause before behavior changes:
+   campaign/hot-seat required-choice entry wiring, unique upgrade prerequisites
+   and compact unit-card presentation, selected-card Auto-explore, and stale
+   zero-city diplomacy rows.
+2. Centralize major-civ panel eligibility around the authoritative city map,
+   then use it when constructing diplomacy rows.
+3. Deduplicate upgrade requirements in the canonical evaluator. Render an
+   explicit compact upgrade-readiness section and cap the unit-card width
+   without changing upgrade rules or AI behavior.
+4. Add an eligible unit-card Auto-explore CTA wired to the existing callback;
+   retain the context-menu entry for desktop discoverability and cancellation.
+5. Invoke existing required-choice logic when a human turn is actually opened
+   (initial campaign, solo completion, and released hot-seat handoff), after
+   state/render ownership switches are complete.
+6. Run focused tests, source-rule checks, full test/build validation, and
+   inspect committed plus working-tree diffs.

--- a/docs/superpowers/specs/2026-07-25-issue-735-736-738-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-25-issue-735-736-738-fixes-design.md
@@ -1,0 +1,63 @@
+# Issues #735, #736, #738 and eliminated-civ diplomacy design
+
+## Scope
+
+- #735: require a research choice as soon as a human opens a turn with no active
+  research and reachable technology remains.
+- #736: make upgrade readiness compact and understandable, and eliminate
+  duplicate prerequisites.
+- #738: expose Auto-explore directly from a selected eligible unit.
+- Do not list major civilizations that have no valid owned cities, even if a
+  legacy/save-state `isEliminated` flag is missing.
+
+## Root causes
+
+1. Required choices are evaluated only by `endTurn()`. Round completion and
+   hot-seat handoff create the new player turn without evaluating them.
+2. Upgrade evaluation independently adds the source obsolescence technology
+   and target production technology, allowing identical technology entries.
+   The renderer displays every entry as an independent, icon-heavy line and
+   the selected-unit panel has no maximum readable width.
+3. Auto-explore is reachable only from the secondary context menu until it is
+   active, at which point only cancellation is visible in the main unit card.
+4. Diplomacy rows only filter `isEliminated`, which is derived state. Older
+   saves can retain a zero-city major civ without that flag.
+
+## Player truth table
+
+| Before | Action / transition | Immediate visible result |
+| --- | --- | --- |
+| A human opens a turn with reachable technology and no current research | Campaign start, solo round completion, or hot-seat handoff | The existing required-choice panel opens before normal input. |
+| An archer cannot upgrade because it needs a city, Tactics, and Copper | Select the unit | A compact `Upgrade to Crossbowman` readiness section names each unique requirement in plain language. |
+| An eligible scout is selected | Tap `Auto-explore` | Automation starts and the same card immediately changes to its active status with `Cancel auto-explore`. |
+| A contacted major civ has no valid owned city but stale `isEliminated` data | Open Diplomacy | No diplomacy row is shown; a civ with even one valid owned city remains visible. |
+
+## Misleading-UI boundaries
+
+- A queued/current research item means research is active, so no required
+  research panel appears.
+- Auto-explore is offered only to the current player's unautomated unit; an
+  already automated unit must show cancellation instead of a duplicate start.
+- Upgrade requirements are deduplicated by requirement identity. Distinct
+  missing requirements remain visible, including resource and host-city gates.
+- A stale zero-city civ is not an active diplomatic counterpart. A stale city
+  id that no longer resolves to a city, or resolves to a city owned by another
+  civ, does not keep the row alive.
+
+## Interaction replay coverage
+
+- Open a solo campaign and a hot-seat recipient turn with missing research;
+  assert the choice surface opens after the handoff is released.
+- Render a blocked upgrade with overlapping technology gates; assert one
+  readable technology requirement plus its distinct blockers.
+- Click Auto-explore from the selected-unit card and assert the callback and
+  active-state card presentation; verify an already automated unit does not
+  offer the start action.
+- Render Diplomacy for a known stale zero-city civ and for a civ with one
+  valid city.
+
+## Save compatibility
+
+No save schema change is required. The diplomacy eligibility check is derived
+from existing `cities` and `state.cities` data, preserving historical
+civilization records while preventing stale records from becoming interactable.

--- a/src/main.ts
+++ b/src/main.ts
@@ -410,6 +410,15 @@ legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
 
 // --- Resize ---
 window.addEventListener('resize', () => renderLoop.resizeCanvas());
+
+function setMapViewportBottomInset(height: number): void {
+  canvas.style.bottom = `${height}px`;
+  // With both top and bottom set, an auto height makes the canvas occupy only
+  // the remaining map viewport instead of living behind the action bar.
+  canvas.style.height = 'auto';
+  renderLoop.resizeCanvas();
+}
+
 window.addEventListener('keydown', event => {
   if (event.key === 'Escape' && pendingJourneyUnitId) {
     pendingJourneyUnitId = null;
@@ -455,6 +464,7 @@ function createUI(): void {
       uiLayer.appendChild(overlay);
     },
     onOpenWonderAtlas: () => openWonderAtlas(),
+    onBottomBarHeightChange: setMapViewportBottomInset,
     onOpenMenu: () => {
       showPauseMenu(uiLayer, {
         turn: gameState.turn,
@@ -2188,6 +2198,7 @@ function selectUnit(
         updateHUD();
         selectUnit(uid);
       },
+      onStartAutoExplore: uid => startAutoExplore(uid),
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
       onCancelJourney: () => cancelJourney(unitId),
       onOpenStack: (coord) => {
@@ -3905,7 +3916,8 @@ function releaseHandoffToViewer(nextSlotId: string): void {
   audio.setMasterVolume(currentMasterVolume);
   setBlockingOverlay(null);
   emitCurrentPlayerAudioSnapshot(nextSlotId);
-  handleVictoryIfNeeded();
+  if (handleVictoryIfNeeded()) return;
+  showRequiredChoicesIfNeeded();
 }
 
 /** These player-owned surfaces may contain strategic targets; never carry them across a hot-seat veil. */
@@ -4130,6 +4142,7 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       renderLoop.setGameState(gameState);
       await replayAIMoves(soloMoves);
       updateHUD();
+      showRequiredChoicesIfNeeded();
 
       showNotification(`Turn ${gameState.turn}`, 'info');
       advisorSystem.check(gameState);
@@ -4932,6 +4945,14 @@ async function init(): Promise<void> {
   persistedSettings = await loadSettings();
 
   if (import.meta.env.MODE === 'e2e') {
+    // Browser tests must target the same live camera transform as player input;
+    // exposing only viewport copies keeps game state and camera internals private.
+    window.__CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__ = coord => getVisibleHexViewportCopies(
+      gameState,
+      renderLoop.camera,
+      gameState.currentPlayer,
+      coord,
+    );
     const { isExactAutosaveE2ERequest } = await import('@/testing/e2e-mode');
     if (isExactAutosaveE2ERequest(import.meta.env.MODE, window.location.search)) {
       const { installE2ERuntime } = await import('@/testing/e2e-runtime');
@@ -5408,6 +5429,7 @@ function startGame(): Promise<void> {
 
   // Initial advisor check
   advisorSystem.check(gameState);
+  showRequiredChoicesIfNeeded();
 
   // Start render loop
   renderLoop.start();

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -382,7 +382,9 @@ export class RenderLoop {
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
-    this.ctx.scale(dpr, dpr);
+    // resizeCanvas can run after responsive UI changes as well as window
+    // resizes. Reset first so repeated calls never compound the DPR scale.
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     this.camera.setViewport(rect.width, rect.height);
   }
 

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -75,7 +75,9 @@ export function evaluateUnitUpgrade(
     missing.push({ kind: 'technology', techId: source.obsoletedByTech });
   }
   for (const techId of evaluateProductionPrerequisites(target, civ?.techState.completed ?? []).missing) {
-    missing.push({ kind: 'technology', techId });
+    if (!missing.some(requirement => requirement.kind === 'technology' && requirement.techId === techId)) {
+      missing.push({ kind: 'technology', techId });
+    }
   }
   if (target.trainedFromBuilding && !city?.buildings.includes(target.trainedFromBuilding)) {
     missing.push({ kind: 'building', buildingId: target.trainedFromBuilding });

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -113,6 +113,10 @@ interface MinorCivRowData {
   atWar: boolean;
 }
 
+function hasValidOwnedCity(state: GameState, civId: string): boolean {
+  return Object.values(state.cities).some(city => city.owner === civId);
+}
+
 export function createDiplomacyPanel(
   container: HTMLElement,
   state: GameState,
@@ -158,6 +162,7 @@ export function createDiplomacyPanel(
   for (const [civId, civ] of Object.entries(state.civilizations)) {
     if (civId === state.currentPlayer) continue;
     if (civ.isEliminated) continue;
+    if (!hasValidOwnedCity(state, civId)) continue;
     if (!shouldListMajorCivForViewer(state, state.currentPlayer, civId)) continue;
 
     const civDef = resolveCivDefinition(state, civ.civType ?? '');

--- a/src/ui/game-shell.ts
+++ b/src/ui/game-shell.ts
@@ -7,13 +7,45 @@ export interface GameShellCallbacks extends PrimaryActionBarCallbacks {
   onOpenWonderAtlas: () => void;
   onOpenPirateWaters?: () => void;
   onOpenMenu: () => void;
+  /** Keeps the canvas viewport above the bottom action bar as its height changes. */
+  onBottomBarHeightChange?: (height: number) => void;
   iconLegendOverlay?: HTMLElement;
 }
 
+let stopBottomBarLayoutTracking: (() => void) | undefined;
+
 function removeExistingShell(container: HTMLElement): void {
+  stopBottomBarLayoutTracking?.();
+  stopBottomBarLayoutTracking = undefined;
   for (const id of ['game-shell', 'hud', 'bottom-bar', 'btn-next-unit', 'btn-notif-log', 'btn-icon-legend', 'btn-wonder-atlas', 'btn-pirate-waters', 'notifications', 'info-panel', 'icon-legend']) {
     container.querySelector(`#${id}`)?.remove();
   }
+}
+
+function trackBottomBarLayout(
+  container: HTMLElement,
+  bottomBar: HTMLElement,
+  onBottomBarHeightChange: GameShellCallbacks['onBottomBarHeightChange'],
+): () => void {
+  const sync = () => {
+    // 88px is the compact action bar's minimum touch-safe height. The measured
+    // value takes over when labels wrap or a device needs more room.
+    const height = Math.max(88, Math.ceil(bottomBar.getBoundingClientRect().height));
+    container.style.setProperty('--bottom-ui-height', `${height}px`);
+    onBottomBarHeightChange?.(height);
+  };
+
+  sync();
+  window.addEventListener('resize', sync);
+  const observer = typeof ResizeObserver === 'undefined'
+    ? undefined
+    : new ResizeObserver(sync);
+  observer?.observe(bottomBar);
+
+  return () => {
+    window.removeEventListener('resize', sync);
+    observer?.disconnect();
+  };
 }
 
 function createHud(): HTMLDivElement {
@@ -41,7 +73,8 @@ export function createGameShell(container: HTMLElement, callbacks: GameShellCall
   shell.id = 'game-shell';
 
   shell.appendChild(createHud());
-  shell.appendChild(createPrimaryActionBar(callbacks));
+  const bottomBar = createPrimaryActionBar(callbacks);
+  shell.appendChild(bottomBar);
 
   const utilityToolbar = document.createElement('div');
   utilityToolbar.id = 'utility-toolbar';
@@ -72,9 +105,11 @@ export function createGameShell(container: HTMLElement, callbacks: GameShellCall
 
   const infoPanel = document.createElement('div');
   infoPanel.id = 'info-panel';
-  infoPanel.style.cssText = 'position:absolute;bottom:80px;left:12px;right:12px;z-index:10;display:none;';
+  infoPanel.setAttribute('aria-label', 'Selected unit details and actions (scroll for more)');
+  infoPanel.style.cssText = 'position:absolute;bottom:calc(var(--bottom-ui-height) + 12px);left:12px;width:calc(100% - 24px);max-width:620px;max-height:calc(100% - 84px - var(--bottom-ui-height));overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;z-index:10;display:none;';
   shell.appendChild(infoPanel);
 
   container.appendChild(shell);
+  stopBottomBarLayoutTracking = trackBottomBarLayout(container, bottomBar, callbacks.onBottomBarHeightChange);
   return shell;
 }

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -73,6 +73,7 @@ export interface SelectedUnitInfoCallbacks {
   onDeleteUnit?: (unitId: string) => void;
   onFortify?: (unitId: string) => void;
   onPillage?: (unitId: string) => void;
+  onStartAutoExplore?: (unitId: string) => void;
   onCancelAutoExplore?: () => void;
   onCancelJourney?: () => void;
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
@@ -244,6 +245,12 @@ export function renderSelectedUnitInfo(
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
 
+  const scrollCue = document.createElement('div');
+  scrollCue.dataset.scrollCue = 'true';
+  scrollCue.style.cssText = 'display:none;margin-top:6px;font-size:11px;font-weight:700;color:#f8d28a;letter-spacing:0.01em;';
+  scrollCue.textContent = '↓ More details and actions below — scroll';
+  wrapper.appendChild(scrollCue);
+
   if (unit.airBase && def.airOperation) {
     const baseName = unit.airBase.kind === 'city'
       ? `${state.cities[unit.airBase.cityId]?.name ?? 'Unknown'} Airfield`
@@ -356,6 +363,12 @@ export function renderSelectedUnitInfo(
 
   const actionsDiv = document.createElement('div');
   actionsDiv.style.cssText = 'margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;';
+
+  if (unit.owner === state.currentPlayer && !unit.automation && callbacks.onStartAutoExplore) {
+    const autoExplore = makeButton('Auto-explore', '#0f766e', () => callbacks.onStartAutoExplore!(unitId));
+    autoExplore.title = 'Explore nearby unknown land automatically until you cancel or the unit can no longer continue.';
+    actionsDiv.appendChild(autoExplore);
+  }
 
   if (unit.transportId) {
     const transport = state.units[unit.transportId];
@@ -790,14 +803,14 @@ export function renderSelectedUnitInfo(
       const requirementLabel = (requirement: UpgradeMissingRequirement): string => {
         const displayId = (id: string) => id.split('_').map(word => word[0]!.toUpperCase() + word.slice(1)).join(' ');
         switch (requirement.kind) {
-          case 'technology': return `📜 Requires technology: ${displayId(requirement.techId)}`;
-          case 'building': return `🏛️ Requires building: ${displayId(requirement.buildingId)}`;
-          case 'resource': return `⛏️ Requires resource: ${requirement.resource}`;
-          case 'gold': return `💰 Requires ${requirement.required} gold (have ${requirement.available})`;
-          case 'friendly-city': return '🏙️ Must be in a friendly city';
-          case 'action-already-spent': return '⏳ This unit has already acted';
-          case 'air-base': return `🛬 Air base unavailable: ${requirement.reason}`;
-          default: return '⚠️ Upgrade target is unavailable';
+          case 'technology': return `Research ${displayId(requirement.techId)}`;
+          case 'building': return `Build ${displayId(requirement.buildingId)}`;
+          case 'resource': return `Acquire ${requirement.resource}`;
+          case 'gold': return `Need ${requirement.required} gold (have ${requirement.available})`;
+          case 'friendly-city': return 'Move into one of your cities';
+          case 'action-already-spent': return 'Wait until next turn';
+          case 'air-base': return `Air base unavailable: ${requirement.reason.replace(/-/g, ' ')}`;
+          default: return 'Upgrade target is unavailable';
         }
       };
       if (upgrade.canUpgrade && upgrade.cityId) {
@@ -814,12 +827,15 @@ export function renderSelectedUnitInfo(
         });
         actionsDiv.appendChild(upgradeButton);
       } else if (upgrade.targetType) {
-        for (const requirement of upgrade.missing) {
-          const blocker = document.createElement('div');
-          blocker.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
-          blocker.textContent = requirementLabel(requirement);
-          wrapper.appendChild(blocker);
-        }
+        const readiness = document.createElement('div');
+        readiness.style.cssText = 'margin-top:8px;padding:8px 10px;border-radius:8px;background:rgba(232,193,112,0.1);border:1px solid rgba(232,193,112,0.28);font-size:11px;color:#f8d28a;line-height:1.45;';
+        const heading = document.createElement('strong');
+        heading.textContent = `Upgrade to ${UNIT_DEFINITIONS[upgrade.targetType].name} needs:`;
+        readiness.appendChild(heading);
+        const details = document.createElement('div');
+        details.textContent = upgrade.missing.map(requirementLabel).join(' · ');
+        readiness.appendChild(details);
+        wrapper.appendChild(readiness);
       }
     }
   }
@@ -829,4 +845,12 @@ export function renderSelectedUnitInfo(
   }
 
   container.appendChild(wrapper);
+
+  const updateScrollCue = () => {
+    const hasOverflow = container.scrollHeight > container.clientHeight + 1;
+    const isAtBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
+    scrollCue.style.display = hasOverflow && !isAtBottom ? 'block' : 'none';
+  };
+  updateScrollCue();
+  container.onscroll = updateScrollCue;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,4 +10,7 @@ interface ImportMeta {
 
 interface Window {
   __CONQUESTORIA_E2E_DIAGNOSTICS__?: import('@/testing/e2e-runtime').E2EDiagnostics;
+  __CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__?: (
+    coord: import('@/core/types').HexCoord,
+  ) => Array<{ x: number; y: number }>;
 }

--- a/tests/e2e/issue-365-map-presentation.spec.ts
+++ b/tests/e2e/issue-365-map-presentation.spec.ts
@@ -44,15 +44,19 @@ async function continueFixture(page: Page): Promise<void> {
   ).click();
   await page.getByRole('button', { name: 'Continue Campaign', exact: true }).click();
   await expect(continueButton).toBeHidden();
+  const requiredChoices = page.locator('#required-choice-panel');
+  await expect(requiredChoices).toBeVisible();
+  await requiredChoices.locator('section').first().getByRole('button').first().click();
+  await expect(requiredChoices).toBeHidden();
   await expect(page.locator('#game-canvas')).toBeVisible();
-  await page.waitForTimeout(500);
 }
 
-function pointyHexPixel(coord: { q: number; r: number }): { x: number; y: number } {
-  return {
-    x: Math.sqrt(3) * (coord.q + coord.r / 2) * 48,
-    y: 1.5 * coord.r * 48,
-  };
+async function clickVisibleHex(page: Page, coord: { q: number; r: number }): Promise<void> {
+  const point = await page.evaluate((target) => (
+    window.__CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__?.(target)[0]
+  ), coord);
+  expect(point, `Expected ${coord.q},${coord.r} to be visible in the live camera`).toBeDefined();
+  await page.mouse.click(point!.x, point!.y);
 }
 
 function findMoveTarget(origin: { q: number; r: number }): { q: number; r: number } {
@@ -118,19 +122,14 @@ test('moving a member out of the crowded stack preserves its rendered size', asy
   const stack = await getOnScreenCopy(page, '#unit-sprites > [data-member-ids*="issue-365-lead"]');
   const before = stack.box;
 
-  await page.mouse.click(before.x + before.width / 2, before.y + before.height / 2);
+  await clickVisibleHex(page, FIXTURE.units['issue-365-lead'].position);
   const leadButton = page.locator('[data-unit-stack-item="true"][data-unit-id="issue-365-lead"]');
   await expect(leadButton).toBeVisible();
   await leadButton.click();
 
   const origin = FIXTURE.units['issue-365-lead'].position;
   const target = findMoveTarget(origin);
-  const originPixel = pointyHexPixel(origin);
-  const targetPixel = pointyHexPixel(target);
-  await page.mouse.click(
-    before.x + before.width / 2 + targetPixel.x - originPixel.x,
-    before.y + before.height / 2 + targetPixel.y - originPixel.y,
-  );
+  await clickVisibleHex(page, target);
 
   await expect(page.locator('#unit-sprites > [data-entity-id="issue-365-lead"]')).not.toHaveCount(0, { timeout: 5_000 });
   const moved = await getOnScreenCopy(page, '#unit-sprites > [data-entity-id="issue-365-lead"]');

--- a/tests/e2e/issue-447-water-recovery.spec.ts
+++ b/tests/e2e/issue-447-water-recovery.spec.ts
@@ -51,81 +51,47 @@ async function continueFixture(page: Page): Promise<void> {
   ).click();
   await page.getByRole('button', { name: 'Continue Campaign', exact: true }).click();
   await expect(continueButton).toBeHidden();
+  const requiredChoices = page.locator('#required-choice-panel');
+  await expect(requiredChoices).toBeVisible();
+  await requiredChoices.locator('section').first().getByRole('button').first().click();
+  await expect(requiredChoices).toBeHidden();
   await expect(page.locator('#game-canvas')).toBeVisible();
-  await page.waitForTimeout(500);
 }
 
-function pointyHexPixel(coord: { q: number; r: number }): { x: number; y: number } {
-  return {
-    x: Math.sqrt(3) * (coord.q + coord.r / 2) * 48,
-    y: 1.5 * coord.r * 48,
-  };
+async function clickVisibleHex(page: Page, coord: { q: number; r: number }): Promise<void> {
+  const point = await page.evaluate((target) => (
+    window.__CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__?.(target)[0]
+  ), coord);
+  expect(point, `Expected ${coord.q},${coord.r} to be visible in the live camera`).toBeDefined();
+  await page.mouse.click(point!.x, point!.y);
 }
 
-async function getOnScreenBox(page: Page, selector: string) {
-  const locator = page.locator(selector);
-  const viewport = page.viewportSize()!;
-  const count = await locator.count();
-  for (let index = 0; index < count; index++) {
-    const box = await locator.nth(index).boundingBox();
-    if (
-      box
-      && box.x + box.width > 0
-      && box.y + box.height > 0
-      && box.x < viewport.width
-      && box.y < viewport.height
-    ) {
-      return box;
-    }
-  }
-  throw new Error(`No on-screen copy for ${selector}`);
-}
-
-async function selectLeadWarrior(page: Page) {
-  const stackBox = await getOnScreenBox(
-    page,
-    '#unit-sprites > [data-member-ids*="issue-365-lead"]',
-  );
-  await page.mouse.click(
-    stackBox.x + stackBox.width / 2,
-    stackBox.y + stackBox.height / 2,
-  );
+async function selectLeadWarrior(page: Page): Promise<void> {
+  await clickVisibleHex(page, ORIGIN);
   const leadButton = page.locator(
     '[data-unit-stack-item="true"][data-unit-id="issue-365-lead"]',
   );
   await expect(leadButton).toBeVisible();
   await leadButton.click();
-  return stackBox;
-}
-
-async function clickHexFromOrigin(
-  page: Page,
-  originBox: { x: number; y: number; width: number; height: number },
-  target: { q: number; r: number },
-): Promise<void> {
-  const originPixel = pointyHexPixel(ORIGIN);
-  const targetPixel = pointyHexPixel(target);
-  await page.mouse.click(
-    originBox.x + originBox.width / 2 + targetPixel.x - originPixel.x,
-    originBox.y + originBox.height / 2 + targetPixel.y - originPixel.y,
-  );
 }
 
 test('saved water unit stays selected after a blocked tap and can return ashore', async ({ page }, testInfo) => {
   await installFixture(page);
   await continueFixture(page);
-  const originBox = await selectLeadWarrior(page);
+  await selectLeadWarrior(page);
   const guidance = page.locator('[data-water-recovery-kind="recoverable"]');
 
   await expect(guidance).toContainText('Move to an amber land tile to return ashore.');
   expect(await page.evaluate(() => window.__issue447AmberFills ?? 0)).toBeGreaterThan(0);
 
   await page.evaluate(() => { window.__issue447ToneFrequencies = []; });
-  await clickHexFromOrigin(page, originBox, WATER_TARGET);
+  await clickVisibleHex(page, WATER_TARGET);
 
-  await expect(page.locator('#notifications')).toContainText(
+  await page.locator('#btn-notif-log').click();
+  await expect(page.locator('#notification-log')).toContainText(
     'Move this land unit to an amber land tile to return ashore',
   );
+  await page.locator('#close-log').click();
   await expect(guidance).toBeVisible();
   const blockedTapTones = await page.evaluate(() => window.__issue447ToneFrequencies ?? []);
   expect(blockedTapTones).toContain(200);
@@ -135,7 +101,7 @@ test('saved water unit stays selected after a blocked tap and can return ashore'
     fullPage: true,
   });
 
-  await clickHexFromOrigin(page, originBox, LAND_EXIT);
+  await clickVisibleHex(page, LAND_EXIT);
 
   await expect(guidance).toHaveCount(0);
   await expect(page.locator(

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -40,6 +40,20 @@ describe('campaign entry wiring', () => {
     expect(main).not.toContain('window.gameState');
     expect(main).not.toContain('window.renderLoop');
   });
+
+  it('opens required research choices whenever a human turn becomes playable', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const release = main.slice(
+      main.indexOf('function releaseHandoffToViewer'),
+      main.indexOf('/** These player-owned surfaces may contain strategic targets'),
+    );
+    const start = main.slice(main.indexOf('function startGame()'), main.indexOf('\ninit();'));
+    const endTurn = main.slice(main.indexOf('async function endTurn'), main.indexOf('function centerOnCurrentPlayer'));
+
+    expect(release).toContain('showRequiredChoicesIfNeeded();');
+    expect(start).toContain('showRequiredChoicesIfNeeded();');
+    expect(endTurn).toMatch(/await replayAIMoves\(soloMoves\);\s*updateHUD\(\);\s*showRequiredChoicesIfNeeded\(\);/);
+  });
 });
 
 describe('player combat wiring', () => {

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -51,6 +51,8 @@ import type { GameState, Unit } from '@/core/types';
 interface LineRecordingCtx {
   moveTo: ReturnType<typeof vi.fn>;
   lineTo: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  setTransform: ReturnType<typeof vi.fn>;
 }
 
 function createCanvasWithCtx(): { canvas: HTMLCanvasElement; ctx: LineRecordingCtx } {
@@ -62,6 +64,7 @@ function createCanvasWithCtx(): { canvas: HTMLCanvasElement; ctx: LineRecordingC
     lineWidth: 0,
     globalAlpha: 1,
     scale: vi.fn(),
+    setTransform: vi.fn(),
     save: vi.fn(),
     restore: vi.fn(),
     setLineDash: vi.fn(),
@@ -145,6 +148,23 @@ describe('render-loop wrap parity', () => {
       'rgba(245, 184, 73, 0.55)',
       '#fff0a8',
     );
+  });
+
+  it('resets the device-pixel transform on every viewport resize instead of compounding it', () => {
+    const windowRef = globalThis.window as Window & typeof globalThis;
+    const originalDpr = windowRef.devicePixelRatio;
+    windowRef.devicePixelRatio = 2;
+    try {
+      const { canvas, ctx } = createCanvasWithCtx();
+      const loop = new RenderLoop(canvas);
+
+      loop.resizeCanvas();
+
+      expect(ctx.setTransform).toHaveBeenLastCalledWith(2, 0, 0, 2, 0, 0);
+      expect(ctx.scale).not.toHaveBeenCalled();
+    } finally {
+      windowRef.devicePixelRatio = originalDpr;
+    }
   });
 
   it('draws air-mission highlights with distinct strike and recon colors', () => {

--- a/tests/renderer/wonder-discovery-highlight.test.ts
+++ b/tests/renderer/wonder-discovery-highlight.test.ts
@@ -14,6 +14,7 @@ function canvas(): HTMLCanvasElement {
     save: vi.fn(),
     restore: vi.fn(),
     scale: vi.fn(),
+    setTransform: vi.fn(),
     fillStyle: '',
     globalAlpha: 1,
     lineWidth: 0,

--- a/tests/systems/helpers/breakaway-fixture.ts
+++ b/tests/systems/helpers/breakaway-fixture.ts
@@ -77,6 +77,7 @@ export function makeBreakawayFixture({
   const cityId = 'city-border';
   const capitalId = 'city-capital';
   const outsiderId = 'outsider';
+  const outsiderCityId = 'city-outsider';
 
   const capital = makeCity(capitalId, playerId, { q: 0, r: 0 });
   const city = makeCity(cityId, breakawayStartedTurn === undefined ? playerId : breakawayId, { q: 4, r: 0 }, {
@@ -84,6 +85,7 @@ export function makeBreakawayFixture({
     unrestLevel,
     unrestTurns,
   });
+  const outsiderCity = makeCity(outsiderCityId, outsiderId, { q: 6, r: 0 });
 
   const playerUnit = makeUnit('unit-player', playerId, { q: 4, r: 1 });
   const playerCapitalUnit = makeUnit('unit-player-capital', playerId, { q: 3, r: 0 });
@@ -103,6 +105,7 @@ export function makeBreakawayFixture({
         '4,0': makeTile({ q: 4, r: 0 }, city.owner),
         '3,0': makeTile({ q: 3, r: 0 }, playerId),
         '4,1': makeTile({ q: 4, r: 1 }, city.owner),
+        ...(includeThirdCiv ? { '6,0': makeTile({ q: 6, r: 0 }, outsiderId) } : {}),
       },
       wrapsHorizontally: false,
       rivers: [],
@@ -115,6 +118,7 @@ export function makeBreakawayFixture({
     cities: {
       [capital.id]: capital,
       [city.id]: city,
+      ...(includeThirdCiv ? { [outsiderCity.id]: outsiderCity } : {}),
     },
     civilizations: {
       [playerId]: {
@@ -161,7 +165,7 @@ export function makeBreakawayFixture({
           color: '#22c55e',
           isHuman: false,
           civType: 'rome',
-          cities: [],
+          cities: [outsiderCityId],
           units: [],
           techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
           gold: 500,

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -300,6 +300,19 @@ describe('applyUnitUpgradeToState', () => {
     }
   });
 
+  it('reports an overlapping source and target technology requirement only once', () => {
+    const { state, city } = setup();
+    state.units['upgrade-unit'].type = 'archer';
+    state.civilizations.player.techState.completed = [];
+    city.buildings = [];
+
+    const missing = evaluateUnitUpgrade(state, 'upgrade-unit', 'crossbowman').missing;
+
+    expect(missing.filter(requirement => requirement.kind === 'technology' && requirement.techId === 'tactics'))
+      .toHaveLength(1);
+    expect(missing).toContainEqual({ kind: 'resource', resource: 'copper' });
+  });
+
   it('reports a full helicopter base for an explicit cross-domain upgrade fixture', () => {
     const { state, city } = setup();
     const definitions = TRAINABLE_UNITS.map(entry => entry.type === 'tank'

--- a/tests/ui/desktop-controls.test.ts
+++ b/tests/ui/desktop-controls.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 
+import { vi } from 'vitest';
 import { createContextMenu } from '@/ui/context-menu';
 import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
 import { createTooltipLayer } from '@/ui/tooltip-layer';
@@ -27,6 +28,33 @@ describe('desktop controls', () => {
     expect(container.textContent).toContain('Auto-exploring');
     const menu = createContextMenu(container, state, { unitId });
     expect(menu.textContent).toContain('Cancel auto-explore');
+  });
+
+  it('offers auto-explore directly from an eligible selected-unit card', () => {
+    const { state, container, unitId } = makeDesktopControlFixture();
+    const start = vi.fn();
+
+    renderSelectedUnitInfo(container, state, unitId, { onStartAutoExplore: start });
+
+    const button = [...container.querySelectorAll('button')]
+      .find(candidate => candidate.textContent === 'Auto-explore');
+    expect(button).toBeDefined();
+    button!.click();
+    expect(start).toHaveBeenCalledWith(unitId);
+  });
+
+  it('shows compact, plain-language upgrade readiness without duplicate technology blockers', () => {
+    const { state, container, unitId } = makeDesktopControlFixture();
+    state.units[unitId].type = 'archer';
+    state.civilizations.player.techState.completed = [];
+
+    renderSelectedUnitInfo(container, state, unitId, { onUpgradeUnit: () => {} });
+
+    expect(container.textContent).toContain('Upgrade to Crossbowman needs:');
+    expect(container.textContent).toContain('Research Tactics');
+    expect(container.textContent).toContain('Acquire copper');
+    expect(container.textContent).toContain('Move into one of your cities');
+    expect(container.textContent?.match(/Research Tactics/g)).toHaveLength(1);
   });
 
   it('does not expose context actions while a blocking overlay is active', () => {

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -197,6 +197,25 @@ describe('diplomacy-panel breakaway rows', () => {
     expect(rendered).not.toContain('Outsider');
   });
 
+  it('hides a known major civ with no valid owned city even when a legacy save lacks isEliminated', () => {
+    const { container, state } = makeDiplomacyFixture({
+      currentPlayer: 'player',
+      includeThirdCiv: true,
+    });
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.outsider.knownCivilizations = ['player'];
+    state.civilizations.outsider.cities = ['missing-city'];
+    delete state.cities['city-outsider'];
+    delete state.civilizations.outsider.isEliminated;
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).not.toContain('Outsider');
+  });
+
   it('keeps a rival named in diplomacy after brief scouting contact is recorded', () => {
     const { container, state } = makeDiplomacyFixture({
       currentPlayer: 'player',

--- a/tests/ui/game-shell.test.ts
+++ b/tests/ui/game-shell.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGameShell } from '@/ui/game-shell';
 
 describe('game-shell', () => {
@@ -119,5 +119,43 @@ describe('game-shell', () => {
       'btn-pirate-waters', 'btn-pause-menu',
     ]);
     expect(toolbar?.querySelectorAll('[style*="right:"]')).toHaveLength(0);
+  });
+
+  it('caps selected-unit cards at a readable desktop width while preserving mobile width', () => {
+    const shell = createGameShell(document.body, {
+      onOpenCouncil: () => {}, onOpenTech: () => {}, onOpenCity: () => {},
+      onOpenEspionage: () => {}, onOpenDiplomacy: () => {}, onOpenMarketplace: () => {},
+      onEndTurn: () => {}, onNextUnit: () => {}, onOpenNotificationLog: () => {},
+      onToggleIconLegend: () => {}, onOpenWonderAtlas: () => {}, onOpenMenu: () => {},
+    });
+
+    const panel = shell.querySelector<HTMLElement>('#info-panel');
+    expect(panel?.style.width).toBe('calc(100% - 24px)');
+    expect(panel?.style.maxWidth).toBe('620px');
+  });
+
+  it('reserves the measured action-bar height for the map and keeps selected-unit details scrollable', () => {
+    const onBottomBarHeightChange = vi.fn();
+    const shell = createGameShell(document.body, {
+      onOpenCouncil: () => {}, onOpenTech: () => {}, onOpenCity: () => {},
+      onOpenEspionage: () => {}, onOpenDiplomacy: () => {}, onOpenMarketplace: () => {},
+      onEndTurn: () => {}, onNextUnit: () => {}, onOpenNotificationLog: () => {},
+      onToggleIconLegend: () => {}, onOpenWonderAtlas: () => {}, onOpenMenu: () => {},
+      onBottomBarHeightChange,
+    });
+    const bottomBar = shell.querySelector<HTMLElement>('#bottom-bar')!;
+    vi.spyOn(bottomBar, 'getBoundingClientRect').mockReturnValue({
+      height: 132,
+    } as DOMRect);
+
+    window.dispatchEvent(new Event('resize'));
+
+    const panel = shell.querySelector<HTMLElement>('#info-panel');
+    expect(onBottomBarHeightChange).toHaveBeenLastCalledWith(132);
+    expect(document.body.style.getPropertyValue('--bottom-ui-height')).toBe('132px');
+    expect(panel?.style.bottom).toBe('calc(var(--bottom-ui-height) + 12px)');
+    expect(panel?.style.maxHeight).toBe('calc(100% - 84px - var(--bottom-ui-height))');
+    expect(panel?.style.overflowY).toBe('auto');
+    expect(panel?.getAttribute('aria-label')).toBe('Selected unit details and actions (scroll for more)');
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -16,6 +16,9 @@ class MockElement {
   type = '';
   disabled = false;
   title = '';
+  scrollHeight = 0;
+  clientHeight = 0;
+  scrollTop = 0;
   listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
 
   get childElementCount(): number {
@@ -113,6 +116,43 @@ function findZoneOfControlWarning(node: unknown): MockElement | undefined {
   }
   return undefined;
 }
+
+function findScrollCue(node: unknown): MockElement | undefined {
+  const el = node as MockElement;
+  if (el.dataset?.scrollCue) return el;
+  for (const child of el.children ?? []) {
+    const found = findScrollCue(child);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+describe('selected-unit scroll affordance', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows a clear cue before details and actions that overflow the capped card', () => {
+    const state = createNewGame(undefined, 'selected-unit-scroll-cue', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const container = new MockElement('div');
+    container.clientHeight = 100;
+    container.scrollHeight = 220;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior', {});
+
+    const cue = findScrollCue(container);
+    expect(cue?.textContent).toBe('↓ More details and actions below — scroll');
+    expect(cue?.style.display).toBe('block');
+  });
+});
 
 describe('land-unit water recovery guidance', () => {
   beforeEach(installMockDocument);
@@ -1242,6 +1282,21 @@ describe('renderSelectedUnitInfo - journey automation', () => {
       civilizations: { player: { color: '#fff', techState: { completed: [] } } },
     } as unknown as GameState;
   }
+
+  it('renders and invokes Auto-explore for an idle owned unit', () => {
+    const state = makeScoutState();
+    const container = new MockElement('div');
+    let startedUnitId: string | null = null;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'scout-1', {
+      onStartAutoExplore: unitId => { startedUnitId = unitId; },
+    });
+
+    const start = findButtons(container).find(button => button.textContent === 'Auto-explore');
+    expect(start).toBeDefined();
+    start!.click();
+    expect(startedUnitId).toBe('scout-1');
+  });
 
   it('shows journey destination text when unit has journey automation', () => {
     const state = makeScoutState({ automation: { mode: 'journey', destination: { q: 5, r: 3 } } });


### PR DESCRIPTION
Closes #735
Closes #736
Closes #738

## Summary

- Opens mandatory research selection whenever a human turn becomes playable, including campaign start, solo AI handoff, and hot-seat handoff.
- Makes selected-unit upgrades concise and deduplicated; exposes Auto-explore directly from the selected-unit card.
- Omits major civilizations that have no currently owned city from diplomacy, including legacy saves without a reliable elimination flag.
- Keeps the bottom action bar out of the map viewport: the canvas now ends above the measured bar height, while selected-unit details are capped, scrollable, and visibly cue overflow.
- Resets the canvas device-pixel transform on responsive resize so bar-height changes cannot progressively zoom rendering.

## Root causes

- Required-choice UI was wired only to a subset of human-turn transitions.
- Upgrade prerequisites were assembled from overlapping source and target requirements without deduplication, and auto-explore was available only through secondary controls.
- Diplomacy trusted stale civilization metadata instead of the authoritative city ownership record.
- Canvas and UI layer both occupied the full viewport, leaving the action bar over the clickable map.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` — 432 files passed; 7,108 tests passed, 3 skipped
- Focused UI, selected-unit, diplomacy, upgrade, and renderer-resize regressions
- `scripts/check-src-rule-violations.sh` for every changed source file