### PR TITLE
feat(sprites): unit sprite v2 live-fallback rendering (#755)

### DIFF
--- a/.claude/hooks/check-src-edit.sh
+++ b/.claude/hooks/check-src-edit.sh
@@ -112,6 +112,20 @@ $lines"
     ;;
 esac
 
+# --- hardcoded numeric width/height SVG attribute in v2/index.ts's unit-sprite live fallback ---
+# (different syntax from the sprite-overlay.ts check above: this is an SVG attribute, width="128",
+# not a CSS style property, width:128px — the DOM overlay wrapper controls actual display size,
+# so the inner <svg> must always be responsive: width="100%" height="100%".)
+case "$file_path" in
+  */src/renderer/sprites/v2/index.ts)
+    if grep -nE 'width="[0-9]+"|height="[0-9]+"' "$file_path" | grep -v '//' >/dev/null; then
+      lines="$(grep -nE 'width="[0-9]+"|height="[0-9]+"' "$file_path" | grep -v '//' | head -5)"
+      append "Hardcoded numeric width/height SVG attribute in v2/index.ts — the DOM overlay wrapper controls display size; the inner <svg> must use width=\"100%\" height=\"100%\" (see .claude/rules/sprites.md#dom-overlay-live-fallback-for-uncovered-unit-sprites):
+$lines"
+    fi
+    ;;
+esac
+
 # --- Object.assign(window or React import in sprite files ---
 case "$file_path" in
   */src/renderer/sprites/*.tsx|*/src/renderer/sprites/*.ts)

--- a/.claude/rules/sprites.md
+++ b/.claude/rules/sprites.md
@@ -59,6 +59,38 @@ same way:
 
 ---
 
+## DOM-Overlay Live Fallback For Uncovered Unit Sprites
+
+`getUnitSpriteV2` (`src/renderer/sprites/v2/index.ts`) no longer returns `null` for a unit type
+with no hand-authored `UNIT_SPRITES` entry, or for a known unit type queried with a `faction`
+string that doesn't match one of the 6 archetype-family keys (which happens for every minor-civ-
+owned unit — `getFaction()` returns the raw owner id for any owner not in `state.civilizations`).
+Instead it calls the live `UNIT_SPRITE_CATALOG` function directly (`{palette, svgOnly: true}`) and
+wraps the result in the same `.cq-sprite-wrap.cq-v2` shell every pre-serialized sprite uses — see
+`isV2NativeUnit(unitType)` to check which path a given unit takes.
+
+**This is intentional and permanent — do not "fix" it by reverting to `null`.** It's what makes
+"every unit animates via the DOM overlay" a structural guarantee (enforced by a test in
+`tests/renderer/sprites/v2/index.test.ts` that loops over `UNIT_SPRITE_CATALOG` and asserts
+`getUnitSpriteV2` is never `null`) instead of something that silently regresses whenever a new unit
+ships without matching hand-authored v2 art — which is exactly what happened before issue #755.
+
+- The inner `<svg>` this path produces is always `width="100%" height="100%"`, never a fixed pixel
+  value — the DOM overlay's outer wrapper (sized from `camera.hexSize`) controls actual display
+  size. A hook (`check-src-edit.sh`) blocks a hardcoded numeric width/height here.
+- `data-kind` is deliberately omitted on fallback-tier sprites — no ambient-effect CSS class is
+  `data-kind`-scoped, and guessing wrong risks triggering an unrelated body-plan animation rule.
+- Fallback-tier units get ambient-effect animation (`.cq-glow`, `.cq-fire`, etc.) and idle motion,
+  but not the 6-way archetype body/armor variation native v2-native units have, nor full
+  limb-level walk-cycle art. Upgrading a specific unit to native v2 art is optional, incremental
+  work — see the migration-backlog issue referenced in `docs/sprite-design-system.md`'s Units
+  section for the recipe.
+- Step 5 of the "Extension Recipe — Unit or Building Sprite" above (adding the catalog entry) is
+  now sufficient by itself for a new unit to animate via the DOM overlay — writing v2-native
+  archetype art is optional richness, not a required step.
+
+---
+
 ## Hard Rules
 
 **Units and buildings:**

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -17,8 +17,8 @@ civilization visual families) or, as of #755, a live-fallback sprite rendered di
 regardless of type). Every unit type is guaranteed to animate via one of these two paths — none
 silently render as a static Canvas bitmap anymore. `isV2NativeUnit(unitType)` tells you which path
 a given type takes. See `.claude/rules/sprites.md`'s "DOM-Overlay Live Fallback" section for the
-mechanism, and the `art: migrate live-fallback unit sprites to native v2 archetype art` GitHub
-issue for the incremental-richness backlog (upgrading fallback-tier units to full archetype art) —
+mechanism, and #759 ("art: migrate live-fallback unit sprites to native v2 archetype art") for
+the incremental-richness backlog (upgrading fallback-tier units to full archetype art) —
 run `Object.keys(UNIT_SPRITE_CATALOG).filter(t => !isV2NativeUnit(t))` for the current, always-up-
 to-date list rather than trusting a pasted snapshot.
 

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -9,6 +9,19 @@ Single source of truth for all visual assets: units, buildings, terrain tiles, i
 ### Units — `src/renderer/sprites/units.tsx`
 Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 
+Live render surfaces: the map's DOM overlay (`sprite-overlay.ts`) shows an animated unit sprite
+whenever `getUnitSpriteV2()` (`src/renderer/sprites/v2/index.ts`) resolves one — either a
+hand-authored v2-native sprite (33 unit types, each with distinct body/armor art per one of 6
+civilization visual families) or, as of #755, a live-fallback sprite rendered directly from
+`UNIT_SPRITE_CATALOG` for everything else (the remaining unit types, plus any minor-civ-owned unit
+regardless of type). Every unit type is guaranteed to animate via one of these two paths — none
+silently render as a static Canvas bitmap anymore. `isV2NativeUnit(unitType)` tells you which path
+a given type takes. See `.claude/rules/sprites.md`'s "DOM-Overlay Live Fallback" section for the
+mechanism, and the `art: migrate live-fallback unit sprites to native v2 archetype art` GitHub
+issue for the incremental-richness backlog (upgrading fallback-tier units to full archetype art) —
+run `Object.keys(UNIT_SPRITE_CATALOG).filter(t => !isV2NativeUnit(t))` for the current, always-up-
+to-date list rather than trusting a pasted snapshot.
+
 | Unit | Status | data-kind |
 |------|--------|-----------|
 | settler | ✅ sprite | civilian |

--- a/docs/superpowers/plans/2026-07-29-unit-sprite-v2-live-fallback.md
+++ b/docs/superpowers/plans/2026-07-29-unit-sprite-v2-live-fallback.md
@@ -1,0 +1,806 @@
+# Unit Sprite v2 Live-Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do NOT use subagent-driven-development or spawn any subagents — this project's CLAUDE.md forbids subagents/parallel agents; execute every task inline in the current session.
+
+**Goal:** Close the unit-sprite DOM-overlay animation gap (issue #755) by making `getUnitSpriteV2`
+fall back to calling the live `UNIT_SPRITE_CATALOG` sprite function directly (instead of returning
+`null`) whenever a unit isn't covered by the hand-authored v2 pre-serialization pipeline — covering
+both the 24 uncovered unit types and, as a real side effect found during design review, all
+minor-civ-owned units of any type (which hit the same `null` path via an unrecognized `faction`
+string today).
+
+**Architecture:** `getUnitSpriteV2(unitType, faction, civColor?)` gains a fallback branch that calls
+the live sprite function with `{palette: derivePalette(civColor), svgOnly: true}`, rewrites its
+baked pixel width/height to responsive `100%` (in place, not duplicated — the same fix shape as the
+city-panel building-icon work), and wraps it in the same `.cq-sprite-wrap.cq-v2` shell every
+pre-serialized sprite already produces. A new exported `isV2NativeUnit()` helper gives tests and
+follow-up tooling a way to tell native from fallback sprites without reaching into the module's
+private `UNIT_SPRITES` table.
+
+**Tech Stack:** TypeScript, vitest + jsdom, no new dependencies.
+
+**Design doc:** `docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md` — read
+this first if anything below is unclear; it has the full rationale and a documented second-pass
+review of the exact mechanism this plan implements.
+
+## Global Constraints
+
+- Never use `Math.random()` — no randomness in this feature, N/A.
+- `civColor` must default gracefully — `derivePalette('')` produces `NaN`-poisoned hex strings
+  (verified against `hexToHsl`/`hslToHex` in `sprite-system.tsx`); always guard with
+  `civColor ? derivePalette(civColor) : NEUTRAL_FACTION_PALETTE`.
+- The DOM-overlay wrapper's inner `<svg>` must never carry a hardcoded pixel `width`/`height` —
+  it must be `width="100%" height="100%"` so the outer wrapper (sized by `sprite-overlay.ts` from
+  `camera.hexSize`) controls actual display size. This is enforced by a hook this plan adds in
+  Task 3 — do not bypass it.
+- `civColor` is being added as an **optional** third parameter to `getUnitSpriteV2`, not required —
+  the existing test suite has ~15 call sites using the current 2-arg signature across
+  `tests/renderer/sprites/v2/index.test.ts` and `tests/renderer/sprites/unit-identity.test.ts`, and
+  none of them need to change just for this signature addition.
+- Do not touch anything building-related (`getBuildingSpriteV2`, `kind: 'building'` `SpriteEntity`s)
+  — that's tracked separately in #658/#659 and explicitly out of scope for this plan.
+
+---
+
+## Task 1: `isV2NativeUnit()` + live-fallback rendering in `getUnitSpriteV2`
+
+**Files:**
+- Modify: `src/renderer/sprites/v2/index.ts:161-167` (`getUnitSpriteV2`), plus new code appended
+  after it
+- Modify: `tests/renderer/sprites/v2/index.test.ts` (imports, one existing test rewritten, several
+  new tests, one existing describe block's iteration source replaced)
+
+**Interfaces:**
+- Produces: `export function getUnitSpriteV2(unitType: string, faction: string, civColor?: string): string | null` (existing export, new optional third param).
+- Produces: `export function isV2NativeUnit(unitType: string): boolean` (new export).
+- Consumes: `UNIT_SPRITE_CATALOG: Record<UnitType, (props: {palette: FactionPalette; svgOnly?: boolean; motion?: UnitSpriteMotion}) => string>` from `@/renderer/sprites/sprite-catalog`. `derivePalette(civColor: string): FactionPalette` and `NEUTRAL_FACTION_PALETTE: FactionPalette` from `../sprite-system` (relative from `v2/index.ts`). `UnitType` type from `@/core/types`.
+
+### Step 1: Update test file imports and remove the now-redundant hardcoded type list
+
+The existing `ALL_SPRITE_UNIT_TYPES` array (lines 10-23) is a manually maintained duplicate of what
+`UNIT_SPRITE_CATALOG`'s keys already track — after this task, the "full unit coverage" test (line
+182) is rewritten to iterate the real catalog instead, so this array becomes dead. Remove it and
+add the new imports needed for the rest of this task.
+
+In `tests/renderer/sprites/v2/index.test.ts`, replace lines 1-23:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  getUnitSpriteV2,
+  getBuildingSpriteV2,
+  getPirateHeadquartersSpriteV2,
+  getImprovementSpriteV2,
+} from '@/renderer/sprites/v2/index';
+
+// All unit types that must have a v2 serialization (MR 1 + MR 2 + MR 4 + MR 6).
+const ALL_SPRITE_UNIT_TYPES = [
+  // MR 1 — already serialized
+  'archer', 'galley', 'musketeer', 'pikeman', 'scout', 'scout_hound', 'settler',
+  'shadow_warden', 'spy_agent', 'spy_hacker', 'spy_informant', 'spy_operative',
+  'spy_scout', 'swordsman', 'trireme', 'war_hound', 'warrior', 'worker',
+  // MR 2 — new
+  'axeman', 'spearman', 'horseman', 'cavalry', 'knight',
+  'crossbowman', 'catapult', 'ballista',
+  'caravan', 'expedition', 'transport',
+  // MR 4 — late-era naval
+  'carrack', 'galleon', 'steamship', 'troop_transport',
+  // MR 6 — legendary beasts
+  'beast_boar',
+];
+```
+
+with:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  getUnitSpriteV2,
+  isV2NativeUnit,
+  getBuildingSpriteV2,
+  getPirateHeadquartersSpriteV2,
+  getImprovementSpriteV2,
+} from '@/renderer/sprites/v2/index';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+```
+
+- [ ] Do this replacement now.
+
+### Step 2: Rewrite the now-incorrect "unknown faction" test
+
+The existing test at (originally) lines 42-44 asserts `getUnitSpriteV2('warrior', 'unknownfaction')`
+returns `null`. This assertion is about to become **wrong on purpose** — this is exactly the
+minor-civ-owned-unit bug the design doc found: a real unit type with an unrecognized faction string
+should render via the live fallback, not silently stay static. Replace it to assert the new,
+correct behavior.
+
+Find (inside `describe('getUnitSpriteV2', ...)`):
+
+```typescript
+  it('returns null for unknown faction', () => {
+    expect(getUnitSpriteV2('warrior', 'unknownfaction')).toBeNull();
+  });
+```
+
+Replace with:
+
+```typescript
+  it('falls back to a live-rendered sprite for a known unit type with an unrecognized faction (e.g. a minor civ)', () => {
+    // Before #755's fix this silently returned null (static Canvas fallback forever) — 'warrior'
+    // is a v2-native type, but 'unknownfaction' isn't one of the 6 baked archetype-family keys,
+    // which is exactly what happens for any minor-civ-owned unit today (getFaction() returns the
+    // raw owner id for any owner not in state.civilizations).
+    const result = getUnitSpriteV2('warrior', 'unknownfaction', '#7a5a16');
+    expect(result).not.toBeNull();
+    expect(result).toContain('cq-sprite-wrap');
+    expect(result).toContain('cq-v2');
+  });
+```
+
+- [ ] Do this replacement now.
+
+### Step 3: Write the remaining failing tests
+
+Add these new `describe` blocks at the end of the file (after the last existing block, before
+nothing — i.e. append):
+
+```typescript
+describe('isV2NativeUnit', () => {
+  it('is true for a v2-native unit', () => {
+    expect(isV2NativeUnit('archer')).toBe(true);
+  });
+
+  it('is false for a unit type that only has the live-fallback path', () => {
+    expect(isV2NativeUnit('tank')).toBe(false);
+  });
+
+  it('is false for a genuinely unknown type', () => {
+    expect(isV2NativeUnit('not-a-real-unit')).toBe(false);
+  });
+});
+
+describe('getUnitSpriteV2 — live fallback for uncovered unit types', () => {
+  // Representative sample of the 24 units with no UNIT_SPRITES entry (confirmed via diff against
+  // UNIT_SPRITE_CATALOG, 2026-07-28) — not exhaustive here; the full-catalog loop later in this
+  // file covers all of them for the "never null" guarantee.
+  const FALLBACK_TIER_SAMPLE = ['tank', 'rifleman', 'submarine', 'combat_drone', 'grenadier'];
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s renders via the live fallback, not v2-native', (type) => {
+    expect(isV2NativeUnit(type)).toBe(false);
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9');
+    expect(result, `${type} should not be null`).not.toBeNull();
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output has the animation hook point (cq-sprite-figure)', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    expect(result).toContain('cq-sprite-wrap');
+    expect(result).toContain('cq-v2');
+    expect(result).toContain('cq-sprite-figure');
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output has exactly one width="100%" and one height="100%", never a hardcoded pixel size', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    expect(result.match(/width="100%"/g)?.length).toBe(1);
+    expect(result.match(/height="100%"/g)?.length).toBe(1);
+    expect(result).not.toMatch(/width="\d+"/);
+    expect(result).not.toMatch(/height="\d+"/);
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output does not contain data-kind (deliberately omitted for fallback-tier units)', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    expect(result).not.toContain('data-kind');
+  });
+
+  it('does not throw and returns non-null for a missing civColor (falls back to NEUTRAL_FACTION_PALETTE)', () => {
+    expect(() => getUnitSpriteV2('tank', 'imperials', '')).not.toThrow();
+    const result = getUnitSpriteV2('tank', 'imperials', '');
+    expect(result).not.toBeNull();
+    expect(result).not.toMatch(/NaN/);
+  });
+
+  it('does not throw and returns non-null when civColor is omitted entirely', () => {
+    expect(() => getUnitSpriteV2('tank', 'imperials')).not.toThrow();
+    expect(getUnitSpriteV2('tank', 'imperials')).not.toBeNull();
+  });
+});
+
+describe('getUnitSpriteV2 — structural guarantee (would have caught #755)', () => {
+  it('never returns null for any type in UNIT_SPRITE_CATALOG, the canonical live unit roster', () => {
+    for (const type of Object.keys(UNIT_SPRITE_CATALOG)) {
+      const result = getUnitSpriteV2(type, 'imperials', '#4a90d9');
+      expect(result, `${type} returned null — silently stuck on static Canvas rendering`).not.toBeNull();
+    }
+  });
+});
+```
+
+- [ ] Write these now.
+
+### Step 4: Rewrite the "full unit coverage" test to iterate the canonical catalog
+
+The existing block hardcodes 33 native-only types via `ALL_SPRITE_UNIT_TYPES` (now removed in Step
+1) — this both duplicates a list that will drift and only proves native coverage, not the full
+57-type guarantee this design adds. Find:
+
+```typescript
+describe('full unit coverage — every type returns a cq-sprite-wrap for imperials', () => {
+  it.each(ALL_SPRITE_UNIT_TYPES)('%s', (type) => {
+    const r = getUnitSpriteV2(type, 'imperials');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+    expect(r!).toContain('cq-v2');
+  });
+});
+```
+
+Replace with:
+
+```typescript
+describe('full unit coverage — every catalog entry returns a cq-sprite-wrap for imperials (native or live-fallback)', () => {
+  it.each(Object.keys(UNIT_SPRITE_CATALOG))('%s', (type) => {
+    const r = getUnitSpriteV2(type, 'imperials', '#4a90d9');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+    expect(r!).toContain('cq-v2');
+  });
+});
+```
+
+- [ ] Do this replacement now.
+
+### Step 5: Run tests to verify they fail
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "v2"`
+
+Expected: multiple failures — `isV2NativeUnit is not exported`, the rewritten "unknown faction"
+test failing (current code still returns `null`), the new fallback-tier tests failing the same way,
+and TypeScript errors on `isV2NativeUnit` import (this will actually fail at the transform step,
+not just at runtime — that's fine, it confirms the target doesn't exist yet).
+
+### Step 6: Implement `isV2NativeUnit` and the live-fallback mechanism
+
+In `src/renderer/sprites/v2/index.ts`, add these imports after the existing import block (after
+line 104, before the `// ── Unit sprites ──` comment on line 106):
+
+```typescript
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import { derivePalette, NEUTRAL_FACTION_PALETTE } from '../sprite-system';
+import type { UnitType } from '@/core/types';
+```
+
+Replace the existing `getUnitSpriteV2` function (lines 161-167):
+
+```typescript
+export function getUnitSpriteV2(unitType: string, faction: string): string | null {
+  // Faction-neutral sprites (e.g. beasts) are stored under 'beast' and shared across all factions
+  const sprites = UNIT_SPRITES[unitType];
+  if (!sprites) return null;
+  if (sprites.pirates) return faction === 'pirates' ? sprites.pirates : null;
+  return sprites[faction] ?? sprites.beast ?? null;
+}
+```
+
+with:
+
+```typescript
+export function isV2NativeUnit(unitType: string): boolean {
+  return unitType in UNIT_SPRITES;
+}
+
+/**
+ * #755: closes the DOM-overlay animation gap for any unit type not hand-authored in
+ * UNIT_SPRITES — both the 24 unit types with no v2 entry at all, and (found during design
+ * review) any unit owned by a faction with no per-family key here, which is what happens for
+ * every minor-civ-owned unit today (getFaction() returns the raw owner id, not one of the 6
+ * archetype names, whenever the owner isn't in state.civilizations). Renders the live
+ * units.tsx/UNIT_SPRITE_CATALOG function directly instead of a second, hand-authored copy.
+ */
+function buildLiveFallbackUnitSprite(unitType: string, civColor: string): string | null {
+  const spriteFn = UNIT_SPRITE_CATALOG[unitType as UnitType];
+  if (!spriteFn) return null; // genuinely unknown type — Canvas handles it, unchanged today
+  const palette = civColor ? derivePalette(civColor) : NEUTRAL_FACTION_PALETTE;
+  const rawSvg = spriteFn({ palette, svgOnly: true });
+  // SpriteFrame's svgOnly output bakes in a fixed pixel width/height (unit sprites: 128x128).
+  // The DOM overlay's outer wrapper (sized in sprite-overlay.ts from camera.hexSize) controls
+  // actual display size; the inner <svg> must fill it responsively instead of carrying its own
+  // fixed size. Replace the baked attribute pair in place — never prepend a duplicate (same fix
+  // shape as the city-panel building-icon feature, #665).
+  const svg = rawSvg.replace(
+    /(<svg\b[^>]*?)\swidth="\d+"\s+height="\d+"/,
+    '$1 width="100%" height="100%"',
+  );
+  // data-kind deliberately omitted: no ambient-effect CSS class (.cq-glow, .cq-fire, etc.) is
+  // data-kind-scoped, and guessing wrong (e.g. tagging a land unit "naval") risks triggering an
+  // unrelated body-plan animation rule. Revisit per-unit once real v2-native art exists (see the
+  // migration-backlog follow-up issue).
+  return `<div class="cq-sprite-wrap cq-v2" data-state="idle" style="--phase:0">${svg}</div>`;
+}
+
+export function getUnitSpriteV2(unitType: string, faction: string, civColor: string = ''): string | null {
+  // Faction-neutral sprites (e.g. beasts) are stored under 'beast' and shared across all factions
+  const sprites = UNIT_SPRITES[unitType];
+  if (sprites) {
+    if (sprites.pirates) return faction === 'pirates' ? sprites.pirates : null;
+    return sprites[faction] ?? sprites.beast ?? buildLiveFallbackUnitSprite(unitType, civColor);
+  }
+  return buildLiveFallbackUnitSprite(unitType, civColor);
+}
+```
+
+Note `civColor: string = ''` (a default value, not `civColor?: string`) — either spelling makes the
+parameter optional for callers, but a concrete default reads more clearly at the call site inside
+this file than an `undefined` that then needs its own `?? ''` a few lines later.
+
+- [ ] Write this now.
+
+### Step 7: Run tests to verify they pass
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "v2"`
+
+Expected: all pass, including every pre-existing test in the file (confirms no regression to
+native-unit behavior, pirate/beast handling, or building/improvement/landmark lookups untouched by
+this task).
+
+### Step 8: Commit
+
+```bash
+git add src/renderer/sprites/v2/index.ts tests/renderer/sprites/v2/index.test.ts
+git commit -m "feat(sprites): add live-fallback rendering to getUnitSpriteV2 (#755)"
+```
+
+---
+
+## Task 2: Wire `civColor` through `sprite-overlay.ts`
+
+**Files:**
+- Modify: `src/renderer/sprite-overlay.ts:197` (call site inside the pool-miss branch),
+  `src/renderer/sprite-overlay.ts:261-271` (`lookupSprite` method signature and its `'unit'` case)
+- Modify: `tests/renderer/sprite-overlay.test.ts` (one new integration test)
+
+**Interfaces:**
+- Consumes: `getUnitSpriteV2(unitType: string, faction: string, civColor?: string): string | null` (Task 1).
+- Produces: `lookupSprite(entity: SpriteEntity, civColor: string): string | null` (private method, new second param — not exported, but the call site change is externally observable via `sync()`'s behavior, which the new test verifies).
+
+### Step 1: Write the failing test
+
+In `tests/renderer/sprite-overlay.test.ts`, add this test in a new `describe` block, appended after
+the existing `describe('SpriteOverlay.sync() — pool invalidation on civColor change', ...)` block
+(after line ~420, the closing `});` of that block):
+
+```typescript
+// ── civColor reaches the live-fallback sprite path ──────────────────────────
+
+describe('SpriteOverlay.sync() — civColor reaches live-fallback unit sprites', () => {
+  it('bakes the real civ color into a fallback-tier unit sprite (e.g. tank), not just native ones', () => {
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ subtype: 'tank', faction: 'imperials', civId: 'civ-1' });
+
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+
+    const el = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.innerHTML).toContain('#2d6a4f');
+  });
+
+  it('still resolves a native unit sprite unchanged when civColor is provided', () => {
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ subtype: 'warrior', faction: 'imperials', civId: 'civ-1' });
+
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+
+    const el = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.innerHTML).toContain('cq-sprite-wrap');
+  });
+});
+```
+
+- [ ] Write this now.
+
+### Step 2: Run tests to verify they fail
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "civColor reaches live-fallback"`
+
+Expected: FAIL on the first test — `el.innerHTML` won't contain `#2d6a4f` yet, because
+`lookupSprite` doesn't pass `civColor` to `getUnitSpriteV2` yet, so the fallback path (if reached
+at all) would use the default `''` → `NEUTRAL_FACTION_PALETTE`, not the real civ color. (The second
+test may already pass by coincidence since it only checks for `cq-sprite-wrap` presence, not color
+— that's fine, TDD doesn't require every new test to fail, only that the feature-defining one does.)
+
+### Step 3: Implement the wiring
+
+In `src/renderer/sprite-overlay.ts`, change the `lookupSprite` call site (line 197):
+
+```typescript
+          const rawSvgHtml = this.lookupSprite(entity);
+```
+
+to:
+
+```typescript
+          const rawSvgHtml = this.lookupSprite(entity, newCivColor);
+```
+
+Then change the `lookupSprite` method itself (lines 261-271):
+
+```typescript
+  private lookupSprite(entity: SpriteEntity): string | null {
+    switch (entity.kind) {
+      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction);
+      case 'building':    return getBuildingSpriteV2(entity.subtype, entity.faction);
+      case 'improvement': return getImprovementSpriteV2(entity.subtype); // always null
+      case 'landmark':    return getPirateHeadquartersSpriteV2(entity.subtype)
+        ?? PIRATE_HEADQUARTERS_SPRITE_CATALOG[entity.subtype as PirateHeadquartersSpriteId]?.({ svgOnly: false })
+        ?? null;
+      default:            return null;
+    }
+  }
+```
+
+to:
+
+```typescript
+  private lookupSprite(entity: SpriteEntity, civColor: string): string | null {
+    switch (entity.kind) {
+      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction, civColor);
+      case 'building':    return getBuildingSpriteV2(entity.subtype, entity.faction);
+      case 'improvement': return getImprovementSpriteV2(entity.subtype); // always null
+      case 'landmark':    return getPirateHeadquartersSpriteV2(entity.subtype)
+        ?? PIRATE_HEADQUARTERS_SPRITE_CATALOG[entity.subtype as PirateHeadquartersSpriteId]?.({ svgOnly: false })
+        ?? null;
+      default:            return null;
+    }
+  }
+```
+
+Only the `'unit'` case changes — `civColor` is accepted by the method for that one case;
+`getBuildingSpriteV2`'s signature is untouched (buildings are out of scope, see Global Constraints).
+
+- [ ] Write this now.
+
+### Step 4: Run tests to verify they pass
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "civColor reaches live-fallback"`
+
+Expected: PASS (both tests).
+
+### Step 5: Run the full sprite-overlay suite and v2 suite together
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "SpriteOverlay|getUnitSpriteV2|v2"`
+
+Expected: all pass — confirms Task 1 and Task 2 compose correctly and nothing in the broader
+`sprite-overlay.test.ts` file (selection rings, stack pills, pool invalidation, landmark rendering,
+etc.) regressed from the `lookupSprite` signature change.
+
+### Step 6: Commit
+
+```bash
+git add src/renderer/sprite-overlay.ts tests/renderer/sprite-overlay.test.ts
+git commit -m "feat(sprites): thread civColor into the DOM overlay's unit sprite lookup"
+```
+
+---
+
+## Task 3: Guardrail hook for hardcoded pixel sizes in `v2/index.ts`
+
+**Files:**
+- Modify: `.claude/hooks/check-src-edit.sh` (new `case` block, added after the existing
+  `sprite-overlay.ts` hardcoded-pixel-size block, currently ending around line 112)
+- Modify: `tests/hooks/check-src-edit.test.sh` (new block/allow smoke-test cases, added before the
+  final `exit "$fail"` line)
+
+**Interfaces:** none (shell script + shell smoke test, no TypeScript interfaces).
+
+### Step 1: Write the failing smoke test
+
+In `tests/hooks/check-src-edit.test.sh`, insert these cases right before the final `exit "$fail"`
+line:
+
+```bash
+# --- v2/index.ts: block hardcoded numeric SVG width/height attribute ---
+mkdir -p "$tmp/src/renderer/sprites/v2"
+cat > "$tmp/src/renderer/sprites/v2/index.ts" <<'EOF'
+const svg = rawSvg.replace(/width="\d+"/, 'width="128" height="128"');
+EOF
+expect_block "$tmp/src/renderer/sprites/v2/index.ts" "hardcoded width=\"128\" in v2/index.ts"
+
+# --- v2/index.ts: allow the correct responsive-percentage replacement ---
+cat > "$tmp/src/renderer/sprites/v2/index.ts" <<'EOF'
+const svg = rawSvg.replace(
+  /(<svg\b[^>]*?)\swidth="\d+"\s+height="\d+"/,
+  '$1 width="100%" height="100%"',
+);
+EOF
+expect_allow "$tmp/src/renderer/sprites/v2/index.ts" "width=\"100%\" replacement in v2/index.ts"
+```
+
+- [ ] Write this now.
+
+### Step 2: Run the smoke test to verify the first new case fails
+
+Run: `bash tests/hooks/check-src-edit.test.sh`
+
+Expected: FAIL on `"hardcoded width=\"128\" in v2/index.ts"` — the hook doesn't check this file
+path yet, so it currently exits 0 (allow) for everything under `v2/`, including the deliberately
+bad fixture. The second case (`width="100%"`) should already pass by coincidence, same reasoning as
+Task 2 Step 2 — that's fine.
+
+### Step 3: Implement the new hook check
+
+In `.claude/hooks/check-src-edit.sh`, find the existing block (ends around line 112, right before
+the `# --- Object.assign(window or React import in sprite files ---` comment):
+
+```bash
+# --- hardcoded pixel size in sprite-overlay.ts (must derive from hexSize × SPRITE_OVERLAY_WORLD_SIZE_FACTOR) ---
+case "$file_path" in
+  */src/renderer/sprite-overlay.ts)
+    if grep -nE 'width:[0-9]+px|height:[0-9]+px' "$file_path" | grep -v '//\|SPRITE_OVERLAY_WORLD_SIZE_FACTOR' >/dev/null; then
+      lines="$(grep -nE 'width:[0-9]+px|height:[0-9]+px' "$file_path" | grep -v '//\|SPRITE_OVERLAY_WORLD_SIZE_FACTOR' | head -5)"
+      append "Hardcoded px size in sprite-overlay.ts — wrapper size must derive from camera.hexSize × SPRITE_OVERLAY_WORLD_SIZE_FACTOR (see .claude/rules/sprites.md#sprite-overlay-sizing):
+$lines"
+    fi
+    ;;
+esac
+```
+
+Add this new block immediately after it (same file, do not modify the block above — this is a
+**separate** `case` statement, not an added arm on the existing one, because the grep pattern is
+different: `sprite-overlay.ts` writes CSS `style.cssText` syntax (`width:128px`), while
+`v2/index.ts` produces SVG *attribute* syntax (`width="128"`) — reusing the CSS-syntax pattern on
+the new file would never match the mistake it needs to catch):
+
+```bash
+# --- hardcoded numeric width/height SVG attribute in v2/index.ts's unit-sprite live fallback ---
+# (different syntax from the sprite-overlay.ts check above: this is an SVG attribute, width="128",
+# not a CSS style property, width:128px — the DOM overlay wrapper controls actual display size,
+# so the inner <svg> must always be responsive: width="100%" height="100%".)
+case "$file_path" in
+  */src/renderer/sprites/v2/index.ts)
+    if grep -nE 'width="[0-9]+"|height="[0-9]+"' "$file_path" | grep -v '//' >/dev/null; then
+      lines="$(grep -nE 'width="[0-9]+"|height="[0-9]+"' "$file_path" | grep -v '//' | head -5)"
+      append "Hardcoded numeric width/height SVG attribute in v2/index.ts — the DOM overlay wrapper controls display size; the inner <svg> must use width=\"100%\" height=\"100%\" (see .claude/rules/sprites.md#dom-overlay-live-fallback-for-uncovered-unit-sprites):
+$lines"
+    fi
+    ;;
+esac
+```
+
+- [ ] Write this now.
+
+### Step 4: Run the smoke test to verify it passes
+
+Run: `bash tests/hooks/check-src-edit.test.sh`
+
+Expected: all cases pass, including confirming the hook does **not** false-positive on the actual
+regex-replace code from Task 1 (`width="\d+"` in source text — `\d` isn't a digit character, so
+`[0-9]+` never matches it) or on the correct `width="100%"` output (`%` before the closing quote
+breaks the `[0-9]+"` match).
+
+### Step 5: Confirm the hook fires correctly against the real file from Task 1
+
+Run: `echo '{"tool_name":"Edit","tool_input":{"file_path":"'"$(pwd)"'/src/renderer/sprites/v2/index.ts"}}' | bash .claude/hooks/check-src-edit.sh; echo "exit: $?"`
+
+Expected: `exit: 0` — the real file (after Task 1's implementation) contains only the correct
+`width="\d+"` regex source and `width="100%"` replacement output, neither of which the new check
+flags.
+
+### Step 6: Commit
+
+```bash
+git add .claude/hooks/check-src-edit.sh tests/hooks/check-src-edit.test.sh
+git commit -m "chore(hooks): guard against hardcoded pixel sizes in v2/index.ts's unit fallback"
+```
+
+---
+
+## Task 4: Documentation — guardrail rules and sprite design system
+
+**Files:**
+- Modify: `.claude/rules/sprites.md` (new section + one addition to the existing "Extension Recipe"
+  list)
+- Modify: `docs/sprite-design-system.md:9-11` (Units section header area)
+
+**Interfaces:** none (docs only).
+
+### Step 1: Add the new section to `.claude/rules/sprites.md`
+
+Find the existing "Extension Recipe — Rail Segment" section's end (the section ends right before
+the `---` horizontal rule that precedes `## Hard Rules`). Insert this new section immediately
+before that `---`:
+
+```markdown
+## DOM-Overlay Live Fallback For Uncovered Unit Sprites
+
+`getUnitSpriteV2` (`src/renderer/sprites/v2/index.ts`) no longer returns `null` for a unit type
+with no hand-authored `UNIT_SPRITES` entry, or for a known unit type queried with a `faction`
+string that doesn't match one of the 6 archetype-family keys (which happens for every minor-civ-
+owned unit — `getFaction()` returns the raw owner id for any owner not in `state.civilizations`).
+Instead it calls the live `UNIT_SPRITE_CATALOG` function directly (`{palette, svgOnly: true}`) and
+wraps the result in the same `.cq-sprite-wrap.cq-v2` shell every pre-serialized sprite uses — see
+`isV2NativeUnit(unitType)` to check which path a given unit takes.
+
+**This is intentional and permanent — do not "fix" it by reverting to `null`.** It's what makes
+"every unit animates via the DOM overlay" a structural guarantee (enforced by a test in
+`tests/renderer/sprites/v2/index.test.ts` that loops over `UNIT_SPRITE_CATALOG` and asserts
+`getUnitSpriteV2` is never `null`) instead of something that silently regresses whenever a new unit
+ships without matching hand-authored v2 art — which is exactly what happened before issue #755.
+
+- The inner `<svg>` this path produces is always `width="100%" height="100%"`, never a fixed pixel
+  value — the DOM overlay's outer wrapper (sized from `camera.hexSize`) controls actual display
+  size. A hook (`check-src-edit.sh`) blocks a hardcoded numeric width/height here.
+- `data-kind` is deliberately omitted on fallback-tier sprites — no ambient-effect CSS class is
+  `data-kind`-scoped, and guessing wrong risks triggering an unrelated body-plan animation rule.
+- Fallback-tier units get ambient-effect animation (`.cq-glow`, `.cq-fire`, etc.) and idle motion,
+  but not the 6-way archetype body/armor variation native v2-native units have, nor full
+  limb-level walk-cycle art. Upgrading a specific unit to native v2 art is optional, incremental
+  work — see the migration-backlog issue referenced in `docs/sprite-design-system.md`'s Units
+  section for the recipe.
+- Step 5 of the "Extension Recipe — Unit or Building Sprite" above (adding the catalog entry) is
+  now sufficient by itself for a new unit to animate via the DOM overlay — writing v2-native
+  archetype art is optional richness, not a required step.
+
+---
+```
+
+- [ ] Write this now.
+
+### Step 2: Add a "Live render surfaces" note to the Units section of `docs/sprite-design-system.md`
+
+Find (lines 9-11):
+
+```markdown
+### Units — `src/renderer/sprites/units.tsx`
+Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
+
+```
+
+Replace with:
+
+```markdown
+### Units — `src/renderer/sprites/units.tsx`
+Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
+
+Live render surfaces: the map's DOM overlay (`sprite-overlay.ts`) shows an animated unit sprite
+whenever `getUnitSpriteV2()` (`src/renderer/sprites/v2/index.ts`) resolves one — either a
+hand-authored v2-native sprite (33 unit types, each with distinct body/armor art per one of 6
+civilization visual families) or, as of #755, a live-fallback sprite rendered directly from
+`UNIT_SPRITE_CATALOG` for everything else (the remaining unit types, plus any minor-civ-owned unit
+regardless of type). Every unit type is guaranteed to animate via one of these two paths — none
+silently render as a static Canvas bitmap anymore. `isV2NativeUnit(unitType)` tells you which path
+a given type takes. See `.claude/rules/sprites.md`'s "DOM-Overlay Live Fallback" section for the
+mechanism, and the `art: migrate live-fallback unit sprites to native v2 archetype art` GitHub
+issue for the incremental-richness backlog (upgrading fallback-tier units to full archetype art) —
+run `Object.keys(UNIT_SPRITE_CATALOG).filter(t => !isV2NativeUnit(t))` for the current, always-up-
+to-date list rather than trusting a pasted snapshot.
+
+```
+
+- [ ] Write this now.
+
+### Step 3: Commit
+
+```bash
+git add .claude/rules/sprites.md docs/sprite-design-system.md
+git commit -m "docs: document the DOM-overlay live-fallback mechanism for unit sprites (#755)"
+```
+
+---
+
+## Task 5: Full verification, manual live-render check, and follow-up issue
+
+**Files:** none modified — verification and process only.
+
+### Step 1: Run the full test suite and build
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+Expected: all files pass.
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+Expected: clean, no TypeScript errors.
+
+- [ ] Run both now and confirm green.
+
+### Step 2: Manual live-render verification
+
+jsdom tests prove markup shape, not that a CSS animation actually runs in a real browser. Verify at
+least one fallback-tier unit that uses an ambient-effect class genuinely animates, using the same
+pattern already established this session (extract real rendered markup via a small script, convert
+to PNG with `rsvg-convert` for a static visual check, and/or publish an Artifact page checking
+`getComputedStyle(...).animationName` for a live check). Confirm:
+- The unit renders recognizably (not a blank/broken SVG).
+- `getComputedStyle(el, null).animationName` is not `"none"` for at least one ambient-effect
+  element inside it (e.g. a `.cq-glow` element on `combat_drone`, which was the unit that
+  originally motivated #755).
+
+- [ ] Do this now and report the result before proceeding.
+
+### Step 3: File the follow-up migration-backlog issue
+
+```bash
+gh issue create \
+  --title "art: migrate live-fallback unit sprites to native v2 archetype art" \
+  --body "$(cat <<'EOF'
+## Context
+
+#755 closed the DOM-overlay animation gap for all unit types (and minor-civ-owned units of any
+type) by adding a live-fallback path to `getUnitSpriteV2` — see
+`docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md` for the full design.
+Fallback-tier units get ambient-effect animation (glow/fire/smoke/etc.) and idle motion, but not
+the 6-way archetype body/armor variation (Imperial vs. Viking vs. Pharaoh, etc.) or full
+limb-level walk-cycle art that the 33 v2-native units have.
+
+This issue tracks the **optional, incremental** work of upgrading specific fallback-tier units to
+real v2-native archetype art. Not blocking anything — the live-fallback path is a complete,
+permanent fix on its own terms.
+
+## Detection (always up to date — don't trust a pasted snapshot)
+
+```ts
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import { isV2NativeUnit } from '@/renderer/sprites/v2';
+
+Object.keys(UNIT_SPRITE_CATALOG).filter(t => !isV2NativeUnit(t));
+```
+
+As of 2026-07-28, that's 24 units: attack_helicopter, autonomous_frigate, biplane, cannon,
+cargo_freighter, carrier, combat_drone, container_ship, drone_controller, exosuit_infantry,
+grenadier, ironclad, jet_fighter, machine_gunner, missile_submarine, missionary, naval_trader,
+observation_balloon, pre_dreadnought, propagandist, rifleman, steamship_trader, submarine, tank —
+re-run the snippet above before picking this up, since the roster shifts as new units ship.
+
+## Recipe for upgrading a unit to v2-native art
+
+1. Use the `.claude/skills/generate-sprite-prompt.md` skill to produce a Claude Design prompt —
+   note this is **not** a standard sprite prompt: v2-native art uses a different prop convention
+   (`{faction, state, phase}` instead of the live `{palette, svgOnly}`) and needs **6 archetype
+   body/armor variants** (imperials, vikings, pharaohs, hellenes, khanate, shogunate) per unit,
+   not one recolorable shape.
+2. Author the result in `design/conquestoria-sprites/lib/units-v2.jsx`, following the existing
+   walk-cycle/attack/wound-tier CSS class contract already used by other v2-native units
+   (`cq-leg-l`/`cq-leg-r`, `cq-weapon`, `cq-wound-1..3`, etc. — grep existing entries in
+   `src/renderer/sprites/v2/*.svg.ts` for the pattern to match).
+3. Run `node scripts/serialize-sprites.mjs` to regenerate the `.svg.ts` file.
+4. Verify: `isV2NativeUnit('<type>')` should now be `true`, and the unit should keep animating via
+   the DOM overlay exactly as it did on the live-fallback tier (no regression), now with full
+   archetype variation.
+
+## Non-goals
+
+- Not blocking #755 or any other shipped work.
+- Not required for every unit — this is a "nice to have more" backlog, not a completeness bar.
+EOF
+)"
+```
+
+- [ ] Run this now and report the issue URL.
+
+### Step 4: Done
+
+All 5 tasks complete. Proceed to `superpowers:finishing-a-development-branch` per the
+executing-plans skill.
+
+---
+
+## Self-Review Notes (completed during plan authoring)
+
+- **Spec coverage:** Architecture (fallback mechanism, `civColor` threading, `isV2NativeUnit`) →
+  Tasks 1-2. Guardrail hook → Task 3. Docs → Task 4. Manual verification + follow-up issue → Task 5.
+  Every section of the design spec maps to a task; nothing was dropped.
+- **Placeholder scan:** no TBD/TODO; every step has real, complete code or an exact command with
+  expected output.
+- **Existing-test-breakage audit (not called out explicitly in the spec, found while planning):**
+  `tests/renderer/sprites/v2/index.test.ts`'s "returns null for unknown faction" test would have
+  silently started failing without an explicit fix — Task 1 Step 2 handles this deliberately,
+  with an explanatory comment distinguishing "test updated because behavior intentionally changed"
+  from "test weakened for convenience." Confirmed no other existing call site (`unit-identity.test.ts`,
+  the mocked `SpriteIndex.getUnitSpriteV2` spy in `sprite-overlay.test.ts`) breaks, since `civColor`
+  is optional and the spy doesn't assert on call arguments.
+- **Type consistency:** `getUnitSpriteV2(unitType: string, faction: string, civColor: string = '')`
+  is the exact signature used consistently in Task 1's implementation, Task 2's call site, and every
+  test across both tasks. `isV2NativeUnit(unitType: string): boolean` likewise consistent between
+  Task 1's definition and Task 4's documentation references. `lookupSprite(entity: SpriteEntity,
+  civColor: string): string | null` consistent between Task 2's signature change and its call site.

--- a/docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md
@@ -14,6 +14,14 @@ functions in `units.tsx` (confirmed by diff, 2026-07-28). The other 24 fall thro
 static bitmap regardless of what CSS exists. This includes all 5 of the newest Era 13 units, whose
 `.cq-glow` usage (shipped in PR #756) is currently invisible in the live game.
 
+That "24 units" count is scoped to unit *type* coverage and undercounts the real gap: a second axis
+exists via owner identity. Minor-civ-owned units of *any* type — including the 33 supposedly-native
+ones — already silently fall back to static Canvas too, because `getFaction()`
+(`unit-map-presentation.ts`) returns the raw owner id string for any owner not in
+`state.civilizations` (minor civs live in a separate `state.minorCivs` map), and that raw id never
+matches any of the 6 baked archetype-family keys. See Architecture for how the fix handles both
+axes with one fallthrough.
+
 `UNIT_SPRITES` entries are hand-authored in a **separate, parallel content tree**
 (`design/conquestoria-sprites/lib/units-v2.jsx`, using a `{faction, state, phase}` prop
 convention), regenerated into `.svg.ts` files via `scripts/serialize-sprites.mjs`. This is not a
@@ -36,8 +44,9 @@ regression for the 33 already-v2-native units (they'd lose their per-family vari
 
 ## Goals
 
-- Close the full 24-unit animation gap now (not just the 5 newest units) — via a **hybrid live
-  fallback**, not new hand-authored art.
+- Close the full 24-unit animation gap now (not just the 5 newest units), **and** the
+  owner-identity gap affecting minor-civ-owned units of any type — via a **hybrid live fallback**,
+  not new hand-authored art.
 - Zero regression to the 33 existing v2-native units' archetype variation.
 - Make "silently returns null / stays static forever" structurally impossible going forward, with
   a regression test that would have caught #755 before it shipped.
@@ -70,12 +79,21 @@ export function getUnitSpriteV2(unitType: string, faction: string, civColor: str
 }
 ```
 
-Note the fallback also covers the narrower case where `sprites` exists (the unit type is in
-`UNIT_SPRITES`) but has no entry for this specific `faction` and no shared `.beast` fallback either
-— today that combination doesn't occur among the 24 missing units (verified: none are beasts or
-pirate hulls, both fully v2-native already), but wiring it generically here — falling through to
-the live function rather than `null` — costs nothing and closes a latent gap the same structural
-guarantee test (see Testing) will otherwise have to special-case around.
+The fallback also covers a case that turned out, on closer check, to be real and currently
+occurring rather than theoretical: `sprites` exists (the unit type is one of the 33 v2-native
+types) but has no entry for this specific `faction`. `getFaction()`
+(`src/renderer/unit-map-presentation.ts:95-99`) returns the raw `ownerId` string whenever the owner
+isn't in `state.civilizations` — which is exactly the case for minor civs, tracked in a *separate*
+`state.minorCivs` map. Minor civs do own real, on-map units (confirmed via ownership/war checks in
+`minor-civ-economy-system.ts`), so **today, any minor-civ-owned unit of an already-native type
+(e.g. a minor civ's `warrior`) already silently falls back to static Canvas rendering** —
+`sprites[minorCivId]` is undefined, `sprites.beast` is undefined for non-beast types, so the
+pre-existing code returns `null`. This is the same bug class #755 describes, just triggered by
+owner identity instead of unit type, and it was undercounted in the Problem section's "24 units"
+framing (that count is scoped to unit *types* covered by name; it doesn't capture this
+owner-identity axis at all). This design's generic fallthrough — `sprites[faction] ?? sprites.beast
+?? buildLiveFallbackUnitSprite(unitType, civColor)` — fixes it as a real, immediate side effect,
+not a hypothetical one.
 
 `buildLiveFallbackUnitSprite(unitType: string, civColor: string): string | null`:
 
@@ -106,6 +124,39 @@ Imports added to `v2/index.ts`: `UNIT_SPRITE_CATALOG` from `@/renderer/sprites/s
 `@/core/types` (`UNIT_SPRITE_CATALOG` is typed `Record<UnitType, UnitSpriteComponent>`, so the
 lookup needs `unitType as UnitType` — confirmed via `sprite-catalog.ts:223`). Confirmed no
 circular import risk — `sprite-catalog.ts` has no dependency on anything under `v2/`.
+
+`UNIT_SPRITES` itself is a private, unexported `const` — nothing outside `v2/index.ts` can read it
+directly. Add one new exported helper alongside `getUnitSpriteV2`:
+
+```ts
+export function isV2NativeUnit(unitType: string): boolean {
+  return unitType in UNIT_SPRITES;
+}
+```
+
+This gives tests and the follow-up issue's detection tooling (see below) a stable, intentional
+public boundary instead of reaching into module internals — and it's the fix for two bugs a
+second-pass review of this spec found: Testing item 3 originally proposed importing `UNIT_SPRITES`
+directly (impossible, it isn't exported), and the follow-up issue's detection snippet had the same
+problem. Both now use `isV2NativeUnit`.
+
+`applyUnitMotion`/`withMotion` (in `sprite-catalog.ts`) only rewrite the inner `<g class=
+"cq-sprite-figure">` tag (adding `data-motion`/`transform`), never the outer `<svg>` tag — so
+calling `UNIT_SPRITE_CATALOG[unitType]({palette, svgOnly:true})` without an explicit `motion`
+(defaults to `'idle'` via `props.motion ?? 'idle'`) is correct, and the width/height regex-replace
+above is unaffected by it.
+
+**Inner-`<svg>` `data-state`/`data-kind` are deliberately omitted, confirmed harmless**: native
+pre-serialized sprites redundantly bake `data-state="idle" data-kind="ranged"` onto *both* the
+outer wrapper div and the inner `<svg>` tag, but grep against `sprite-animations-v2.css` confirms
+zero CSS selectors ever target `svg[data-state=...]` or `svg[data-kind=...]` directly — every rule
+is scoped `.cq-v2[data-state=...] ...` (the outer wrapper). The inner svg's copies are vestigial
+carryover from the JSX author-time render, not functional. The fallback's simpler single-copy
+(outer div only) is therefore not a behavioral gap. Similarly, the inner `<svg class="cq-anim-idle">`
+class inherited from `SpriteFrame`'s raw output has no matching rule when `svgOnly:true` (the
+`<style>${ANIM_CSS}</style>` tag that would define `.cq-anim-idle` is only emitted when
+`svgOnly:false`) — inert dead markup in both the native and fallback cases alike, not something
+this design introduces.
 
 `sprite-overlay.ts`'s private `lookupSprite(entity: SpriteEntity): string | null` gains a second
 parameter, `civColor: string`, threaded through from its one call site (which already computes
@@ -146,10 +197,21 @@ extra function call and regex only run once per unit-instance-appearing-on-scree
   *Canvas* sprite cache's eager-preload behavior (a different pipeline, a performance/caching
   decision), not a "must stay static" requirement for the DOM overlay — this design does not
   change or conflict with that Canvas-cache rule.
-- **Pirates and beasts**: unaffected. None of the 24 currently-missing units are pirate hulls or
-  beasts (both are already 100% v2-native today) — their existing dedicated branches in
-  `getUnitSpriteV2` are untouched by this change, and the new fallback line at the bottom of the
-  `sprites` branch (see Architecture) only matters if that ever changes in the future.
+- **Minor civs**: `getFaction()` returns the raw minor-civ id as `faction` (not one of the 6
+  archetype names), so minor-civ-owned units of native types now correctly reach
+  `buildLiveFallbackUnitSprite` via the `sprites[faction] ?? sprites.beast ?? ...` fallthrough
+  instead of silently returning `null` as they do today — see Architecture for the full
+  explanation. Confirmed `colorLookup` already resolves every minor civ id to a real hex color
+  (`render-loop.ts`: populated in a loop over `state.minorCivs` immediately after the
+  civilizations loop, via `MINOR_CIV_DEFINITIONS`), so this reaches `derivePalette()` with a valid
+  color, not the `NEUTRAL_FACTION_PALETTE` guard — no additional wiring needed.
+- **Pirates and beasts**: unaffected by *unit-type* coverage — none of the 24 currently-missing
+  unit types are pirate hulls or beasts (both are already 100% v2-native today), and their
+  dedicated branches (`sprites.pirates`, `sprites.beast`) in `getUnitSpriteV2` are untouched. The
+  general `sprites[faction] ?? sprites.beast ?? buildLiveFallbackUnitSprite(...)` fallthrough does
+  reach real cases today (see Minor Civs above) — that's a different axis (owner identity, not
+  unit type), and doesn't interact with pirates/beasts specifically since neither is minor-civ
+  owned in practice.
 
 ## Testing
 
@@ -162,28 +224,56 @@ file — confirm during planning):
    as new units are added; it's what makes "no unit ever silently stays static" a structural
    guarantee rather than a documentation promise.
 2. Per-fallback-unit tests (the 24 units, or a representative sample plus the full-catalog loop
-   above for exhaustiveness): output contains `cq-sprite-wrap cq-v2`, contains
+   above for exhaustiveness): output contains `cq-sprite-wrap cq-v2`, contains `cq-sprite-figure`
+   (the actual class the idle-breathing CSS rule targets — asserting just the outer wrapper
+   classes isn't enough to prove the ambient-animation hook point survived), contains
    `width="100%" height="100%"` **exactly once each** (regression-guarding the duplicate-attribute
    mistake class fixed in #665), does not contain `data-kind`.
-3. **Native-unit regression test**: for a v2-native unit (e.g. `archer`), assert the returned string
-   is byte-identical to calling `UNIT_SPRITES.archer[faction]` directly — proves the new fallback
-   branch is never reached for already-covered units.
+3. **Native-vs-fallback classification test**: `isV2NativeUnit('archer') === true` (a native unit)
+   and `isV2NativeUnit('tank') === false` (a fallback unit). Note this can't be proven by comparing
+   output markup shape — native output already has `width="100%"` baked in by the design/*.jsx
+   serializer too, so both paths converge on the same final attribute values; `isV2NativeUnit` is
+   the only reliable signal for which path a given unit takes.
 4. **Empty/invalid civColor guard test**: `getUnitSpriteV2('rifleman', 'imperials', '')` does not
    throw and the output contains no `NaN` substring.
 5. **Genuinely-unknown-type test**: `getUnitSpriteV2('not-a-real-unit', 'imperials', '#4a90d9')`
    returns `null`.
-6. Full `yarn test` + `yarn build` at the end, per repo convention.
+6. **Minor-civ-owned native-unit regression test** (the real, currently-occurring gap found during
+   review, not a hypothetical): `getUnitSpriteV2('warrior', 'some-minor-civ-id', '#7a5a16')` — a
+   native unit type with a non-archetype `faction` string — is non-null and uses the fallback path
+   (i.e. `isV2NativeUnit('warrior') === true` but the returned markup came from
+   `buildLiveFallbackUnitSprite`, not a `UNIT_SPRITES.warrior[...]` entry). This is the test that
+   would have caught the fact that minor-civ-owned units of *any* type were silently static before
+   this design existed.
+7. Full `yarn test` + `yarn build` at the end, per repo convention.
+8. **Manual live-render verification (before merge, not automated)**: jsdom tests only prove markup
+   shape — they cannot prove a CSS animation actually runs in a real browser. Following the pattern
+   already established this session (rsvg-convert-to-PNG for static checks, an Artifact-published
+   page checking `getComputedStyle(...).animationName` for live checks), verify at least one
+   fallback-tier unit that uses an ambient-effect class (e.g. a unit with `.cq-glow`) genuinely
+   animates once rendered through the real DOM overlay path, not just that its markup contains the
+   right class names.
 
 ## Guardrail file updates
 
-- **`.claude/hooks/check-src-edit.sh`**: the hardcoded-pixel-size `case` pattern (currently scoped
-  to exactly `*/src/renderer/sprite-overlay.ts`) gains a second matched path,
-  `*/src/renderer/sprites/v2/index.ts` — this is exactly the mistake class the check exists to
-  prevent (a literal `128px`/`192px` instead of the responsive `100%` this design requires), and
-  the new fallback code lives in a file the hook doesn't currently watch.
-- **`tests/hooks/check-src-edit.test.sh`**: add a block case (hardcoded `width:128px` in
-  `v2/index.ts`) and an allow case (the real `width="100%"` regex-replace pattern), mirroring the
-  existing `sprite-overlay.ts` pair.
+- **`.claude/hooks/check-src-edit.sh`**: **not** a matter of adding `v2/index.ts` to the existing
+  `sprite-overlay.ts` case arm — a second-pass review of this spec caught that the existing check's
+  grep pattern (`width:[0-9]+px|height:[0-9]+px`) matches CSS `style.cssText` syntax
+  (`width:128px`), which is what `sprite-overlay.ts` writes. The code this design adds to
+  `v2/index.ts` produces SVG *attribute* syntax instead (`width="128"` — no colon, no `px` unit).
+  Reusing the existing pattern on the new file would add a case arm that can structurally never
+  fire on the mistake it's meant to catch — a guardrail that looks present but provides zero actual
+  protection. Instead, add a **new, separately-patterned** check scoped to
+  `*/src/renderer/sprites/v2/index.ts` that greps for a literal hardcoded `width="[0-9]+"` (digits
+  immediately followed by the closing quote — i.e. NOT the correct `width="100%"` output, since `%`
+  before the quote doesn't match, and NOT the regex source `width="\d+"` either, since `\d` isn't a
+  digit character). This correctly flags a future author accidentally hardcoding a literal pixel
+  value in the fallback's replacement string while leaving the correct code and this file's own
+  pattern-matching regex untouched (both verified by hand against the proposed grep pattern).
+- **`tests/hooks/check-src-edit.test.sh`**: add a block case (a literal `width="128" height="128"`
+  string in `v2/index.ts`) and two allow cases — the correct `width="100%" height="100%"` output,
+  and the regex literal `width="\d+"` itself (proving the hook doesn't flag its own detection
+  pattern) — mirroring the existing `sprite-overlay.ts` pair's block/allow structure.
 - **`.claude/rules/sprites.md`**: new subsection documenting the fallback mechanism as an
   intentional, permanent pattern — what triggers it, the `width="100%"` requirement, the
   deliberate omission of `data-kind`, and a pointer to the follow-up migration issue. Update the
@@ -203,10 +293,11 @@ file — confirm during planning):
 Title: `art: migrate live-fallback unit sprites to native v2 archetype art`
 
 Contents:
-- **Detection, not a frozen list**: `Object.keys(UNIT_SPRITE_CATALOG).filter(t => !(t in
-  UNIT_SPRITES))` as the canonical, always-current way to regenerate the fallback-tier roster —
-  plus today's snapshot (the 24 units enumerated above) for immediate actionability, explicitly
-  labeled as a snapshot, not a source of truth.
+- **Detection, not a frozen list**: `Object.keys(UNIT_SPRITE_CATALOG).filter(t =>
+  !isV2NativeUnit(t))` — using the exported `isV2NativeUnit` helper this design adds (not
+  `UNIT_SPRITES` directly, which is private) — as the canonical, always-current way to regenerate
+  the fallback-tier roster, plus today's snapshot (the 24 units enumerated above) for immediate
+  actionability, explicitly labeled as a snapshot, not a source of truth.
 - **Claude Design prompt recipe**: pointing at `.claude/skills/generate-sprite-prompt.md`, plus
   what's different about v2-native art specifically — the `{faction, state, phase}` prop
   convention (vs. live `{palette, svgOnly}`), the 6 archetype body/armor styles each unit needs,
@@ -217,6 +308,7 @@ Contents:
 
 ## Self-review notes
 
+**First pass** (at authoring time):
 - **Scope check**: unit-only, matching #755's actual title/scope; buildings and damage-tier art
   are explicitly out of scope and cross-referenced to their own tracking issues (#658/#659, #364).
 - **Placeholder scan**: no TBD/TODO; every code sketch is a complete, real signature.
@@ -227,3 +319,45 @@ Contents:
 - **Ambiguity check**: `data-kind` omission, the `applyFactionCivColor` no-op behavior, and the
   civColor-empty-string guard were all candidates for being under-specified: each now has an
   explicit decision and rationale rather than being left to implementation-time judgment.
+
+**Second pass** (requested review against completeness/correctness/rendering/animation/guardrails/
+consistency — every item below was a real bug or gap, not a formality check; all fixed inline):
+- **Correctness bug**: Testing item 3 and the follow-up issue's detection snippet both referenced
+  `UNIT_SPRITES` as if importable — it's a private, unexported `const`, so neither was actually
+  runnable as written. Fixed by adding an exported `isV2NativeUnit()` helper and routing both
+  through it.
+- **Guardrail bug (the most serious finding)**: the hook-extension proposal reused the existing
+  `sprite-overlay.ts` check's grep pattern (`width:[0-9]+px`, CSS syntax) for a file
+  (`v2/index.ts`) that produces a structurally different syntax (`width="128"`, SVG-attribute
+  syntax). That pattern can never match the mistake it's meant to catch on the new file — a
+  guardrail that would look present in a diff but provide zero real protection. Replaced with a
+  correctly-patterned, separately-scoped check, hand-verified against both the correct output
+  (`width="100%"`) and the detection regex's own source text (`width="\d+"`) to confirm neither
+  false-positives.
+- **Verified, not assumed**: `withMotion`'s `motion` parameter defaults to `'idle'` when omitted
+  (checked `sprite-catalog.ts`'s implementation directly rather than assuming), so the Architecture
+  code sketch's `spriteFn({palette, svgOnly:true})` call (no explicit `motion`) is correct.
+  `applyUnitMotion` only rewrites the inner `<g class="cq-sprite-figure">` tag, never the outer
+  `<svg>` tag, confirming the width/height regex-replace is unaffected by it.
+  `updateUnitDecorations` (selection ring, stack pill, health bar, fortified badge, role marker)
+  reads only from the `entity` object, never from the sprite's own `data-kind`/`data-state`
+  attributes — confirmed by reading the full function, not just skimming — so omitting them from
+  the fallback's inner `<svg>` cannot break unit decorations.
+- **Testing gap**: item 2 originally checked only for `cq-sprite-wrap cq-v2` presence, not
+  `cq-sprite-figure` — the actual class the idle-breathing CSS rule targets. A markup shape could
+  pass the original assertion while still failing to animate. Fixed.
+- **Missing verification tier**: added an explicit manual live-render check (item 8) — jsdom tests
+  can prove markup shape but not that a CSS animation actually runs in a real browser; this closes
+  that gap using the rsvg-convert/Artifact-based pattern already established elsewhere this
+  session, rather than treating passing unit tests as sufficient proof of "proper animation."
+- **Completeness gap, the most consequential finding**: the Problem/Goals sections originally
+  scoped this fix to "24 unit types" — undercounting the real impact. Tracing `getFaction()`
+  (`unit-map-presentation.ts`) showed it returns the raw owner id, not an archetype name, whenever
+  the owner isn't in `state.civilizations` — true for minor civs (a separate `state.minorCivs`
+  map), which do own real on-map units per `minor-civ-economy-system.ts`'s ownership/war checks.
+  So minor-civ-owned units of *any* of the 57 types — not just the 24 fallback-tier ones — are
+  *already*, today, silently static, via the same root cause. Verified `colorLookup` already
+  resolves minor civ ids to real colors (`render-loop.ts`), so no extra wiring is needed beyond
+  this design's existing generic fallthrough — but the Problem, Goals, Edge Cases, and Testing
+  sections all needed rewording to state this as a real fix, not a "latent, doesn't occur today"
+  footnote (which is what the first pass incorrectly claimed).

--- a/docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md
@@ -1,0 +1,229 @@
+# Unit Sprite v2 Live-Fallback Design
+
+> Fixes issue #755. Overlaps but is deliberately narrower than #611 (which additionally covers
+> buildings, damage-state semantics, and coordination with #364 — out of scope here).
+
+## Problem
+
+The DOM-overlay animation pipeline (`sprite-overlay.ts` inserting live `<svg>` elements, which is
+what lets `sprite-animations-v2.css`'s ambient-effect classes — `.cq-glow`, `.cq-fire`, `.cq-smoke`,
+`.cq-wheel`, etc. — actually animate) only works for units with a hand-authored entry in
+`UNIT_SPRITES` (`src/renderer/sprites/v2/index.ts`). Today that's 33 of 57 live unit sprite
+functions in `units.tsx` (confirmed by diff, 2026-07-28). The other 24 fall through to `null` from
+`getUnitSpriteV2`, which `sprite-overlay.ts` treats as "render via Canvas instead" — a permanently
+static bitmap regardless of what CSS exists. This includes all 5 of the newest Era 13 units, whose
+`.cq-glow` usage (shipped in PR #756) is currently invisible in the live game.
+
+`UNIT_SPRITES` entries are hand-authored in a **separate, parallel content tree**
+(`design/conquestoria-sprites/lib/units-v2.jsx`, using a `{faction, state, phase}` prop
+convention), regenerated into `.svg.ts` files via `scripts/serialize-sprites.mjs`. This is not a
+config gap — closing it for all 24 units the same way would mean hand-authoring real art, which
+is out of scope for a mechanism fix.
+
+### The v2 pipeline is richer than "pre-serialized with animation"
+
+`civTypeToFaction()` (`src/renderer/civilization-visual-family.ts`) maps all 30 playable civs down
+to 6 visual-style families (`imperials`, `vikings`, `pharaohs`, `hellenes`, `khanate`, `shogunate`),
+and the v2 dialect hand-authors **distinct body/armor art per family** — a Viking Archer and an
+Imperial Archer are different drawings, not just different colors. `FACTION_SPRITE_ACCENT` bakes a
+fixed placeholder hex per family at author time; `applyFactionCivColor()` swaps it for the actual
+civ's chosen color via string-replace at render time.
+
+The live `units.tsx` catalog has none of this — one universal shape per unit type, recolored via
+`FactionPalette` (`{dark, mid, bright, trim}`) derived from an arbitrary hex color via
+`derivePalette()`. So closing the gap by switching wholesale to live functions would be a visible
+regression for the 33 already-v2-native units (they'd lose their per-family variation).
+
+## Goals
+
+- Close the full 24-unit animation gap now (not just the 5 newest units) — via a **hybrid live
+  fallback**, not new hand-authored art.
+- Zero regression to the 33 existing v2-native units' archetype variation.
+- Make "silently returns null / stays static forever" structurally impossible going forward, with
+  a regression test that would have caught #755 before it shipped.
+- File a follow-up issue for incrementally upgrading fallback-tier units to real v2-native
+  archetype art — explicitly non-blocking for this design.
+
+## Non-goals
+
+- Building DOM-overlay coverage (`kind: 'building'` `SpriteEntity`s are never constructed for the
+  live map at all — tracked separately in #658/#659; unrelated to this fix, which is unit-only).
+- 4-tier damage-state art extension (#364) — the fallback tier gets whatever `units.tsx` already
+  has inline (some units have partial `data-state="attack"`-gated elements like muzzle flash; none
+  have wound-tier art), unchanged by this design.
+- Full #611 scope (buildings, semantic body-plan matrix, coordinated damage-state policy).
+- Authoring any new v2-native archetype art in this change — that's the follow-up issue.
+
+## Architecture
+
+`getUnitSpriteV2(unitType, faction)` in `src/renderer/sprites/v2/index.ts` gains a third parameter,
+`civColor`, and a fallback branch:
+
+```ts
+export function getUnitSpriteV2(unitType: string, faction: string, civColor: string): string | null {
+  const sprites = UNIT_SPRITES[unitType];
+  if (sprites) {
+    if (sprites.pirates) return faction === 'pirates' ? sprites.pirates : null;
+    return sprites[faction] ?? sprites.beast ?? buildLiveFallbackUnitSprite(unitType, civColor);
+  }
+  return buildLiveFallbackUnitSprite(unitType, civColor);
+}
+```
+
+Note the fallback also covers the narrower case where `sprites` exists (the unit type is in
+`UNIT_SPRITES`) but has no entry for this specific `faction` and no shared `.beast` fallback either
+— today that combination doesn't occur among the 24 missing units (verified: none are beasts or
+pirate hulls, both fully v2-native already), but wiring it generically here — falling through to
+the live function rather than `null` — costs nothing and closes a latent gap the same structural
+guarantee test (see Testing) will otherwise have to special-case around.
+
+`buildLiveFallbackUnitSprite(unitType: string, civColor: string): string | null`:
+
+```ts
+function buildLiveFallbackUnitSprite(unitType: string, civColor: string): string | null {
+  const spriteFn = UNIT_SPRITE_CATALOG[unitType as UnitType];
+  if (!spriteFn) return null; // genuinely unknown type — Canvas handles it, unchanged today
+  const palette = civColor ? derivePalette(civColor) : NEUTRAL_FACTION_PALETTE;
+  const rawSvg = spriteFn({ palette, svgOnly: true });
+  // SpriteFrame's svgOnly output bakes in a fixed pixel width/height (unit sprites: 128x128).
+  // The DOM overlay's outer wrapper (created in sprite-overlay.ts) controls actual display size
+  // via CSS derived from camera.hexSize; the inner <svg> must fill it responsively instead of
+  // carrying its own fixed size — same class of bug fixed for the building-icon feature (#665),
+  // same fix shape: replace the baked attribute pair in place, never prepend a duplicate.
+  const svg = rawSvg.replace(
+    /(<svg\b[^>]*?)\swidth="\d+"\s+height="\d+"/,
+    '$1 width="100%" height="100%"',
+  );
+  // data-kind deliberately omitted: no ambient-effect CSS class (.cq-glow, .cq-fire, etc.) is
+  // data-kind-scoped, and guessing wrong (e.g. tagging a land unit "naval") risks triggering an
+  // unrelated body-plan animation rule. Revisit per-unit once real v2-native art exists.
+  return `<div class="cq-sprite-wrap cq-v2" data-state="idle" style="--phase:0">${svg}</div>`;
+}
+```
+
+Imports added to `v2/index.ts`: `UNIT_SPRITE_CATALOG` from `@/renderer/sprites/sprite-catalog`,
+`derivePalette`, `NEUTRAL_FACTION_PALETTE` from `../sprite-system`, and the `UnitType` type from
+`@/core/types` (`UNIT_SPRITE_CATALOG` is typed `Record<UnitType, UnitSpriteComponent>`, so the
+lookup needs `unitType as UnitType` — confirmed via `sprite-catalog.ts:223`). Confirmed no
+circular import risk — `sprite-catalog.ts` has no dependency on anything under `v2/`.
+
+`sprite-overlay.ts`'s private `lookupSprite(entity: SpriteEntity): string | null` gains a second
+parameter, `civColor: string`, threaded through from its one call site (which already computes
+`newCivColor` in the same scope for the later `applyFactionCivColor` call — no new plumbing, just
+passing an existing local one call earlier):
+
+```ts
+case 'unit': return getUnitSpriteV2(entity.subtype, entity.faction, civColor);
+```
+
+`applyFactionCivColor(rawSvgHtml, entity.faction, newCivColor)` still runs unconditionally on
+whatever `lookupSprite` returns, for both native and fallback output. For native output it performs
+its existing accent-swap. For fallback output it is a **harmless no-op** — the fallback's color is
+already final (baked in directly via `derivePalette`, not via a placeholder-accent substitution),
+so there is nothing in the string for it to find and replace. This will be called out with an
+inline comment on the `buildLiveFallbackUnitSprite` return so a future reader doesn't mistake the
+no-op for a bug.
+
+## Data flow
+
+No change to `RenderLoop`'s entity-building or its call to `spriteOverlay.sync()`. On a pool miss
+(a unit-sprite instance never seen before), `sync()` already computes `newCivColor =
+colorLookup[entity.civId] ?? ''` before calling `lookupSprite`; that value is now passed through.
+Once generated, the HTML string is cached in the sprite pool exactly like native sprites — the
+extra function call and regex only run once per unit-instance-appearing-on-screen, not per frame.
+
+### Edge cases
+
+- **Genuinely unknown/typo'd unit type** (missing from both `UNIT_SPRITES` and
+  `UNIT_SPRITE_CATALOG`): still returns `null` → Canvas, unchanged from today.
+- **Empty/missing `civColor`**: falls back to `NEUTRAL_FACTION_PALETTE` rather than calling
+  `derivePalette('')`, which would propagate `NaN` through the HSL math into a garbage hex string
+  (confirmed by reading `hexToHsl`/`hslToHex` — `parseInt('', 16)` is `NaN`, and nothing downstream
+  guards against it). Same defensive pattern already used in the city-panel building-icon feature.
+- **Barbarians**: `colorLookup` is pre-seeded with `{ barbarian: '#8b4513' }`, so barbarian-owned
+  units get a real, valid palette through the normal path — no special case needed. The
+  `.claude/rules/sprites.md` note "barbarians and minor civs are not preloaded" is about the
+  *Canvas* sprite cache's eager-preload behavior (a different pipeline, a performance/caching
+  decision), not a "must stay static" requirement for the DOM overlay — this design does not
+  change or conflict with that Canvas-cache rule.
+- **Pirates and beasts**: unaffected. None of the 24 currently-missing units are pirate hulls or
+  beasts (both are already 100% v2-native today) — their existing dedicated branches in
+  `getUnitSpriteV2` are untouched by this change, and the new fallback line at the bottom of the
+  `sprites` branch (see Architecture) only matters if that ever changes in the future.
+
+## Testing
+
+New/extended coverage in `tests/renderer/sprites/v2-index.test.ts` (or the closest existing v2 test
+file — confirm during planning):
+
+1. **Structural guarantee test** (the one that would have caught #755): loop over every key in
+   `UNIT_SPRITE_CATALOG` — the canonical live roster — and assert
+   `getUnitSpriteV2(type, 'imperials', '#4a90d9')` is never `null`. This stays correct automatically
+   as new units are added; it's what makes "no unit ever silently stays static" a structural
+   guarantee rather than a documentation promise.
+2. Per-fallback-unit tests (the 24 units, or a representative sample plus the full-catalog loop
+   above for exhaustiveness): output contains `cq-sprite-wrap cq-v2`, contains
+   `width="100%" height="100%"` **exactly once each** (regression-guarding the duplicate-attribute
+   mistake class fixed in #665), does not contain `data-kind`.
+3. **Native-unit regression test**: for a v2-native unit (e.g. `archer`), assert the returned string
+   is byte-identical to calling `UNIT_SPRITES.archer[faction]` directly — proves the new fallback
+   branch is never reached for already-covered units.
+4. **Empty/invalid civColor guard test**: `getUnitSpriteV2('rifleman', 'imperials', '')` does not
+   throw and the output contains no `NaN` substring.
+5. **Genuinely-unknown-type test**: `getUnitSpriteV2('not-a-real-unit', 'imperials', '#4a90d9')`
+   returns `null`.
+6. Full `yarn test` + `yarn build` at the end, per repo convention.
+
+## Guardrail file updates
+
+- **`.claude/hooks/check-src-edit.sh`**: the hardcoded-pixel-size `case` pattern (currently scoped
+  to exactly `*/src/renderer/sprite-overlay.ts`) gains a second matched path,
+  `*/src/renderer/sprites/v2/index.ts` — this is exactly the mistake class the check exists to
+  prevent (a literal `128px`/`192px` instead of the responsive `100%` this design requires), and
+  the new fallback code lives in a file the hook doesn't currently watch.
+- **`tests/hooks/check-src-edit.test.sh`**: add a block case (hardcoded `width:128px` in
+  `v2/index.ts`) and an allow case (the real `width="100%"` regex-replace pattern), mirroring the
+  existing `sprite-overlay.ts` pair.
+- **`.claude/rules/sprites.md`**: new subsection documenting the fallback mechanism as an
+  intentional, permanent pattern — what triggers it, the `width="100%"` requirement, the
+  deliberate omission of `data-kind`, and a pointer to the follow-up migration issue. Update the
+  "Extension Recipe — Unit or Building Sprite" list to note that adding a new unit's catalog entry
+  (existing step 5) now automatically grants DOM-overlay animation via the fallback — v2-native
+  archetype art is optional richness, not a required step.
+- **`docs/sprite-design-system.md`**: add a "Live render surfaces" paragraph to the Units section
+  (the same pattern already used for Buildings after #659), explaining the two-pipeline split
+  (DOM overlay = animated, Canvas = static fallback), the new three-tier reality (v2-native /
+  live-fallback / — after this ships — zero units on silent static-only), and a pointer to the
+  follow-up issue for the fallback-tier roster. Deliberately not retrofitting the existing
+  40-row Units table (already flagged elsewhere in the doc as unmaintained past Era 5) with a new
+  data axis.
+
+## Follow-up issue (filed alongside this design, non-blocking)
+
+Title: `art: migrate live-fallback unit sprites to native v2 archetype art`
+
+Contents:
+- **Detection, not a frozen list**: `Object.keys(UNIT_SPRITE_CATALOG).filter(t => !(t in
+  UNIT_SPRITES))` as the canonical, always-current way to regenerate the fallback-tier roster —
+  plus today's snapshot (the 24 units enumerated above) for immediate actionability, explicitly
+  labeled as a snapshot, not a source of truth.
+- **Claude Design prompt recipe**: pointing at `.claude/skills/generate-sprite-prompt.md`, plus
+  what's different about v2-native art specifically — the `{faction, state, phase}` prop
+  convention (vs. live `{palette, svgOnly}`), the 6 archetype body/armor styles each unit needs,
+  the walk-cycle/attack/wound-tier CSS class contract (`cq-leg-l`, `cq-weapon`, `cq-wound-1..3`,
+  etc.), and the `scripts/serialize-sprites.mjs` regeneration + verification step.
+- Explicitly non-blocking: this design's fix does not depend on it; it's the incremental-richness
+  path for whenever there's appetite for it.
+
+## Self-review notes
+
+- **Scope check**: unit-only, matching #755's actual title/scope; buildings and damage-tier art
+  are explicitly out of scope and cross-referenced to their own tracking issues (#658/#659, #364).
+- **Placeholder scan**: no TBD/TODO; every code sketch is a complete, real signature.
+- **Internal consistency**: the `sprites[faction] ?? sprites.beast ?? buildLiveFallbackUnitSprite(...)`
+  fallthrough in Architecture and the "latent gap" note in the same section agree with each other
+  and with the Edge Cases section's "pirates and beasts unaffected today" claim — the extra
+  fallthrough exists for future-proofing, not because a live gap exists today.
+- **Ambiguity check**: `data-kind` omission, the `applyFactionCivColor` no-op behavior, and the
+  civColor-empty-string guard were all candidates for being under-specified: each now has an
+  explicit decision and rationale rather than being left to implementation-time judgment.

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -194,7 +194,7 @@ export class SpriteOverlay {
           }
         } else {
           // Pool miss — create element
-          const rawSvgHtml = this.lookupSprite(entity);
+          const rawSvgHtml = this.lookupSprite(entity, newCivColor);
           if (!rawSvgHtml) continue; // no v2 sprite — canvas handles it
           const svgHtml = applyFactionCivColor(rawSvgHtml, entity.faction, newCivColor);
 
@@ -258,9 +258,9 @@ export class SpriteOverlay {
     }
   }
 
-  private lookupSprite(entity: SpriteEntity): string | null {
+  private lookupSprite(entity: SpriteEntity, civColor: string): string | null {
     switch (entity.kind) {
-      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction);
+      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction, civColor);
       case 'building':    return getBuildingSpriteV2(entity.subtype, entity.faction);
       case 'improvement': return getImprovementSpriteV2(entity.subtype); // always null
       case 'landmark':    return getPirateHeadquartersSpriteV2(entity.subtype)

--- a/src/renderer/sprites/v2/index.ts
+++ b/src/renderer/sprites/v2/index.ts
@@ -103,6 +103,10 @@ import { svg as caravanseraiSvg }      from './caravanserai.svg';
 import { svg as bankSvg }              from './bank.svg';
 import { svg as stockExchangeSvg }     from './stock_exchange.svg';
 
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import { derivePalette, NEUTRAL_FACTION_PALETTE } from '../sprite-system';
+import type { UnitType } from '@/core/types';
+
 // ── Unit sprites ─────────────────────────────────────────────────────────────
 
 const UNIT_SPRITES: Record<string, Record<string, string>> = {
@@ -158,12 +162,47 @@ const UNIT_SPRITES: Record<string, Record<string, string>> = {
   pirate_mothership: pirateMothershipSvg,
 };
 
-export function getUnitSpriteV2(unitType: string, faction: string): string | null {
+export function isV2NativeUnit(unitType: string): boolean {
+  return unitType in UNIT_SPRITES;
+}
+
+/**
+ * #755: closes the DOM-overlay animation gap for any unit type not hand-authored in
+ * UNIT_SPRITES — both the 24 unit types with no v2 entry at all, and (found during design
+ * review) any unit owned by a faction with no per-family key here, which is what happens for
+ * every minor-civ-owned unit today (getFaction() returns the raw owner id, not one of the 6
+ * archetype names, whenever the owner isn't in state.civilizations). Renders the live
+ * units.tsx/UNIT_SPRITE_CATALOG function directly instead of a second, hand-authored copy.
+ */
+function buildLiveFallbackUnitSprite(unitType: string, civColor: string): string | null {
+  const spriteFn = UNIT_SPRITE_CATALOG[unitType as UnitType];
+  if (!spriteFn) return null; // genuinely unknown type — Canvas handles it, unchanged today
+  const palette = civColor ? derivePalette(civColor) : NEUTRAL_FACTION_PALETTE;
+  const rawSvg = spriteFn({ palette, svgOnly: true });
+  // SpriteFrame's svgOnly output bakes in a fixed pixel width/height (unit sprites: 128x128).
+  // The DOM overlay's outer wrapper (sized in sprite-overlay.ts from camera.hexSize) controls
+  // actual display size; the inner <svg> must fill it responsively instead of carrying its own
+  // fixed size. Replace the baked attribute pair in place — never prepend a duplicate (same fix
+  // shape as the city-panel building-icon feature, #665).
+  const svg = rawSvg.replace(
+    /(<svg\b[^>]*?)\swidth="\d+"\s+height="\d+"/,
+    '$1 width="100%" height="100%"',
+  );
+  // data-kind deliberately omitted: no ambient-effect CSS class (.cq-glow, .cq-fire, etc.) is
+  // data-kind-scoped, and guessing wrong (e.g. tagging a land unit "naval") risks triggering an
+  // unrelated body-plan animation rule. Revisit per-unit once real v2-native art exists (see the
+  // migration-backlog follow-up issue).
+  return `<div class="cq-sprite-wrap cq-v2" data-state="idle" style="--phase:0">${svg}</div>`;
+}
+
+export function getUnitSpriteV2(unitType: string, faction: string, civColor: string = ''): string | null {
   // Faction-neutral sprites (e.g. beasts) are stored under 'beast' and shared across all factions
   const sprites = UNIT_SPRITES[unitType];
-  if (!sprites) return null;
-  if (sprites.pirates) return faction === 'pirates' ? sprites.pirates : null;
-  return sprites[faction] ?? sprites.beast ?? null;
+  if (sprites) {
+    if (sprites.pirates) return faction === 'pirates' ? sprites.pirates : null;
+    return sprites[faction] ?? sprites.beast ?? buildLiveFallbackUnitSprite(unitType, civColor);
+  }
+  return buildLiveFallbackUnitSprite(unitType, civColor);
 }
 
 const PIRATE_HEADQUARTERS_SPRITES: Record<string, Record<string, string>> = {

--- a/tests/hooks/check-src-edit.test.sh
+++ b/tests/hooks/check-src-edit.test.sh
@@ -136,4 +136,20 @@ wrapper.style.cssText = `position:absolute;width:${wrapSizePx}px;height:${wrapSi
 EOF
 expect_allow "$tmp/src/renderer/sprite-overlay.ts" "dynamic hexSize-derived size in sprite-overlay.ts"
 
+# --- v2/index.ts: block hardcoded numeric SVG width/height attribute ---
+mkdir -p "$tmp/src/renderer/sprites/v2"
+cat > "$tmp/src/renderer/sprites/v2/index.ts" <<'EOF'
+const svg = rawSvg.replace(/width="\d+"/, 'width="128" height="128"');
+EOF
+expect_block "$tmp/src/renderer/sprites/v2/index.ts" "hardcoded width=\"128\" in v2/index.ts"
+
+# --- v2/index.ts: allow the correct responsive-percentage replacement ---
+cat > "$tmp/src/renderer/sprites/v2/index.ts" <<'EOF'
+const svg = rawSvg.replace(
+  /(<svg\b[^>]*?)\swidth="\d+"\s+height="\d+"/,
+  '$1 width="100%" height="100%"',
+);
+EOF
+expect_allow "$tmp/src/renderer/sprites/v2/index.ts" "width=\"100%\" replacement in v2/index.ts"
+
 exit "$fail"

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -411,3 +411,29 @@ describe('SpriteOverlay.sync() — pool invalidation on civColor change', () => 
     spy.mockRestore();
   });
 });
