### PR TITLE
fix(tooling): isolate nested worktree caches

### DIFF
--- a/scripts/run-with-mise.sh
+++ b/scripts/run-with-mise.sh
@@ -52,7 +52,7 @@ MAIN_ROOT="$(git_without_local_env -C "$SCRIPT_DIR" worktree list --porcelain 2>
 
 # Linked worktrees share Yarn's read-only PnP installation but must not share
 # Vite's writable cache. The active config consumes this override for Vitest.
-export CONQUESTORIA_VITEST_CACHE_DIR="${CONQUESTORIA_VITEST_CACHE_DIR:-$CURRENT_ROOT/.vite/vitest}"
+export CONQUESTORIA_VITEST_CACHE_DIR="$CURRENT_ROOT/.vite/vitest"
 
 if [ -n "$MAIN_ROOT" ] && [ "$CURRENT_ROOT" != "$MAIN_ROOT" ]; then
   MAIN_RUN="$MAIN_ROOT/scripts/run-with-mise.sh"

--- a/tests/hooks/run-with-mise-worktree.test.sh
+++ b/tests/hooks/run-with-mise-worktree.test.sh
@@ -130,6 +130,7 @@ rm -f "$mise_log" "$lock_log"
   PATH="$fake_bin:$PATH" \
     MISE_LOG="$mise_log" \
     VERIFY_LOCK_LOG="$lock_log" \
+    CONQUESTORIA_VITEST_CACHE_DIR="$tmpdir/inherited-cache" \
     ./scripts/run-with-mise.sh yarn build
 )
 grep -Fq "$linked|$linked/.vite/vitest|exec -- node $linked/scripts/version-sw-cache.mjs" "$mise_log" || {


### PR DESCRIPTION
Fixes a reentrancy regression in #746: nested linked-worktree commands inherited the caller's internal Vite cache path. The wrapper now always derives that path from its own worktree.

Validation:
- `bash tests/hooks/run-with-mise-worktree.test.sh`
- `bash tests/hooks/run.sh`
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test`
- `git diff --check`