### PR TITLE
feat(ui): clarify unit roles and counterplay (#668)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,13 @@ When writing or updating implementation plans for interactive UI, queueing, or r
 ## Required Verification
 `./scripts/run-with-mise.sh yarn test` does not type-check. Run `./scripts/run-with-mise.sh yarn build` whenever TypeScript correctness matters, and always before `git push`, PR creation, or merge.
 
-If a push or long-running verification returns incomplete output, inspect the live process
-and remote ref before retrying. Never start a second push while the first pre-push hook
-may still be running.
+If a push or long-running verification returns incomplete output, treat it as
+**incomplete**, not successful: preserve its terminal session ID, inspect the live process,
+and poll that same session until it supplies an exit code and normal completion summary.
+Never start a second equivalent verification command while the first process may still be
+running. If the process exits but its status cannot be recovered, report verification as
+inconclusive rather than retrying automatically or claiming it passed. Never start a
+second push while the first pre-push hook may still be running.
 
 After editing files under `src/`, run:
 

--- a/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
+++ b/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
@@ -161,8 +161,9 @@ Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/tech-panel.test.ts`
 
 In `renderInspector`, replace plain unit-only unlock strings with child rows that retain
 the existing unlock copy and append role summary plus a native details disclosure. Use the
-same current-player completed technology IDs passed to the shared helper. Do not change
-research queue eligibility or controls.
+current player's completed technology IDs plus the inspected technology, because the
+details describe the unit after that unlock is researched. Do not change research queue
+eligibility or controls.
 
 - [ ] **Step 4: Run the tech-panel test and verify it passes**
 

--- a/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
+++ b/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
@@ -1,0 +1,206 @@
+# Issue #668 Unit Role Legibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show canonical unit roles, counters, vulnerabilities, prerequisites, and upgrade direction on each live unit decision surface.
+
+**Architecture:** A pure presentation module converts canonical role and prerequisite data into ordered, viewer-neutral display facts. City production, selected-unit information, and the tech inspector render that model without changing eligibility, combat, AI, saves, audio, or notifications.
+
+**Tech Stack:** TypeScript, Vitest, DOM rendering tests.
+
+---
+
+## Inline review resolution
+
+- No gameplay value, unit definition, AI behavior, difficulty rule, save shape, audio event,
+  or notification changes are allowed in this MR.
+- The live app lacks a unit Codex. Do not create an unlaunched module; cover the three
+  player-reachable surfaces specified by Task 4 and declare a future unit Codex out of scope.
+- All labels must be icon plus text; role summaries remain 18 words or fewer by the existing
+  catalog validator; all catalog entries remain reachable.
+
+### Task 1: Canonical unit-role presentation model
+
+**Files:**
+- Create: `src/ui/unit-role-presentation.ts`
+- Create: `tests/ui/unit-role-presentation.test.ts`
+- Modify: `src/ui/selected-unit-info.ts`
+
+- [ ] **Step 1: Write failing presentation tests**
+
+```ts
+expect(getUnitRolePresentation('pikeman', ['fortification'])).toMatchObject({
+  summary: 'Polearm defender that stops charging mounted attackers.',
+  counters: [{ icon: '🎯', text: 'Strong against shock units' }],
+  vulnerabilities: [{ icon: '⚠️', text: 'Vulnerable to ranged units' }],
+});
+expect(getUnitRolePresentation('artillery', ['mass-firepower'])?.upgrade.text)
+  .toContain('Current siege apex');
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails because the module is absent**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/unit-role-presentation.test.ts`
+
+- [ ] **Step 3: Implement the pure model**
+
+```ts
+export interface UnitRolePresentation {
+  summary: string;
+  roleText: string;
+  counters: readonly IconTextFact[];
+  vulnerabilities: readonly IconTextFact[];
+  upgrade: IconTextFact;
+  requirements: readonly IconTextFact[];
+}
+
+export function getUnitRolePresentation(
+  type: UnitType,
+  completedTechs: readonly string[] = [],
+): UnitRolePresentation | undefined
+```
+
+Use `getUnitRoleDefinition`, `TRAINABLE_UNITS`, `evaluateProductionPrerequisites`, and
+`TECH_TREE`; convert only typed role keys to label text in one local map. For a terminal
+unit render its explicit `terminalReason`; for a missing conjunction render each required
+technology with `Complete` or `Missing` text.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/unit-role-presentation.test.ts`
+
+### Task 2: Render live selected-unit information
+
+**Files:**
+- Modify: `src/ui/selected-unit-info.ts`
+- Modify: `tests/ui/selected-unit-info.test.ts`
+
+- [ ] **Step 1: Write failing rendered-DOM tests**
+
+```ts
+renderSelectedUnitInfo(container, state, 'pikeman', {});
+expect(collectAllText(container).join(' ')).toContain('Strong against shock units');
+expect(collectAllText(container).join(' ')).toContain('Vulnerable to ranged units');
+expect(findDetails(container)?.textContent).toContain('Role details');
+```
+
+Add a terminal-artillery test proving it renders the terminal explanation and does not
+invent a successor.
+
+- [ ] **Step 2: Run the selected-unit test and verify the new assertions fail**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/selected-unit-info.test.ts`
+
+- [ ] **Step 3: Render the shared model**
+
+Append a static summary line and a native `details` element after the existing description.
+Populate every dynamic label with `textContent`; give disclosure summary `Role details`;
+render counter, vulnerability, upgrade, and requirement rows as icon-plus-text divs.
+
+- [ ] **Step 4: Run the selected-unit test and verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/selected-unit-info.test.ts`
+
+### Task 3: Render the city production catalog without filtering it
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Modify: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Write failing catalog tests**
+
+```ts
+expect(collectText(panel)).toContain('Polearm defender that stops charging mounted attackers.');
+expect(panel.querySelectorAll('[data-unit-role-summary]').length)
+  .toBe(getTrainableUnitsForCity(/* matching city context */).length);
+```
+
+Add a partial-prerequisite state asserting the remaining technology is named and the unit
+is not in the legal trainable section.
+
+- [ ] **Step 2: Run the city-panel test and verify the new assertions fail**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/city-panel.test.ts`
+
+- [ ] **Step 3: Add role placeholders to every legal unit card**
+
+For every `availableUnits` entry, derive the shared presentation with the active
+civilization's completed technologies. Add a `data-unit-role-summary` placeholder and
+populate it through the existing safe `setText` path. Do not alter `availableUnits`, its
+sort order, build-item click handler, queue behavior, or locked-item visibility.
+
+- [ ] **Step 4: Run the city-panel test and verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/city-panel.test.ts`
+
+### Task 4: Render role facts and conjunctions in the tech inspector
+
+**Files:**
+- Modify: `src/ui/tech-panel.ts`
+- Modify: `tests/ui/tech-panel.test.ts`
+
+- [ ] **Step 1: Write failing inspector tests**
+
+```ts
+expect(panel.textContent).toContain('Strong against shock units');
+expect(panel.textContent).toContain('Bronze Working · Missing');
+```
+
+Add a hot-seat regression that renders the same inspected tech after changing
+`state.currentPlayer` and asserts only the new player’s completed-tech markers appear.
+
+- [ ] **Step 2: Run the tech-panel test and verify the new assertions fail**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/tech-panel.test.ts`
+
+- [ ] **Step 3: Render shared presentation for each unlocked unit**
+
+In `renderInspector`, replace plain unit-only unlock strings with child rows that retain
+the existing unlock copy and append role summary plus a native details disclosure. Use the
+same current-player completed technology IDs passed to the shared helper. Do not change
+research queue eligibility or controls.
+
+- [ ] **Step 4: Run the tech-panel test and verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/tech-panel.test.ts`
+
+### Task 5: Cross-surface regression and source-rule verification
+
+**Files:**
+- Verify: `src/ui/unit-role-presentation.ts`, `src/ui/selected-unit-info.ts`, `src/ui/city-panel.ts`, `src/ui/tech-panel.ts`
+- Verify: `tests/ui/unit-role-presentation.test.ts`, `tests/ui/selected-unit-info.test.ts`, `tests/ui/city-panel.test.ts`, `tests/ui/tech-panel.test.ts`
+
+- [ ] **Step 1: Run all focused tests together**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/unit-role-presentation.test.ts tests/ui/selected-unit-info.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts tests/systems/combat-role-definitions.test.ts`
+
+- [ ] **Step 2: Check source rules**
+
+Run: `scripts/check-src-rule-violations.sh src/ui/unit-role-presentation.ts src/ui/selected-unit-info.ts src/ui/city-panel.ts src/ui/tech-panel.ts`
+
+- [ ] **Step 3: Inspect MR scope**
+
+Run: `git diff --check && git diff --stat origin/main...HEAD && git diff --stat`
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Legal unit card | Open city Build tab | Role summary appears; every legal card remains reachable. |
+| Selected friendly unit | Open info panel | Role details, counters, vulnerabilities, and successor/terminal reason appear. |
+| Tech unlock has an unmet conjunction | Inspect tech | Missing technology is stated; no false “available” claim appears. |
+| Hot-seat handoff | Reopen player panel | Completed/missing requirement markers reflect only `currentPlayer`. |
+
+## Misleading UI Risks
+
+- Never infer a terminal successor.
+- Never mark a partial conjunction as available.
+- Never show icon-only role or counter information.
+- Never use roles to filter or rank the legal production catalog.
+
+## Interaction Replay Checklist
+
+- Build catalog open → queue item → rerender retains catalog and summary.
+- Selected unit open → upgrade → rerender presents the target unit facts.
+- Tech inspector open → queue research → panel reopens with updated facts.
+- Switch `currentPlayer` → reopen each surface → requirements recompute without stale markers.

--- a/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
+++ b/docs/superpowers/plans/2026-07-26-issue-668-unit-role-legibility.md
@@ -18,6 +18,10 @@
   player-reachable surfaces specified by Task 4 and declare a future unit Codex out of scope.
 - All labels must be icon plus text; role summaries remain 18 words or fewer by the existing
   catalog validator; all catalog entries remain reachable.
+- `run-with-mise.sh` special install/setup paths must exit after their delegated command;
+  the linked-worktree smoke test must reject a fall-through `install --immutable` call.
+- Long-running verification must retain and poll one terminal session through its final exit
+  code and summary; an incomplete response blocks completion and never justifies a retry.
 
 ### Task 1: Canonical unit-role presentation model
 

--- a/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
@@ -1,7 +1,7 @@
 # Issue #668 Unit Role Legibility Design
 
-**Date:** 2026-07-26  
-**Status:** Approved through inline review  
+**Date:** 2026-07-26
+**Status:** Approved through inline review
 **Issue:** #668
 
 ## Scope and drift decision
@@ -59,7 +59,7 @@ each unit unlocked by the selected technology, including a partial-conjunction c
 |---|---|---|
 | Eligible unit is visible in a city build catalog | Open Build tab | Its summary and role/counter line appear; all other legal units remain reachable. |
 | Selected friendly unit has an upgrade | Open its info panel | Role details and the explicit successor or terminal reason appear before the upgrade action. |
-| Selected tech unlocks a unit with two technology requirements | Inspect the tech | The unit's missing requirement is visible and it is not presented as immediately trainable. |
+| Selected tech unlocks a unit with two technology requirements | Inspect the tech | The inspected unlock is shown as complete after research; any other missing requirement remains visible, and the unit is not presented as immediately trainable. |
 | Current player changes in hot seat | Open that player's city, unit, or tech panel | The panel derives eligibility and missing requirements from the new current player only. |
 | Player queues research or completes an upgrade | Existing callback rerenders the open panel | The same presentation recomputes from current state; stale requirement text is not retained. |
 

--- a/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
@@ -1,0 +1,86 @@
+# Issue #668 Unit Role Legibility Design
+
+**Date:** 2026-07-26  
+**Status:** Approved through inline review  
+**Issue:** #668
+
+## Scope and drift decision
+
+Issue #668's title mentions a Codex, but the live application has a Wonder Codex only;
+it has no unit Codex launcher, unit catalog, or player-reachable unit reference surface.
+The governing Task 4 instead names the three live decision surfaces: city production,
+selected-unit information, and the tech inspector. This slice implements those surfaces
+and does not create an unreachable unit-Codex module. A future unit-Codex surface is
+explicitly out of scope for this focused MR.
+
+## Player outcome
+
+Every player sees the same canonical role facts where they decide to build, research,
+inspect, or upgrade a unit:
+
+- a plain-language role sentence of at most 18 words;
+- icon-and-text role, counters, vulnerabilities, and upgrade direction;
+- an optional native disclosure for exact typed values and unmet technologies;
+- a terminal explanation when no successor exists.
+
+The presentation never changes eligibility, combat calculations, AI decisions, difficulty,
+queues, or saves. It is a legibility layer over `UNIT_ROLE_DEFINITIONS`,
+`TRAINABLE_UNITS`, and `evaluateProductionPrerequisites`.
+
+## Inline review
+
+| Dimension | Finding and decision |
+|---|---|
+| Gameplay and balance | No values, gates, combat rules, or upgrade edges change. The UI reports existing facts only, so balance fixtures and tuning envelopes do not change. |
+| Fun, ages 7–43, play styles | The first sentence stays short and jargon-free; icon-plus-text supports quick reading while exact rows remain available for optimizers. No recommendation hides legal choices. |
+| Difficulty and computer players | Explorer, Standard, and Veteran retain identical unit facts and legality. AI already consumes the same role definition; this UI-only change adds no AI branch or hidden information. |
+| UI and UX | Production cards, selected-unit info, and the tech inspector each show the role summary. Details use a native `details` disclosure, retain 44-pixel controls already present, and refresh through existing panel rerender paths after queue/research/upgrade interactions. |
+| Architecture and extensibility | A pure `unit-role-presentation` helper owns labels, ordered facts, terminal copy, and prerequisite status. UI modules consume it; no unit-ID switch or duplicated role list is permitted. |
+| Data and saved games | Read-only derivation from existing serializable definitions and game state. No schema, migration, normalizer, or save round-trip change is required. |
+| SFX and notifications | Inspecting static information has no mechanical consequence. No sound, animation, notification, history entry, or mixer event is introduced, preventing handoff leakage. |
+| Solo and hot seat | Presentation is derived from the currently rendered city/unit/tech and `state.currentPlayer`; it never reads another player's private state. Tests render two current-player contexts and assert the active player's legality and missing requirements. |
+| Regression strategy | DOM tests cover readable summary, icon-plus-text counter rows, terminal state, partial conjunctive gate, full catalog reachability, disclosure content, and post-action rerender behavior. Existing system role and prerequisite tests remain the canonical metadata guard. |
+
+## Presentation contract
+
+`getUnitRolePresentation` accepts a unit type and optional completed technology IDs. It
+returns no value for non-catalog data, otherwise returns the definition's short summary,
+primary and secondary role labels, counter and vulnerability rows, an upgrade row, and
+ordered prerequisite rows. Icons never stand alone: every row includes visible text.
+
+The city build catalog displays the summary and compact role line for every legal unit,
+without filtering or reordering entries. The selected-unit panel displays the same summary
+and an expandable details block. The tech inspector displays the same role presentation for
+each unit unlocked by the selected technology, including a partial-conjunction checklist.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Eligible unit is visible in a city build catalog | Open Build tab | Its summary and role/counter line appear; all other legal units remain reachable. |
+| Selected friendly unit has an upgrade | Open its info panel | Role details and the explicit successor or terminal reason appear before the upgrade action. |
+| Selected tech unlocks a unit with two technology requirements | Inspect the tech | The unit's missing requirement is visible and it is not presented as immediately trainable. |
+| Current player changes in hot seat | Open that player's city, unit, or tech panel | The panel derives eligibility and missing requirements from the new current player only. |
+| Player queues research or completes an upgrade | Existing callback rerenders the open panel | The same presentation recomputes from current state; stale requirement text is not retained. |
+
+## Misleading UI risks
+
+- A unit with one completed technology out of two must show the remaining technology and
+  must not be labeled as available.
+- Terminal units must never imply an inferred successor; they show their explicit terminal
+  reason instead.
+- A counter is a role relationship, not a combat guarantee; labels use “Strong against”
+  and “Vulnerable to”, never promised outcomes.
+- Production recommendations are out of scope. The complete legal catalog remains the
+  only production catalog and no role metadata changes its order or reachability.
+
+## Interaction replay checklist
+
+- Open a city build catalog, select a legal unit, queue it, and assert the refreshed panel
+  still exposes role information and preserves queue content.
+- Open a selected unit, inspect details, upgrade through the existing confirmation path,
+  and assert the rerendered panel reflects the target unit.
+- Inspect a partially gated tech, change the current player, reopen the inspector, and
+  assert the old player's completed-tech markers do not remain.
+- Reopen each surface after its existing state mutation; no disclosure or stale-DOM
+  callback owns persistent state.

--- a/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-668-unit-role-legibility-design.md
@@ -84,3 +84,11 @@ each unit unlocked by the selected technology, including a partial-conjunction c
   assert the old player's completed-tech markers do not remain.
 - Reopen each surface after its existing state mutation; no disclosure or stale-DOM
   callback owns persistent state.
+
+## Verification ownership
+
+The worktree command wrapper must return immediately after its special `yarn install`
+and `yarn setup:hooks` paths. The smoke test rejects a second fall-through invocation.
+For long-running verification, agent tooling must retain and poll the original terminal
+session until it yields both an exit code and its normal completion summary; an incomplete
+tool response is not a passing result and must not trigger a duplicate run.

--- a/scripts/run-with-mise.sh
+++ b/scripts/run-with-mise.sh
@@ -30,11 +30,13 @@ export CONQUESTORIA_VITEST_CACHE_DIR="$CURRENT_ROOT/.vite/vitest"
 case "${1:-},${2:-}" in
   yarn,setup:hooks)
     run_without_local_git_env sh "$CURRENT_ROOT/scripts/setup-git-hooks.sh"
+    exit $?
     ;;
   yarn,install)
     cd "$CURRENT_ROOT"
     shift
     run_without_local_git_env mise exec -- yarn "$@"
+    exit $?
     ;;
 esac
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -725,6 +725,7 @@ export function createCityPanel(
       <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(u.type)} <span data-text="unit-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
       <div style="font-size:11px;opacity:0.82;margin-top:3px;" data-unit-role-summary="${u.type}"></div>
+      <div style="font-size:10px;opacity:0.72;margin-top:2px;line-height:1.35;" data-unit-role-facts="${u.type}"></div>
       ${resourceRequirementLine(u.type, u.resourceRequired)}
     </div>`;
   }
