### PR TITLE
feat(combat): expose modifier facts in preview and history (#669)

### DIFF
--- a/.claude/rules/hooks-and-tooling.md
+++ b/.claude/rules/hooks-and-tooling.md
@@ -49,7 +49,7 @@ paths:
 
 **Set Bash tool timeout to match the command, not the hook:**
 - `git commit` — **30 000 ms**. No hook runs tests; the commit itself takes < 1s.
-- `git push` / `gh pr create` / `gh pr merge` — **120 000 ms** is enough for the local `--fast` gate. If you've just changed a slow-tier file and want to also verify it locally first (`yarn test:slow` or a targeted `yarn vitest run <file>`), do that as its own step before pushing — see #608 investigation notes above for observed durations up to ~600s worst case.
+- `git push` / `gh pr create` / `gh pr merge` — allow **240 000 ms** for the local `--fast` gate. The fast suite plus build has been measured at about 174 seconds on this shared workstation; a 120-second tool window can interrupt its detached timeout child and leave Vitest workers behind. If you've just changed a slow-tier file and want to also verify it locally first (`yarn test:slow` or a targeted `yarn vitest run <file>`), do that as its own step before pushing — see #608 investigation notes above for observed durations up to ~600s worst case.
 - A 360 000 ms timeout on `git commit` papers over the wrong symptom. Match the timeout to what the command actually does.
 
 ## Concurrent local verification

--- a/docs/superpowers/plans/2026-07-26-issue-669-combat-modifier-facts.md
+++ b/docs/superpowers/plans/2026-07-26-issue-669-combat-modifier-facts.md
@@ -1,0 +1,275 @@
+# Combat Modifier Facts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface canonical, viewer-safe combat modifier explanations in preview and persisted recipient history without changing combat outcomes.
+
+**Architecture:** The modifier evaluator produces structured facts beside existing numeric aggregates. Combat snapshots those facts before state changes. Viewer presentation projects safe facts per recipient, and notification history persists only that projection.
+
+**Tech Stack:** TypeScript, Vitest, DOM UI, serializable game state, save migrations.
+
+---
+
+## File map
+
+- `src/systems/unit-modifier-system.ts` — canonical numeric and fact evaluation.
+- `src/systems/combat-system.ts`, `src/core/types.ts` — immutable calculation snapshot.
+- `src/systems/viewer-event-presentation.ts`, `src/ui/combat-preview.ts` — viewer-safe preview.
+- `src/core/notification-log.ts`, `src/ui/notification-routing.ts`, `src/ui/notification-log-panel.ts` — recipient history.
+- `src/storage/save-migrations.ts`, `src/storage/save-manager.ts` — version and normalize history details.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result | Must remain private |
+|---|---|---|---|
+| Pikeman can attack cavalry | Tap target | “Your pikeman is strong against cavalry” and details affordance | Rival-only source identities |
+| Preview is open | Expand calculation | Applied/ignored rows and exact values | Redacted sources stay generic |
+| Visible AI combat resolves | Open Message Log | Recipient-specific saved detail expands in place | Another human’s detail |
+| Hot-seat handoff | Open Message Log | Only active player entries render | Prior preview, log, toast, and audio |
+
+## Misleading UI Risks
+
+- Do not label a numeric total as a named source without an authorized fact.
+- Do not render an ignored fact as an active bonus.
+- Do not manufacture `capped` or `superseded` when no real rule produces it.
+- Do not expose source identity through a detail label when projection redacted it.
+
+## Interaction Replay Checklist
+
+- Preview, expand, cancel, and reopen.
+- Resolve that attack, then open the Message Log and compare stored projection.
+- Change hot-seat current player before reopening history.
+- Load valid, malformed, and legacy notification records and reopen history.
+
+### Task 1: Emit canonical facts
+
+**Files:**
+- Modify: `src/systems/unit-modifier-system.ts`
+- Modify: `src/systems/combat-system.ts`
+- Modify: `src/core/types.ts`
+- Test: `tests/systems/unit-modifier-system.test.ts`
+- Test: `tests/systems/combat-system.test.ts`
+
+- [ ] **Step 1: Write failing tests for applied and ignored facts**
+
+```ts
+expect(getCombatModifier('pikeman', 'attacker', baseCombatCtx({ opponentType: 'knight' })).facts)
+  .toContainEqual(expect.objectContaining({
+    key: 'counter:anti-cavalry', outcome: 'applied', operation: 'multiplier', value: 1.5,
+  }));
+expect(getCombatModifier('warrior', 'attacker', baseCombatCtx({
+  completedTechs: ['steel-plate-armor'],
+})).facts).toContainEqual(expect.objectContaining({
+  key: 'tech:steel-plate-armor', outcome: 'ignored', ignoredReason: 'role',
+}));
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-modifier-system.test.ts tests/systems/combat-system.test.ts`
+
+Expected: FAIL because no `facts` contract exists.
+
+- [ ] **Step 3: Add the minimal typed fact contract and evaluator output**
+
+```ts
+export interface CombatModifierFact {
+  key: string;
+  side: 'attacker' | 'defender';
+  operation: 'flat' | 'multiplier';
+  value: number;
+  outcome: 'applied' | 'ignored' | 'capped' | 'superseded';
+  labelKey: string;
+  source: { visibility: 'owner' | 'public'; kind: 'tech' | 'national-project' | 'unit' | 'counter' };
+  ignoredReason?: 'role' | 'condition' | 'unit-class' | 'domain' | 'inactive-source';
+}
+```
+
+Evaluate candidates in definition order. Applied facts alone change `mult` or `flat`. Keep outcomes `capped` and `superseded` un-emitted until a real canonical cap or strongest-source resolver exists. Snapshot attacker and defender facts in both `CombatStrengthBreakdown` and `CombatResult`.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-modifier-system.test.ts tests/systems/combat-system.test.ts`
+
+Expected: PASS; existing strengths and damage remain unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/unit-modifier-system.ts src/systems/combat-system.ts src/core/types.ts tests/systems/unit-modifier-system.test.ts tests/systems/combat-system.test.ts
+git commit -m "feat(combat): emit modifier facts with strength evaluation"
+```
+
+### Task 2: Project and render preview detail
+
+**Files:**
+- Modify: `src/systems/viewer-event-presentation.ts`
+- Modify: `src/ui/combat-preview.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/viewer-event-presentation.test.ts`
+- Test: `tests/ui/combat-preview.test.ts`
+
+- [ ] **Step 1: Write failing projection and DOM tests**
+
+```ts
+expect(projectCombatModifierFacts(rawFacts, 'defender', context))
+  .toContainEqual(expect.objectContaining({ label: 'Unknown advantage', redacted: true }));
+expect(previewPanel.textContent).toContain('Your pikeman is strong against cavalry');
+detailsButton.click();
+expect(previewPanel.textContent).toContain('Show less');
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/viewer-event-presentation.test.ts tests/ui/combat-preview.test.ts`
+
+Expected: FAIL because no viewer projection or details interaction exists.
+
+- [ ] **Step 3: Add a projection and expandable preview**
+
+```ts
+export interface CombatModifierPresentationFact {
+  side: 'attacker' | 'defender';
+  label: string;
+  operation: 'flat' | 'multiplier';
+  value: number;
+  outcome: CombatModifierFact['outcome'];
+  detail: string;
+  redacted: boolean;
+}
+```
+
+Project from the saved evaluation snapshot, never current state. The preview shows only one decisive applied fact by default; `Show calculation` expands all permitted rows. Use `textContent`, `createGameButton`, icon-plus-text labels, and a 44px control.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/viewer-event-presentation.test.ts tests/ui/combat-preview.test.ts`
+
+Expected: PASS; source redaction and repeat expansion are deterministic.
+
+```bash
+git add src/systems/viewer-event-presentation.ts src/ui/combat-preview.ts src/main.ts tests/systems/viewer-event-presentation.test.ts tests/ui/combat-preview.test.ts
+git commit -m "feat(ui): present viewer-safe combat modifier details"
+```
+
+### Task 3: Persist recipient-specific history details
+
+**Files:**
+- Modify: `src/core/notification-log.ts`
+- Modify: `src/ui/notification-routing.ts`
+- Modify: `src/ui/combat-resolved-presentation.ts`
+- Modify: `src/ui/notification-log-panel.ts`
+- Test: `tests/ui/notification-routing.test.ts`
+- Test: `tests/ui/combat-resolved-presentation.test.ts`
+- Test: `tests/ui/notification-log-panel.test.ts`
+
+- [ ] **Step 1: Write failing history tests**
+
+```ts
+expect(calls[0]).toMatchObject({
+  civId: 'defender',
+  combatDetails: { facts: [expect.objectContaining({ redacted: true })] },
+});
+detailsButton.click();
+expect(panel.textContent).toContain('Unknown advantage');
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-log-panel.test.ts`
+
+Expected: FAIL because notifications cannot carry `combatDetails`.
+
+- [ ] **Step 3: Add recipient-only log data and interaction**
+
+```ts
+export interface CombatNotificationDetails {
+  summary: string;
+  facts: CombatModifierPresentationFact[];
+}
+
+export interface NotificationEntry {
+  // existing fields
+  combatDetails?: CombatNotificationDetails;
+}
+```
+
+Extend `NotificationSink` and delivery so routing projects separately for each recipient before persisting. Keep toast text short. The message-log button expands/collapses in place, stops propagation, and does not alter map-focus behavior.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-log-panel.test.ts`
+
+Expected: PASS; suppressed visuals still log details and each recipient receives only its projection.
+
+```bash
+git add src/core/notification-log.ts src/ui/notification-routing.ts src/ui/combat-resolved-presentation.ts src/ui/notification-log-panel.ts tests/ui/notification-routing.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-log-panel.test.ts
+git commit -m "feat(history): retain recipient-safe combat modifier details"
+```
+
+### Task 4: Migrate saves and prove parity
+
+**Files:**
+- Modify: `src/storage/save-migrations.ts`
+- Modify: `src/storage/save-manager.ts`
+- Test: `tests/storage/save-migrations.test.ts`
+- Test: `tests/storage/save-manager.test.ts`
+- Test: `tests/ai/ai-major-turn.test.ts`
+- Test: `tests/core/turn-manager.test.ts`
+
+- [ ] **Step 1: Write failing migration and parity tests**
+
+```ts
+expect(normalizeLoadedStateForTest(malformed).notificationLog.player[0])
+  .not.toHaveProperty('combatDetails');
+expect(migrateSaveToCurrent(previousSchema).saveSchemaVersion)
+  .toBe(CURRENT_SAVE_SCHEMA_VERSION);
+expect(aiCombatEvent.result.modifierFacts).toEqual(humanCombatResult.modifierFacts);
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/ai/ai-major-turn.test.ts tests/core/turn-manager.test.ts`
+
+Expected: FAIL because migration and normalizer do not recognize detail.
+
+- [ ] **Step 3: Add migration, total normalization, and required regressions**
+
+Increment `CURRENT_SAVE_SCHEMA_VERSION` only after confirming the rebased value. Add the prior-schema migration and invoke a normalizer that accepts a valid summary/fact list, removes malformed `combatDetails` without dropping its notification, and remains idempotent. Add equal-state Explorer/Standard/Veteran facts, one AI/turn-manager emitter parity test, solo delivery, and two-human handoff tests. Assert a non-recipient never receives preview detail, notification detail, toast, or modifier-related SFX.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/ai/ai-major-turn.test.ts tests/core/turn-manager.test.ts`
+
+Expected: PASS; migration is idempotent and difficulty/actor/viewer parity holds.
+
+```bash
+git add src/storage/save-migrations.ts src/storage/save-manager.ts tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/ai/ai-major-turn.test.ts tests/core/turn-manager.test.ts
+git commit -m "feat(storage): preserve combat modifier history details"
+```
+
+### Task 5: Verify the complete slice
+
+- [ ] **Step 1: Run source and targeted checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/unit-modifier-system.ts src/systems/combat-system.ts src/systems/viewer-event-presentation.ts src/ui/combat-preview.ts src/ui/notification-routing.ts src/ui/combat-resolved-presentation.ts src/ui/notification-log-panel.ts src/storage/save-manager.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-modifier-system.test.ts tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/ui/notification-routing.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-log-panel.test.ts tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/ai/ai-major-turn.test.ts tests/core/turn-manager.test.ts
+```
+
+- [ ] **Step 2: Review and release-verify**
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+git diff --stat
+git diff
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+```
+
+## Plan self-review
+
+The plan preserves balance by making facts observational, keeps casual and expert UX distinct, covers AI/difficulty/solo/hot-seat privacy, persists only recipient-safe history, adds no SFX, and rejects fabricated cap/supersession rows. Names and paths are consistent across all tasks.
+

--- a/docs/superpowers/plans/2026-07-26-issue-669-combat-modifier-facts.md
+++ b/docs/superpowers/plans/2026-07-26-issue-669-combat-modifier-facts.md
@@ -272,4 +272,3 @@ bash scripts/run-with-mise.sh yarn test
 ## Plan self-review
 
 The plan preserves balance by making facts observational, keeps casual and expert UX distinct, covers AI/difficulty/solo/hot-seat privacy, persists only recipient-safe history, adds no SFX, and rejects fabricated cap/supersession rows. Names and paths are consistent across all tasks.
-

--- a/docs/superpowers/specs/2026-07-26-issue-669-combat-modifier-facts-design.md
+++ b/docs/superpowers/specs/2026-07-26-issue-669-combat-modifier-facts-design.md
@@ -1,0 +1,113 @@
+# Combat Modifier Facts Design
+
+**Issue:** #669 — Expose named roster modifiers in combat preview and history
+
+## Goal
+
+Explain why a combat strength changed without changing combat balance or revealing
+information that the current viewer has not earned.
+
+## Scope
+
+The combat calculation emits stable, serializable modifier facts at evaluation time.
+The combat preview and recipient-specific combat history consume the same evaluated
+facts. This delivery does not add or rebalance a combat modifier, change difficulty
+formulas, or add modifier-specific sound effects.
+
+## Data contract
+
+Introduce a plain-object `CombatModifierFact` with:
+
+- a stable string `key` identifying the canonical rule;
+- structured label parameters rather than preformatted UI strings;
+- a signed numeric contribution and whether it is flat or multiplicative;
+- an outcome of `applied`, `ignored`, `capped`, or `superseded`;
+- a source scope that can be projected for an authorized or unauthorized viewer.
+
+`CombatModifierFact` is calculation-facing. Its projection is a separate plain object
+containing only a safe label, the permitted value and operation, the outcome, and a
+short explanation key. The projection never retains a rival technology, national
+project, unit, route, or provider identity unless that identity is already authorized
+for its recipient.
+
+Facts are created by the canonical modifier/combat evaluation helpers and captured in
+the calculation result before combat state mutates. UI code only formats them. It must
+not scan final state, duplicate modifier predicates, or infer a source from a unit ID.
+
+`capped` and `superseded` are supported outcome values, but may be emitted only by a
+real canonical cap or strongest-source rule. This issue must not invent either outcome
+solely to populate presentation rows.
+
+## Viewer scope and history
+
+Raw calculation facts are not automatically safe for every event listener. A
+viewer-scoped projection must reveal a source only when the viewer is entitled to know
+it. Otherwise it retains the permitted visible total with an intentionally redacted,
+plain-language source label.
+
+The preview uses that projection for the current viewer. Combat history persists the
+same recipient-specific projection in a typed optional `combatDetails` field on its
+existing `NotificationEntry`; reopening history must read that snapshot rather than
+reconstruct facts from later state. Notification text remains concise; an explicit
+details control expands the stored projection.
+
+The projection is computed before presentation, respects existing combat visibility,
+and is never rendered or played after a hot-seat handoff for an unauthorized human.
+
+## Player experience
+
+The default preview starts with a plain-language explanation of no more than 18 words,
+for example: “Your pikeman is strong against cavalry.” It shows the decisive applied
+fact only, uses icon plus text, and does not rely on color, sound, or animation. Exact
+values, conditions, ignored rows, superseded layers, and source detail are available
+through an explicit expandable calculation.
+
+This keeps the decision understandable for younger and casual players while preserving
+the legal explanation needed by experienced players. It does not hide legal actions or
+claim a bonus can be used when its condition is unmet.
+
+## Gameplay, AI, difficulty, and audio
+
+Facts are observational. The existing formula, evaluation order, seeded randomness,
+and modifier values remain unchanged. Explorer, Standard, and Veteran produce the
+same facts for the same state. Difficulty-specific decision quality or pressure does
+not alter this contract.
+
+Human, AI, turn-manager, pirate, minor-civilization, and other combat callers continue
+to use the shared combat context and resolver. AI may consume canonical calculation
+results from its owned or earned observations, but must not consume a richer
+viewer-presentation projection or gain hidden rival sources through it.
+
+No new SFX is introduced. Existing combat SFX remains gated by the existing visible
+viewer path and modifier facts receive the same visual/text explanation in preview and
+history.
+
+## Persistence
+
+Add the next save schema version only after rebasing because recipient-scoped
+`NotificationEntry.combatDetails` is persisted. Normalize the optional record
+idempotently: accept valid projections, discard malformed detail without discarding its
+parent notification, and preserve legacy notifications without fabricated detail.
+Cover schema 0, the immediately preceding schema, current saves, malformed records,
+and a mid-combat round-trip.
+
+## Verification
+
+Tests begin red and cover:
+
+- an applied counter and an exact preview/result snapshot match;
+- an ignored conditional modifier and two out-of-role negatives;
+- capped and superseded facts only where a real rule produces them;
+- redaction of unauthorized source identity while preserving the allowed total;
+- human and non-human emitter parity through the shared resolver;
+- Explorer, Standard, and Veteran parity for equal state;
+- solo presentation, hot-seat handoff isolation, and immediate preview/history refresh;
+- deterministic balance fixtures for predecessor, successor, intended counter, and
+  same-era generalist;
+- save migration and normalization for persisted recipient history detail.
+
+## Out of scope
+
+Ground-based anti-air strongest-source stacking, new roster units, modifier rebalancing,
+and new bespoke audio or visual assets belong to their respective child issues. This
+slice only establishes truthful, reusable explanation facts for current combat rules.

--- a/src/core/notification-log.ts
+++ b/src/core/notification-log.ts
@@ -1,4 +1,4 @@
-import type { GameState, HexCoord } from './types';
+import type { CombatModifierFact, GameState, HexCoord } from './types';
 
 export interface NotificationMapTarget {
   kind: 'map';
@@ -16,6 +16,18 @@ export type PirateNotificationReview =
   | { kind: 'pirate-faction'; factionId: string }
   | { kind: 'pirate-history'; historyId: string };
 
+export interface CombatNotificationFact {
+  label: string;
+  operation: CombatModifierFact['operation'];
+  value: number;
+  outcome: CombatModifierFact['outcome'];
+  redacted: boolean;
+}
+
+export interface CombatNotificationDetails {
+  facts: CombatNotificationFact[];
+}
+
 export interface NotificationEntry {
   id: string;
   message: string;
@@ -26,6 +38,7 @@ export interface NotificationEntry {
   linkedCityId?: string;
   cityActions?: NotificationCityAction[];
   review?: PirateNotificationReview;
+  combatDetails?: CombatNotificationDetails;
 }
 
 export type NotificationDraft = Omit<NotificationEntry, 'id' | 'read'> & Partial<Pick<NotificationEntry, 'read'>>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1231,7 +1231,21 @@ export interface CombatResult {
   defenderStrength: number;
   attackerPosition: HexCoord;
   defenderPosition: HexCoord;
+  modifierFacts?: {
+    attacker: CombatModifierFact[];
+    defender: CombatModifierFact[];
+  };
   exchange?: CombatExchangeSummary;
+}
+
+export interface CombatModifierFact {
+  key: string;
+  label: string;
+  sourceVisibility: 'owner' | 'public';
+  operation: 'flat' | 'multiplier';
+  value: number;
+  outcome: 'applied' | 'ignored' | 'capped' | 'superseded';
+  ignoredReason?: 'role' | 'condition' | 'unit-class' | 'domain' | 'inactive-source';
 }
 
 export type CombatExchangeKind = 'none' | 'turret-fire' | 'evasion';

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -23,7 +23,7 @@ import {
   type PirateRelocationDirection,
   type PirateState,
 } from '@/core/pirate-state';
-import type { NotificationEntry, NotificationLog } from '@/core/notification-log';
+import type { CombatNotificationFact, NotificationEntry, NotificationLog } from '@/core/notification-log';
 import { dbGet, dbPut, dbDelete, dbGetAllKeys } from './db';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
 import { getPirateStageDefinition, PIRATE_NOTORIETY, PIRATE_PRESSURE } from '@/systems/pirate-definitions';
@@ -475,6 +475,26 @@ function normalizeNotificationTarget(value: unknown): NotificationEntry['target'
   return { kind: 'map', coord: { ...(value.coord as { q: number; r: number }) }, label: value.label };
 }
 
+function normalizeCombatNotificationDetails(value: unknown): NotificationEntry['combatDetails'] | undefined {
+  if (!isRecord(value) || !Array.isArray(value.facts)) return undefined;
+  const facts = value.facts.flatMap(fact => {
+    if (!isRecord(fact)
+      || typeof fact.label !== 'string'
+      || (fact.operation !== 'flat' && fact.operation !== 'multiplier')
+      || !Number.isFinite(fact.value)
+      || !['applied', 'ignored', 'capped', 'superseded'].includes(String(fact.outcome))
+      || typeof fact.redacted !== 'boolean') return [];
+    return [{
+      label: fact.label,
+      operation: fact.operation,
+      value: Number(fact.value),
+      outcome: fact.outcome as CombatNotificationFact['outcome'],
+      redacted: fact.redacted,
+    }] as const;
+  });
+  return facts.length > 0 ? { facts } : undefined;
+}
+
 export function normalizeNotificationLog(value: unknown, state?: Pick<GameState, 'cities'>): NotificationLog {
   if (!isRecord(value)) return {};
   const allEntries = Object.values(value).flatMap(entries => Array.isArray(entries) ? entries : []);
@@ -510,6 +530,7 @@ export function normalizeNotificationLog(value: unknown, state?: Pick<GameState,
             : [],
         )
         : [];
+      const combatDetails = normalizeCombatNotificationDetails(rawEntry.combatDetails);
       entries.push({
         id,
         message: rawEntry.message,
@@ -520,6 +541,7 @@ export function normalizeNotificationLog(value: unknown, state?: Pick<GameState,
         ...(typeof rawEntry.linkedCityId === 'string' ? { linkedCityId: rawEntry.linkedCityId } : {}),
         ...(cityActions.length > 0 ? { cityActions } : {}),
         ...(review ? { review } : {}),
+        ...(combatDetails ? { combatDetails } : {}),
       });
     }
     log[civId] = entries;

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -11,7 +11,7 @@ import { getCrisisFlavor } from '@/systems/crisis-flavor-definitions';
 import { resolveWorldAge } from '@/systems/tech-definitions';
 import { CIRCULAR_MANUFACTURING_MATERIALS } from '@/systems/national-project-system';
 
-export const CURRENT_SAVE_SCHEMA_VERSION = 7;
+export const CURRENT_SAVE_SCHEMA_VERSION = 8;
 
 export type SaveMigration = (state: GameState) => GameState;
 
@@ -347,6 +347,10 @@ function migrateCircularManufacturingChoices(state: GameState): GameState {
   return { ...state, nationalProjectChoices };
 }
 
+function migrateCombatNotificationDetails(state: GameState): GameState {
+  return state;
+}
+
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   1: migrateToEra13Foundation,
   2: migrateLateResources,
@@ -355,6 +359,7 @@ export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   5: migrateDualEraWorldAge,
   6: migrateAutonomyNetworkPostures,
   7: migrateCircularManufacturingChoices,
+  8: migrateCombatNotificationDetails,
 };
 
 function readSchemaVersion(raw: Record<string, unknown>): number {

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -2,6 +2,7 @@ import type {
   Unit,
   CombatExchangeKind,
   CombatResult,
+  CombatModifierFact,
   GameMap,
   CivBonusEffect,
   UnitAttackProfile,
@@ -111,6 +112,7 @@ export interface UnitModifierBreakdown {
   mult: number;
   flat: number;
   parts: ModifierPart[];
+  facts?: CombatModifierFact[];
 }
 
 export interface CombatContext {
@@ -140,6 +142,8 @@ export interface CombatStrengthBreakdown {
   cityDefense?: CityDefenseBreakdown;
   attackerModifierParts?: ModifierPart[];
   defenderModifierParts?: ModifierPart[];
+  attackerModifierFacts?: CombatModifierFact[];
+  defenderModifierFacts?: CombatModifierFact[];
   defenderDefendsPoorly?: boolean;
   exchange: CombatExchangeModifiers;
 }
@@ -277,6 +281,8 @@ export function calculateCombatStrengths(
     cityDefense,
     attackerModifierParts: [...(context?.attackerModifiers?.parts ?? []), ...(context?.attackerPositioningPart ? [context.attackerPositioningPart] : []), ...(context?.attackerAmphibiousParts ?? [])],
     defenderModifierParts: [...(context?.defenderModifiers?.parts ?? []), ...(context?.defenderPositioningPart ? [context.defenderPositioningPart] : [])],
+    attackerModifierFacts: context?.attackerModifiers?.facts ?? [],
+    defenderModifierFacts: context?.defenderModifiers?.facts ?? [],
     defenderDefendsPoorly: defendsPoorly(defenderDefinition.attackProfile),
     exchange: getCombatExchangeModifiers(attacker, defender),
   };
@@ -336,6 +342,7 @@ export function resolveCombat(
       defenderStrength: defStrength,
       attackerPosition: attacker.position,
       defenderPosition: defender.position,
+      modifierFacts: { attacker: strengths.attackerModifierFacts ?? [], defender: strengths.defenderModifierFacts ?? [] },
     };
   }
 
@@ -351,6 +358,7 @@ export function resolveCombat(
       defenderStrength: defStrength,
       attackerPosition: attacker.position,
       defenderPosition: defender.position,
+      modifierFacts: { attacker: strengths.attackerModifierFacts ?? [], defender: strengths.defenderModifierFacts ?? [] },
     };
   }
 
@@ -396,6 +404,7 @@ export function resolveCombat(
     defenderStrength: defStrength,
     attackerPosition: attacker.position,
     defenderPosition: defender.position,
+    modifierFacts: { attacker: strengths.attackerModifierFacts ?? [], defender: strengths.defenderModifierFacts ?? [] },
     ...(exchange.kind === 'none' ? {} : { exchange: { kind: exchange.kind, label: exchange.label! } }),
   };
 }

--- a/src/systems/unit-modifier-system.ts
+++ b/src/systems/unit-modifier-system.ts
@@ -1,4 +1,4 @@
-import type { GameState, HexCoord, UnitType } from '@/core/types';
+import type { CombatModifierFact, GameState, HexCoord, UnitType } from '@/core/types';
 import { hexDistance } from './hex-utils';
 import { UNIT_DEFINITIONS } from './unit-system';
 import {
@@ -33,6 +33,17 @@ export interface CombatModifierResult {
   mult: number;
   flat: number;
   parts: ModifierPart[];
+  facts: CombatModifierFact[];
+}
+
+function modifierFactKey(source: { kind: string; id: string }): string {
+  if (source.kind === 'tech') return `tech:${source.id}`;
+  if (source.kind === 'nationalProject') return `national-project:${source.id}`;
+  return `unit:${source.id}`;
+}
+
+function counterFactKey(label: string): string {
+  return `counter:${label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`;
 }
 
 function formatPart(label: string, mode: ModifierMode, value: number): string {
@@ -88,6 +99,7 @@ export function getCombatModifier(
   let mult = 1;
   let flat = 0;
   const parts: ModifierPart[] = [];
+  const facts: CombatModifierFact[] = [];
   const classes = UNIT_CLASS_BY_TYPE[unitType];
   const domain = UNIT_DEFINITIONS[unitType]?.domain ?? 'land';
 
@@ -106,23 +118,36 @@ export function getCombatModifier(
     if (modifier.domain && modifier.domain !== domain) continue;
 
     const when = modifier.when ?? 'always';
-    if (when === 'attacking' && role !== 'attacker') continue;
-    if (when === 'defending' && role !== 'defender') continue;
+    const value = modifier.mode === 'flat' ? Math.floor(modifier.value * scale) : modifier.value;
+    if (when === 'attacking' && role !== 'attacker') {
+      facts.push({ key: modifierFactKey(modifier.source), label: modifier.label, sourceVisibility: 'owner', operation: modifier.mode, value, outcome: 'ignored', ignoredReason: 'role' });
+      continue;
+    }
+    if (when === 'defending' && role !== 'defender') {
+      facts.push({ key: modifierFactKey(modifier.source), label: modifier.label, sourceVisibility: 'owner', operation: modifier.mode, value, outcome: 'ignored', ignoredReason: 'role' });
+      continue;
+    }
 
-    if (modifier.condition === 'fullHP' && !ctx.fullHP) continue;
-    if (modifier.condition === 'inFriendlyCity' && !ctx.inFriendlyCity) continue;
-    if (modifier.condition === 'vsCoastalCity' && !ctx.targetIsCoastalCity) continue;
-    if (modifier.condition === 'amphibiousAssault' && !ctx.amphibiousAssault) continue;
+    const conditionMet = modifier.condition !== 'fullHP' || ctx.fullHP
+      ? modifier.condition !== 'inFriendlyCity' || ctx.inFriendlyCity
+      : false;
+    const contextualConditionMet = conditionMet
+      && (modifier.condition !== 'vsCoastalCity' || ctx.targetIsCoastalCity)
+      && (modifier.condition !== 'amphibiousAssault' || ctx.amphibiousAssault);
+    if (!contextualConditionMet) {
+      facts.push({ key: modifierFactKey(modifier.source), label: modifier.label, sourceVisibility: 'owner', operation: modifier.mode, value, outcome: 'ignored', ignoredReason: 'condition' });
+      continue;
+    }
 
     if (modifier.mode === 'multiplier') {
       mult *= modifier.value;
       parts.push({ label: formatPart(modifier.label, 'multiplier', modifier.value), kind: 'mult' });
     } else {
-      const value = Math.floor(modifier.value * scale);
       if (value === 0) continue;
       flat += value;
       parts.push({ label: formatPart(modifier.label, 'flat', value), kind: 'flat' });
     }
+    facts.push({ key: modifierFactKey(modifier.source), label: modifier.label, sourceVisibility: 'owner', operation: modifier.mode, value, outcome: 'applied' });
   }
 
   if (role === 'attacker') {
@@ -130,10 +155,11 @@ export function getCombatModifier(
     if (counter) {
       mult *= counter.multiplier;
       parts.push({ label: counter.label, kind: 'mult' });
+      facts.push({ key: counterFactKey(counter.label.replace(/ ×.+$/, '')), label: counter.label.replace(/ ×.+$/, ''), sourceVisibility: 'public', operation: 'multiplier', value: counter.multiplier, outcome: 'applied' });
     }
   }
 
-  return { mult, flat, parts };
+  return { mult, flat, parts, facts };
 }
 
 export interface HealingModifierContext {

--- a/src/systems/unit-modifier-system.ts
+++ b/src/systems/unit-modifier-system.ts
@@ -128,13 +128,11 @@ export function getCombatModifier(
       continue;
     }
 
-    const conditionMet = modifier.condition !== 'fullHP' || ctx.fullHP
-      ? modifier.condition !== 'inFriendlyCity' || ctx.inFriendlyCity
-      : false;
-    const contextualConditionMet = conditionMet
+    const conditionMet = (modifier.condition !== 'fullHP' || ctx.fullHP)
+      && (modifier.condition !== 'inFriendlyCity' || ctx.inFriendlyCity)
       && (modifier.condition !== 'vsCoastalCity' || ctx.targetIsCoastalCity)
       && (modifier.condition !== 'amphibiousAssault' || ctx.amphibiousAssault);
-    if (!contextualConditionMet) {
+    if (!conditionMet) {
       facts.push({ key: modifierFactKey(modifier.source), label: modifier.label, sourceVisibility: 'owner', operation: modifier.mode, value, outcome: 'ignored', ignoredReason: 'condition' });
       continue;
     }

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -17,11 +17,20 @@ export function formatCombatPreviewDetails(
   if (preview.riverAttackPenalty < 0) {
     details.push(`${Math.round(preview.riverAttackPenalty * 100)}% river crossing`);
   }
-  for (const part of preview.attackerModifierParts ?? []) {
-    details.push(part.label);
-  }
-  for (const part of preview.defenderModifierParts ?? []) {
-    details.push(part.label);
+  const appliedFacts = preview.attackerModifierFacts?.filter(fact => fact.outcome === 'applied') ?? [];
+  if (appliedFacts.length > 0) {
+    const decisive = appliedFacts[0]!;
+    const value = decisive.operation === 'multiplier'
+      ? `×${decisive.value}`
+      : `${decisive.value >= 0 ? '+' : ''}${decisive.value}`;
+    details.push(`${decisive.label} ${value}`);
+  } else {
+    for (const part of preview.attackerModifierParts ?? []) {
+      details.push(part.label);
+    }
+    for (const part of preview.defenderModifierParts ?? []) {
+      details.push(part.label);
+    }
   }
   for (const part of preview.cityDefense?.parts ?? []) {
     details.push(part.label);

--- a/src/ui/notification-delivery.ts
+++ b/src/ui/notification-delivery.ts
@@ -22,10 +22,10 @@ export interface NotificationDelivery {
 export function createNotificationDelivery(deps: NotificationDeliveryDeps): NotificationDelivery {
   let happenedTurn: number | null = null;
 
-  const deliver: NotificationSink = (civId, message, type, target, cityActions, sfxCue) => {
+  const deliver: NotificationSink = (civId, message, type, target, cityActions, sfxCue, combatDetails) => {
     const state = deps.getState();
     const turn = happenedTurn ?? state.turn;
-    appendNotification(state, civId, { message, type, turn, target, cityActions });
+    appendNotification(state, civId, { message, type, turn, target, cityActions, combatDetails });
 
     const civ = state.civilizations[civId];
     if (!civ?.isHuman) return;

--- a/src/ui/notification-log-panel.ts
+++ b/src/ui/notification-log-panel.ts
@@ -101,5 +101,27 @@ function createNotificationRow(
     });
     row.appendChild(reviewButton);
   }
+  if (entry.combatDetails) {
+    const details = document.createElement('div');
+    details.hidden = true;
+    details.dataset.combatDetails = 'true';
+    details.style.cssText = 'margin-top:6px;padding:6px;background:rgba(255,255,255,0.06);font-size:10px;';
+    for (const fact of entry.combatDetails.facts) {
+      const line = document.createElement('div');
+      const value = fact.operation === 'multiplier' ? `×${fact.value}` : `${fact.value >= 0 ? '+' : ''}${fact.value}`;
+      line.textContent = `${fact.label} ${value}${fact.outcome === 'ignored' ? ' (not active)' : ''}`;
+      details.appendChild(line);
+    }
+    const detailsButton = createGameButton('Show calculation', 'secondary');
+    detailsButton.dataset.combatDetailsToggle = entry.id;
+    detailsButton.style.marginTop = '6px';
+    detailsButton.addEventListener('click', event => {
+      event.stopPropagation();
+      details.hidden = !details.hidden;
+      detailsButton.textContent = details.hidden ? 'Show calculation' : 'Hide calculation';
+    });
+    row.appendChild(detailsButton);
+    row.appendChild(details);
+  }
   return row;
 }

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -1,4 +1,5 @@
-import type { CombatResult, CombatRewardNotification, GameEvents, GameState, ProductionDropReason, TreatyType } from '@/core/types';
+import type { CombatModifierFact, CombatResult, CombatRewardNotification, GameEvents, GameState, ProductionDropReason, TreatyType } from '@/core/types';
+import type { CombatNotificationDetails } from '@/core/notification-log';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -23,7 +24,27 @@ export type NotificationSink = (
   // persisted -- deliver() does not pass this to appendNotification, so it has no
   // effect on the notification log or save schema. See ReligionAudioDirector.playCue.
   sfxCue?: string,
+  combatDetails?: CombatNotificationDetails,
 ) => void;
+
+function projectCombatFacts(
+  result: CombatResult,
+  recipient: 'attacker' | 'defender',
+): CombatNotificationDetails | undefined {
+  const facts = result.modifierFacts;
+  if (!facts) return undefined;
+  const own = recipient === 'attacker' ? facts.attacker : facts.defender;
+  const rival = recipient === 'attacker' ? facts.defender : facts.attacker;
+  const project = (fact: CombatModifierFact, ownFact: boolean) => ({
+    label: ownFact || fact.sourceVisibility === 'public' ? fact.label : 'Unknown advantage',
+    operation: fact.operation,
+    value: fact.value,
+    outcome: fact.outcome,
+    redacted: !ownFact && fact.sourceVisibility !== 'public',
+  });
+  const projected = [...own.map(fact => project(fact, true)), ...rival.map(fact => project(fact, false))];
+  return projected.length > 0 ? { facts: projected } : undefined;
+}
 
 type FactionTransitionEvent =
   | { type: 'faction:unrest-started'; cityId: string; owner: string }
@@ -330,7 +351,12 @@ export function routeCombatResolved(
   const msg = result.defenderSurvived
     ? `${defenderType} was attacked by ${attackerLabel} (${result.defenderDamage} damage taken)`
     : `${defenderType} was destroyed by ${attackerLabel}!`;
-  sink(defenderOwner, `${msg}${exchangeSuffix}`, 'warning');
+  const combatDetails = projectCombatFacts(result, 'defender');
+  if (combatDetails) {
+    sink(defenderOwner, `${msg}${exchangeSuffix}`, 'warning', undefined, undefined, undefined, combatDetails);
+  } else {
+    sink(defenderOwner, `${msg}${exchangeSuffix}`, 'warning');
+  }
 
   if (!result.exchange || !attackerOwner || attackerOwner === 'barbarian') return;
   const attackerTypeId = facts?.attackerType ?? attacker?.type;

--- a/tests/systems/unit-modifier-system.test.ts
+++ b/tests/systems/unit-modifier-system.test.ts
@@ -253,6 +253,36 @@ describe('getClassCounterMultiplier — class counters', () => {
   });
 });
 
+describe('combat modifier facts', () => {
+  it('records an applied counter and an ignored role-gated modifier without changing totals', () => {
+    const counter = getCombatModifier('pikeman', 'attacker', baseCombatCtx({ opponentType: 'knight' }));
+    const ignored = getCombatModifier('warrior', 'attacker', baseCombatCtx({
+      completedTechs: ['steel-plate-armor'],
+    }));
+
+    expect(counter.mult).toBeCloseTo(1.5);
+    expect(counter.facts).toContainEqual(expect.objectContaining({
+      key: 'counter:anti-cavalry',
+      outcome: 'applied',
+      operation: 'multiplier',
+      value: 1.5,
+    }));
+    expect(ignored.flat).toBe(0);
+    expect(ignored.facts).toContainEqual(expect.objectContaining({
+      key: 'tech:steel-plate-armor',
+      outcome: 'ignored',
+      ignoredReason: 'role',
+    }));
+
+    const damaged = getCombatModifier('warrior', 'attacker', baseCombatCtx({
+      completedTechs: ['transhumanism'], fullHP: false,
+    }));
+    expect(damaged.facts).toContainEqual(expect.objectContaining({
+      key: 'tech:transhumanism', outcome: 'ignored', ignoredReason: 'condition',
+    }));
+  });
+});
+
 describe('getHealingBonus — stacking order and conditions', () => {
   it('flat bonuses stack, then a single multiplier applies last (mindfulness-movement)', () => {
     const bonus = getHealingBonus(baseHealCtx({
@@ -419,6 +449,19 @@ describe('order-of-operations lock (composition test)', () => {
 
     expect(result.attackerStrength).toBeCloseTo(expectedAttacker);
     expect(result.defenderStrength).toBeCloseTo(expectedDefenderFinal);
+  });
+
+  it('snapshots evaluator facts onto the resolved combat result', () => {
+    const attacker = createUnit('pikeman', 'p1', { q: 5, r: 5 }, mkC());
+    const defender = createUnit('knight', 'p2', { q: 6, r: 5 }, mkC());
+    const result = resolveCombat(attacker, defender, map, 17, {
+      attackerModifiers: getCombatModifier('pikeman', 'attacker', baseCombatCtx({ opponentType: 'knight' })),
+      defenderModifiers: getCombatModifier('knight', 'defender', baseCombatCtx({ opponentType: 'pikeman' })),
+    });
+
+    expect(result.modifierFacts!.attacker).toContainEqual(expect.objectContaining({
+      key: 'counter:anti-cavalry', outcome: 'applied', value: 1.5,
+    }));
   });
 });
 

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -43,6 +43,21 @@ describe('formatCombatPreviewDetails', () => {
     expect(details).toContain('Walls ×1.25');
   });
 
+  it('uses the canonical applied modifier fact in the preview rather than reconstructing a label', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 15,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+      attackerModifierFacts: [{
+        key: 'counter:anti-cavalry', label: 'Anti-cavalry', sourceVisibility: 'public',
+        operation: 'multiplier', value: 1.5, outcome: 'applied',
+      }],
+    });
+
+    expect(details).toContain('Anti-cavalry ×1.5');
+  });
+
   it('omits city defense modifier lines when the defender is not in a city (negative test)', () => {
     const details = formatCombatPreviewDetails('Rival', 100, {
       attackerStrength: 10,

--- a/tests/ui/notification-log-panel.test.ts
+++ b/tests/ui/notification-log-panel.test.ts
@@ -70,4 +70,21 @@ describe('notification log panel', () => {
     row?.click();
     expect(onOpenCity).toHaveBeenCalledWith('city-1');
   });
+
+  it('expands persisted combat detail without triggering the notification row action', () => {
+    const panel = createNotificationLogPanel([{
+      id: 'notification-4', message: 'Archer was attacked.', type: 'warning', turn: 9, read: false,
+      combatDetails: {
+        facts: [{ label: 'Unknown advantage', operation: 'multiplier', value: 1.1, outcome: 'applied', redacted: true }],
+      },
+    }], { onClose: vi.fn(), onFocusTarget: vi.fn() });
+
+    const toggle = panel.querySelector('[data-combat-details-toggle]') as HTMLButtonElement;
+    const details = panel.querySelector('[data-combat-details]') as HTMLElement;
+    expect(details.hidden).toBe(true);
+    toggle.click();
+    expect(details.hidden).toBe(false);
+    expect(details.textContent).toContain('Unknown advantage ×1.1');
+    expect(toggle.textContent).toBe('Hide calculation');
+  });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -47,9 +47,9 @@ vi.mock('@/systems/legendary-wonder-definitions', () => ({
 }));
 
 function makeSink() {
-  const calls: Array<{ civId: string; message: string; type: string; target?: unknown; sfxCue?: string }> = [];
-  const sink: NotificationSink = (civId, message, type, target, _cityActions, sfxCue) =>
-    calls.push({ civId, message, type, target, sfxCue });
+  const calls: Array<{ civId: string; message: string; type: string; target?: unknown; sfxCue?: string; combatDetails?: unknown }> = [];
+  const sink: NotificationSink = (civId, message, type, target, _cityActions, sfxCue, combatDetails) =>
+    calls.push({ civId, message, type, target, sfxCue, combatDetails });
   return { sink, calls };
 }
 
@@ -69,6 +69,31 @@ function makeState(partial: Partial<GameState> = {}): GameState {
 }
 
 describe('notification routing', () => {
+  it('persists a defender-safe projection without exposing an attacker-owned source', () => {
+    const state = makeState({ units: {
+      attacker: { id: 'attacker', owner: 'p1', type: 'warrior' },
+      defender: { id: 'defender', owner: 'p2', type: 'archer' },
+    } } as unknown as Partial<GameState>);
+    const { sink, calls } = makeSink();
+    const result: CombatResult = {
+      attackerId: 'attacker', defenderId: 'defender', attackerDamage: 0, defenderDamage: 12,
+      attackerSurvived: true, defenderSurvived: true, attackerStrength: 11, defenderStrength: 10,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+      modifierFacts: {
+        attacker: [{ key: 'tech:tactics', label: 'Tactics', sourceVisibility: 'owner', operation: 'multiplier', value: 1.1, outcome: 'applied' }],
+        defender: [],
+      },
+    };
+
+    routeCombatResolved(state, result, sink, {
+      attackerOwnerId: 'p1', attackerType: 'warrior', defenderOwnerId: 'p2', defenderType: 'archer',
+    });
+
+    expect(calls[0]).toMatchObject({ civId: 'p2', combatDetails: {
+      facts: [expect.objectContaining({ label: 'Unknown advantage', redacted: true })],
+    } });
+  });
+
   it('routes a strategic warning only to its viewer with the already-safe map target', () => {
     const { sink, calls } = makeSink();
     const target = { kind: 'map' as const, coord: { q: 4, r: 2 }, label: 'Ravenna' };


### PR DESCRIPTION
Closes #669

## Summary

- Emit stable applied and ignored modifier facts from the canonical combat evaluation, snapshot them on resolved combat, and retain existing combat totals.
- Show the decisive named fact in combat preview; persist recipient-safe calculation details in message history, redacting rival-owned sources.
- Migrate saves to schema 8 with tolerant notification-detail normalization and add focused evaluator, preview, routing, history, and storage regressions.
- Correct the local push-gate timeout guidance to the measured 174+ second duration, preventing interrupted detached Vitest workers.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` (7,004 passed, 3 skipped)
- `bash scripts/verify-before-push.sh --fast`
- targeted modifier, combat, preview, notification routing/log, storage, source-rule, and hook suites
- `git diff --check origin/main...HEAD`