### PR TITLE
feat(tooling): persist worktree-local test results

### DIFF
--- a/.claude/rules/hooks-and-tooling.md
+++ b/.claude/rules/hooks-and-tooling.md
@@ -59,6 +59,15 @@ concurrently across linked worktrees. Do not add a repository-wide lock around
 them: it turns unrelated agents into a queue and does not make a test suite
 safer.
 
+When an agent needs a durable complete-suite result, use `yarn test:durable`.
+It writes only under the active worktree's ignored `.verification/` directory,
+cleans stale completed artifacts before starting, and refuses to overwrite a
+live run in that same worktree. Read it with `yarn test:durable:status`; a
+passing result is valid only when its recorded commit and working-tree state
+match the current worktree. Different worktrees keep independent durable
+evidence and must never share an artifact directory or a repository-wide
+verification lock.
+
 Vitest's worker limit applies to one process, not the whole machine. The config
 uses 25% of the available CPU locally, leaving capacity for four simultaneous
 worktree runs; CI uses 100% on isolated hardware. Override a one-off run with

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ playwright-report/
 # OS
 .DS_Store
 .vite/
+.verification/
 Thumbs.db
 
 # Environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,15 @@ Before `git push`, PR creation, or merge, run:
 - `./scripts/run-with-mise.sh yarn build`
 - `./scripts/run-with-mise.sh yarn test`
 
+When a full-suite terminal session may be interrupted or its final status is
+not recoverable, run `./scripts/run-with-mise.sh yarn test:durable` instead of
+inferring success from partial output. It clears stale completed evidence and
+writes only under the active worktree's ignored `.verification/` directory.
+Confirm it with `./scripts/run-with-mise.sh yarn test:durable:status`; it
+accepts a result only when it passed for the current `HEAD` and working tree.
+Do not point two worktrees at a shared durable-artifact directory or add a
+repository-wide verification lock.
+
 When `HEAD` is ahead of `origin/main`, also review both:
 
 - `git diff --stat origin/main...HEAD`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ This is enforced by the user and is not optional.
 - `bash scripts/run-with-mise.sh yarn dev` — Start dev server
 - `bash scripts/run-with-mise.sh yarn build` — Production build
 - `bash scripts/run-with-mise.sh yarn test` — Run vitest + hook smoke tests. DOES NOT type-check — `yarn build` is the only path that runs `tsc`. Before any `git push`, `gh pr create`, or `gh pr merge`, run `yarn build` and `yarn test` and confirm both exit 0. The `require-green-before-push` hook enforces this, but catching it locally is faster.
+- `bash scripts/run-with-mise.sh yarn test:durable` — Run the complete suite and persist its result in this worktree's ignored `.verification/` directory. Use this for agent-driven full-suite checks when terminal output might be interrupted; it removes stale completed evidence before it starts, refuses to replace a live run in the same worktree, and records the tested HEAD plus exit code.
+- `bash scripts/run-with-mise.sh yarn test:durable:status` — Accept durable evidence only when it passed and belongs to the current `HEAD` and working tree; otherwise it exits non-zero and explains why.
 - `bash scripts/run-with-mise.sh yarn test:watch` — Run tests in watch mode
 
 **Bash tool timeout guidance** — set `timeout` to match what the command actually does:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "tauri:check:mac-artifacts": "node scripts/check-tauri-macos-artifacts.mjs",
     "setup:hooks": "sh scripts/setup-git-hooks.sh",
     "test": "sh scripts/run-test-suite.sh full",
+    "test:durable": "sh scripts/run-durable-test-suite.sh full -- sh scripts/run-test-suite.sh full",
+    "test:durable:status": "sh scripts/read-durable-test-result.sh full",
     "test:fast": "sh scripts/run-test-suite.sh fast",
     "test:slow": "sh scripts/run-test-suite.sh slow",
     "test:ai-playability": "bash scripts/run-ai-playability-regressions.sh",

