### PR TITLE
refactor(renderer): unify buildUnitEntities with the live render path (#760)

### DIFF
--- a/docs/superpowers/plans/2026-07-30-unify-build-unit-entities.md
+++ b/docs/superpowers/plans/2026-07-30-unify-build-unit-entities.md
@@ -1,0 +1,467 @@
+# Unify buildUnitEntities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do NOT use subagent-driven-development or spawn any subagents — this project's CLAUDE.md forbids subagents/parallel agents; execute every task inline in the current session.
+
+**Goal:** Close issue #760 by making `buildUnitEntities()` (currently dead code, tested by 3 files
+as if it were live) byte-for-byte match the real render loop's inline entity-construction logic,
+then replace the real render loop's inline block with a call to it — eliminating the duplicate and
+turning the 3 existing test files into real regression coverage.
+
+**Architecture:** `buildUnitEntities` gains two new required parameters — `pirateSpriteState:
+PirateSpriteStateController` and `nowMs: number` — and its `.map()` callback is extended to match
+the real inline block's logic exactly (civId, pirate visual-state resolution, combat-transient
+state). The render loop's own inline block is then deleted and replaced with a single call.
+
+**Tech Stack:** TypeScript, vitest, no new dependencies.
+
+**Design doc:** `docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md` — full
+rationale, including why a state-based signature was chosen over passing pre-computed
+presentations, and the documented mutation side effect of `pirateSpriteState.resolve()`.
+
+## Global Constraints
+
+- `buildUnitEntities` is **not a pure function** once `pirateSpriteState` is threaded through —
+  `pirateSpriteState.resolve()` mutates the controller's internal transients map on expiry. Call it
+  exactly once per frame in production code; document this on the function itself.
+- This is a **behavior-preserving refactor** — the live game's rendered output must not change.
+  Every line moved from the inline block into `buildUnitEntities` must be copied verbatim (only
+  `this.state`/`this.pirateSpriteState` become the function's own `state`/`pirateSpriteState`
+  parameters).
+- `selectedUnitId` keeps its existing `string | null = null` default — do not remove it. Every
+  existing call site currently omits it (relying on the default); when those call sites are edited
+  to add the 2 new trailing parameters, pass `null` explicitly for `selectedUnitId` at that time
+  (JS/TS positional args can't skip a parameter to reach a later one).
+- Do not touch `buildUnitMapPresentations`, `SpriteOverlay`, `getUnitSpriteV2`, or anything from
+  #755 — this is scoped to which function constructs the `SpriteEntity[]` array.
+
+---
+
+## Task 1: Update `buildUnitEntities` — civId, pirate visual state, combat-transient state
+
+**Files:**
+- Modify: `src/renderer/render-loop.ts:75-106` (`buildUnitEntities` function)
+- Modify: `tests/renderer/damage-tier.test.ts` (12 call sites gain 3 new trailing args)
+- Modify: `tests/renderer/unit-renderer-overlay.test.ts` (8 call sites gain 3 new trailing args, plus 3 new tests)
+- Modify: `tests/renderer/city-renderer-overlay.test.ts` (1 call site gains 3 new trailing args)
+
+**Interfaces:**
+- Produces: `export function buildUnitEntities(state: GameState, viewerId: string, viewerVisibility: VisibilityMap, movingUnitIds: ReadonlySet<string>, selectedUnitId: string | null, pirateSpriteState: PirateSpriteStateController, nowMs: number): SpriteEntity[]` — Task 2 calls this exact signature.
+- Consumes: `PirateSpriteStateController` (class, `resolve(entityId, persistent, nowMs)` and `resolveTransientState(entityId, nowMs)` methods) from `./pirate-sprite-state` (relative from `render-loop.ts`) / `@/renderer/pirate-sprite-state` (from test files).
+
+### Step 1: Update the failing call sites — mechanical argument additions
+
+All existing call sites currently call `buildUnitEntities(state, viewerId, visibility,
+movingSet)` — 4 positional args, relying on `selectedUnitId`'s default. Every one needs `, null,
+new PirateSpriteStateController(), 0` appended (explicit `null` for the now-reached
+`selectedUnitId`, a fresh controller instance, and an arbitrary `nowMs` — `0` works since nothing
+populates the transients map in these existing tests).
+
+**`tests/renderer/damage-tier.test.ts`** — add the import, then fix all 12 identical call sites in
+one pass:
+
+```typescript
+// add near the top, after the existing `import { buildUnitEntities } from '@/renderer/render-loop';`
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
+```
+
+Then replace every occurrence (all 12 are byte-identical) of:
+
+```typescript
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+```
+
+with:
+
+```typescript
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
+```
+
+**`tests/renderer/unit-renderer-overlay.test.ts`** — update the existing import line and fix the
+7 identical call sites, then the 1 different one separately:
+
+```typescript
+// change:
+import { buildUnitEntities, CIVTYPE_TO_FACTION, civTypeToFaction } from '@/renderer/render-loop';
+// to:
+import { buildUnitEntities, CIVTYPE_TO_FACTION, civTypeToFaction } from '@/renderer/render-loop';
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
+```
+
+Replace every occurrence (7 of the 8 are byte-identical) of:
+
+```typescript
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+```
+
+with:
+
+```typescript
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+```
+
+Then separately fix the 1 remaining call site (the "excludes moving units" test, which passes
+`new Set(['u1'])` instead of `new Set()`):
+
+```typescript
+// change:
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']));
+// to:
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']), null, new PirateSpriteStateController(), 0);
+```
+
+**`tests/renderer/city-renderer-overlay.test.ts`** — add the import and fix the 1 call site:
+
+```typescript
+// change:
+import { buildUnitEntities } from '@/renderer/render-loop';
+// to:
+import { buildUnitEntities } from '@/renderer/render-loop';
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
+```
+
+```typescript
+// change:
+    const entities = buildUnitEntities(state, 'player1', visibility, new Set());
+// to:
+    const entities = buildUnitEntities(state, 'player1', visibility, new Set(), null, new PirateSpriteStateController(), 0);
+```
+
+- [ ] Make all of the above edits now.
+
+### Step 2: Write the new failing tests
+
+Append to `tests/renderer/unit-renderer-overlay.test.ts`, inside the existing `describe('buildUnitEntities', ...)` block (add as a new test alongside the existing ones, e.g. after the `'returns kind=unit and correct subtype'` test):
+
+```typescript
+  it('sets civId from the unit owner (#760)', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player2' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.civId).toBe('player2');
+  });
+```
+
+Then append these two new `describe` blocks at the end of the same file (after the existing
+`describe('civTypeToFaction', ...)` block):
+
+```typescript
+// ── pirate visual state (#760) ────────────────────────────────────────────────
+
+describe('buildUnitEntities — pirate visual state (#760)', () => {
+  it('resolves persistent mode/tier/stage for a pirate-owned unit', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'pirate-1', type: 'pirate_corsair' });
+    const baseState = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const state = {
+      ...baseState,
+      pirates: { factions: { 'pirate-1': { behavior: 'raiding', maritimeStage: 2 } } },
+    } as unknown as GameState;
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.mode).toBe('raid');
+    expect(entity?.tier).toBe(2);
+    expect(entity?.stage).toBe(2);
+  });
+});
+
+// ── combat-transient state (#760) ─────────────────────────────────────────────
+
+describe('buildUnitEntities — combat-transient state (#760)', () => {
+  it('surfaces an attack transient for a non-pirate unit', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const pirateSpriteState = new PirateSpriteStateController();
+    pirateSpriteState.apply({ type: 'attack', entityId: 'u1' }, 0);
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, pirateSpriteState, 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.state).toBe('attack');
+  });
+
+  it('defaults to idle when no transient exists', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.state).toBe('idle');
+  });
+});
+```
+
+- [ ] Write these now.
+
+### Step 3: Run tests to verify they fail
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "buildUnitEntities|damage tier computation|strategic-map overlay"`
+
+Expected: the 3 new tests fail on their assertions, not on a compile error. `yarn vitest` transpiles
+via esbuild rather than type-checking (per CLAUDE.md: `yarn test` does not type-check — only `yarn
+build` runs `tsc`), so calling the still-5-param `buildUnitEntities` with 7 arguments doesn't fail
+at this step — the extra `pirateSpriteState`/`nowMs` arguments are silently dropped at runtime, the
+function still returns its old shape, and the new tests fail because `civId`/`mode`/`tier`/`stage`
+are `undefined` and `state` is hardcoded `'idle'` regardless of the transient set up in the test.
+The mismatched arity would only surface via `yarn build`, which this step doesn't run. Confirm the
+3 new tests fail with assertion
+mismatches, not the pre-existing tests (which don't assert on the new fields and should still
+pass even before Step 4's implementation).
+
+### Step 4: Implement the updated `buildUnitEntities`
+
+In `src/renderer/render-loop.ts`, add the import (near the top, alongside other renderer imports —
+`PirateSpriteStateController` is already imported once in this file for the class's own
+`pirateSpriteState` field, so no new import line is needed here; just confirm it's already in
+scope).
+
+Replace the current function (lines 75-106):
+
+```typescript
+export function buildUnitEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+  movingUnitIds: ReadonlySet<string>,
+  selectedUnitId: string | null = null,
+): SpriteEntity[] {
+  return buildUnitMapPresentations(
+    state,
+    viewerId,
+    viewerVisibility,
+    movingUnitIds,
+    selectedUnitId,
+  ).map(presentation => {
+      return {
+        id: presentation.leadUnitId,
+        memberIds: presentation.memberIds,
+        kind: 'unit' as const,
+        subtype: presentation.leadUnit.type,
+        coord: presentation.coord,
+        state: 'idle' as const,
+        faction: presentation.faction,
+        damage: presentation.damage,
+        stackCount: presentation.stackCount,
+        selected: presentation.isSelected,
+        health: presentation.leadUnit.health,
+        fortified: presentation.leadUnit.isFortified,
+        roleMarker: presentation.roleMarker,
+        anchorOffsetFactor: presentation.anchorOffsetFactor,
+      };
+    });
+}
+```
+
+with:
+
+```typescript
+/**
+ * Not a pure function: mutates `pirateSpriteState` as a side effect (clears expired combat/pirate
+ * transients on read, inside PirateSpriteStateController.resolve()). Calling this twice with the
+ * same arguments in the same frame can return different results for the second call — call it
+ * exactly once per frame, matching the real render loop's usage.
+ */
+export function buildUnitEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+  movingUnitIds: ReadonlySet<string>,
+  selectedUnitId: string | null = null,
+  pirateSpriteState: PirateSpriteStateController,
+  nowMs: number,
+): SpriteEntity[] {
+  return buildUnitMapPresentations(
+    state,
+    viewerId,
+    viewerVisibility,
+    movingUnitIds,
+    selectedUnitId,
+  ).map(presentation => {
+    const faction = state.pirates?.factions[presentation.leadUnit.owner];
+    // besieging shares blockading's sprite mode/tier (#522) -- the apex threat must
+    // never render as indistinguishable from a harmless patrol.
+    const persistentMode = faction?.behavior === 'besieging' || faction?.behavior === 'blockading'
+      ? 'blockade' as const
+      : faction?.behavior === 'raiding' ? 'raid' as const : 'patrol' as const;
+    const visual = faction
+      ? pirateSpriteState.resolve(presentation.leadUnitId, {
+          mode: persistentMode,
+          damage: presentation.damage as 0 | 1 | 2 | 3,
+          tier: faction.behavior === 'besieging' || faction.behavior === 'blockading' ? 3 : faction.behavior === 'raiding' ? 2 : 1,
+          stage: faction.maritimeStage,
+        }, nowMs)
+      : null;
+    // Non-pirate units have no PirateSpriteVisualState (mode/tier/stage are pirate-only
+    // concepts), but applyCombatVisual() records an attack/hurt/death transient for every
+    // combat's attacker/defender unconditionally, pirate or not — this reads it back for
+    // everyone else so the transient doesn't just expire unread.
+    const combatState = visual?.state
+      ?? pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
+    return {
+      id: presentation.leadUnitId,
+      memberIds: presentation.memberIds,
+      kind: 'unit' as const,
+      subtype: presentation.leadUnit.type,
+      coord: presentation.coord,
+      state: combatState,
+      faction: presentation.faction,
+      damage: visual?.damage ?? presentation.damage,
+      stackCount: presentation.stackCount,
+      selected: presentation.isSelected,
+      health: presentation.leadUnit.health,
+      fortified: presentation.leadUnit.isFortified,
+      roleMarker: presentation.roleMarker,
+      anchorOffsetFactor: presentation.anchorOffsetFactor,
+      civId: presentation.leadUnit.owner,
+      ...(visual ? { mode: visual.mode, tier: visual.tier, stage: visual.stage } : {}),
+    };
+  });
+}
+```
+
+Note `selectedUnitId: string | null = null` keeps its default (per Global Constraints); the two
+new parameters after it are required (no default), matching every call site now passing them
+explicitly.
+
+- [ ] Write this now.
+
+### Step 5: Run tests to verify they pass
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "buildUnitEntities|damage tier computation|strategic-map overlay"`
+
+Expected: all pass — the 21 pre-existing assertions (unchanged expectations) plus the 4 new ones
+(civId, pirate mode/tier/stage, attack transient, idle default).
+
+### Step 6: Commit
+
+```bash
+git add src/renderer/render-loop.ts tests/renderer/damage-tier.test.ts tests/renderer/unit-renderer-overlay.test.ts tests/renderer/city-renderer-overlay.test.ts
+git commit -m "feat(renderer): bring buildUnitEntities up to date with the live render path (#760)"
+```
+
+---
+
+## Task 2: Wire the real render loop to call `buildUnitEntities`
+
+**Files:**
+- Modify: `src/renderer/render-loop.ts:616-656` (the inline `unitEntities` construction block)
+
+**Interfaces:**
+- Consumes: `buildUnitEntities(state, viewerId, viewerVisibility, movingUnitIds, selectedUnitId, pirateSpriteState, nowMs): SpriteEntity[]` (Task 1).
+
+This task is a **pure behavior-preserving refactor** — there is no new user-facing behavior to
+write a failing test for. The verification strategy is: confirm the full relevant test suite
+passes unchanged before and after, proving the extraction didn't alter live rendering.
+
+### Step 1: Replace the inline block
+
+In `src/renderer/render-loop.ts`, find the current inline construction (lines 616-656):
+
+```typescript
+      const unitEntities = unitPresentations.map(presentation => {
+        const faction = this.state!.pirates?.factions[presentation.leadUnit.owner];
+        // besieging shares blockading's sprite mode/tier (#522) -- the apex threat must
+        // never render as indistinguishable from a harmless patrol.
+        const persistentMode = faction?.behavior === 'besieging' || faction?.behavior === 'blockading'
+          ? 'blockade' as const
+          : faction?.behavior === 'raiding' ? 'raid' as const : 'patrol' as const;
+        const visual = faction
+          ? this.pirateSpriteState.resolve(presentation.leadUnitId, {
+              mode: persistentMode,
+              damage: presentation.damage as 0 | 1 | 2 | 3,
+              tier: faction.behavior === 'besieging' || faction.behavior === 'blockading' ? 3 : faction.behavior === 'raiding' ? 2 : 1,
+              stage: faction.maritimeStage,
+            }, nowMs)
+          : null;
+        // Non-pirate units have no PirateSpriteVisualState (mode/tier/stage are pirate-only
+        // concepts), but applyCombatVisual() records an attack/hurt/death transient for every
+        // combat's attacker/defender unconditionally, pirate or not. Before this fix that
+        // transient was only ever read back through the `faction ?` branch above, so it
+        // silently expired unread for every non-pirate combat.
+        const combatState = visual?.state
+          ?? this.pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
+        return {
+          id: presentation.leadUnitId,
+          memberIds: presentation.memberIds,
+          kind: 'unit' as const,
+          subtype: presentation.leadUnit.type,
+          coord: presentation.coord,
+          state: combatState,
+          faction: presentation.faction,
+          damage: visual?.damage ?? presentation.damage,
+          stackCount: presentation.stackCount,
+          selected: presentation.isSelected,
+          health: presentation.leadUnit.health,
+          fortified: presentation.leadUnit.isFortified,
+          roleMarker: presentation.roleMarker,
+          anchorOffsetFactor: presentation.anchorOffsetFactor,
+          civId: presentation.leadUnit.owner,
+          ...(visual ? { mode: visual.mode, tier: visual.tier, stage: visual.stage } : {}),
+        };
+      });
+```
+
+Replace with:
+
+```typescript
+      const unitEntities = buildUnitEntities(
+        this.state,
+        viewerId,
+        viewerVisibility,
+        movingUnitIds,
+        this.selectedUnitId,
+        this.pirateSpriteState,
+        nowMs,
+      );
+```
+
+This is a straight substitution — `unitPresentations` (still needed separately for the
+terrain-label-suppression call at line ~485 and the `drawUnitPresentations` call later in the same
+method) is untouched; only this one block's construction changes from inline `.map()` to a
+function call. `viewerId`, `viewerVisibility`, `movingUnitIds`, and `nowMs` are all already in
+scope at this point in the method (unchanged variable names).
+
+- [ ] Make this replacement now.
+
+### Step 2: Run the full relevant test suite to confirm zero regression
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run -t "RenderLoop|render-loop|SpriteOverlay|sprite-overlay|buildUnitEntities|damage tier|strategic-map overlay|unit-renderer"`
+
+Expected: all pass. If any render-loop-level integration test asserts on `unitEntities`'s exact
+shape and fails, compare its expectation against this task's inline block being byte-identical to
+Task 1's new `buildUnitEntities` body — a failure here would mean the extraction introduced a real
+discrepancy and needs fixing before proceeding, not adjusting the test to match.
+
+### Step 3: Run the full suite and build
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: all files pass.
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: clean, no TypeScript errors.
+
+### Step 4: Commit
+
+```bash
+git add src/renderer/render-loop.ts
+git commit -m "refactor(renderer): wire the live render loop to buildUnitEntities, removing the duplicate"
+```
+
+---
+
+## Self-Review Notes (completed during plan authoring)
+
+- **Spec coverage**: civId, pirate visual-state resolution, and combat-transient state (the 3
+  confirmed divergences) → Task 1's implementation + new tests. Removing the duplicate inline block
+  → Task 2. The documented mutation side effect from the spec's second-pass review → Task 1 Step 4's
+  doc comment.
+- **Placeholder scan**: no TBD/TODO; every step has real, complete code.
+- **Type consistency**: `buildUnitEntities`'s final signature —
+  `(state, viewerId, viewerVisibility, movingUnitIds, selectedUnitId, pirateSpriteState, nowMs)` —
+  is identical across Task 1's implementation, all 21 updated call sites, the 4 new tests, and
+  Task 2's call site.
+- **Existing-call-site audit**: confirmed via grep during design investigation that the only
+  references to `buildUnitEntities`'s pre-existing 5-arg signature are the 3 test files this plan
+  edits — no other production code depends on the signature being changed.

--- a/docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md
+++ b/docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md
@@ -66,9 +66,24 @@ anyway, weighed against complexity/bugs/testability/regression-risk rather than 
 
 ## Implementation
 
+**Not a pure function — document the mutation.** `pirateSpriteState.resolve()` internally calls
+`this.transients.delete(entityId)` when a transient has expired — a real mutation of the passed-in
+controller. This is unchanged, pre-existing behavior (the current shipped inline code already does
+this); the fix doesn't introduce it. But moving it into an exported, directly-testable function
+makes the misleading appearance worse: a future caller could reasonably assume calling a "builder"
+function twice with the same inputs is safe, and hit a subtle bug when the second call sees a
+different result because the first call already cleared an expired transient. Add a doc comment on
+`buildUnitEntities` making this explicit — found during review, not in the original investigation.
+
 New `buildUnitEntities` (replacing the current one in `render-loop.ts`):
 
 ```ts
+/**
+ * Not a pure function: mutates `pirateSpriteState` as a side effect (clears expired combat/pirate
+ * transients on read). Calling this twice with the same arguments in the same frame can return
+ * different results for the second call — call it exactly once per frame, matching the real
+ * render loop's usage.
+ */
 export function buildUnitEntities(
   state: GameState,
   viewerId: string,
@@ -184,6 +199,7 @@ still pass"):
 
 ## Self-review
 
+**First pass** (at authoring time):
 - **Scope check**: single-function unification, matching #760's actual title/scope.
 - **Placeholder scan**: no TBD/TODO; the implementation is a verbatim extraction, not a sketch.
 - **Behavior-preservation check**: the new `buildUnitEntities` body was compared line-by-line
@@ -192,3 +208,28 @@ still pass"):
 - **Regression risk**: the render loop change is a pure extract-and-call refactor; the three
   existing test files need only additive argument changes, not restructuring, minimizing edit risk
   to already-passing assertions.
+
+**Second pass** (requested review against balance/fun/ages/playstyles/AI/UI/architecture/testing/
+data/hot-seat/proper implementation):
+- **Real finding — hidden mutation side effect**: `buildUnitEntities` reads as a pure query
+  function but isn't, once `pirateSpriteState` is threaded through (`resolve()` mutates the
+  controller's internal transients map on expiry). Pre-existing in the current shipped code, not
+  introduced by this fix — but exporting it as a directly-testable, prominently-named function
+  makes the misleading "looks pure" appearance worse. Fixed by adding an explicit doc comment
+  warning against calling it more than once per frame with the same state.
+- **Hot-seat traced, confirmed unchanged and out of scope**: `pirateSpriteState`'s transients are
+  keyed by unit id, not by viewer, so a combat-transient animation could in principle remain
+  visible across a hot-seat player switch mid-animation (420ms–1200ms window). Confirmed this is
+  identical to current shipped behavior (this fix is a byte-for-byte extraction, not a behavior
+  change) — not something #760 introduces or needs to fix, and too narrow an edge case to justify
+  a separate issue on its own.
+- **AI decoupling reconfirmed**: no AI code references `buildUnitEntities`, `SpriteEntity`, or
+  anything in the renderer layer — unaffected by this change, same as #755's finding.
+- **Test-fixture safety verified, not assumed**: checked all three existing test files' `makeState`
+  helpers directly — none set `state.pirates`, and `state.pirates?.factions[...]` optional-chains
+  safely to `undefined` → `faction` is `undefined` → falls through to the non-pirate
+  `resolveTransientState` path (`'idle'` for a fresh controller) without throwing. None of the
+  existing assertions check the `.state` field either, so the fix doesn't touch what they validate.
+- **No new regression surface**: reconfirmed via grep that the only references to
+  `buildUnitEntities`'s current 5-argument signature are the three test files — no other
+  production code depends on the signature this change modifies.

--- a/docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md
+++ b/docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md
@@ -1,0 +1,194 @@
+# Unify buildUnitEntities With The Live Render Path
+
+> Fixes issue #760.
+
+## Problem
+
+`buildUnitEntities()` (exported from `src/renderer/render-loop.ts`) has zero production callers.
+The real live render loop builds its own `unitEntities` array inline (`render-loop.ts`, inside the
+`if (viewerVisibility)` block), with logic that has drifted from `buildUnitEntities` in three
+confirmed ways:
+
+1. **`civId` is never set** in `buildUnitEntities`'s output. The real path sets
+   `civId: presentation.leadUnit.owner`.
+2. **No pirate visual-state resolution.** The real path resolves
+   `this.pirateSpriteState.resolve(...)` for pirate-owned units to compute persistent
+   `mode`/`tier`/`stage` and an overridden `damage`. `buildUnitEntities` has none of this.
+3. **No combat-transient state.** The real path resolves `combatState` (attack/hurt/death, via
+   `pirateSpriteState.resolveTransientState()`) for *every* unit's `state` field, pirate or not.
+   `buildUnitEntities` hardcodes `state: 'idle'`.
+
+Three test files (`damage-tier.test.ts`, `unit-renderer-overlay.test.ts`,
+`city-renderer-overlay.test.ts`) exercise `buildUnitEntities` directly, as if it were live.
+
+## What's actually shared vs. divergent (found during investigation, not in the original issue)
+
+Both the real inline path and `buildUnitEntities` call the exact same `buildUnitMapPresentations()`
+— confirmed by reading both call sites (`render-loop.ts`'s `unitPresentations` assignment and
+`buildUnitEntities`'s own body) side by side. That function does all the real work: visibility
+filtering, unit stacking/grouping, faction resolution (`civTypeToFaction`), and the base
+health→damage-tier computation. **The three existing test files are validating this real, shared
+logic correctly** — they are not testing fake behavior, they're testing real behavior through a
+currently-unused entry point. Only the final `presentation → SpriteEntity` field-mapping step
+diverges (the three items above).
+
+This matters for scope: the fix is a narrow, mechanical unification of one `.map()` callback, not
+a rewrite of well-tested shared logic.
+
+## Architecture decision: fully unify, state-based signature
+
+`buildUnitEntities` gains two new required parameters — `pirateSpriteState:
+PirateSpriteStateController` and `nowMs: number` — and its `.map()` callback becomes byte-identical
+to the real inline block. The real render loop's ~40-line inline block is deleted and replaced with
+a single call to `buildUnitEntities`.
+
+**Why a state-based signature (recomputing `buildUnitMapPresentations` internally) rather than
+accepting pre-computed presentations as a parameter** (the alternative considered): the render loop
+already has its own separately-computed `unitPresentations` (needed independently for terrain-label
+suppression and a canvas-drawing pass, at two other call sites), so a presentations-parameter
+signature would eliminate one redundant, pure, deterministic function call per frame. Rejected
+anyway, weighed against complexity/bugs/testability/regression-risk rather than raw performance:
+
+- **Bugs**: a presentations-parameter signature creates a silent invariant — "the presentations you
+  pass in must have been computed with the same viewerId/visibility/movingUnitIds you intend" —
+  enforced by nothing at the type level. The state-based signature has no such surface: the
+  function computes its own presentations from its own inputs, internally consistent by
+  construction.
+- **Testability**: state-based keeps every test a single call (matching all three existing test
+  files' current pattern almost exactly — just two new arguments, no restructuring).
+- **Regression risk**: state-based means the smallest possible diff to the three existing test
+  files.
+- **Performance**: the rejected alternative wins here, but `buildUnitMapPresentations` only
+  iterates already-visibility-filtered units, and the render loop does far heavier work every frame
+  (canvas drawing, hex map rendering, sprite DOM diffing) — no evidence this specific redundant
+  call is a measurable cost. Not worth the added bug surface on unmeasured suspicion; a real
+  profiling-backed follow-up remains trivial later if it ever matters.
+
+## Implementation
+
+New `buildUnitEntities` (replacing the current one in `render-loop.ts`):
+
+```ts
+export function buildUnitEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+  movingUnitIds: ReadonlySet<string>,
+  selectedUnitId: string | null,
+  pirateSpriteState: PirateSpriteStateController,
+  nowMs: number,
+): SpriteEntity[] {
+  return buildUnitMapPresentations(
+    state,
+    viewerId,
+    viewerVisibility,
+    movingUnitIds,
+    selectedUnitId,
+  ).map(presentation => {
+    const faction = state.pirates?.factions[presentation.leadUnit.owner];
+    // besieging shares blockading's sprite mode/tier (#522) -- the apex threat must
+    // never render as indistinguishable from a harmless patrol.
+    const persistentMode = faction?.behavior === 'besieging' || faction?.behavior === 'blockading'
+      ? 'blockade' as const
+      : faction?.behavior === 'raiding' ? 'raid' as const : 'patrol' as const;
+    const visual = faction
+      ? pirateSpriteState.resolve(presentation.leadUnitId, {
+          mode: persistentMode,
+          damage: presentation.damage as 0 | 1 | 2 | 3,
+          tier: faction.behavior === 'besieging' || faction.behavior === 'blockading' ? 3 : faction.behavior === 'raiding' ? 2 : 1,
+          stage: faction.maritimeStage,
+        }, nowMs)
+      : null;
+    // Non-pirate units have no PirateSpriteVisualState (mode/tier/stage are pirate-only
+    // concepts), but applyCombatVisual() records an attack/hurt/death transient for every
+    // combat's attacker/defender unconditionally, pirate or not — this reads it back for
+    // everyone else so the transient doesn't just expire unread.
+    const combatState = visual?.state
+      ?? pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
+    return {
+      id: presentation.leadUnitId,
+      memberIds: presentation.memberIds,
+      kind: 'unit' as const,
+      subtype: presentation.leadUnit.type,
+      coord: presentation.coord,
+      state: combatState,
+      faction: presentation.faction,
+      damage: visual?.damage ?? presentation.damage,
+      stackCount: presentation.stackCount,
+      selected: presentation.isSelected,
+      health: presentation.leadUnit.health,
+      fortified: presentation.leadUnit.isFortified,
+      roleMarker: presentation.roleMarker,
+      anchorOffsetFactor: presentation.anchorOffsetFactor,
+      civId: presentation.leadUnit.owner,
+      ...(visual ? { mode: visual.mode, tier: visual.tier, stage: visual.stage } : {}),
+    };
+  });
+}
+```
+
+This is a **byte-for-byte extraction** of the real inline block's callback (`presentation => {...}`
+body), with `this.state`/`this.pirateSpriteState` rewritten to the function's own `state`/
+`pirateSpriteState` parameters. No new logic, no behavior change to the live game — purely moving
+existing, already-correct code into the currently-stale exported function.
+
+Real render loop call site (replacing the ~40-line inline block):
+
+```ts
+const unitEntities = buildUnitEntities(
+  this.state,
+  viewerId,
+  viewerVisibility,
+  movingUnitIds,
+  this.selectedUnitId,
+  this.pirateSpriteState,
+  nowMs,
+);
+```
+
+`PirateSpriteStateController` is already imported in `render-loop.ts` (`import {
+PirateSpriteStateController } from './pirate-sprite-state';`) — `buildUnitEntities` needs the same
+import added since it's defined in the same file, no new cross-module dependency.
+
+## Test migration
+
+All three existing test files call `buildUnitEntities(state, viewerId, viewerVisibility,
+movingUnitIds, selectedUnitId)` with 5 positional arguments. Each call site gains two more:
+`new PirateSpriteStateController()` (a fresh instance — no pirate/combat events applied, so
+`resolve`/`resolveTransientState` both return the harmless `'idle'` default, preserving every
+existing assertion unchanged) and a `nowMs` value (e.g. `0` or `Date.now()` — value doesn't matter
+since nothing populates the transients map in these tests).
+
+New tests added (this is what makes the fix actually verified, not just "compiles and old tests
+still pass"):
+
+- **`civId` is now set**: a test asserting `buildUnitEntities(...)[0].civId` equals the unit's
+  owner — this is the exact assertion that would have failed before this fix and is central to
+  #755's civColor threading actually working when accessed through this function.
+- **Pirate visual-state resolution**: a test giving a pirate-owned unit a `state.pirates.factions`
+  entry with a `behavior` (e.g. `'raiding'`) and asserting the returned entity has `mode: 'raid'`,
+  `tier: 2`, and the expected `stage`.
+- **Combat-transient state for non-pirate units**: a test that calls `pirateSpriteState.apply({type:
+  'attack', entityId: ...}, nowMs)` before calling `buildUnitEntities`, then asserts the returned
+  entity's `state` is `'attack'` — this is the "every other unit gets only the transient combat
+  pulse" behavior documented in `pirate-sprite-state.ts`'s class comment, which `buildUnitEntities`
+  couldn't exercise at all before this fix.
+
+## Non-goals
+
+- Not touching `buildUnitMapPresentations` — it's correct and already shared.
+- Not touching `SpriteOverlay`, `getUnitSpriteV2`, or anything from #755 — this is purely about
+  which function constructs the `SpriteEntity[]` array before it reaches `sync()`.
+- Not adding new production behavior — the live game's rendered output is unchanged; this is a
+  refactor (extract + rewire), not a feature.
+
+## Self-review
+
+- **Scope check**: single-function unification, matching #760's actual title/scope.
+- **Placeholder scan**: no TBD/TODO; the implementation is a verbatim extraction, not a sketch.
+- **Behavior-preservation check**: the new `buildUnitEntities` body was compared line-by-line
+  against the current real inline block during investigation — identical apart from `this.` →
+  parameter-name rewrites. No live-game behavior change expected.
+- **Regression risk**: the render loop change is a pure extract-and-call refactor; the three
+  existing test files need only additive argument changes, not restructuring, minimizing edit risk
+  to already-passing assertions.

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -72,12 +72,20 @@ export function drawZoneOfControlChevrons(
   ctx.restore();
 }
 
+/**
+ * Not a pure function: mutates `pirateSpriteState` as a side effect (clears expired combat/pirate
+ * transients on read, inside PirateSpriteStateController.resolve()). Calling this twice with the
+ * same arguments in the same frame can return different results for the second call — call it
+ * exactly once per frame, matching the real render loop's usage.
+ */
 export function buildUnitEntities(
   state: GameState,
   viewerId: string,
   viewerVisibility: VisibilityMap,
   movingUnitIds: ReadonlySet<string>,
   selectedUnitId: string | null = null,
+  pirateSpriteState: PirateSpriteStateController,
+  nowMs: number,
 ): SpriteEntity[] {
   return buildUnitMapPresentations(
     state,
@@ -86,23 +94,45 @@ export function buildUnitEntities(
     movingUnitIds,
     selectedUnitId,
   ).map(presentation => {
-      return {
-        id: presentation.leadUnitId,
-        memberIds: presentation.memberIds,
-        kind: 'unit' as const,
-        subtype: presentation.leadUnit.type,
-        coord: presentation.coord,
-        state: 'idle' as const,
-        faction: presentation.faction,
-        damage: presentation.damage,
-        stackCount: presentation.stackCount,
-        selected: presentation.isSelected,
-        health: presentation.leadUnit.health,
-        fortified: presentation.leadUnit.isFortified,
-        roleMarker: presentation.roleMarker,
-        anchorOffsetFactor: presentation.anchorOffsetFactor,
-      };
-    });
+    const faction = state.pirates?.factions[presentation.leadUnit.owner];
+    // besieging shares blockading's sprite mode/tier (#522) -- the apex threat must
+    // never render as indistinguishable from a harmless patrol.
+    const persistentMode = faction?.behavior === 'besieging' || faction?.behavior === 'blockading'
+      ? 'blockade' as const
+      : faction?.behavior === 'raiding' ? 'raid' as const : 'patrol' as const;
+    const visual = faction
+      ? pirateSpriteState.resolve(presentation.leadUnitId, {
+          mode: persistentMode,
+          damage: presentation.damage as 0 | 1 | 2 | 3,
+          tier: faction.behavior === 'besieging' || faction.behavior === 'blockading' ? 3 : faction.behavior === 'raiding' ? 2 : 1,
+          stage: faction.maritimeStage,
+        }, nowMs)
+      : null;
+    // Non-pirate units have no PirateSpriteVisualState (mode/tier/stage are pirate-only
+    // concepts), but applyCombatVisual() records an attack/hurt/death transient for every
+    // combat's attacker/defender unconditionally, pirate or not — this reads it back for
+    // everyone else so the transient doesn't just expire unread.
+    const combatState = visual?.state
+      ?? pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
+    return {
+      id: presentation.leadUnitId,
+      memberIds: presentation.memberIds,
+      kind: 'unit' as const,
+      subtype: presentation.leadUnit.type,
+      coord: presentation.coord,
+      state: combatState,
+      faction: presentation.faction,
+      damage: visual?.damage ?? presentation.damage,
+      stackCount: presentation.stackCount,
+      selected: presentation.isSelected,
+      health: presentation.leadUnit.health,
+      fortified: presentation.leadUnit.isFortified,
+      roleMarker: presentation.roleMarker,
+      anchorOffsetFactor: presentation.anchorOffsetFactor,
+      civId: presentation.leadUnit.owner,
+      ...(visual ? { mode: visual.mode, tier: visual.tier, stage: visual.stage } : {}),
+    };
+  });
 }
 
 type TimedMovementAnimation = UnitMovementAnimation & {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -643,47 +643,15 @@ export class RenderLoop {
         if (def) colorLookup[mc.id] = def.color;
       }
       const nowMs = performance.now();
-      const unitEntities = unitPresentations.map(presentation => {
-        const faction = this.state!.pirates?.factions[presentation.leadUnit.owner];
-        // besieging shares blockading's sprite mode/tier (#522) -- the apex threat must
-        // never render as indistinguishable from a harmless patrol.
-        const persistentMode = faction?.behavior === 'besieging' || faction?.behavior === 'blockading'
-          ? 'blockade' as const
-          : faction?.behavior === 'raiding' ? 'raid' as const : 'patrol' as const;
-        const visual = faction
-          ? this.pirateSpriteState.resolve(presentation.leadUnitId, {
-              mode: persistentMode,
-              damage: presentation.damage as 0 | 1 | 2 | 3,
-              tier: faction.behavior === 'besieging' || faction.behavior === 'blockading' ? 3 : faction.behavior === 'raiding' ? 2 : 1,
-              stage: faction.maritimeStage,
-            }, nowMs)
-          : null;
-        // Non-pirate units have no PirateSpriteVisualState (mode/tier/stage are pirate-only
-        // concepts), but applyCombatVisual() records an attack/hurt/death transient for every
-        // combat's attacker/defender unconditionally, pirate or not. Before this fix that
-        // transient was only ever read back through the `faction ?` branch above, so it
-        // silently expired unread for every non-pirate combat.
-        const combatState = visual?.state
-          ?? this.pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
-        return {
-          id: presentation.leadUnitId,
-          memberIds: presentation.memberIds,
-          kind: 'unit' as const,
-          subtype: presentation.leadUnit.type,
-          coord: presentation.coord,
-          state: combatState,
-          faction: presentation.faction,
-          damage: visual?.damage ?? presentation.damage,
-          stackCount: presentation.stackCount,
-          selected: presentation.isSelected,
-          health: presentation.leadUnit.health,
-          fortified: presentation.leadUnit.isFortified,
-          roleMarker: presentation.roleMarker,
-          anchorOffsetFactor: presentation.anchorOffsetFactor,
-          civId: presentation.leadUnit.owner,
-          ...(visual ? { mode: visual.mode, tier: visual.tier, stage: visual.stage } : {}),
-        };
-      });
+      const unitEntities = buildUnitEntities(
+        this.state,
+        viewerId,
+        viewerVisibility,
+        movingUnitIds,
+        this.selectedUnitId,
+        this.pirateSpriteState,
+        nowMs,
+      );
       for (const [unitId, snapshot] of this.pirateUnitDeathSnapshots) {
         if (snapshot.expiresAtMs <= nowMs) {
           this.pirateUnitDeathSnapshots.delete(unitId);

--- a/tests/renderer/city-renderer-overlay.test.ts
+++ b/tests/renderer/city-renderer-overlay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildUnitEntities } from '@/renderer/render-loop';
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
 import type { GameState, City, VisibilityMap } from '@/core/types';
 
 describe('strategic-map overlay ownership', () => {
@@ -25,7 +26,7 @@ describe('strategic-map overlay ownership', () => {
       map: { width: 20, height: 20, wrapsHorizontally: false, tiles: {}, rivers: [] },
     } as unknown as GameState;
 
-    const entities = buildUnitEntities(state, 'player1', visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', visibility, new Set(), null, new PirateSpriteStateController(), 0);
 
     expect(entities).toEqual([]);
   });

--- a/tests/renderer/damage-tier.test.ts
+++ b/tests/renderer/damage-tier.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/renderer/unit-renderer', () => ({ drawUnits: vi.fn(), drawUnitGlyph: 
 vi.mock('@/renderer/sprite-overlay', () => ({ SpriteOverlay: class { sync = vi.fn(); getActiveIds = () => new Set() } }));
 
 import { buildUnitEntities } from '@/renderer/render-loop';
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
 import type { GameState, Unit } from '@/core/types';
 
 function makeState(units: Partial<Unit>[]): GameState {
@@ -42,61 +43,61 @@ const visMap = { tiles: { '0,0': 'visible' as const }, exploredTiles: {} };
 describe('damage tier computation in buildUnitEntities', () => {
   it('warrior at 100 HP → damage tier 0', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 100 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(0);
   });
 
   it('warrior at 76 HP → damage tier 0 (boundary)', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 76 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(0);
   });
 
   it('warrior at 75 HP → damage tier 1', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 75 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(1);
   });
 
   it('warrior at 51 HP → damage tier 1 (boundary)', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 51 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(1);
   });
 
   it('warrior at 50 HP → damage tier 2', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 50 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(2);
   });
 
   it('warrior at 26 HP → damage tier 2 (boundary)', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 26 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(2);
   });
 
   it('warrior at 25 HP → damage tier 3 (near death)', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 25 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(3);
   });
 
   it('warrior at 1 HP → damage tier 3', () => {
     const state = makeState([{ id: 'u1', type: 'warrior', owner: 'player', health: 1 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(3);
   });
 
   it('worker (strength 0) at 1 HP → damage tier 0 (non-combat units never show damage)', () => {
     const state = makeState([{ id: 'u1', type: 'worker', owner: 'player', health: 1 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(0);
   });
 
   it('settler (strength 0) at 25 HP → damage tier 0', () => {
     const state = makeState([{ id: 'u1', type: 'settler', owner: 'player', health: 25 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(0);
   });
 
@@ -104,13 +105,13 @@ describe('damage tier computation in buildUnitEntities', () => {
     // Beast units have strength > 0, so they progress through all 4 tiers
     const state = makeState([{ id: 'beast1', type: 'beast_boar', owner: 'beasts', health: 30 }]);
     // beasts owner has no civ entry — that is intentional
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(2);
   });
 
   it('beast_boar at 100 HP → damage tier 0', () => {
     const state = makeState([{ id: 'beast1', type: 'beast_boar', owner: 'beasts', health: 100 }]);
-    const entities = buildUnitEntities(state, 'player', visMap as any, new Set());
+    const entities = buildUnitEntities(state, 'player', visMap as any, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.damage).toBe(0);
   });
 });

--- a/tests/renderer/unit-renderer-overlay.test.ts
+++ b/tests/renderer/unit-renderer-overlay.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildUnitEntities, CIVTYPE_TO_FACTION, civTypeToFaction } from '@/renderer/render-loop';
+import { PirateSpriteStateController } from '@/renderer/pirate-sprite-state';
 import type { GameState, Unit, VisibilityMap } from '@/core/types';
 import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
 
@@ -34,35 +35,35 @@ describe('buildUnitEntities', () => {
   it('includes units in visible hexes', () => {
     const u = makeUnit({ position: { q: 2, r: 3 } });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities.map(e => e.id)).toContain('u1');
   });
 
   it('excludes units in fog hexes', () => {
     const u = makeUnit({ position: { q: 2, r: 3 } });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'fog'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities.map(e => e.id)).not.toContain('u1');
   });
 
   it('excludes units in unexplored hexes', () => {
     const u = makeUnit({ position: { q: 2, r: 3 } });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'unexplored'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities.map(e => e.id)).not.toContain('u1');
   });
 
   it('excludes moving units (movement animation gate)', () => {
     const u = makeUnit({ position: { q: 2, r: 3 } });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']), null, new PirateSpriteStateController(), 0);
     expect(entities.map(e => e.id)).not.toContain('u1');
   });
 
   it('maps civType to faction', () => {
     const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.faction).toBe('imperials');
   });
 
@@ -70,7 +71,7 @@ describe('buildUnitEntities', () => {
     // player2 is visible to player1, owns the unit
     const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player2' });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     // player2 civType = 'england' → maps to 'vikings' via CIVTYPE_TO_FACTION
     const entity = entities.find(e => e.id === 'u1');
     expect(entity?.faction).toBe('vikings');
@@ -79,7 +80,7 @@ describe('buildUnitEntities', () => {
   it('falls back to imperials for unknown civType', () => {
     const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player3' });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     const entity = entities.find(e => e.id === 'u1');
     expect(entity?.faction).toBe('imperials');
   });
@@ -87,9 +88,17 @@ describe('buildUnitEntities', () => {
   it('returns kind=unit and correct subtype', () => {
     const u = makeUnit({ position: { q: 2, r: 3 }, type: 'archer' });
     const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
-    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
     expect(entities[0]?.kind).toBe('unit');
     expect(entities[0]?.subtype).toBe('archer');
+  });
+
+  it('sets civId from the unit owner (#760)', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player2' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.civId).toBe('player2');
   });
 });
 
@@ -107,5 +116,51 @@ describe('civTypeToFaction', () => {
   it('every CivDefinition.id has an explicit entry in CIVTYPE_TO_FACTION (no silent fallback for real civs)', () => {
     const missing = CIV_DEFINITIONS.filter(d => !(d.id in CIVTYPE_TO_FACTION));
     expect(missing.map(d => d.id)).toEqual([]);
+  });
+});
+
+// ── pirate visual state (#760) ────────────────────────────────────────────────
+
+describe('buildUnitEntities — pirate visual state (#760)', () => {
+  it('resolves persistent mode/tier/stage for a pirate-owned unit', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'pirate-1', type: 'pirate_corsair' });
+    const baseState = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const state = {
+      ...baseState,
+      pirates: { factions: { 'pirate-1': { behavior: 'raiding', maritimeStage: 2 } } },
+    } as unknown as GameState;
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.mode).toBe('raid');
+    expect(entity?.tier).toBe(2);
+    expect(entity?.stage).toBe(2);
+  });
+});
+
+// ── combat-transient state (#760) ─────────────────────────────────────────────
+
+describe('buildUnitEntities — combat-transient state (#760)', () => {
+  it('surfaces an attack transient for a non-pirate unit', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const pirateSpriteState = new PirateSpriteStateController();
+    pirateSpriteState.apply({ type: 'attack', entityId: 'u1' }, 0);
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, pirateSpriteState, 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.state).toBe('attack');
+  });
+
+  it('defaults to idle when no transient exists', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(), null, new PirateSpriteStateController(), 0);
+
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.state).toBe('idle');
   });
 });


### PR DESCRIPTION
## Summary

Closes issue #760: `buildUnitEntities()` (exported from `render-loop.ts`) had zero production
callers — the real render loop built its own `unitEntities` array inline, with logic that had
drifted from `buildUnitEntities` in three ways (no `civId`, no pirate visual-state resolution, no
combat-transient state). Despite being dead in production, three test files exercised it directly
as if it were live, so they weren't actually validating the game's real rendering behavior.

Design doc: `docs/superpowers/specs/2026-07-30-unify-build-unit-entities-design.md` (includes a
documented second-pass review that found `buildUnitEntities` isn't actually pure once
`pirateSpriteState` is threaded through, and traced/confirmed a hot-seat edge case is unchanged
pre-existing behavior, not something this fix introduces).

## What's shipped

- **`buildUnitEntities` brought up to date**: gains `pirateSpriteState: PirateSpriteStateController`
  and `nowMs: number` parameters; its `.map()` callback now sets `civId`, resolves pirate
  persistent visual state (`mode`/`tier`/`stage`, with a damage override), and resolves
  combat-transient `state` (attack/hurt/death) for every unit — a byte-for-byte match of what the
  real render loop already did inline.
- **The real render loop's ~40-line inline block replaced with a single call** to
  `buildUnitEntities` — the duplicate is gone; there is now exactly one place that constructs a
  unit's `SpriteEntity`.
- **Documented the mutation side effect**: `buildUnitEntities` looks like a pure query function but
  isn't — `pirateSpriteState.resolve()` mutates the controller's transients map on expiry. Added an
  explicit doc comment warning against calling it more than once per frame with the same state,
  since exporting this logic as a directly-testable function made the "looks pure" appearance more
  likely to mislead a future caller than the previous inline-only version.
- **4 new tests** proving the previously-missing behavior actually works: `civId` set from the unit
  owner, pirate mode/tier/stage resolution, a surfaced attack-transient for a non-pirate unit, and
  the idle default when no transient exists. All 21 existing call sites across the 3 affected test
  files (`damage-tier.test.ts`, `unit-renderer-overlay.test.ts`, `city-renderer-overlay.test.ts`)
  updated to the new signature — these are now real regression coverage for the live game's
  rendering, not indirect coverage of a dead wrapper.

## Architecture decision (from the design review)

Considered switching `buildUnitEntities` to accept pre-computed `UnitMapPresentation[]` instead of
recomputing them internally, to avoid `buildUnitMapPresentations()` running twice per frame (the
render loop also needs `unitPresentations` separately, for terrain-label suppression and a
canvas-drawing pass). Rejected in favor of keeping the state-based signature, weighed explicitly
against complexity/bugs/testability/regression-risk rather than raw performance: a
presentations-parameter signature creates a silent invariant (the presentations passed in must have
been computed with the same viewer/visibility/moving-set the caller intends) with nothing at the
type level enforcing it, while the state-based version is internally consistent by construction and
keeps every test a single call. No evidence the redundant computation is a measurable cost — the
render loop does far heavier work every frame — so not worth the added bug surface on unmeasured
suspicion.

## Inline review across balance / fun / ages 7–43 / play styles / difficulty / AI / UI / UX /
## architecture / extensibility / data / SFX / saves / testing / regressions / solo & hot-seat

- **No mechanical or player-visible changes** — this is a behavior-preserving refactor. The live
  game's rendered output is unchanged; only the code path that produces it is unified.
- **AI decoupling reconfirmed**: no AI code references `buildUnitEntities`, `SpriteEntity`, or
  anything in the renderer layer.
- **Hot-seat traced explicitly**: `pirateSpriteState`'s transients are keyed by unit id, not by
  viewer, so a combat-transient animation could in principle remain visible across a hot-seat
  player switch mid-animation (420ms–1200ms window). Confirmed this is identical to the current
  shipped behavior (this is a byte-for-byte extraction, not a behavior change) — not introduced by
  this PR, and too narrow an edge case to justify a separate issue.
- **No save-schema changes** — nothing persisted, no migration needed.
- **Regression risk minimized by construction**: confirmed via grep that the only references to
  `buildUnitEntities`'s old 5-argument signature were the 3 test files this PR updates — no other
  production code depended on it.
- **Rebased onto a newly-landed "Chariot opener" feature** (adds a new `UnitType`) — full suite
  passed with 14 new tests and zero special-casing needed, confirming the unified function is
  fully generic across unit types, not hardcoded to any roster.

## Test plan

- [x] `yarn build` clean at every commit
- [x] `yarn test`: 439 files, 7180 passed, 3 skipped (pre-existing, unrelated) — includes the new
      Chariot unit content from the rebase
- [x] All 4 new tests pass; all 21 pre-existing assertions across the 3 affected files pass
      unchanged

Closes #760