+
+// ── civColor reaches the live-fallback sprite path ──────────────────────────
+
+describe('SpriteOverlay.sync() — civColor reaches live-fallback unit sprites', () => {
+  it('bakes the real civ color into a fallback-tier unit sprite (e.g. tank), not just native ones', () => {
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ subtype: 'tank', faction: 'imperials', civId: 'civ-1' });
+
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+
+    const el = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.innerHTML).toContain('#2d6a4f');
+  });
+
+  it('still resolves a native unit sprite unchanged when civColor is provided', () => {
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ subtype: 'warrior', faction: 'imperials', civId: 'civ-1' });
+
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+
+    const el = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.innerHTML).toContain('cq-sprite-wrap');
+  });
+});

--- a/tests/renderer/sprites/v2/index.test.ts
+++ b/tests/renderer/sprites/v2/index.test.ts
@@ -1,26 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
   getUnitSpriteV2,
+  isV2NativeUnit,
   getBuildingSpriteV2,
   getPirateHeadquartersSpriteV2,
   getImprovementSpriteV2,
 } from '@/renderer/sprites/v2/index';
-
-// All unit types that must have a v2 serialization (MR 1 + MR 2 + MR 4 + MR 6).
-const ALL_SPRITE_UNIT_TYPES = [
-  // MR 1 — already serialized
-  'archer', 'galley', 'musketeer', 'pikeman', 'scout', 'scout_hound', 'settler',
-  'shadow_warden', 'spy_agent', 'spy_hacker', 'spy_informant', 'spy_operative',
-  'spy_scout', 'swordsman', 'trireme', 'war_hound', 'warrior', 'worker',
-  // MR 2 — new
-  'axeman', 'spearman', 'horseman', 'cavalry', 'knight',
-  'crossbowman', 'catapult', 'ballista',
-  'caravan', 'expedition', 'transport',
-  // MR 4 — late-era naval
-  'carrack', 'galleon', 'steamship', 'troop_transport',
-  // MR 6 — legendary beasts
-  'beast_boar',
-];
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
 
 // All building types that must have a v2 serialization (MR 1 + MR 3).
 const ALL_SPRITE_BUILDING_TYPES = [
@@ -39,8 +26,15 @@ describe('getUnitSpriteV2', () => {
     expect(getUnitSpriteV2('unknown', 'imperials')).toBeNull();
   });
 
-  it('returns null for unknown faction', () => {
-    expect(getUnitSpriteV2('warrior', 'unknownfaction')).toBeNull();
+  it('falls back to a live-rendered sprite for a known unit type with an unrecognized faction (e.g. a minor civ)', () => {
+    // Before #755's fix this silently returned null (static Canvas fallback forever) — 'warrior'
+    // is a v2-native type, but 'unknownfaction' isn't one of the 6 baked archetype-family keys,
+    // which is exactly what happens for any minor-civ-owned unit today (getFaction() returns the
+    // raw owner id for any owner not in state.civilizations).
+    const result = getUnitSpriteV2('warrior', 'unknownfaction', '#7a5a16');
+    expect(result).not.toBeNull();
+    expect(result).toContain('cq-sprite-wrap');
+    expect(result).toContain('cq-v2');
   });
 
   it('returns a cq-sprite-wrap string for warrior/imperials', () => {
@@ -179,12 +173,95 @@ describe('beast_boar v2 sprite', () => {
   });
 });
 
-describe('full unit coverage — every type returns a cq-sprite-wrap for imperials', () => {
-  it.each(ALL_SPRITE_UNIT_TYPES)('%s', (type) => {
-    const r = getUnitSpriteV2(type, 'imperials');
+describe('full unit coverage — every catalog entry returns a cq-sprite-wrap for imperials (native or live-fallback)', () => {
+  // Pirate hull types are deliberately faction-gated to 'pirates' only (see 'neutral pirate v2
+  // sprites' above) — querying them with 'imperials' is supposed to return null, not a gap.
+  const nonPirateTypes = Object.keys(UNIT_SPRITE_CATALOG)
+    .filter(type => !(PIRATE_HULL_TYPES as readonly string[]).includes(type));
+
+  it.each(nonPirateTypes)('%s', (type) => {
+    const r = getUnitSpriteV2(type, 'imperials', '#4a90d9');
     expect(r).not.toBeNull();
     expect(r!).toContain('cq-sprite-wrap');
     expect(r!).toContain('cq-v2');
+  });
+});
+
+describe('isV2NativeUnit', () => {
+  it('is true for a v2-native unit', () => {
+    expect(isV2NativeUnit('archer')).toBe(true);
+  });
+
+  it('is false for a unit type that only has the live-fallback path', () => {
+    expect(isV2NativeUnit('tank')).toBe(false);
+  });
+
+  it('is false for a genuinely unknown type', () => {
+    expect(isV2NativeUnit('not-a-real-unit')).toBe(false);
+  });
+});
+
+describe('getUnitSpriteV2 — live fallback for uncovered unit types', () => {
+  // Representative sample of the 24 units with no UNIT_SPRITES entry (confirmed via diff against
+  // UNIT_SPRITE_CATALOG, 2026-07-28) — not exhaustive here; the full-catalog loop above covers
+  // all of them for the "never null" guarantee.
+  const FALLBACK_TIER_SAMPLE = ['tank', 'rifleman', 'submarine', 'combat_drone', 'grenadier'];
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s renders via the live fallback, not v2-native', (type) => {
+    expect(isV2NativeUnit(type)).toBe(false);
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9');
+    expect(result, `${type} should not be null`).not.toBeNull();
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output has the animation hook point (cq-sprite-figure)', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    expect(result).toContain('cq-sprite-wrap');
+    expect(result).toContain('cq-v2');
+    expect(result).toContain('cq-sprite-figure');
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output has exactly one width="100%" and one height="100%" on the outer <svg> tag, never a hardcoded pixel size', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    // Scope the check to the <svg ...> opening tag itself, not the whole markup string — child
+    // elements legitimately have their own width="N" attributes (e.g. a <rect width="6" .../>)
+    // that have nothing to do with the sprite's overall display size.
+    const svgTag = /<svg\b[^>]*>/.exec(result)![0];
+    expect(svgTag.match(/width="100%"/g)?.length).toBe(1);
+    expect(svgTag.match(/height="100%"/g)?.length).toBe(1);
+    expect(svgTag).not.toMatch(/width="\d+"/);
+    expect(svgTag).not.toMatch(/height="\d+"/);
+  });
+
+  it.each(FALLBACK_TIER_SAMPLE)('%s output does not contain data-kind (deliberately omitted for fallback-tier units)', (type) => {
+    const result = getUnitSpriteV2(type, 'imperials', '#4a90d9')!;
+    expect(result).not.toContain('data-kind');
+  });
+
+  it('does not throw and returns non-null for a missing civColor (falls back to NEUTRAL_FACTION_PALETTE)', () => {
+    expect(() => getUnitSpriteV2('tank', 'imperials', '')).not.toThrow();
+    const result = getUnitSpriteV2('tank', 'imperials', '');
+    expect(result).not.toBeNull();
+    expect(result).not.toMatch(/NaN/);
+  });
+
+  it('does not throw and returns non-null when civColor is omitted entirely', () => {
+    expect(() => getUnitSpriteV2('tank', 'imperials')).not.toThrow();
+    expect(getUnitSpriteV2('tank', 'imperials')).not.toBeNull();
+  });
+});
+
+describe('getUnitSpriteV2 — structural guarantee (would have caught #755)', () => {
+  it('never returns null for any type in UNIT_SPRITE_CATALOG, the canonical live unit roster', () => {
+    // Pirate hull types are deliberately faction-gated (see 'neutral pirate v2 sprites' above) —
+    // getUnitSpriteV2(pirateType, 'imperials') is SUPPOSED to return null, that's not a coverage
+    // gap. This loop asserts the "never silently static" guarantee for every type that isn't
+    // pirate-exclusive; pirate hull coverage is already asserted with the correct 'pirates'
+    // faction in the dedicated describe block above.
+    for (const type of Object.keys(UNIT_SPRITE_CATALOG)) {
+      if ((PIRATE_HULL_TYPES as readonly string[]).includes(type)) continue;
+      const result = getUnitSpriteV2(type, 'imperials', '#4a90d9');
+      expect(result, `${type} returned null — silently stuck on static Canvas rendering`).not.toBeNull();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Closes issue #755: the DOM-overlay animation pipeline (`sprite-overlay.ts`, which is what lets
`sprite-animations-v2.css`'s ambient-effect classes — `.cq-glow`, `.cq-fire`, `.cq-smoke`, etc. —
actually animate) only worked for the 33 of 57 unit types with a hand-authored `UNIT_SPRITES`
entry. Everything else silently fell back to a static Canvas bitmap forever, including all 5 new
Era 13 units shipped in #756.

`getUnitSpriteV2` now falls back to rendering the live `UNIT_SPRITE_CATALOG` function directly
(`{palette, svgOnly: true}`) instead of returning `null`, closing the gap for:
- The 24 unit types with no v2-native art at all.
- **Every minor-civ-owned unit of any type** — found during design review, not part of the
  original issue: `getFaction()` returns the raw owner id (not an archetype name) for any owner
  not in `state.civilizations`, which is exactly the case for minor civs. This was silently
  broken today for all 57 unit types when owned by a minor civ, not just the 24.

Design doc: `docs/superpowers/specs/2026-07-28-unit-sprite-v2-live-fallback-design.md` (includes a
documented second-pass review that caught and fixed 4 real issues before implementation — an
inaccessible private export two tests relied on, a hook-check pattern that would never have
matched its target mistake, and the minor-civ scope gap above).

## What's shipped

- **`isV2NativeUnit(unitType)`** — new exported helper distinguishing v2-native from
  live-fallback sprites, used by tests, docs tooling, and the follow-up migration-backlog issue.
- **`buildLiveFallbackUnitSprite()`** in `src/renderer/sprites/v2/index.ts` — renders the live
  catalog function, rewrites its baked `width="128" height="128"` to responsive `width="100%"
  height="100%"` in place (never duplicating the attribute — same fix shape as the city-panel
  building-icon work), wraps it in the standard `.cq-sprite-wrap.cq-v2` shell.
- **`civColor` threaded through `sprite-overlay.ts`'s `lookupSprite()`** so the fallback path gets
  the real civ color via `derivePalette()`, not a placeholder.
- **New guardrail hook check** (`check-src-edit.sh`) blocking a hardcoded numeric SVG
  width/height in `v2/index.ts` — a genuinely different grep pattern from the pre-existing
  `sprite-overlay.ts` check (CSS `style` syntax vs. SVG attribute syntax), confirmed by hand that
  neither false-positives on the other.
- **Structural guarantee test**: loops over the full `UNIT_SPRITE_CATALOG` and asserts
  `getUnitSpriteV2` is never `null` (excluding pirate hulls, which are intentionally
  faction-gated) — this is the test that would have caught #755 before it shipped, and stays
  correct automatically as new units are added.
- **Docs**: `.claude/rules/sprites.md` gets a new "DOM-Overlay Live Fallback" section documenting
  the mechanism as intentional and permanent (not something to "fix" back to `null`);
  `docs/sprite-design-system.md`'s Units section gets a "Live render surfaces" note.
- **Follow-up issue filed**: #759, tracking the optional, non-blocking backlog of upgrading
  specific fallback-tier units to full v2-native archetype art (6-way body/armor variation),
  including a detection snippet and the Claude Design prompt recipe for that different dialect.

## Inline review across balance / fun / ages 7–43 / play styles / difficulty / AI / UI / UX /
## architecture / extensibility / data / SFX / saves / testing / regressions / solo & hot-seat

- **No mechanical changes** — purely a rendering fix, no yields/costs/pacing touched.
- **AI decoupling verified**, not assumed: `grep -rln "sprite-overlay\|getUnitSpriteV2\|UNIT_SPRITE_CATALOG" src/ai/` returns nothing — zero AI code imports anything from the renderer/sprite layer.
- **Hot-seat/solo safe by construction**: `civColor` flows as an explicit parameter through every
  new function; nothing reads `state.currentPlayer`.
- **No save-schema changes** — sprites are derived at render time, nothing persisted, no
  migration needed.
- **Testing gap found and fixed during implementation** (not just the design-review issues): my
  own first-pass regex for "no hardcoded pixel width" matched child-element `width="6"`
  attributes on `<rect>` elements instead of just the outer `<svg>` tag — caught immediately when
  the test failed against real `combat_drone`/`grenadier` output, fixed to scope the check to the
  `<svg ...>` opening tag only. Separately, my first-pass "never null" structural test didn't
  account for pirate hull types being intentionally faction-gated to `'pirates'` only — fixed by
  excluding them (with a comment explaining why, backed by `PIRATE_HULL_TYPES` from
  `pirate-definitions.ts` rather than a second hardcoded list).
- **Real pre-existing architecture/testing-fidelity issue found and filed separately (#760)**:
  while verifying `civId` propagation for hot-seat correctness, found that `buildUnitEntities()`
  (exported from `render-loop.ts`) has zero production callers — the real render loop builds its
  own `unitEntities` inline with different logic (including pirate visual-state resolution
  `buildUnitEntities` lacks entirely, and `civId`, which it never sets at all). Three test files
  (`damage-tier.test.ts`, `unit-renderer-overlay.test.ts`, `city-renderer-overlay.test.ts`)
  exercise this dead function as if it were live. Confirmed this doesn't affect #755's own
  correctness (its tests use the correct construction pattern via `sprite-overlay.test.ts`'s
  `entity()` helper), so not fixed inline — genuinely unrelated root cause, filed as its own issue
  per this session's established pattern for adjacent findings.
- **Manual live-render verification**: published an Artifact rendering `combat_drone`'s real
  fallback-tier markup against the real `sprite-animations-v2.css`, checking
  `getComputedStyle(...).animationName` — confirmed non-`none` for the idle-breathe animation and
  both `.cq-glow` elements. (The idle-breathe motion is visually subtle by design — 1.8% scale,
  ~1.4px shift, same `cq2-breathe` keyframe every v2-native sprite already uses — confirmed via
  the keyframe definition, not just the computed-style readout.)

## Test plan

- [x] `yarn build` clean at every commit
- [x] `yarn test`: 438 files, 7149 passed, 3 skipped (pre-existing, unrelated)
- [x] New hook smoke-test cases confirm the guardrail fires on the real mistake pattern and
      doesn't false-positive on the correct code or its own detection regex
- [x] Manual live-render verification via published Artifact, confirmed by direct keyframe
      inspection

Closes #755