--- a/scripts/read-durable-test-result.sh
+++ b/scripts/read-durable-test-result.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Read durable test evidence only when it belongs to the current worktree HEAD.
+
+set -eu
+
+scope="${1:-full}"
+case "$scope" in
+  ''|*[!a-z0-9_-]*)
+    echo 'Usage: read-durable-test-result.sh [scope]' >&2
+    exit 2
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+prefix="$repo_root/.verification/${scope}-suite"
+running="$prefix.running"
+status="$prefix.status"
+
+if [ -f "$running" ]; then
+  echo "Durable $scope test evidence is still being produced: $running" >&2
+  exit 3
+fi
+if [ ! -f "$status" ]; then
+  echo "No durable $scope test result exists for this worktree." >&2
+  exit 2
+fi
+
+field() {
+  sed -n "s/^$1=//p" "$status" | head -n 1
+}
+
+recorded_scope="$(field scope)"
+recorded_worktree="$(field worktree)"
+if [ "$recorded_scope" != "$scope" ] || [ "$recorded_worktree" != "$repo_root" ]; then
+  echo "Durable $scope status has mismatched scope or worktree metadata; inspect $status." >&2
+  exit 1
+fi
+
+recorded_head="$(field head)"
+current_head="$(git -C "$repo_root" rev-parse HEAD)"
+if [ "$recorded_head" != "$current_head" ]; then
+  echo "Durable $scope result belongs to $recorded_head, not current HEAD $current_head." >&2
+  exit 1
+fi
+
+recorded_worktree_state="$(field worktree_state)"
+current_worktree_state="$(git -C "$repo_root" status --porcelain=v1 --untracked-files=all | cksum | awk '{print $1 "-" $2}')"
+if [ "$recorded_worktree_state" != "$current_worktree_state" ]; then
+  echo "Durable $scope result does not match the current working tree; rerun the suite." >&2
+  exit 1
+fi
+
+exit_code="$(field exit_code)"
+if [ "$exit_code" != '0' ]; then
+  echo "Durable $scope test run failed with exit code ${exit_code:-unknown}; inspect $status." >&2
+  exit 1
+fi
+
+printf 'Durable %s test run passed for %s.\n' "$scope" "$current_head"

