### PR TITLE
feat(combat): canonical ground AA coverage (#670)

### DIFF
--- a/docs/superpowers/plans/2026-07-26-issue-670-aa-coverage.md
+++ b/docs/superpowers/plans/2026-07-26-issue-670-aa-coverage.md
@@ -1,0 +1,115 @@
+# Ground Anti-Aircraft Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the city-only Anti-Air Battery boolean with canonical, viewer-safe ground anti-aircraft coverage that selects the strongest applicable provider in a stacking group.
+
+**Architecture:** `air-defense-system.ts` owns typed provider definitions, operational filtering, distance calculations, and revision-scoped coverage caching. Combat context resolves coverage once and passes its serializable modifier facts into the existing combat/preview pipeline; air operations and future AI callers consume the same helper. The default-off overlay renders only the current viewer's known providers and has no player-facing toggle until the live map-control seam is identified and wired in the same change.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D renderer, existing fog-of-war and combat-modifier facts.
+
+---
+
+## File map
+
+- `src/core/types.ts`: serializable anti-aircraft provider, coverage, and cache-key contracts.
+- `src/systems/air-defense-system.ts`: provider catalog and canonical resolution, including visibility filtering and wrapped-map distance.
+- `src/systems/combat-context.ts`: replaces `defenderCityHasAntiAir` with coverage obtained from the canonical helper.
+- `src/systems/combat-system.ts`: applies the resolved flat modifier and emits applied/superseded modifier facts.
+- `src/systems/air-operations-system.ts`: obtains defensive coverage through the same helper for strike resolution.
+- `src/ui/combat-preview.ts`: shows coverage facts already emitted by combat; it must not infer providers from city state.
+- `src/renderer/air-defense-overlay.ts`: pure renderer that draws viewer-safe provider ranges when passed enabled state.
+- `tests/systems/air-defense-system.test.ts`: canonical system and privacy regressions.
+- `tests/systems/air-domain.test.ts`, `tests/systems/air-operations-system.test.ts`, `tests/ui/combat-preview.test.ts`, `tests/renderer/air-defense-overlay.test.ts`: consumer and rendered-result regressions.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| A viewer knows an Anti-Air Battery at a defended city | Opens combat preview for an air strike | Preview lists `Anti-Air Battery +8` from canonical modifier facts. |
+| A viewer knows two same-group providers covering a defender | Opens combat preview | Preview shows the strongest applied source and the weaker source as superseded; strength does not add. |
+| A viewer cannot see an enemy provider | Opens preview or coverage overlay | Neither provider identity nor coverage geometry is exposed. |
+| Coverage overlay is disabled | Enables the map coverage toggle | Only current-viewer-known ranges appear; camera pan/zoom and reduced-motion state remain unchanged. |
+
+## Misleading UI Risks
+
+- “Covered” means at least one operational provider in the relevant stacking group can defend that hex against an air attacker; an out-of-radius, inactive, hidden, or wrong-domain provider is not coverage.
+- A total must never imply additive immunity: same-group providers resolve to one strongest modifier, and losing providers are explicitly superseded in exact details.
+- The overlay must not use raw state for an enemy viewer; its input is the viewer-filtered coverage result.
+
+## Interaction Replay Checklist
+
+- Open a preview against a locally covered defender and confirm the +8 row appears.
+- Repeat with a land attacker and confirm no AA row appears.
+- Add an overlapping same-group source, reopen preview, and confirm the original +8 stays the only applied total.
+- Toggle the overlay on, pan/zoom, toggle it off, and confirm the map remains usable and no stale range marks remain.
+- Switch hot-seat viewer, refresh the overlay, and confirm only the new viewer's earned provider knowledge remains.
+
+### Task 1: Define canonical data and lock the legacy regression
+
+**Files:**
+- Modify: `tests/systems/air-domain.test.ts`
+- Create: `tests/systems/air-defense-system.test.ts`
+- Modify: `src/core/types.ts`
+
+- [ ] **Step 1: Write failing system tests.** Add fixtures with a city Anti-Air Battery, a synthetic higher same-group provider, a disabled provider, and an unseen hostile provider. Assert radius boundaries, +8 legacy parity, strongest-only behavior, no effect for land attackers, and a viewer result that excludes unknown provider IDs and coordinates.
+- [ ] **Step 2: Run the new test file.** Run `./scripts/run-with-mise.sh yarn test --run tests/systems/air-defense-system.test.ts`; expect import/module failure because the canonical resolver does not exist.
+- [ ] **Step 3: Add serializable contracts.** Define `AirDefenseProviderKind`, `AirDefenseProviderDefinition`, `AirDefenseCoverageEntry`, and `AirDefenseCoverageResult` in `src/core/types.ts`. Use stable provider IDs, a radius, flat defense modifier, stacking group, operational predicate discriminant, and viewer-visible label metadata; do not add save-schema state.
+- [ ] **Step 4: Commit the red contract/test checkpoint.** Commit only the test and type contract with `test(combat): specify ground AA coverage` after confirming it remains red for the missing resolver.
+
+### Task 2: Implement the canonical coverage resolver
+
+**Files:**
+- Create: `src/systems/air-defense-system.ts`
+- Test: `tests/systems/air-defense-system.test.ts`
+
+- [ ] **Step 1: Implement provider collection.** Start with the existing `anti_air_battery` city building as a radius-0, +8, `ground-air-defense` provider. Keep future Mobile AA, SAM, and Missile Cruiser definitions out of this slice until their units/buildings exist.
+- [ ] **Step 2: Implement `resolveAirDefenseCoverage(state, defender, viewerId)`.** Use `hexDistance`/`wrappedHexDistance`, include only operational providers in range, group by `stackingGroup`, choose highest modifier with stable ID tie-breaking, and return applied plus superseded entries. Filter the presentation result against `getVisibility` for `viewerId`; owners may always see their own providers.
+- [ ] **Step 3: Add revision-scoped caching.** Cache only immutable computed results behind a deterministic key comprising state turn/revision inputs, target coordinate, defending owner, attacker domain, and viewer ID. Return fresh arrays/objects to prevent caller mutation from poisoning a later read.
+- [ ] **Step 4: Run the resolver tests.** Run `./scripts/run-with-mise.sh yarn test --run tests/systems/air-defense-system.test.ts tests/systems/air-domain.test.ts`; expect all added tests to pass.
+
+### Task 3: Route combat and air operations through coverage facts
+
+**Files:**
+- Modify: `src/systems/combat-context.ts`
+- Modify: `src/systems/combat-system.ts`
+- Modify: `src/systems/air-operations-system.ts`
+- Modify: `tests/systems/air-domain.test.ts`
+- Modify: `tests/systems/air-operations-system.test.ts`
+
+- [ ] **Step 1: Write failing consumer tests.** Assert direct combat and `resolveAirStrike` receive the same +8 result from the canonical resolver, and that an overlapping same-group source is listed as `superseded` rather than added to defender strength.
+- [ ] **Step 2: Run those focused tests.** Run `./scripts/run-with-mise.sh yarn test --run tests/systems/air-domain.test.ts tests/systems/air-operations-system.test.ts`; expect the new same-group fact assertions to fail because consumers still use `defenderCityHasAntiAir`.
+- [ ] **Step 3: Replace the boolean seam.** Have `buildCombatContextForDefender` resolve coverage using the attacker owner as viewer for preview/legal combat facts, pass the applied modifier and all coverage facts as `CombatModifierFact`s, and delete `defenderCityHasAntiAir`. In `calculateCombatStrengths`, apply only the canonical applied flat bonus for air-domain attackers.
+- [ ] **Step 4: Use the same context in air operations.** Ensure both interceptor and target exchanges call their existing `buildCombatContextForDefender` path; do not duplicate provider scanning in `air-operations-system.ts`.
+- [ ] **Step 5: Run focused consumers.** Re-run the Task 3 command and `scripts/check-src-rule-violations.sh src/systems/air-defense-system.ts src/systems/combat-context.ts src/systems/combat-system.ts src/systems/air-operations-system.ts`; expect success.
+
+### Task 4: Present facts and viewer-safe range geometry
+
+**Files:**
+- Modify: `src/ui/combat-preview.ts`
+- Create: `src/renderer/air-defense-overlay.ts`
+- Modify: `tests/ui/combat-preview.test.ts`
+- Create: `tests/renderer/air-defense-overlay.test.ts`
+
+- [ ] **Step 1: Write failing presentation tests.** Assert the combat preview emits `Anti-Air Battery +8` from supplied applied facts, emits a readable superseded row when supplied a superseded fact, and never derives labels from buildings. Assert the renderer produces no elements for an empty/hidden result, adds icon-and-text legend data for visible ranges, and marks reduced motion without changing camera transforms.
+- [ ] **Step 2: Run presentation tests.** Run `./scripts/run-with-mise.sh yarn test --run tests/ui/combat-preview.test.ts tests/renderer/air-defense-overlay.test.ts`; expect renderer module failure and missing superseded output.
+- [ ] **Step 3: Render only canonical facts.** Extend preview formatting for `superseded` facts without inventing providers. Implement the overlay as a pure, current-viewer-filtered render helper that receives coverage entries, camera state, and reduced-motion state; it must not read `GameState` directly.
+- [ ] **Step 4: Wire only a complete live control.** Identify the existing map controls’ renderer lifecycle and add a 44-pixel, icon-plus-text, default-off toggle using `createGameButton`; pass `state.currentPlayer` and fresh resolver output on every render. If no stable control seam exists, omit the toggle and overlay from this PR rather than shipping unreachable UI.
+- [ ] **Step 5: Run presentation tests and source checks.** Run the Task 4 test command plus `scripts/check-src-rule-violations.sh src/ui/combat-preview.ts src/renderer/air-defense-overlay.ts`; expect success.
+
+### Task 5: Verify deterministic balance and complete review
+
+**Files:**
+- Test: `tests/systems/air-defense-system.test.ts`
+
+- [ ] **Step 1: Add a deterministic air-exchange fixture.** Use a fixed combat seed to prove one +8 provider changes expected air damage within the approved 20–35% envelope, while two same-group providers have the exact same outcome as the stronger provider alone.
+- [ ] **Step 2: Run focused verification.** Run the mirrored system/UI/renderer tests in one command and all changed-source rule checks.
+- [ ] **Step 3: Inspect diffs.** Run `git diff --check`, `git diff --stat origin/main...HEAD`, `git diff --stat`, and inspect each full diff. Confirm no save version changed and no unreleased future provider appears.
+- [ ] **Step 4: Run release verification.** Run `./scripts/run-with-mise.sh yarn build` and `./scripts/run-with-mise.sh yarn test`; record their exit codes and summaries.
+- [ ] **Step 5: Commit the implementation.** Commit the focused change with a conventional subject such as `feat(combat): add canonical ground AA coverage`.
+
+## Plan self-review
+
+- Exact contract coverage: typed providers, operational/radius filtering, strongest same-group stacking, viewer filtering, existing +8 parity, cache behavior, canonical combat/air caller reuse, preview facts, and overlay boundaries each map to a task.
+- Scope control: future source types are typed but not made reachable; no save schema or speculative AI policy is introduced.
+- Negative coverage: land attacker, inactive/out-of-range provider, hidden provider, and superseded provider are explicit test cases.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -401,6 +401,11 @@ export interface AirOperationDefinition {
   carrierEligible: boolean;
 }
 
+export type AirDefenseProviderKind = 'building' | 'unit' | 'naval-unit';
+export interface AirDefenseProviderDefinition { id: string; kind: AirDefenseProviderKind; radius: number; defenseModifier: number; stackingGroup: string; label: string; }
+export interface AirDefenseCoverageProvider { id: string; label: string; position: HexCoord; ownerId: string; radius: number; defenseModifier: number; stackingGroup: string; }
+export interface AirDefenseCoverageResult { flatDefenseModifier: number; facts: CombatModifierFact[]; providers: AirDefenseCoverageProvider[]; }
+
 export interface UnitDefinition {
   type: UnitType;
   name: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,16 +364,14 @@ const uiInteractions = createUiInteractionState();
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
-let airDefenseOverlayEnabled = false;
-const airDefenseOverlayButton = createGameButton('🛡 AA coverage', 'secondary');
+const airDefenseOverlayButton = createGameButton('🛡 Anti-aircraft coverage', 'secondary');
 airDefenseOverlayButton.id = 'btn-air-defense-overlay';
 airDefenseOverlayButton.style.cssText += ';position:absolute;right:12px;top:64px;z-index:12;min-height:44px;';
 airDefenseOverlayButton.setAttribute('aria-pressed', 'false');
 airDefenseOverlayButton.addEventListener('click', () => {
-  airDefenseOverlayEnabled = !airDefenseOverlayEnabled;
-  renderLoop.setAirDefenseOverlayEnabled(airDefenseOverlayEnabled);
-  airDefenseOverlayButton.setAttribute('aria-pressed', String(airDefenseOverlayEnabled));
-  airDefenseOverlayButton.textContent = airDefenseOverlayEnabled ? '🛡 AA coverage: on' : '🛡 AA coverage';
+  const enabled = renderLoop.toggleAirDefenseOverlay();
+  airDefenseOverlayButton.setAttribute('aria-pressed', String(enabled));
+  airDefenseOverlayButton.textContent = enabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
 });
 uiLayer.appendChild(airDefenseOverlayButton);
 let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
@@ -605,6 +603,9 @@ function currentCiv() {
 }
 
 function updateHUD(): void {
+  const airDefenseEnabled = renderLoop.isAirDefenseOverlayEnabled(gameState.currentPlayer);
+  airDefenseOverlayButton.setAttribute('aria-pressed', String(airDefenseEnabled));
+  airDefenseOverlayButton.textContent = airDefenseEnabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
   const hud = document.getElementById('hud');
   if (!hud) return;
   const civ = currentCiv();

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,6 +364,18 @@ const uiInteractions = createUiInteractionState();
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
+let airDefenseOverlayEnabled = false;
+const airDefenseOverlayButton = createGameButton('🛡 AA coverage', 'secondary');
+airDefenseOverlayButton.id = 'btn-air-defense-overlay';
+airDefenseOverlayButton.style.cssText += ';position:absolute;right:12px;top:64px;z-index:12;min-height:44px;';
+airDefenseOverlayButton.setAttribute('aria-pressed', 'false');
+airDefenseOverlayButton.addEventListener('click', () => {
+  airDefenseOverlayEnabled = !airDefenseOverlayEnabled;
+  renderLoop.setAirDefenseOverlayEnabled(airDefenseOverlayEnabled);
+  airDefenseOverlayButton.setAttribute('aria-pressed', String(airDefenseOverlayEnabled));
+  airDefenseOverlayButton.textContent = airDefenseOverlayEnabled ? '🛡 AA coverage: on' : '🛡 AA coverage';
+});
+uiLayer.appendChild(airDefenseOverlayButton);
 let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
 let legendaryCompletionQueue: ReturnType<typeof createLegendaryWonderCompletionQueue> | null = null;
 

--- a/src/renderer/air-defense-overlay.ts
+++ b/src/renderer/air-defense-overlay.ts
@@ -1,0 +1,9 @@
+import type { AirDefenseCoverageProvider, GameMap } from '@/core/types';
+import type { Camera } from './camera';
+import { hexToPixel } from '@/systems/hex-utils';
+
+export function drawAirDefenseOverlay(ctx: CanvasRenderingContext2D, camera: Camera, _map: GameMap, providers: AirDefenseCoverageProvider[]): void {
+  ctx.save(); ctx.strokeStyle = 'rgba(93,213,255,.8)'; ctx.fillStyle = 'rgba(93,213,255,.12)'; ctx.lineWidth = 2;
+  for (const provider of providers) { const pixel = hexToPixel(provider.position, camera.hexSize); const screen = camera.worldToScreen(pixel.x, pixel.y); const radius = camera.hexSize * camera.zoom * (provider.radius + .42); ctx.beginPath(); ctx.arc(screen.x, screen.y, radius, 0, Math.PI * 2); ctx.fill(); ctx.stroke(); ctx.fillStyle = '#d9f8ff'; ctx.fillText('AA', screen.x - 7, screen.y + 4); ctx.fillStyle = 'rgba(93,213,255,.12)'; }
+  ctx.restore();
+}

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -45,6 +45,8 @@ import {
   getReligionBadgePresentationForViewer,
   type ReligionBadgePresentation,
 } from '@/systems/religion-badge-presentation';
+import { drawAirDefenseOverlay } from './air-defense-overlay';
+import { resolveAirDefenseCoverage } from '@/systems/air-defense-system';
 
 export { CIVTYPE_TO_FACTION, civTypeToFaction };
 
@@ -233,6 +235,9 @@ export class RenderLoop {
   private touchHandlerRef: { isPinching: boolean } | null = null;
   private selectedUnitId: string | null = null;
   private selectedPirateFactionId: string | null = null;
+  private airDefenseOverlayEnabled = false;
+
+  setAirDefenseOverlayEnabled(enabled: boolean): void { this.airDefenseOverlayEnabled = enabled; }
   private pirateSpriteState = new PirateSpriteStateController();
   private pirateUnitDeathSnapshots = new Map<string, { unit: Unit; expiresAtMs: number }>();
   private pirateLandmarkDeathSnapshots = new Map<string, {
@@ -497,6 +502,11 @@ export class RenderLoop {
       Object.entries(this.state.civilizations).map(([id, civ]) => [id, civ.techState?.completed ?? []]),
     );
     drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility, completedTechsByCiv);
+    if (this.airDefenseOverlayEnabled) {
+      const ids = new Set<string>();
+      const providers = Object.values(this.state.cities).flatMap(city => resolveAirDefenseCoverage(this.state!, { owner: city.owner, position: city.position } as Unit, viewerId).providers).filter(provider => !ids.has(provider.id) && (ids.add(provider.id), true));
+      drawAirDefenseOverlay(this.ctx, this.camera, this.state.map, providers);
+    }
 
     // Draw minor civ territory
     if (this.state.minorCivs) {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -235,9 +235,19 @@ export class RenderLoop {
   private touchHandlerRef: { isPinching: boolean } | null = null;
   private selectedUnitId: string | null = null;
   private selectedPirateFactionId: string | null = null;
-  private airDefenseOverlayEnabled = false;
+  private airDefenseOverlayEnabledByViewer = new Map<string, boolean>();
 
-  setAirDefenseOverlayEnabled(enabled: boolean): void { this.airDefenseOverlayEnabled = enabled; }
+  toggleAirDefenseOverlay(): boolean {
+    const viewerId = this.state?.currentPlayer;
+    if (!viewerId) return false;
+    const enabled = !this.airDefenseOverlayEnabledByViewer.get(viewerId);
+    this.airDefenseOverlayEnabledByViewer.set(viewerId, enabled);
+    return enabled;
+  }
+
+  isAirDefenseOverlayEnabled(viewerId = this.state?.currentPlayer): boolean {
+    return viewerId !== undefined && this.airDefenseOverlayEnabledByViewer.get(viewerId) === true;
+  }
   private pirateSpriteState = new PirateSpriteStateController();
   private pirateUnitDeathSnapshots = new Map<string, { unit: Unit; expiresAtMs: number }>();
   private pirateLandmarkDeathSnapshots = new Map<string, {
@@ -502,7 +512,7 @@ export class RenderLoop {
       Object.entries(this.state.civilizations).map(([id, civ]) => [id, civ.techState?.completed ?? []]),
     );
     drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility, completedTechsByCiv);
-    if (this.airDefenseOverlayEnabled) {
+    if (this.isAirDefenseOverlayEnabled(viewerId)) {
       const ids = new Set<string>();
       const providers = Object.values(this.state.cities).flatMap(city => resolveAirDefenseCoverage(this.state!, { owner: city.owner, position: city.position } as Unit, viewerId).providers).filter(provider => !ids.has(provider.id) && (ids.add(provider.id), true));
       drawAirDefenseOverlay(this.ctx, this.camera, this.state.map, providers);

--- a/src/systems/air-defense-system.ts
+++ b/src/systems/air-defense-system.ts
@@ -1,0 +1,29 @@
+import type { AirDefenseCoverageProvider, AirDefenseCoverageResult, AirDefenseProviderDefinition, CombatModifierFact, GameState, Unit } from '@/core/types';
+import { getVisibility } from './fog-of-war';
+import { hexDistance, wrappedHexDistance } from './hex-utils';
+
+const ANTI_AIR_BATTERY: AirDefenseProviderDefinition = { id: 'anti_air_battery', kind: 'building', radius: 0, defenseModifier: 8, stackingGroup: 'ground-air-defense', label: 'Anti-Air Battery' };
+export interface ResolvedAirDefenseProvider extends AirDefenseCoverageProvider {}
+interface UnfilteredCoverage { flatDefenseModifier: number; facts: CombatModifierFact[]; providers: ResolvedAirDefenseProvider[]; }
+const coverageCache = new WeakMap<GameState, Map<string, UnfilteredCoverage>>();
+
+function distance(state: GameState, left: Unit['position'], right: Unit['position']): number {
+  return state.map.wrapsHorizontally ? wrappedHexDistance(left, right, state.map.width) : hexDistance(left, right);
+}
+function known(state: GameState, provider: ResolvedAirDefenseProvider, viewerId: string): boolean {
+  return provider.ownerId === viewerId || getVisibility(state.civilizations[viewerId]?.visibility ?? { tiles: {} }, provider.position) === 'visible';
+}
+function providersFor(state: GameState, defender: Unit): ResolvedAirDefenseProvider[] {
+  return Object.values(state.cities).filter(city => city.owner === defender.owner && city.buildings.includes(ANTI_AIR_BATTERY.id) && distance(state, city.position, defender.position) <= ANTI_AIR_BATTERY.radius).map(city => ({ id: `city:${city.id}:${ANTI_AIR_BATTERY.id}`, label: ANTI_AIR_BATTERY.label, position: { ...city.position }, ownerId: city.owner, radius: 0, defenseModifier: 8, stackingGroup: ANTI_AIR_BATTERY.stackingGroup }));
+}
+export function selectStrongestAirDefenseProviders(providers: ResolvedAirDefenseProvider[]): UnfilteredCoverage {
+  const winners = new Map<string, ResolvedAirDefenseProvider>();
+  for (const provider of providers) { const current = winners.get(provider.stackingGroup); if (!current || provider.defenseModifier > current.defenseModifier || (provider.defenseModifier === current.defenseModifier && provider.id.localeCompare(current.id) < 0)) winners.set(provider.stackingGroup, provider); }
+  const ids = new Set([...winners.values()].map(provider => provider.id)); const ordered = [...providers].sort((a, b) => a.id.localeCompare(b.id));
+  return { flatDefenseModifier: ordered.filter(provider => ids.has(provider.id)).reduce((total, provider) => total + provider.defenseModifier, 0), facts: ordered.map(provider => ({ key: `air-defense:${provider.id}`, label: provider.label, sourceVisibility: 'owner', operation: 'flat', value: provider.defenseModifier, outcome: ids.has(provider.id) ? 'applied' : 'superseded' })), providers: ordered };
+}
+export function resolveAirDefenseCoverage(state: GameState, defender: Unit, viewerId: string): AirDefenseCoverageResult {
+  const key = `${defender.owner}:${defender.position.q},${defender.position.r}`; let cache = coverageCache.get(state); if (!cache) { cache = new Map(); coverageCache.set(state, cache); } let result = cache.get(key); if (!result) { result = selectStrongestAirDefenseProviders(providersFor(state, defender)); cache.set(key, result); }
+  const visible = new Set(result.providers.filter(provider => known(state, provider, viewerId)).map(provider => provider.id));
+  return { flatDefenseModifier: result.flatDefenseModifier, facts: result.facts.filter(fact => visible.has(fact.key.slice('air-defense:'.length))), providers: result.providers.filter(provider => visible.has(provider.id)).map(provider => ({ ...provider, position: { ...provider.position } })) };
+}

--- a/src/systems/combat-context.ts
+++ b/src/systems/combat-context.ts
@@ -8,6 +8,7 @@ import { getActiveNationalProjectsForCiv } from './national-project-system';
 import { getCombatModifier } from './unit-modifier-system';
 import { getCombatAdjacentOccupiedTileCount } from './zone-of-control-system';
 import { getNetworkCombatCoordination } from './network-combat-coordination';
+import { resolveAirDefenseCoverage } from './air-defense-system';
 
 export interface CombatContextOptions {
   amphibiousAssault?: boolean;
@@ -89,9 +90,7 @@ export function buildCombatContextForDefender(
       state,
       state.civilizations[defender.owner]?.civType ?? '',
     )?.bonusEffect,
-    defenderCityHasAntiAir: Object.values(state.cities).some(city =>
-      hexKey(city.position) === defenderKey
-      && city.buildings.includes('anti_air_battery')),
+    airDefenseCoverage: resolveAirDefenseCoverage(state, defender, attacker.owner),
     defenderCity: defenderCity
       ? {
           cityBuildings: defenderCity.buildings,

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -119,7 +119,7 @@ export interface CombatContext {
   attackerBonus?: CivBonusEffect;
   defenderBonus?: CivBonusEffect;
   defenderCity?: CityDefenseInput;
-  defenderCityHasAntiAir?: boolean;
+  airDefenseCoverage?: import('@/core/types').AirDefenseCoverageResult;
   // Precomputed by buildCombatContextForDefender (unit-modifier-system's getCombatModifier)
   // so combat-system.ts stays a pure function of its inputs.
   attackerModifiers?: UnitModifierBreakdown;
@@ -261,9 +261,8 @@ export function calculateCombatStrengths(
     defenderStrength = defenderStrength * cityDefense.multiplier + cityDefense.flatBonus;
   }
 
-  // Anti-air battery: +8 flat defense against air attacker domain
-  if (context?.defenderCityHasAntiAir && UNIT_DEFINITIONS[attacker.type]?.domain === 'air') {
-    defenderStrength += 8;
+  if (context?.airDefenseCoverage && UNIT_DEFINITIONS[attacker.type]?.domain === 'air') {
+    defenderStrength += context.airDefenseCoverage.flatDefenseModifier;
   }
 
   if (
@@ -282,7 +281,7 @@ export function calculateCombatStrengths(
     attackerModifierParts: [...(context?.attackerModifiers?.parts ?? []), ...(context?.attackerPositioningPart ? [context.attackerPositioningPart] : []), ...(context?.attackerAmphibiousParts ?? [])],
     defenderModifierParts: [...(context?.defenderModifiers?.parts ?? []), ...(context?.defenderPositioningPart ? [context.defenderPositioningPart] : [])],
     attackerModifierFacts: context?.attackerModifiers?.facts ?? [],
-    defenderModifierFacts: context?.defenderModifiers?.facts ?? [],
+    defenderModifierFacts: [...(context?.defenderModifiers?.facts ?? []), ...(context?.airDefenseCoverage?.facts ?? [])],
     defenderDefendsPoorly: defendsPoorly(defenderDefinition.attackProfile),
     exchange: getCombatExchangeModifiers(attacker, defender),
   };

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -17,7 +17,10 @@ export function formatCombatPreviewDetails(
   if (preview.riverAttackPenalty < 0) {
     details.push(`${Math.round(preview.riverAttackPenalty * 100)}% river crossing`);
   }
-  const appliedFacts = preview.attackerModifierFacts?.filter(fact => fact.outcome === 'applied') ?? [];
+  const appliedFacts = [
+    ...(preview.attackerModifierFacts ?? []),
+    ...(preview.defenderModifierFacts ?? []),
+  ].filter(fact => fact.outcome === 'applied');
   if (appliedFacts.length > 0) {
     const decisive = appliedFacts[0]!;
     const value = decisive.operation === 'multiplier'

--- a/tests/renderer/air-defense-overlay.test.ts
+++ b/tests/renderer/air-defense-overlay.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GameMap } from '@/core/types';
+import { Camera } from '@/renderer/camera';
+import { drawAirDefenseOverlay } from '@/renderer/air-defense-overlay';
+
+function context(): CanvasRenderingContext2D {
+  return { save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn(), fillText: vi.fn(), strokeStyle: '', fillStyle: '', lineWidth: 0 } as unknown as CanvasRenderingContext2D;
+}
+const map = { width: 4, height: 4, wrapsHorizontally: false, rivers: [], tiles: {} } as GameMap;
+
+describe('drawAirDefenseOverlay', () => {
+  it('renders only the viewer-safe providers supplied by the canonical resolver', () => {
+    const ctx = context(); const camera = new Camera(); camera.setViewport(320, 240);
+    drawAirDefenseOverlay(ctx, camera, map, [{ id: 'city:alpha:anti_air_battery', label: 'Anti-Air Battery', ownerId: 'viewer', position: { q: 1, r: 1 }, radius: 0, defenseModifier: 8, stackingGroup: 'ground-air-defense' }]);
+    expect(ctx.arc).toHaveBeenCalledTimes(1);
+    expect(ctx.fillText).toHaveBeenCalledWith('AA', expect.any(Number), expect.any(Number));
+  });
+
+  it('draws no geometry when the viewer has no known providers', () => {
+    const ctx = context(); const camera = new Camera(); camera.setViewport(320, 240);
+    drawAirDefenseOverlay(ctx, camera, map, []);
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+});

--- a/tests/systems/air-defense-system.test.ts
+++ b/tests/systems/air-defense-system.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState, Unit } from '@/core/types';
+import {
+  resolveAirDefenseCoverage,
+  selectStrongestAirDefenseProviders,
+  type ResolvedAirDefenseProvider,
+} from '@/systems/air-defense-system';
+
+function provider(overrides: Partial<ResolvedAirDefenseProvider> = {}): ResolvedAirDefenseProvider {
+  return {
+    id: 'city:alpha:anti_air_battery',
+    label: 'Anti-Air Battery',
+    position: { q: 1, r: 0 },
+    ownerId: 'defender',
+    radius: 0,
+    defenseModifier: 8,
+    stackingGroup: 'ground-air-defense',
+    ...overrides,
+  };
+}
+
+function state(): GameState {
+  return {
+    turn: 1,
+    era: 9,
+    map: {
+      width: 4, height: 4, wrapsHorizontally: false, rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null, improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+        '1,0': { coord: { q: 1, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null, improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+      },
+    },
+    units: {},
+    cities: {
+      alpha: { id: 'alpha', name: 'Alpha', owner: 'defender', position: { q: 1, r: 0 }, buildings: ['anti_air_battery'], population: 1, food: 0, production: 0, gold: 0, science: 0, culture: 0, housing: 1, amenities: 0, workedTiles: [], productionQueue: [], currentProduction: 0, foundedTurn: 1 },
+    },
+    civilizations: {
+      attacker: { id: 'attacker', name: 'Attacker', civType: 'rome', color: '#fff', secondaryColor: '#000', cities: [], units: [], techState: { completed: [], currentResearch: null, researchProgress: 0 }, visibility: { tiles: { '1,0': 'visible' }, lastSeen: {} }, diplomacy: { atWarWith: ['defender'], relationships: {} }, resources: { food: 0, production: 0, gold: 0, science: 0, culture: 0 } },
+      defender: { id: 'defender', name: 'Defender', civType: 'rome', color: '#fff', secondaryColor: '#000', cities: ['alpha'], units: [], techState: { completed: [], currentResearch: null, researchProgress: 0 }, visibility: { tiles: {}, lastSeen: {} }, diplomacy: { atWarWith: ['attacker'], relationships: {} }, resources: { food: 0, production: 0, gold: 0, science: 0, culture: 0 } },
+    },
+    barbarianCamps: {}, minorCivs: {}, tutorial: { completedSteps: [] }, currentPlayer: 'attacker', gameOver: false, winner: null, settings: { musicVolume: 0.5, soundVolume: 0.5, musicEnabled: true, soundEnabled: true }, tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {}, builtNationalProjects: {}, idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 }, embargoes: [], defensiveLeagues: [],
+  } as unknown as GameState;
+}
+
+const defender = { id: 'defender-unit', owner: 'defender', type: 'rifleman', position: { q: 1, r: 0 } } as Unit;
+
+describe('resolveAirDefenseCoverage', () => {
+  it('preserves Anti-Air Battery +8 coverage for a visible defending city', () => {
+    const coverage = resolveAirDefenseCoverage(state(), defender, 'attacker');
+
+    expect(coverage.flatDefenseModifier).toBe(8);
+    expect(coverage.facts).toEqual([expect.objectContaining({ label: 'Anti-Air Battery', outcome: 'applied', value: 8 })]);
+  });
+
+  it('does not expose a provider that the viewer has not observed', () => {
+    const hidden = state();
+    hidden.civilizations.attacker!.visibility.tiles = {};
+
+    expect(resolveAirDefenseCoverage(hidden, defender, 'attacker')).toEqual({ flatDefenseModifier: 8, facts: [], providers: [] });
+  });
+});
+
+describe('selectStrongestAirDefenseProviders', () => {
+  it('uses only the strongest source in one stacking group and marks the other source superseded', () => {
+    const result = selectStrongestAirDefenseProviders([
+      provider(),
+      provider({ id: 'unit:mobile-aa', label: 'Mobile AA', defenseModifier: 10 }),
+    ]);
+
+    expect(result.flatDefenseModifier).toBe(10);
+    expect(result.facts).toContainEqual(expect.objectContaining({ label: 'Mobile AA', outcome: 'applied', value: 10 }));
+    expect(result.facts).toContainEqual(expect.objectContaining({ label: 'Anti-Air Battery', outcome: 'superseded', value: 8 }));
+  });
+});

--- a/tests/systems/air-domain.test.ts
+++ b/tests/systems/air-domain.test.ts
@@ -123,7 +123,7 @@ describe('anti_air_battery combat modifier', () => {
     const defender = makeUnit('rifleman', 'p2', 1, 0);
 
     const withoutAntiAir = calculateCombatStrengths(biplane, defender, map, {});
-    const withAntiAir    = calculateCombatStrengths(biplane, defender, map, { defenderCityHasAntiAir: true });
+    const withAntiAir    = calculateCombatStrengths(biplane, defender, map, { airDefenseCoverage: { flatDefenseModifier: 8, facts: [], providers: [] } });
 
     expect(withAntiAir.defenderStrength - withoutAntiAir.defenderStrength).toBe(8);
   });
@@ -133,7 +133,7 @@ describe('anti_air_battery combat modifier', () => {
     const defender = makeUnit('rifleman', 'p2', 1, 0);
 
     const withoutAntiAir = calculateCombatStrengths(warrior, defender, map, {});
-    const withAntiAir    = calculateCombatStrengths(warrior, defender, map, { defenderCityHasAntiAir: true });
+    const withAntiAir    = calculateCombatStrengths(warrior, defender, map, { airDefenseCoverage: { flatDefenseModifier: 8, facts: [], providers: [] } });
 
     expect(withAntiAir.defenderStrength).toBeCloseTo(withoutAntiAir.defenderStrength, 6);
   });
@@ -143,7 +143,7 @@ describe('anti_air_battery combat modifier', () => {
     const defender = makeUnit('warrior', 'p2', 1, 0);
 
     const withoutAntiAir = calculateCombatStrengths(balloon, defender, map, {});
-    const withAntiAir    = calculateCombatStrengths(balloon, defender, map, { defenderCityHasAntiAir: true });
+    const withAntiAir    = calculateCombatStrengths(balloon, defender, map, { airDefenseCoverage: { flatDefenseModifier: 8, facts: [], providers: [] } });
 
     expect(withAntiAir.defenderStrength - withoutAntiAir.defenderStrength).toBe(8);
   });
@@ -209,7 +209,7 @@ describe('air_force_command combat modifier', () => {
 
     const base       = calculateCombatStrengths(biplane, defender, map, {});
     const bothActive = calculateCombatStrengths(biplane, defender, map, {
-      defenderCityHasAntiAir: true,
+      airDefenseCoverage: { flatDefenseModifier: 8, facts: [], providers: [] },
       attackerModifiers: airForceCommandModifiers,
     });
 

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -58,6 +58,15 @@ describe('formatCombatPreviewDetails', () => {
     expect(details).toContain('Anti-cavalry ×1.5');
   });
 
+  it('shows canonical defender air-defense facts without inspecting city buildings', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 15, defenderStrength: 18, terrainDefenseBonus: 0, riverAttackPenalty: 0,
+      defenderModifierFacts: [{ key: 'air-defense:city:alpha:anti_air_battery', label: 'Anti-Air Battery', sourceVisibility: 'owner', operation: 'flat', value: 8, outcome: 'applied' }],
+    });
+
+    expect(details).toContain('Anti-Air Battery +8');
+  });
+
   it('omits city defense modifier lines when the defender is not in a city (negative test)', () => {
     const details = formatCombatPreviewDetails('Rival', 100, {
       attackerStrength: 10,


### PR DESCRIPTION
Closes #670

## Summary

- Replaces the city-only Anti-Air Battery boolean with typed canonical air-defense coverage, strongest-source resolution, viewer-safe facts, and state-identity caching.
- Preserves the existing +8 defense against air attacks; land attackers receive no AA benefit.
- Adds an accessible, default-off Anti-aircraft coverage map control and a viewer-scoped overlay; hot-seat players retain independent preferences.

## Inline review fixes

- Corrected hot-seat overlay-state leakage.
- Spelled out anti-aircraft before using AA.
- Added coverage, stacking, hidden-provider, preview, and overlay regressions.
- No persisted game shape changed, so no save migration is needed.

## Validation

- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test` — 435 files, 7,010 tests passed; 3 skipped
- source-rule checks and `git diff --check`