@@ -1145,6 +1146,15 @@ export function createCityPanel(
     const roleSummary = panel.querySelector(`[data-unit-role-summary="${u.type}"]`);
     if (roleSummary) {
       roleSummary.textContent = getUnitRolePresentation(u.type, completedTechs)?.summary ?? '';
+    }
+    const roleFacts = panel.querySelector(`[data-unit-role-facts="${u.type}"]`);
+    const presentation = getUnitRolePresentation(u.type, completedTechs);
+    if (roleFacts && presentation) {
+      roleFacts.textContent = [
+        ...presentation.counters,
+        ...presentation.vulnerabilities,
+        presentation.upgrade,
+      ].map(fact => `${fact.icon} ${fact.text}`).join(' · ');
     }
   });
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -32,6 +32,7 @@ import {
 import { getLegendaryLandmarkPreviewViewForCity } from '@/systems/legendary-wonder-landmark-presentation';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
 import {
   getUnrestYieldMultiplier,
   getCityAppeaseCost,
@@ -723,6 +724,7 @@ export function createCityPanel(
     unitPlaceholders += `<div class="build-item" data-item-id="${u.type}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
       <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(u.type)} <span data-text="unit-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
+      <div style="font-size:11px;opacity:0.82;margin-top:3px;" data-unit-role-summary="${u.type}"></div>
       ${resourceRequirementLine(u.type, u.resourceRequired)}
     </div>`;
   }
@@ -1140,6 +1142,10 @@ export function createCityPanel(
 
   availableUnits.forEach((u, i) => {
     setText(`unit-name-${i}`, u.name);
+    const roleSummary = panel.querySelector(`[data-unit-role-summary="${u.type}"]`);
+    if (roleSummary) {
+      roleSummary.textContent = getUnitRolePresentation(u.type, completedTechs)?.summary ?? '';
+    }
   });
 
   // Fill locked item names and reasons via textContent (XSS-safe)

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -38,6 +38,7 @@ import { canPreachTarget } from '@/systems/religion-system';
 import { getAirBaseCapacity, getAirBaseRoster } from '@/systems/air-operations-system';
 import type { AirBaseRef } from '@/core/types';
 import { canPillageTile } from '@/systems/pillage-system';
+import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -244,6 +245,39 @@ export function renderSelectedUnitInfo(
 
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
+
+  const rolePresentation = getUnitRolePresentation(
+    unit.type,
+    unit.owner === state.currentPlayer
+      ? state.civilizations[state.currentPlayer]?.techState.completed ?? []
+      : [],
+  );
+  if (rolePresentation) {
+    const roleSummary = document.createElement('div');
+    roleSummary.style.cssText = 'font-size:11px;line-height:1.35;margin-top:6px;color:#f8d28a;';
+    roleSummary.textContent = rolePresentation.summary;
+    wrapper.appendChild(roleSummary);
+
+    const details = document.createElement('details');
+    details.style.cssText = 'margin-top:6px;font-size:11px;line-height:1.4;';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Role details';
+    summary.style.cssText = 'cursor:pointer;color:#f8d28a;font-weight:700;';
+    details.appendChild(summary);
+    for (const fact of [
+      { icon: '🛡️', text: rolePresentation.roleText },
+      ...rolePresentation.counters,
+      ...rolePresentation.vulnerabilities,
+      rolePresentation.upgrade,
+      ...(unit.owner === state.currentPlayer ? rolePresentation.requirements : []),
+    ]) {
+      const row = document.createElement('div');
+      row.style.cssText = 'margin-top:3px;';
+      row.textContent = `${fact.icon} ${fact.text}`;
+      details.appendChild(row);
+    }
+    wrapper.appendChild(details);
+  }
 
   const scrollCue = document.createElement('div');
   scrollCue.dataset.scrollCue = 'true';

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -338,7 +338,10 @@ function renderInspector(
   inspector.appendChild(unlocks);
 
   for (const unitType of selectedNode.tech.unlocksUnits ?? []) {
-    const presentation = getUnitRolePresentation(unitType, civ.techState.completed);
+    const presentation = getUnitRolePresentation(
+      unitType,
+      [...civ.techState.completed, selectedNode.tech.id],
+    );
     if (!presentation) continue;
     const details = document.createElement('details');
     details.style.cssText = 'margin:0 0 8px;font-size:12px;line-height:1.4;';

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -13,6 +13,7 @@ import { TECH_TREE, getEffectiveTechCost } from '@/systems/tech-system';
 import { getEraAdvancementFraction, getEraAdvancementTechs, resolveCivilizationEra } from '@/systems/tech-definitions';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { evaluateProductionPrerequisites } from '@/systems/production-prerequisites';
+import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
 
 function getUnlockLines(tech: Tech, completedTechs?: readonly string[]): string[] {
   const lines = [...tech.unlocks];
@@ -335,6 +336,30 @@ function renderInspector(
   unlocks.textContent = getUnlockLines(selectedNode.tech, civ.techState.completed).join(', ') || 'New options for your empire';
   unlocks.style.cssText = 'font-size:12px;line-height:1.35;margin-bottom:10px;';
   inspector.appendChild(unlocks);
+
+  for (const unitType of selectedNode.tech.unlocksUnits ?? []) {
+    const presentation = getUnitRolePresentation(unitType, civ.techState.completed);
+    if (!presentation) continue;
+    const details = document.createElement('details');
+    details.style.cssText = 'margin:0 0 8px;font-size:12px;line-height:1.4;';
+    const summary = document.createElement('summary');
+    summary.textContent = `${UNIT_DEFINITIONS[unitType].name} role details`;
+    summary.style.cssText = 'cursor:pointer;color:#f8d28a;font-weight:700;';
+    details.appendChild(summary);
+    for (const fact of [
+      { icon: '🛡️', text: presentation.summary },
+      ...presentation.counters,
+      ...presentation.vulnerabilities,
+      presentation.upgrade,
+      ...presentation.requirements,
+    ]) {
+      const row = document.createElement('div');
+      row.style.cssText = 'margin-top:3px;';
+      row.textContent = `${fact.icon} ${fact.text}`;
+      details.appendChild(row);
+    }
+    inspector.appendChild(details);
+  }
 
   const prereqTitle = document.createElement('div');
   prereqTitle.textContent = 'Prerequisites';

--- a/src/ui/unit-role-presentation.ts
+++ b/src/ui/unit-role-presentation.ts
@@ -1,0 +1,79 @@
+import type { CombatRole, UnitType } from '@/core/types';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { getUnitRoleDefinition } from '@/systems/combat-role-definitions';
+import { evaluateProductionPrerequisites } from '@/systems/production-prerequisites';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export interface IconTextFact {
+  icon: string;
+  text: string;
+}
+
+export interface UnitRolePresentation {
+  summary: string;
+  roleText: string;
+  counters: readonly IconTextFact[];
+  vulnerabilities: readonly IconTextFact[];
+  upgrade: IconTextFact;
+  requirements: readonly IconTextFact[];
+}
+
+const ROLE_LABELS: Record<CombatRole, string> = {
+  frontline: 'frontline',
+  ranged: 'ranged',
+  siege: 'siege',
+  shock: 'shock',
+  pursuit: 'pursuit',
+  reconnaissance: 'reconnaissance',
+  detection: 'detection',
+  'anti-mounted': 'anti-mounted',
+  'anti-armor': 'anti-armor',
+  'air-superiority': 'air-superiority',
+  'ground-air-defense': 'ground anti-air defense',
+  'capital-ship': 'capital ships',
+  escort: 'escort',
+  'formation-support': 'formation support',
+  capture: 'capture',
+  civilian: 'civilian',
+};
+
+function pluralRole(role: CombatRole): string {
+  return `${ROLE_LABELS[role]} units`;
+}
+
+function techName(id: string): string {
+  return TECH_TREE.find(tech => tech.id === id)?.name ?? id;
+}
+
+export function getUnitRolePresentation(
+  type: UnitType,
+  completedTechs: readonly string[] = [],
+): UnitRolePresentation | undefined {
+  const definition = getUnitRoleDefinition(type);
+  if (!definition) return undefined;
+
+  const entry = TRAINABLE_UNITS.find(unit => unit.type === type);
+  const roleNames = [definition.primaryRole, ...(definition.secondaryRoles ?? [])]
+    .map(role => ROLE_LABELS[role]);
+  const prerequisites = entry
+    ? evaluateProductionPrerequisites(entry, completedTechs)
+    : { required: [], satisfied: [], missing: [] };
+  const target = entry?.upgradesTo;
+
+  return {
+    summary: definition.roleSummary,
+    roleText: `Role: ${roleNames.join(' · ')}`,
+    counters: definition.counters.map(role => ({ icon: '🎯', text: `Strong against ${pluralRole(role)}` })),
+    vulnerabilities: definition.vulnerableTo.map(role => ({ icon: '⚠️', text: `Vulnerable to ${pluralRole(role)}` })),
+    upgrade: target
+      ? { icon: '⬆️', text: `Upgrades to ${UNIT_DEFINITIONS[target].name}` }
+      : definition.terminalReason
+        ? { icon: '🏁', text: definition.terminalReason }
+        : { icon: '—', text: 'No upgrade path' },
+    requirements: prerequisites.required.map(id => ({
+      icon: prerequisites.satisfied.includes(id) ? '✓' : '🔒',
+      text: `${techName(id)} · ${prerequisites.satisfied.includes(id) ? 'Complete' : 'Missing'}`,
+    })),
+  };
+}

--- a/tests/hooks/run-with-mise-worktree.test.sh
+++ b/tests/hooks/run-with-mise-worktree.test.sh
@@ -114,3 +114,7 @@ grep -Fq "$linked|$linked/.vite/vitest||exec -- yarn install --immutable" "$mise
   echo 'install did not target the active worktree' >&2
   exit 1
 }
+! grep -Fq "$linked|$linked/.vite/vitest||exec -- install --immutable" "$mise_log" || {
+  echo 'install fell through and invoked the system install command' >&2
+  exit 1
+}

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -24,6 +24,19 @@ function clickElement(element: Element | null | undefined): void {
 }
 
 describe('city-panel national projects', () => {
+  it('keeps every legal unit reachable while showing its canonical role summary', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+
+    expect(panel.querySelector('[data-item-id="warrior"]')).toBeTruthy();
+    expect(panel.querySelector('[data-unit-role-summary="warrior"]')?.textContent)
+      .toBe('Cheap early defender that holds ground and captures exposed positions.');
+    expect(panel.querySelectorAll('[data-unit-role-summary]').length)
+      .toBe(panel.querySelectorAll('[data-section="trainable-units"] [data-item-id]').length);
+  });
+
   it('keeps a partially satisfied conjunctive unit gate visible with every ordered technology state', () => {
     const { container, city, state } = makeWonderPanelFixture();
     state.civilizations.player.techState.completed = ['archery'];

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -33,6 +33,10 @@ describe('city-panel national projects', () => {
     expect(panel.querySelector('[data-item-id="warrior"]')).toBeTruthy();
     expect(panel.querySelector('[data-unit-role-summary="warrior"]')?.textContent)
       .toBe('Cheap early defender that holds ground and captures exposed positions.');
+    expect(panel.querySelector('[data-unit-role-facts="warrior"]')?.textContent)
+      .toContain('Strong against civilian units');
+    expect(panel.querySelector('[data-unit-role-facts="warrior"]')?.textContent)
+      .toContain('Upgrades to Spearman');
     expect(panel.querySelectorAll('[data-unit-role-summary]').length)
       .toBe(panel.querySelectorAll('[data-section="trainable-units"] [data-item-id]').length);
   });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -97,6 +97,16 @@ function findButtons(node: unknown): MockElement[] {
   return result;
 }
 
+function findDetails(node: unknown): MockElement | undefined {
+  const el = node as MockElement;
+  if (el.tagName === 'DETAILS') return el;
+  for (const child of el.children ?? []) {
+    const found = findDetails(child);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 function findWaterRecoveryGuidance(node: unknown): MockElement | undefined {
   const el = node as MockElement;
   if (el.dataset?.waterRecoveryKind) return el;
@@ -151,6 +161,53 @@ describe('selected-unit scroll affordance', () => {
     const cue = findScrollCue(container);
     expect(cue?.textContent).toBe('↓ More details and actions below — scroll');
     expect(cue?.style.display).toBe('block');
+  });
+});
+
+describe('selected-unit role presentation', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('renders canonical counterplay as expandable icon-and-text details', () => {
+    const state = createNewGame(undefined, 'selected-unit-role-presentation', 'small');
+    const unit = {
+      ...createUnit('pikeman', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'pikeman',
+    };
+    state.currentPlayer = 'player';
+    state.units = { pikeman: unit };
+    state.civilizations.player.units = ['pikeman'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'pikeman', {});
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('Polearm defender that stops charging mounted attackers.');
+    expect(text).toContain('Strong against shock units');
+    expect(text).toContain('Vulnerable to ranged units');
+    expect(findDetails(container)?.children[0]?.textContent).toBe('Role details');
+  });
+
+  it('renders a terminal explanation instead of inventing an artillery successor', () => {
+    const state = createNewGame(undefined, 'selected-unit-terminal-role', 'small');
+    const unit = {
+      ...createUnit('artillery', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'artillery',
+    };
+    state.currentPlayer = 'player';
+    state.units = { artillery: unit };
+    state.civilizations.player.units = ['artillery'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'artillery', {});
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('Current siege apex; rocket artillery is future content.');
+    expect(text).not.toContain('Upgrades to');
   });
 });
 

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -12,6 +12,56 @@ import { createTechPanel, formatTechNodeEta } from '@/ui/tech-panel';
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
 describe('tech-panel', () => {
+  it('shows canonical role facts and current-player prerequisite status in the inspector', () => {
+    const state = createNewGame(undefined, 'tech-role-inspector');
+    state.civilizations.player.techState.completed = ['archery'];
+    state.civilizations.player.techState.currentResearch = 'archery';
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      const panel = createTechPanel(document.body, state, {
+        onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
+      });
+      expect(panel.textContent).toContain('Safe early ranged support that punishes slow frontline units.');
+      expect(panel.textContent).toContain('Strong against frontline units');
+      expect(panel.textContent).toContain('Bronze Working · Missing');
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
+  it('recomputes role prerequisites for the current hot-seat player', () => {
+    const state = createNewGame(undefined, 'tech-role-hot-seat');
+    state.civilizations['player-2'] = {
+      ...structuredClone(state.civilizations.player),
+      id: 'player-2',
+      isHuman: true,
+      techState: { ...state.civilizations.player.techState, completed: ['archery'], currentResearch: 'archery' },
+    };
+    state.civilizations.player.techState = {
+      ...state.civilizations.player.techState,
+      completed: ['archery', 'bronze-working'],
+      currentResearch: 'archery',
+    };
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      state.currentPlayer = 'player-2';
+      expect(createTechPanel(document.body, state, {
+        onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
+      }).textContent).toContain('Bronze Working · Missing');
+
+      state.currentPlayer = 'player';
+      expect(createTechPanel(document.body, state, {
+        onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
+      }).textContent).toContain('Bronze Working · Complete');
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+
   it('explains an unlocked unit\'s remaining conjunctive technology in the inspector', () => {
     const state = createNewGame(undefined, 'tech-conjunctive-inspector');
     state.civilizations.player.techState.completed = ['stone-weapons'];

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -31,6 +31,19 @@ describe('tech-panel', () => {
     }
   });
 
+  it('treats the inspected unlock technology as complete in its unit role facts', () => {
+    const state = createNewGame(undefined, 'tech-role-unlock-projection');
+    state.civilizations.player.techState.completed = ['stone-weapons'];
+    state.civilizations.player.techState.currentResearch = 'archery';
+
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {}, onMoveQueuedResearch: () => {}, onRemoveQueuedResearch: () => {}, onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Archery · Complete');
+    expect(panel.textContent).not.toContain('Archery · Missing');
+  });
+
   it('recomputes role prerequisites for the current hot-seat player', () => {
     const state = createNewGame(undefined, 'tech-role-hot-seat');
     state.civilizations['player-2'] = {

--- a/tests/ui/unit-role-presentation.test.ts
+++ b/tests/ui/unit-role-presentation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
+
+describe('unit role presentation', () => {
+  it('turns canonical counterplay into readable icon-and-text facts', () => {
+    expect(getUnitRolePresentation('pikeman', ['fortification'])).toMatchObject({
+      summary: 'Polearm defender that stops charging mounted attackers.',
+      counters: [{ icon: '🎯', text: 'Strong against shock units' }],
+      vulnerabilities: [
+        { icon: '⚠️', text: 'Vulnerable to ranged units' },
+        { icon: '⚠️', text: 'Vulnerable to siege units' },
+      ],
+    });
+  });
+
+  it('shows explicit terminal and conjunctive prerequisite facts without inferring a successor', () => {
+    expect(getUnitRolePresentation('artillery', ['mass-firepower'])?.upgrade)
+      .toEqual({ icon: '🏁', text: 'Current siege apex; rocket artillery is future content.' });
+
+    const archer = TRAINABLE_UNITS.find(unit => unit.type === 'archer')!;
+    const original = archer.requiredTechs;
+    archer.requiredTechs = ['bronze-working'];
+    try {
+      expect(getUnitRolePresentation('archer', ['archery', 'bronze-working'])?.requirements)
+        .toEqual([
+          { icon: '✓', text: 'Archery · Complete' },
+          { icon: '✓', text: 'Bronze Working · Complete' },
+        ]);
+    } finally {
+      archer.requiredTechs = original;
+    }
+  });
+});


### PR DESCRIPTION
Closes #668

## Summary

- Shows canonical unit role summaries, counters, vulnerabilities, prerequisites, and upgrade/terminal direction in city production, selected-unit information, and the tech inspector.
- Keeps this as a read-only presentation layer: gameplay balance, AI, difficulty, saves, SFX, notifications, queues, and ordering are unchanged.
- Fixes the worktree command wrapper so `yarn install` and `yarn setup:hooks` return the delegated exit status instead of falling through; adds a regression guard and terminal-session verification guidance.
- Fixes tech-inspector role prerequisites to project the inspected unlock as complete, while keeping any other missing conjunctive requirements visible.

## Inline review

Reviewed gameplay balance, fun/readability for ages 7–43, play styles, difficulty, AI, UI/UX, architecture, extensibility, data, SFX, saves, solo and hot-seat privacy, implementation, and regressions. Findings fixed: wrapper fall-through, documentation whitespace, and misleading self-prerequisite status in the tech inspector.

## Verification

- `scripts/check-src-rule-violations.sh src/ui/unit-role-presentation.ts src/ui/selected-unit-info.ts src/ui/city-panel.ts src/ui/tech-panel.ts`
- `bash scripts/run-with-mise.sh yarn test --run tests/ui/unit-role-presentation.test.ts tests/ui/selected-unit-info.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts tests/systems/combat-role-definitions.test.ts` — 249 passed
- `bash scripts/run-with-mise.sh yarn test:hooks`
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` — 433 files passed; 6,999 tests passed; 3 skipped
- Push gate repeated the full suite and production build successfully