### PR TITLE
feat(combat): define typed unit role catalog (#667)

### DIFF
--- a/src/ai/ai-unit-roles.ts
+++ b/src/ai/ai-unit-roles.ts
@@ -1,44 +1,6 @@
 import type { AIStrategicRole, UnitType } from '@/core/types';
+import { getUnitRoleDefinition } from '@/systems/combat-role-definitions';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-
-const ROLE_OVERRIDES: Partial<Record<UnitType, readonly AIStrategicRole[]>> = {
-  scout: ['recon'],
-  observation_balloon: ['recon'],
-  caravan: ['trade'],
-  // Trade Routes Overhaul (#553 MR1/4) — Naval Trader line. Without this override these
-  // fall through to the naval-domain branch below and get misclassified as
-  // ['naval-combat', 'escort'] despite strength 0 and no cargoCapacity.
-  naval_trader: ['trade'],
-  steamship_trader: ['trade'],
-  cargo_freighter: ['trade'],
-  container_ship: ['trade'],
-  // Trade Routes Overhaul (#553 MR2/4) — Land trade line successors to Caravan.
-  merchant_wagon: ['trade'],
-  freight_convoy: ['trade'],
-  // Trade Routes Overhaul (#553 MR3/4) — Air trade line. Without this override these
-  // fall through to the air-domain branch and get misclassified as ['recon'] (no
-  // attackProfile), same rationale as the Naval Trader line above.
-  air_freighter: ['trade'],
-  jet_freighter: ['trade'],
-  global_air_cargo: ['trade'],
-  expedition: ['resource-expedition', 'recon'],
-  settler: ['settlement'],
-  worker: ['worker'],
-  missionary: ['missionary'],
-  spy_scout: ['espionage', 'recon'],
-  spy_informant: ['espionage'],
-  spy_agent: ['espionage'],
-  spy_operative: ['espionage'],
-  spy_hacker: ['espionage'],
-  cyber_unit: ['espionage'],
-  // Era 13 specialists have no conventional strength. Their explicit roles keep
-  // production demand-driven rather than silently treating them as combat units.
-  propagandist: ['espionage'],
-  drone_controller: ['detection'],
-  scout_hound: ['detection', 'frontline'],
-  shadow_warden: ['detection', 'frontline'],
-  war_hound: ['detection', 'frontline', 'mobile', 'capture'],
-};
 
 const COMBAT_ROLES = new Set<AIStrategicRole>([
   'capture',
@@ -52,9 +14,10 @@ const COMBAT_ROLES = new Set<AIStrategicRole>([
 ]);
 
 export function getAIStrategicRoles(type: UnitType): readonly AIStrategicRole[] {
-  const override = ROLE_OVERRIDES[type];
-  if (override) return override;
+  const catalogDefinition = getUnitRoleDefinition(type);
+  if (catalogDefinition) return catalogDefinition.aiRoles;
 
+  // Non-trainable actors, such as pirate-only hulls, retain generic AI handling.
   const definition = UNIT_DEFINITIONS[type];
   if (definition.domain === 'air') {
     return definition.attackProfile ? ['air-combat', 'ranged'] : ['recon'];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -908,6 +908,52 @@ export interface TrainableUnitEntry {
   trainedFromBuilding?: string;  // city must contain this building to train the unit
 }
 
+export type CombatRole =
+  | 'frontline'
+  | 'ranged'
+  | 'siege'
+  | 'shock'
+  | 'pursuit'
+  | 'reconnaissance'
+  | 'detection'
+  | 'anti-mounted'
+  | 'anti-armor'
+  | 'air-superiority'
+  | 'ground-air-defense'
+  | 'capital-ship'
+  | 'escort'
+  | 'formation-support'
+  | 'capture'
+  | 'civilian';
+
+export type UpgradeFamily =
+  | 'line-infantry'
+  | 'mounted'
+  | 'ranged-infantry'
+  | 'siege'
+  | 'surface-warship'
+  | 'submarine'
+  | 'fighter'
+  | 'bomber'
+  | 'air-support'
+  | 'transport'
+  | 'trade'
+  | 'espionage'
+  | 'detection'
+  | 'civilian';
+
+export interface UnitRoleDefinition {
+  primaryRole: CombatRole;
+  secondaryRoles?: readonly CombatRole[];
+  counters: readonly CombatRole[];
+  vulnerableTo: readonly CombatRole[];
+  roleSummary: string;
+  upgradeFamily: UpgradeFamily;
+  aiRoles: readonly AIStrategicRole[];
+  terminalReason?: string;
+  domainTransitionReason?: string;
+}
+
 // --- Civilizations ---
 
 export interface Civilization {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -12,6 +12,7 @@ import {
   getLegendaryWonderQueueItemMetadata,
 } from './legendary-wonder-production';
 import { evaluateProductionPrerequisites } from './production-prerequisites';
+import { getTerminalCombatUnitReasons } from './combat-role-definitions';
 
 export const CITY_NAMES = DEFAULT_CITY_NAMES;
 
@@ -1209,25 +1210,7 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
  * tests/systems/city-system.test.ts — a new combat unit added to TRAINABLE_UNITS without
  * either obsoletedByTech or an entry here will fail that test.
  */
-export const TERMINAL_COMBAT_UNITS: Partial<Record<UnitType, string>> = {
-  tank: 'current top-tier armor, no later replacement in the roster yet — stays apex over modern infantry',
-  submarine: 'current top-tier submarine, no later replacement in the roster yet',
-  stealth_bomber: 'current air-combat apex (era 12), no later replacement in the roster yet',
-  cyber_unit: 'era 12 economic-sabotage unit, unique role (city-only ranged target), no later replacement in the roster yet',
-  carrier: 'current top-tier naval projection, no later replacement in the roster yet',
-  artillery: 'current siege apex; rocket artillery is future content',
-  jet_fighter: 'air-superiority apex; stealth bomber is the bomber line, not a fighter upgrade',
-  missile_submarine: 'era 11, newest naval-deterrent unit, no later replacement yet',
-  scout: 'recon unit, strength is a self-defense stat not its primary role, no replacement chain',
-  observation_balloon: 'recon unit (air-recon role), strength is a self-defense stat, no replacement chain',
-  spy_hacker: 'terminal tier of the espionage chain (spy_operative already obsoletes into this at cyber-warfare), no further replacement yet',
-  scout_hound: 'recon/detection unit, strength is a self-defense stat, no replacement chain',
-  shadow_warden: 'civ-specific (Persia) recon/detection replacement for scout_hound, same reasoning',
-  war_hound: 'civ-specific (Rome) recon/detection replacement for scout_hound, same reasoning',
-  combat_drone: 'Era 13 coordinated air-support apex; later eras may introduce an autonomous-air successor.',
-  autonomous_frigate: 'Era 13 autonomous surface-escort apex; later eras may introduce a successor.',
-  exosuit_infantry: 'Era 13 advanced line-infantry apex; Tank remains the separate armor apex.',
-};
+export const TERMINAL_COMBAT_UNITS = getTerminalCombatUnitReasons();
 
 export const SETTLER_COST_BY_ERA: Record<number, number> = {
   1: 24,

--- a/src/systems/combat-role-definitions.ts
+++ b/src/systems/combat-role-definitions.ts
@@ -1,0 +1,167 @@
+import type {
+  AIStrategicRole,
+  CombatRole,
+  TrainableUnitEntry,
+  UnitDefinition,
+  UnitRoleDefinition,
+  UnitType,
+} from '@/core/types';
+import { getRequiredTechIds } from './production-prerequisites';
+
+const role = (
+  primaryRole: CombatRole,
+  roleSummary: string,
+  aiRoles: readonly AIStrategicRole[],
+  options: Omit<UnitRoleDefinition, 'primaryRole' | 'roleSummary' | 'aiRoles'>,
+): UnitRoleDefinition => ({ primaryRole, roleSummary, aiRoles, ...options });
+
+const civilian = (
+  roleSummary: string,
+  aiRoles: readonly AIStrategicRole[],
+  upgradeFamily: UnitRoleDefinition['upgradeFamily'] = 'civilian',
+): UnitRoleDefinition => role('civilian', roleSummary, aiRoles, {
+  counters: [], vulnerableTo: [], upgradeFamily,
+});
+
+export const UNIT_ROLE_DEFINITIONS = {
+  warrior: role('frontline', 'Cheap early defender that holds ground and captures exposed positions.', ['frontline', 'capture'], { counters: ['civilian'], vulnerableTo: ['ranged', 'shock'], upgradeFamily: 'line-infantry' }),
+  archer: role('ranged', 'Safe early ranged support that punishes slow frontline units.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'ranged-infantry' }),
+  scout: role('reconnaissance', 'Fast scout that reveals terrain and avoids prolonged fights.', ['recon'], { counters: [], vulnerableTo: ['frontline', 'ranged'], upgradeFamily: 'detection', terminalReason: 'Reconnaissance specialist with self-defense strength and no replacement chain.' }),
+  worker: civilian('Builds improvements that grow the city and secure resources.', ['worker']),
+  missionary: civilian('Spreads faith and supports cities without direct combat.', ['missionary']),
+  settler: civilian('Founds a new city and must avoid enemy forces.', ['settlement']),
+  swordsman: role('frontline', 'Armored frontline fighter that trades well in direct land combat.', ['frontline', 'capture'], { counters: ['frontline'], vulnerableTo: ['ranged', 'siege'], upgradeFamily: 'line-infantry' }),
+  pikeman: role('anti-mounted', 'Polearm defender that stops charging mounted attackers.', ['frontline', 'capture'], { counters: ['shock'], vulnerableTo: ['ranged', 'siege'], upgradeFamily: 'line-infantry' }),
+  musketeer: role('ranged', 'Gunpowder infantry that supports the line from a safe distance.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'siege'], upgradeFamily: 'line-infantry' }),
+  galley: role('escort', 'Early coastal escort that protects friendly waters and transports.', ['naval-combat', 'escort'], { counters: ['civilian'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  transport: civilian('Carries land units between coasts and cannot attack.', ['transport'], 'transport'),
+  carrack: civilian('Carries more land units safely across coastal waters.', ['transport'], 'transport'),
+  galleon: civilian('Carries a larger army across seas without fighting.', ['transport'], 'transport'),
+  steamship: civilian('Reliable transport that carries a large expeditionary force.', ['transport'], 'transport'),
+  troop_transport: civilian('Military transport that moves six land units across oceans.', ['transport'], 'transport'),
+  trireme: role('escort', 'Coastal warship that escorts transports and contests nearby seas.', ['naval-combat', 'escort'], { counters: ['civilian'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  frigate: role('escort', 'Ranged escort that protects fleets and pressures coastal targets.', ['naval-combat', 'escort'], { counters: ['escort'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  axeman: role('frontline', 'Copper frontline fighter that wins early direct engagements.', ['frontline', 'capture'], { counters: ['frontline'], vulnerableTo: ['ranged', 'shock'], upgradeFamily: 'line-infantry' }),
+  spearman: role('anti-mounted', 'Resource-free polearm defender that counters mounted charges.', ['frontline', 'capture'], { counters: ['shock'], vulnerableTo: ['ranged', 'siege'], upgradeFamily: 'line-infantry' }),
+  horseman: role('shock', 'Fast mounted attacker that flanks exposed ranged units.', ['mobile', 'capture'], { counters: ['ranged', 'siege'], vulnerableTo: ['anti-mounted'], upgradeFamily: 'mounted' }),
+  cavalry: role('shock', 'Heavy mounted attacker that breaks exposed formations quickly.', ['mobile', 'capture'], { secondaryRoles: ['pursuit'], counters: ['ranged', 'siege'], vulnerableTo: ['anti-mounted'], upgradeFamily: 'mounted' }),
+  knight: role('shock', 'Armored mounted attacker that overwhelms vulnerable land units.', ['mobile', 'capture'], { counters: ['ranged', 'siege'], vulnerableTo: ['anti-mounted'], upgradeFamily: 'mounted' }),
+  marine: role('frontline', 'Coastal assault infantry that attacks effectively after landing.', ['frontline', 'capture'], { counters: ['ranged'], vulnerableTo: ['siege', 'shock'], upgradeFamily: 'line-infantry' }),
+  crossbowman: role('ranged', 'Precise ranged unit that pressures armored frontline fighters.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'ranged-infantry' }),
+  catapult: role('siege', 'Slow bombard unit that damages cities and concentrated defenders.', ['siege', 'ranged'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'siege' }),
+  ballista: role('ranged', 'Long-range bolt thrower that punishes exposed unit formations.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'siege' }),
+  cannon: role('siege', 'Gunpowder bombard unit that breaks cities and fortified positions.', ['siege', 'ranged'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'siege' }),
+  grenadier: role('siege', 'Short-range specialist that cracks forts and entrenched defenders.', ['siege', 'ranged'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'line-infantry' }),
+  rifleman: role('ranged', 'Reliable line infantry that holds ground with ranged fire.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'siege'], upgradeFamily: 'line-infantry' }),
+  artillery: role('siege', 'Long-range siege apex that destroys cities from behind allies.', ['siege', 'ranged'], { counters: ['frontline'], vulnerableTo: ['shock', 'pursuit'], upgradeFamily: 'siege', terminalReason: 'Current siege apex; rocket artillery is future content.' }),
+  ironclad: role('capital-ship', 'Armored warship that wins direct fights against older fleets.', ['naval-combat', 'escort'], { counters: ['escort'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  machine_gunner: role('ranged', 'Suppressive defender that holds territory against frontline troops.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'siege'], upgradeFamily: 'line-infantry' }),
+  infantry: role('frontline', 'Modern line infantry that captures ground and supports ranged attacks.', ['ranged', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'siege'], upgradeFamily: 'line-infantry' }),
+  pre_dreadnought: role('capital-ship', 'Heavy surface warship that bombards fleets and coastal cities.', ['naval-combat', 'escort'], { counters: ['escort'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  tank: role('shock', 'Armored breakthrough unit that crushes exposed land defenders.', ['ranged', 'mobile', 'capture'], { counters: ['frontline', 'ranged'], vulnerableTo: ['anti-armor'], upgradeFamily: 'mounted', terminalReason: 'Current top-tier armor with no later roster replacement.' }),
+  submarine: role('capital-ship', 'Stealthy naval hunter that threatens expensive surface warships.', ['naval-combat', 'escort'], { counters: ['capital-ship'], vulnerableTo: ['escort'], upgradeFamily: 'submarine', terminalReason: 'Current top-tier submarine with no later roster replacement.' }),
+  observation_balloon: role('reconnaissance', 'Aerial scout that reveals distant terrain but cannot fight.', ['recon'], { counters: [], vulnerableTo: ['air-superiority'], upgradeFamily: 'detection', terminalReason: 'Air-recon specialist with self-defense strength and no replacement chain.' }),
+  biplane: role('air-superiority', 'Early fighter that contests enemy aircraft and supports ground attacks.', ['air-combat', 'ranged'], { counters: ['reconnaissance'], vulnerableTo: ['ground-air-defense', 'air-superiority'], upgradeFamily: 'fighter' }),
+  jet_fighter: role('air-superiority', 'Fast fighter that wins air battles and intercepts enemy bombers.', ['air-combat', 'ranged'], { counters: ['air-superiority', 'siege'], vulnerableTo: ['ground-air-defense'], upgradeFamily: 'fighter', terminalReason: 'Air-superiority apex; bombers are a separate upgrade family.' }),
+  recon_aircraft: civilian('Unarmed aircraft that surveys an area from a friendly airbase.', ['recon'], 'detection'),
+  bomber: role('siege', 'Long-range bomber that damages cities and distant enemy formations.', ['air-combat', 'ranged'], { counters: ['frontline', 'capital-ship'], vulnerableTo: ['air-superiority', 'ground-air-defense'], upgradeFamily: 'bomber' }),
+  carrier: role('capital-ship', 'Mobile airbase that projects fighters and bombers across seas.', ['naval-combat', 'escort'], { counters: ['capital-ship'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship', terminalReason: 'Current top-tier naval projection with no later roster replacement.' }),
+  destroyer: role('escort', 'Fast surface escort that hunts submarines and protects fleets.', ['naval-combat', 'escort'], { counters: ['capital-ship'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship' }),
+  attack_helicopter: role('anti-armor', 'Mobile air attacker that punishes armored land formations.', ['air-combat', 'ranged'], { counters: ['shock'], vulnerableTo: ['ground-air-defense', 'air-superiority'], upgradeFamily: 'air-support' }),
+  missile_submarine: role('capital-ship', 'Long-range deterrent submarine that threatens distant coastal targets.', ['naval-combat', 'escort'], { counters: ['capital-ship'], vulnerableTo: ['escort'], upgradeFamily: 'submarine', terminalReason: 'Newest naval deterrent with no later roster replacement.' }),
+  cyber_unit: role('formation-support', 'Capturable saboteur that weakens nearby undefended enemy cities.', ['espionage'], { counters: ['civilian'], vulnerableTo: ['frontline', 'ranged'], upgradeFamily: 'espionage', terminalReason: 'Economic sabotage specialist with no later roster replacement.' }),
+  stealth_bomber: role('siege', 'Stealth bomber that strikes distant cities while avoiding ordinary radar.', ['air-combat', 'ranged'], { counters: ['frontline', 'capital-ship'], vulnerableTo: ['air-superiority', 'ground-air-defense'], upgradeFamily: 'bomber', terminalReason: 'Current air-combat apex with no later roster replacement.' }),
+  combat_drone: role('formation-support', 'Networked air support that is strongest in a valid formation.', ['air-combat', 'ranged'], { secondaryRoles: ['ranged'], counters: ['frontline'], vulnerableTo: ['ground-air-defense', 'air-superiority'], upgradeFamily: 'air-support', terminalReason: 'Era 13 coordinated air-support apex with no later successor.' }),
+  autonomous_frigate: role('escort', 'Autonomous surface escort that supports fleets at long range.', ['naval-combat', 'escort'], { counters: ['escort'], vulnerableTo: ['capital-ship'], upgradeFamily: 'surface-warship', terminalReason: 'Era 13 surface-escort apex with no later successor.' }),
+  exosuit_infantry: role('frontline', 'Advanced line infantry that holds ground below dedicated armor.', ['ranged', 'mobile', 'capture'], { counters: ['frontline'], vulnerableTo: ['shock', 'anti-armor'], upgradeFamily: 'line-infantry', terminalReason: 'Era 13 line-infantry apex; armor remains a separate family.' }),
+  propagandist: civilian('Civic specialist that rallies allies and undermines enemy loyalty.', ['espionage']),
+  drone_controller: role('formation-support', 'Support specialist that coordinates valid drone formations safely.', ['detection'], { counters: [], vulnerableTo: ['frontline', 'ranged'], upgradeFamily: 'civilian' }),
+  spy_scout: civilian('Early spy that scouts and infiltrates rival cities.', ['espionage'], 'espionage'),
+  spy_informant: civilian('Experienced spy that maintains intelligence operations in cities.', ['espionage'], 'espionage'),
+  spy_agent: civilian('Field spy that sabotages, steals technology, and disrupts rivals.', ['espionage'], 'espionage'),
+  spy_operative: civilian('Elite spy that performs high-stakes covert operations.', ['espionage'], 'espionage'),
+  spy_hacker: role('formation-support', 'Cyber spy that conducts remote operations against rival infrastructure.', ['espionage'], { counters: [], vulnerableTo: ['frontline', 'ranged'], upgradeFamily: 'espionage', terminalReason: 'Terminal tier of the espionage chain with no later replacement.' }),
+  scout_hound: role('detection', 'Detection scout that reveals disguised spies while patrolling territory.', ['detection', 'frontline'], { counters: ['formation-support'], vulnerableTo: ['ranged'], upgradeFamily: 'detection', terminalReason: 'Detection specialist with self-defense strength and no replacement chain.' }),
+  shadow_warden: role('detection', 'Elite detection scout that reveals disguised spies more reliably.', ['detection', 'frontline'], { counters: ['formation-support'], vulnerableTo: ['ranged'], upgradeFamily: 'detection', terminalReason: 'Persian detection replacement with no separate successor chain.' }),
+  war_hound: role('detection', 'Combat detection scout that catches spies and harasses exposed units.', ['detection', 'frontline', 'mobile', 'capture'], { counters: ['formation-support'], vulnerableTo: ['ranged'], upgradeFamily: 'detection', terminalReason: 'Roman detection replacement with no separate successor chain.' }),
+  caravan: civilian('Land trade unit that establishes a profitable route.', ['trade'], 'trade'),
+  merchant_wagon: civilian('Improved land trader that carries a route farther and safer.', ['trade'], 'trade'),
+  freight_convoy: civilian('Top-tier land trader that sustains valuable long routes.', ['trade'], 'trade'),
+  naval_trader: civilian('Coastal trade unit that establishes profitable sea routes.', ['trade'], 'trade'),
+  steamship_trader: civilian('Steam-powered trader that carries sea routes farther.', ['trade'], 'trade'),
+  cargo_freighter: civilian('Large freighter that sustains valuable maritime trade routes.', ['trade'], 'trade'),
+  container_ship: civilian('Top-tier container ship that sustains global sea trade.', ['trade'], 'trade'),
+  air_freighter: civilian('Air trader that establishes routes across difficult terrain.', ['trade'], 'trade'),
+  jet_freighter: civilian('Fast air trader that sustains long-distance trade routes.', ['trade'], 'trade'),
+  global_air_cargo: civilian('Top-tier air trader that connects the entire empire.', ['trade'], 'trade'),
+  expedition: civilian('Civilian explorer that establishes outposts on remote resources.', ['resource-expedition', 'recon']),
+} as const satisfies Partial<Record<UnitType, UnitRoleDefinition>>;
+
+export function getUnitRoleDefinition(type: UnitType): UnitRoleDefinition | undefined {
+  return (UNIT_ROLE_DEFINITIONS as Partial<Record<UnitType, UnitRoleDefinition>>)[type];
+}
+
+export function getTerminalCombatUnitReasons(): Partial<Record<UnitType, string>> {
+  return Object.fromEntries(Object.entries(UNIT_ROLE_DEFINITIONS)
+    .flatMap(([type, definition]) => definition.terminalReason ? [[type, definition.terminalReason]] : [])) as Partial<Record<UnitType, string>>;
+}
+
+export function validateUnitRoleDefinitions(
+  trainableUnits: readonly TrainableUnitEntry[],
+  unitDefinitions: Record<UnitType, UnitDefinition>,
+  reachableTechIds: ReadonlySet<string> = new Set(),
+): string[] {
+  const errors: string[] = [];
+  const trainableTypes = new Set(trainableUnits.map(unit => unit.type));
+  const visiting = new Set<UnitType>();
+  const visited = new Set<UnitType>();
+
+  for (const unit of trainableUnits) {
+    const definition = getUnitRoleDefinition(unit.type);
+    if (!definition) {
+      errors.push(`${unit.type}: missing role definition`);
+      continue;
+    }
+    if (!definition.roleSummary.trim() || definition.roleSummary.trim().split(/\s+/).length > 18) {
+      errors.push(`${unit.type}: role summary must contain 1-18 words`);
+    }
+    if (!definition.aiRoles.length) errors.push(`${unit.type}: missing AI roles`);
+    if (unitDefinitions[unit.type].strength > 0 && !unit.upgradesTo && !definition.terminalReason) {
+      errors.push(`${unit.type}: combat unit needs an upgrade target or terminal reason`);
+    }
+    if (unit.upgradesTo && !trainableTypes.has(unit.upgradesTo)) {
+      errors.push(`${unit.type}: upgrade target ${unit.upgradesTo} is not trainable`);
+    }
+    const target = unit.upgradesTo
+      ? trainableUnits.find(candidate => candidate.type === unit.upgradesTo)
+      : undefined;
+    if (target && reachableTechIds.size > 0) {
+      for (const techId of getRequiredTechIds(target)) {
+        if (!reachableTechIds.has(techId)) {
+          errors.push(`${unit.type}: target ${target.type} needs unreachable technology ${techId}`);
+        }
+      }
+    }
+    if (unit.upgradesTo
+      && (unitDefinitions[unit.type].domain ?? 'land') !== (unitDefinitions[unit.upgradesTo].domain ?? 'land')
+      && !definition.domainTransitionReason) {
+      errors.push(`${unit.type}: cross-domain upgrade needs a documented transition`);
+    }
+  }
+
+  const visit = (type: UnitType): void => {
+    if (visiting.has(type)) {
+      errors.push(`${type}: upgrade cycle detected`);
+      return;
+    }
+    if (visited.has(type)) return;
+    visited.add(type);
+    const unit = trainableUnits.find(candidate => candidate.type === type);
+    if (!unit?.upgradesTo || !trainableTypes.has(unit.upgradesTo)) return;
+    visiting.add(type);
+    visit(unit.upgradesTo);
+    visiting.delete(type);
+  };
+  for (const unit of trainableUnits) visit(unit.type);
+  return errors;
+}

--- a/tests/ai/ai-unit-roles.test.ts
+++ b/tests/ai/ai-unit-roles.test.ts
@@ -4,8 +4,14 @@ import type { UnitType } from '@/core/types';
 import { TRAINABLE_UNITS } from '@/systems/city-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { UNIT_ROLE_DEFINITIONS } from '@/systems/combat-role-definitions';
 
 describe('AI strategic unit roles', () => {
+  it('reads strategic roles from the typed unit-role catalog', () => {
+    const definition = UNIT_ROLE_DEFINITIONS.warrior;
+    expect(getAIStrategicRoles('warrior')).toBe(definition.aiRoles);
+  });
+
   it('classifies every trainable unit into at least one strategic role', () => {
     for (const unit of TRAINABLE_UNITS) {
       expect(getAIStrategicRoles(unit.type), unit.type).not.toHaveLength(0);

--- a/tests/systems/combat-role-definitions.test.ts
+++ b/tests/systems/combat-role-definitions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+import {
+  getUnitRoleDefinition,
+  validateUnitRoleDefinitions,
+} from '@/systems/combat-role-definitions';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
+
+describe('combat role definitions', () => {
+  it('classifies every trainable unit with readable, typed metadata', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      const definition = getUnitRoleDefinition(unit.type);
+      expect(definition, unit.type).toBeDefined();
+      expect(definition!.roleSummary.trim(), unit.type).not.toBe('');
+      expect(definition!.roleSummary.trim().split(/\s+/).length, unit.type).toBeLessThanOrEqual(18);
+      expect(definition!.aiRoles.length, unit.type).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps counterplay distinct rather than treating every unit as a generalist', () => {
+    expect(getUnitRoleDefinition('pikeman')).toMatchObject({
+      primaryRole: 'anti-mounted',
+      counters: ['shock'],
+      vulnerableTo: ['ranged', 'siege'],
+    });
+    expect(getUnitRoleDefinition('cavalry')).toMatchObject({
+      primaryRole: 'shock',
+      secondaryRoles: ['pursuit'],
+      vulnerableTo: ['anti-mounted'],
+    });
+    expect(getUnitRoleDefinition('artillery')).toMatchObject({
+      primaryRole: 'siege',
+      vulnerableTo: ['shock', 'pursuit'],
+    });
+    expect(getUnitRoleDefinition('combat_drone')).toMatchObject({
+      primaryRole: 'formation-support',
+      secondaryRoles: ['ranged'],
+    });
+  });
+
+  it('accepts the live catalog and rejects malformed upgrade contracts', () => {
+    const reachableTechIds = new Set(TECH_TREE.map(tech => tech.id));
+    expect(validateUnitRoleDefinitions(TRAINABLE_UNITS, UNIT_DEFINITIONS, reachableTechIds)).toEqual([]);
+
+    const impossibleTarget = TRAINABLE_UNITS.map(unit => {
+      if (unit.type === 'warrior') return { ...unit, upgradesTo: 'archer' as const };
+      if (unit.type === 'archer') return { ...unit, requiredTechs: ['never-reachable'] };
+      return unit;
+    });
+    expect(validateUnitRoleDefinitions(impossibleTarget, UNIT_DEFINITIONS, reachableTechIds))
+      .toContain('warrior: target archer needs unreachable technology never-reachable');
+
+    const cyclic = TRAINABLE_UNITS.map(unit => {
+      if (unit.type === 'warrior') return { ...unit, upgradesTo: 'archer' as const };
+      if (unit.type === 'archer') return { ...unit, upgradesTo: 'warrior' as const };
+      return unit;
+    });
+    expect(validateUnitRoleDefinitions(cyclic, UNIT_DEFINITIONS, reachableTechIds))
+      .toContain('warrior: upgrade cycle detected');
+
+    const inferredEdge = TRAINABLE_UNITS.map(unit => unit.type === 'warrior'
+      ? { ...unit, upgradesTo: undefined }
+      : unit);
+    expect(validateUnitRoleDefinitions(inferredEdge, UNIT_DEFINITIONS, reachableTechIds))
+      .toContain('warrior: combat unit needs an upgrade target or terminal reason');
+  });
+});


### PR DESCRIPTION
Closes #667

## Summary

- Centralizes every trainable unit’s plain-language primary/secondary role, counter/vulnerability, upgrade family, AI roles, and explicit terminal rationale in typed data.
- Removes duplicate unit-ID AI role overrides; AI retains generic handling only for non-trainable actors.
- Validates missing classifications, accidental terminals, invalid/unreachable upgrade targets, cycles, and undocumented domain transitions.
- Preserves all existing combat values, difficulty behavior, saves, UI/UX, hot-seat visibility, and audio: this foundational slice introduces metadata only, with no player-reachable change yet.

## Inline review

Reviewed gameplay balance/fun, new mechanics, ages 7–43, play styles, difficulty parity, computer-player use, UI/UX, architecture/extensibility, data, SFX, saves, tests, solo/hot-seat regressions, and implementation. Replaced a shared-catalog mutation in the AI test to keep parallel test runs isolated.

## Validation

- focused role-catalog and AI tests plus hook smoke suite
- source-rule scan
- full `yarn test`
- `yarn build`
- pre-push fast suite and build