--- a/scripts/run-durable-test-suite.sh
+++ b/scripts/run-durable-test-suite.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Run a test command with worktree-local, durable evidence for agent workflows.
+
+set -eu
+
+usage() {
+  echo 'Usage: run-durable-test-suite.sh <scope> -- <test command> [arguments...]' >&2
+  exit 2
+}
+
+scope="${1:-}"
+[ "$#" -ge 3 ] && [ "${2:-}" = '--' ] || usage
+case "$scope" in
+  ''|*[!a-z0-9_-]*) usage ;;
+esac
+shift 2
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+artifact_dir="$repo_root/.verification"
+prefix="$artifact_dir/${scope}-suite"
+lock_dir="$prefix.lock"
+running="$prefix.running"
+log="$prefix.log"
+status="$prefix.status"
+status_tmp="$status.tmp.$$"
+head_sha="$(git -C "$repo_root" rev-parse HEAD)"
+started_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+mkdir -p "$artifact_dir"
+
+release_lock() {
+  rm -f "$lock_dir/pid"
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+acquire_lock() {
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf 'pid=%s\n' "$$" > "$lock_dir/pid"
+    return
+  fi
+
+  lock_pid="$(sed -n 's/^pid=//p' "$lock_dir/pid" 2>/dev/null | head -n 1)"
+  if [ -z "$lock_pid" ] || kill -0 "$lock_pid" 2>/dev/null; then
+    echo "A durable $scope test run is already active or establishing its lock in this worktree; inspect $lock_dir." >&2
+    exit 1
+  fi
+
+  rm -f "$lock_dir/pid"
+  if ! rmdir "$lock_dir" 2>/dev/null || ! mkdir "$lock_dir" 2>/dev/null; then
+    echo "Unable to replace stale durable $scope lock at $lock_dir." >&2
+    exit 1
+  fi
+  printf 'pid=%s\n' "$$" > "$lock_dir/pid"
+}
+
+worktree_state() {
+  git -C "$repo_root" status --porcelain=v1 --untracked-files=all | cksum | awk '{print $1 "-" $2}'
+}
+
+acquire_lock
+
+if [ -f "$running" ]; then
+  running_pid="$(sed -n 's/^pid=//p' "$running" | head -n 1)"
+  if [ -n "$running_pid" ] && kill -0 "$running_pid" 2>/dev/null; then
+    echo "A durable $scope test run is already active in this worktree; inspect $running or $log." >&2
+    release_lock
+    exit 1
+  fi
+fi
+
+# Finished and abandoned artifacts cannot be evidence for the run about to
+# start. A live marker is handled above before anything is removed.
+rm -f "$running" "$log" "$status" "$status_tmp"
+initial_worktree_state="$(worktree_state)"
+printf 'pid=%s\nworktree=%s\nhead=%s\nstarted_at=%s\n' \
+  "$$" "$repo_root" "$head_sha" "$started_at" > "$running"
+
+finish() {
+  exit_code="$1"
+  completed_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  {
+    printf 'scope=%s\n' "$scope"
+    printf 'worktree=%s\n' "$repo_root"
+    printf 'head=%s\n' "$head_sha"
+    printf 'worktree_state=%s\n' "$initial_worktree_state"
+    printf 'started_at=%s\n' "$started_at"
+    printf 'completed_at=%s\n' "$completed_at"
+    printf 'exit_code=%s\n' "$exit_code"
+  } > "$status_tmp"
+  mv "$status_tmp" "$status"
+  rm -f "$running"
+}
+
+on_exit() {
+  exit_code="$?"
+  finish "$exit_code"
+  release_lock
+}
+trap on_exit EXIT
+
+if "$@" > "$log" 2>&1; then
+  test_exit_code=0
+else
+  test_exit_code=$?
+fi
+
+cat "$log"
+trap - EXIT
+finish "$test_exit_code"
+release_lock
+exit "$test_exit_code"

--- a/tests/hooks/run-durable-test-suite.test.sh
+++ b/tests/hooks/run-durable-test-suite.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Contract tests for worktree-local durable full-suite evidence.
+
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNNER="$ROOT/scripts/run-durable-test-suite.sh"
+READER="$ROOT/scripts/read-durable-test-result.sh"
+
+[ -x "$RUNNER" ] || {
+  echo "durable test runner is missing or not executable" >&2
+  exit 1
+}
+[ -x "$READER" ] || {
+  echo "durable test-result reader is missing or not executable" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+repo="$tmpdir/worktree-a"
+mkdir -p "$repo/scripts"
+cp "$RUNNER" "$READER" "$repo/scripts/"
+cp "$ROOT/.gitignore" "$repo/.gitignore"
+
+git -C "$repo" init -q
+git -C "$repo" config user.email durable-test@example.invalid
+git -C "$repo" config user.name durable-test
+touch "$repo/initial"
+git -C "$repo" add initial .gitignore
+git -C "$repo" commit -qm initial
+git -C "$repo" add scripts
+git -C "$repo" commit -qm runner
+
+mkdir -p "$repo/.verification"
+printf 'old log\n' > "$repo/.verification/full-suite.log"
+printf 'exit_code=0\n' > "$repo/.verification/full-suite.status"
+mkdir "$repo/.verification/full-suite.lock"
+printf 'pid=999999\n' > "$repo/.verification/full-suite.lock/pid"
+
+(
+  cd "$repo"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'printf "fresh output\\n"; exit 0'
+)
+
+grep -Fxq 'fresh output' "$repo/.verification/full-suite.log" || {
+  echo "durable runner did not replace a stale log" >&2
+  exit 1
+}
+grep -Fxq 'exit_code=0' "$repo/.verification/full-suite.status" || {
+  echo "durable runner did not persist a successful status" >&2
+  exit 1
+}
+[ ! -d "$repo/.verification/full-suite.lock" ] || {
+  echo "durable runner did not clean a stale lock" >&2
+  exit 1
+}
+(
+  cd "$repo"
+  sh scripts/read-durable-test-result.sh full
+) >/dev/null
+
+set +e
+(
+  cd "$repo"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'exit 7'
+) >/dev/null 2>&1
+failure_status=$?
+set -e
+[ "$failure_status" -eq 7 ] || {
+  echo "durable runner did not preserve a test failure: $failure_status" >&2
+  exit 1
+}
+grep -Fxq 'exit_code=7' "$repo/.verification/full-suite.status" || {
+  echo "durable runner did not persist a failing status" >&2
+  exit 1
+}
+set +e
+(
+  cd "$repo"
+  sh scripts/read-durable-test-result.sh full
+) >/dev/null 2>&1
+reader_failure_status=$?
+set -e
+[ "$reader_failure_status" -eq 1 ] || {
+  echo "durable reader accepted a failed test result: $reader_failure_status" >&2
+  exit 1
+}
+
+printf 'pid=%s\nworktree=%s\n' "$$" "$repo" > "$repo/.verification/full-suite.running"
+set +e
+(
+  cd "$repo"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'exit 0'
+) >/dev/null 2>&1
+active_status=$?
+set -e
+[ "$active_status" -eq 1 ] || {
+  echo "durable runner replaced a live run marker: $active_status" >&2
+  exit 1
+}
+set +e
+(
+  cd "$repo"
+  sh scripts/read-durable-test-result.sh full
+) >/dev/null 2>&1
+active_reader_status=$?
+set -e
+[ "$active_reader_status" -eq 3 ] || {
+  echo "durable reader did not report an active run: $active_reader_status" >&2
+  exit 1
+}
+rm -f "$repo/.verification/full-suite.running"
+
+mkdir "$repo/.verification/full-suite.lock"
+printf 'pid=%s\n' "$$" > "$repo/.verification/full-suite.lock/pid"
+set +e
+(
+  cd "$repo"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'exit 0'
+) >/dev/null 2>&1
+lock_status=$?
+set -e
+[ "$lock_status" -eq 1 ] || {
+  echo "durable runner started while another runner held the worktree lock: $lock_status" >&2
+  exit 1
+}
+rm -f "$repo/.verification/full-suite.lock/pid"
+rmdir "$repo/.verification/full-suite.lock"
+
+(
+  cd "$repo"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'exit 0'
+) >/dev/null
+printf 'uncommitted change\n' >> "$repo/initial"
+set +e
+(
+  cd "$repo"
+  sh scripts/read-durable-test-result.sh full
+) >/dev/null 2>&1
+dirty_status=$?
+set -e
+[ "$dirty_status" -eq 1 ] || {
+  echo "durable reader accepted evidence after an uncommitted change: $dirty_status" >&2
+  exit 1
+}
+git -C "$repo" checkout -- initial
+touch "$repo/next"
+git -C "$repo" add next
+git -C "$repo" commit -qm next
+set +e
+(
+  cd "$repo"
+  sh scripts/read-durable-test-result.sh full
+) >/dev/null 2>&1
+stale_status=$?
+set -e
+[ "$stale_status" -eq 1 ] || {
+  echo "durable reader accepted evidence from another HEAD: $stale_status" >&2
+  exit 1
+}
+
+repo_b="$tmpdir/worktree-b"
+git -C "$repo" worktree add -qb durable-sibling "$repo_b"
+(
+  cd "$repo_b"
+  sh scripts/run-durable-test-suite.sh full -- sh -c 'exit 0'
+) >/dev/null
+[ -f "$repo/.verification/full-suite.status" ] && [ -f "$repo_b/.verification/full-suite.status" ] || {
+  echo "separate worktrees did not retain independent durable artifacts" >&2
+  exit 1
+}

--- a/tests/hooks/verification-config.test.sh
+++ b/tests/hooks/verification-config.test.sh
@@ -66,3 +66,15 @@ grep -Fxq '.vite/' "$ROOT/.gitignore" || {
   echo "worktree-local Vite caches are not ignored"
   exit 1
 }
+grep -Fxq '.verification/' "$ROOT/.gitignore" || {
+  echo "worktree-local durable verification artifacts are not ignored"
+  exit 1
+}
+grep -Fq '"test:durable": "sh scripts/run-durable-test-suite.sh full -- sh scripts/run-test-suite.sh full"' "$ROOT/package.json" || {
+  echo "package.json does not expose the durable full-suite runner"
+  exit 1
+}
+grep -Fq '"test:durable:status": "sh scripts/read-durable-test-result.sh full"' "$ROOT/package.json" || {
+  echo "package.json does not expose the durable full-suite status reader"
+  exit 1
+}


### PR DESCRIPTION
## Summary

- Adds `yarn test:durable`, which records full-suite output and status under the active worktree’s ignored `.verification/` directory.
- Adds `yarn test:durable:status`, which accepts evidence only for the current HEAD and working tree.
- Uses an atomic per-worktree lock, stale-artifact cleanup, and regression coverage for failures, interrupted/stale state, concurrent launches, linked worktrees, and source changes.

## Review

Inline review covered gameplay balance/fun/mechanics, player ages and play styles, difficulty, AI, UI/UX, architecture/extensibility, data, SFX, saves, solo/hot-seat regression risk, and implementation/testing. This is isolated test tooling: it changes none of the gameplay, UI, AI, save, or audio runtime paths. The review found and fixed same-worktree start races and stale green results after uncommitted changes.

## Verification

- `yarn test:durable` — 438 files passed; 7,076 tests passed; 3 skipped.
- `yarn test:durable:status` — accepted evidence for `0d700119`.
- `yarn build` — passed.
- `bash tests/hooks/run.sh` — passed.