### PR TITLE
fix(units): enforce worker actions and refresh upgrades

### DIFF
--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -519,6 +519,7 @@ function rankCivilianAndTransportActions(
   if (
     unit.type === 'worker'
     && !unit.hasActed
+    && unit.movementPointsLeft > 0
     && getWorkerChargesRemaining(unit) > 0
   ) {
     const tile = context.state.map.tiles[hexKey(unit.position)];

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -71,6 +71,8 @@ interface PoolEntry {
   el:           HTMLDivElement; // positional wrapper (world-space left/top)
   spriteWrapEl: HTMLElement;    // .cq-sprite-wrap.cq-v2 — animation root
   phase:        number;
+  kind:         SpriteEntity['kind'];
+  subtype:      string;
   faction:      string;
   civColor:     string;
   coord:        HexCoord;       // stored so we can detect position change after movement
@@ -156,8 +158,13 @@ export class SpriteOverlay {
         const anchorOffsetFactor = entity.anchorOffsetFactor ?? { x: 0, y: 0 };
         const newCivColor = entity.civId ? (colorLookup[entity.civId] ?? '') : '';
         const poolEntry = this.pool.get(key);
-        // Invalidate if faction or civ color changed (e.g. unit captured or color reassigned)
-        if (poolEntry && (poolEntry.faction !== entity.faction || poolEntry.civColor !== newCivColor)) {
+        // Invalidate if sprite identity or palette changed (e.g. unit upgrades, capture, or color reassignment).
+        if (poolEntry && (
+          poolEntry.kind !== entity.kind
+          || poolEntry.subtype !== entity.subtype
+          || poolEntry.faction !== entity.faction
+          || poolEntry.civColor !== newCivColor
+        )) {
           poolEntry.el.remove();
           this.pool.delete(key);
         }
@@ -224,6 +231,8 @@ export class SpriteOverlay {
             el: wrapper,
             spriteWrapEl,
             phase,
+            kind: entity.kind,
+            subtype: entity.subtype,
             faction: entity.faction,
             civColor: newCivColor,
             coord,

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -36,6 +36,7 @@ export type WorkerActionFailureReason =
   | 'invalid-action'
   | 'outside-territory'
   | 'no-charges'
+  | 'no-movement'
   | 'already-acted';
 
 export interface WorkerActionOptions {
@@ -120,6 +121,7 @@ export function applyWorkerAction(
   if (!unit) return { ok: false, state, reason: 'missing-unit', events: [] };
   if (unit.type !== 'worker') return { ok: false, state, reason: 'not-worker', events: [] };
   if (unit.hasActed) return { ok: false, state, reason: 'already-acted', events: [] };
+  if (unit.movementPointsLeft <= 0) return { ok: false, state, reason: 'no-movement', events: [] };
   const chargesBefore = getWorkerChargesRemaining(unit);
   if (chargesBefore <= 0) return { ok: false, state, reason: 'no-charges', events: [] };
 

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -440,7 +440,7 @@ export function renderSelectedUnitInfo(
     chargeDiv.textContent = `Worker Charges: ${charges}/${DEFAULT_WORKER_CHARGES}`;
     wrapper.appendChild(chargeDiv);
 
-    if (charges > 0 && !unit.hasActed && callbacks.onWorkerAction) {
+    if (charges > 0 && !unit.hasActed && unit.movementPointsLeft > 0 && callbacks.onWorkerAction) {
       const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
       const unitTileKey = hexKey(unit.position);
       const isCityTile = Object.values(state.cities).some(city => hexKey(city.position) === unitTileKey);

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -784,6 +784,26 @@ describe('AI road-building', () => {
     expect(outpost.id).toBe('outpost'); // sanity: second city exists and is the disconnection target
   });
 
+  it('does not queue a worker action after the worker has spent all movement', () => {
+    const state = makeState('veteran');
+    state.civilizations[AI].techState.completed = ['road-building'];
+    const capital = addCity(state, 'capital', AI, { q: 0, r: 0 });
+    addCity(state, 'outpost', AI, { q: 2, r: 0 });
+    for (const tile of Object.values(state.map.tiles)) tile.owner = AI;
+    const worker = addUnit(state, 'road-worker', 'worker', AI, { q: 1, r: 0 }, {
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: false,
+    });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: capital.position },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    expect(chooseUnitTacticalAction(context(state, plan), worker.id)).toEqual({ kind: 'hold', unitId: worker.id });
+  });
+
   it('moves the worker toward the road target when not yet standing on it', () => {
     const state = makeState('veteran');
     state.civilizations[AI].techState.completed = ['road-building'];

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -182,6 +182,18 @@ describe('sync() pool lifecycle', () => {
     expect((original as HTMLElement).getAttribute('data-state')).toBe('walk');
   });
 
+  it('replaces the pooled sprite when a unit upgrades to a different subtype', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity({ subtype: 'warrior' })], MAP, OPTS);
+    const original = mount.querySelector('.cq-sprite-wrap');
+
+    overlay.sync(cam({ zoom: 1 }), [entity({ subtype: 'archer' })], MAP, OPTS);
+
+    const upgraded = mount.querySelector('.cq-sprite-wrap');
+    expect(upgraded).not.toBe(original);
+    expect((upgraded as HTMLElement).getAttribute('data-kind')).toBe('ranged');
+  });
+
   it('updates landmark state, mode, damage, tier, and stage without replacing its DOM node', () => {
     const { overlay, mount } = mountOverlay();
     const first = entity({

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -127,6 +127,19 @@ describe('worker action system', () => {
     expect(getWorkerChargesRemaining(worker({ chargesRemaining: undefined }))).toBe(2);
   });
 
+  it('rejects a worker action after the worker has spent all movement', () => {
+    const start = state({
+      units: { 'worker-1': worker({ movementPointsLeft: 0, hasMoved: true, hasActed: false }) },
+    });
+
+    expect(applyWorkerAction(start, 'worker-1', 'farm')).toEqual({
+      ok: false,
+      state: start,
+      reason: 'no-movement',
+      events: [],
+    });
+  });
+
   it('builds lumber camp, keeps forest, and consumes one charge', () => {
     const start = state();
     start.map.tiles['0,0'] = tile({ terrain: 'forest' });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -838,6 +838,19 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     expect(buttons).not.toContain('Build Lumber Camp (+2 Prod)');
   });
 
+  it('hides worker actions after the worker has spent all movement', () => {
+    const state = makeWorkerState({ terrain: 'forest' }, { movementPointsLeft: 0, hasMoved: true });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(buttons).not.toContain('Build Farm (+2 Food)');
+    expect(buttons).not.toContain('Build Lumber Camp (+2 Prod)');
+  });
+
   it('hides worker actions when the worker has no charges left', () => {
     const state = makeWorkerState({ terrain: 'forest' }, { chargesRemaining: 0 });
     const container = new MockElement('div');


### PR DESCRIPTION
Closes #739
Closes #740

## Summary

- Enforces the worker movement budget in the canonical action helper, selected-unit UI, and AI tactical ranking so workers cannot improve terrain after spending all movement.
- Invalidates pooled DOM sprites when a unit's render subtype changes, so upgrades immediately display their new icon.

## Root causes

- Worker actions only checked `hasActed`; moving to zero movement leaves that flag false.
- Sprite-overlay pool entries were keyed by unit ID and invalidated only for palette changes, leaving the old serialized SVG active after an upgrade.

## Validation

- Focused worker-action, selected-unit-info, AI tactics, and sprite-overlay regressions
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test` (432 files, 7,112 passing, 3 skipped)
- Pre-push verification (423 files, 6,996 passing, 3 skipped) and production build
