### PR TITLE
feat(sprites): de-alias chariot/infantry/artillery/marine/cyber_unit (#769 batch 1)

### DIFF
--- a/docs/claude-design-sprites-prompt.md
+++ b/docs/claude-design-sprites-prompt.md
@@ -1,37 +1,64 @@
 # Claude Design Prompt: Conquestoria Sprites
 
-**This file has no active prompt right now.** The last one — #759 batch 1 (v2-native animation-hook
-rigging for `combat_drone`, `autonomous_frigate`, `exosuit_infantry`, `propagandist`,
-`drone_controller`) — shipped 2026-08-01. All 5 are now v2-native (`isV2NativeUnit()` returns
-`true`), integrated into `design/conquestoria-sprites/lib/units-v2.jsx`,
-`scripts/serialize-sprites.mjs`, and `src/renderer/sprites/v2/index.ts`, and verified live via a
-published Artifact against the real `sprite-animations-v2.css`.
+**This file has no active prompt right now.** The last one — #769 batch 1 (real, distinct
+live-catalog sprites for `chariot`, `infantry`, `artillery`, `marine`, `cyber_unit`) — shipped
+2026-08-01. All 5 now render their own bespoke `units.tsx` sprite function instead of aliasing
+another unit's exact art.
 
-## Durable correction (keep this, unlike the rest of this file's history)
+## Durable note: check for other issues owning the same units before scoping a batch
 
-Issue #759's original framing — "v2-native sprites have 6 hand-drawn body/armor variants per
-faction" — is **wrong**, verified 2026-07-31 by reading `design/conquestoria-sprites/lib/units-v2.jsx`
-directly. Every v2-native sprite, including the file's own flagship `SwordsmanV2Sprite`, uses
-`faction` only to derive 4-5 fill colors on one fixed shape — the same palette-recolor pattern the
-live `units.tsx` catalog already uses. **What v2-native sprites actually have that live-fallback
-sprites don't is CSS-animation-hook richness**: articulated limbs (`.cq-leg-l`/`.cq-leg-r`), a
-weapon/tool pivot (`.cq-weapon` with `--pivot-x`/`--pivot-y`), secondary motion (`.cq-plume`), and
-state-gated effects (`.cq-hit-spark`, `.cq-muzzle-flash`, `.cq-step-dust`). Migrating a unit is a
-rigging upgrade to its existing silhouette, not a redesign — keep future prompts scoped that way.
+When #769 was filed, it audited `UNIT_SPRITE_CATALOG` and found 17 aliased units, without checking
+whether any were already owned by a pre-existing tracked issue. They were: issue **#708** (part of
+the larger #547 combat-roster initiative) already owned `chariot`/`beast_handler`/`war_elephant`/
+`cuirassier`'s bespoke-sprite work, with its own design doc and implementation plan, before #769
+was ever filed. This was discovered mid-batch-1 (2026-08-01) when a delivered sprite batch's own
+authored comments correctly cited `#708` — because the generation prompt's reference files pulled
+the live repo's existing `sprite-catalog.ts`, which already had `// #708 owns ...` comments on
+those exact lines.
 
-Also don't trust a fallback-tier count pasted into any past prompt as durable — it was 24 when
-#759 was filed, 39 before batch 1, 34 after. Always regenerate via
-`Object.keys(UNIT_SPRITE_CATALOG).filter(t => !isV2NativeUnit(t))` before scoping a new batch.
+**Resolution**: `chariot` shipped under #769 (folding in that slice of #708's scope; #708's
+comment was updated to reflect it). `beast_handler`/`war_elephant`/`cuirassier` remain #708's
+scope, not #769's — removed from #769's batch plan. `armored_car` (a newly-added alias discovered
+during the same reconciliation) belongs to issue #709, also not #769.
 
-Everything else that has ever lived in this file — the original economy-sprite batch, the
-terrain-tiles prompt, the naval transport sprites, the legendary beast prompt, the rail-segment
-addendum, both Era 13 batches, and now #759 batch 1 — was pruned out once shipped, verified
-against the actual source each time before removal. If you need the history of any of it, it's in
-this file's git history; there's no reason to resurrect it here.
+**Before drafting any future #769 batch:**
+1. Run the audit script (below) to get the live alias list — don't trust a roster pasted into an
+   old prompt or issue body.
+2. For every alias it reports, check whether the comment already on that catalog line names a
+   different issue (`grep -B2 "<unit_id>:" src/renderer/sprites/sprite-catalog.ts`). If so, that
+   issue owns it — don't add it to #769 without reconciling first (ask before assuming).
+3. Only units with no other stated owner are genuinely #769's to batch.
 
-**When a new sprite/terrain/prompt need comes up:** use the
-`.claude/skills/generate-sprite-prompt.md` skill for live-catalog (`units.tsx`/`buildings.tsx`)
-sprites, or hand-write a v2-native prompt following #759 batch 1's pattern (see git history for
-the exact prompt if useful as a template) for animation-hook rigging work. Append it to this file
-the same way every prior prompt was — dated, scoped to the specific issue — and prune it back out
-once shipped rather than leaving it to accumulate.
+## Audit before starting every batch
+
+Two new aliases (`cuirassier`, `armored_car`) landed on `main` between batch 1 being filed and
+batch 1 shipping — added by a separate, actively-landing automated initiative (issue #547). This
+is exactly the drift this audit step exists to catch:
+
+```bash
+bash scripts/run-with-mise.sh yarn node scripts/audit-sprite-aliases.mjs
+```
+
+This re-derives the alias list directly from `sprite-catalog.ts` (not from this doc or any issue
+body) and exits non-zero while any alias remains. Cross-check its output against:
+- `tests/renderer/sprites/sprite-catalog.test.ts` → `describe('#769 pending sprite-alias audit
+  baseline', ...)` — the mechanically-enforced remaining-scope list for #769 specifically (10
+  units as of 2026-08-01, batch 1 shipped, beast_handler/war_elephant/cuirassier/armored_car
+  excluded as described above). A unit is only "done" when its row is deleted here — that
+  deletion is the proof, not a checkbox in prose.
+- Issue #769's body, for the batch grouping of whatever's left.
+
+If the audit reports a unit not in either place, don't assume it's #769's — check for another
+owning issue first (see "Durable note" above), then update both the baseline test and #769's plan
+in the same PR.
+
+## When a new sprite/terrain/prompt need comes up
+
+Use the `.claude/skills/generate-sprite-prompt.md` skill for live-catalog (`units.tsx`/
+`buildings.tsx`) sprites, or hand-write a v2-native prompt (see git history for #759 batch 1's
+prompt as a template) for animation-hook rigging work. Append the new prompt to this file the same
+way every prior prompt was — dated, scoped to the specific issue — and prune it back out once
+shipped rather than leaving it to accumulate. Everything that has ever lived in this file (economy
+sprites, terrain tiles, naval transports, legendary beasts, rail segments, both Era 13 batches,
+#759 batch 1, #769 batch 1) was pruned the same way, verified against actual source each time
+before removal — the history is in git, not preserved here.

--- a/scripts/audit-sprite-aliases.mjs
+++ b/scripts/audit-sprite-aliases.mjs
@@ -1,0 +1,84 @@
+// Audits UNIT_SPRITE_CATALOG for units rendering via another unit's sprite function
+// (id and function name resolve to different sprites) rather than their own bespoke art.
+// See issue #769. Run: bash scripts/run-with-mise.sh yarn node scripts/audit-sprite-aliases.mjs
+import { readFileSync } from 'node:fs';
+
+const CATALOG_PATH = new URL('../src/renderer/sprites/sprite-catalog.ts', import.meta.url);
+
+// Legendary beasts intentionally have real, bespoke, descriptively-named sprites whose
+// function name doesn't match their unit id (e.g. beast_boar -> GiantBoarSprite). Verified
+// manually when #769 was filed — do not remove an entry from this list without re-verifying
+// the sprite is genuinely bespoke, not a reuse.
+const KNOWN_NON_ALIAS_EXCEPTIONS = new Set([
+  'beast_boar',
+  'beast_wolf',
+  'beast_basilisk',
+  'beast_sea_serpent',
+  'beast_wurm',
+  'beast_roc',
+  'beast_hydra',
+  'beast_dragon',
+]);
+
+function expectedFunctionName(unitId) {
+  const pascal = unitId
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+  return `${pascal}Sprite`;
+}
+
+const source = readFileSync(CATALOG_PATH, 'utf8');
+const catalogBlockMatch = source.match(
+  /export const UNIT_SPRITE_CATALOG[^{]*\{([\s\S]*?)\n\};/
+);
+if (!catalogBlockMatch) {
+  console.error('Could not locate UNIT_SPRITE_CATALOG block — sprite-catalog.ts structure may have changed.');
+  process.exit(1);
+}
+
+const entryPattern = /^\s*(\w+):\s*withMotion\('(\w+)',\s*(\w+)\)/gm;
+const entries = [];
+
+let match;
+while ((match = entryPattern.exec(catalogBlockMatch[1])) !== null) {
+  const [, key, motionId, functionName] = match;
+  if (key !== motionId) {
+    console.warn(`Mismatched catalog key/withMotion id: ${key} vs ${motionId} — investigate manually.`);
+  }
+  entries.push({ unit: key, function: functionName });
+}
+
+// A unit "owns" its sprite function when the function name follows the standard
+// <PascalCase(id)>Sprite convention. This is order-independent (unlike "first entry using
+// a function wins"), so e.g. `rifleman -> RiflemanSprite` is correctly identified as the
+// owner even though `marine` (which reuses the same function) appears earlier in the file.
+const functionToOwner = new Map();
+for (const { unit, function: fn } of entries) {
+  if (fn === expectedFunctionName(unit)) {
+    functionToOwner.set(fn, unit);
+  }
+}
+
+const aliases = [];
+for (const { unit, function: fn } of entries) {
+  if (KNOWN_NON_ALIAS_EXCEPTIONS.has(unit)) continue;
+  const owner = functionToOwner.get(fn);
+  if (owner && owner !== unit) {
+    aliases.push({ unit, function: fn, donor: owner });
+  }
+}
+
+if (aliases.length === 0) {
+  console.log('No new sprite aliases found — every UNIT_SPRITE_CATALOG entry renders its own function.');
+  process.exit(0);
+}
+
+console.log(`Found ${aliases.length} unit(s) reusing another unit's exact sprite function:\n`);
+for (const { unit, function: fn, donor } of aliases) {
+  console.log(`  ${unit.padEnd(20)} -> ${fn}  (same as ${donor})`);
+}
+console.log('\nCross-check this list against issue #769 before starting the next batch:');
+console.log('  gh issue view 769 --json body -q .body | head -40');
+console.log('If this list has grown since #769 was filed, update the issue\'s plan/batches before proceeding.');
+process.exit(1);

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -6,11 +6,11 @@ import {
   WarHoundSprite, ShadowWardenSprite, WarriorSprite, SwordsmanSprite,
   PikemanSprite, ArcherSprite, MusketeerSprite, GalleySprite,
   TriremeSprite, TransportSprite, SpyScoutSprite, SpyInformantSprite, SpyAgentSprite,
-  SpyOperativeSprite, SpyHackerSprite,
-  AxemanSprite, SpearmanSprite, HorsemanSprite, CavalrySprite, KnightSprite,
-  CrossbowmanSprite, CatapultSprite, BallistaSprite, CannonSprite, GrenadierSprite,
-  RiflemanSprite, IroncladSprite,
-  MachineGunnerSprite, PreDreadnoughtSprite, TankSprite, SubmarineSprite,
+  SpyOperativeSprite, SpyHackerSprite, CyberUnitSprite,
+  AxemanSprite, SpearmanSprite, HorsemanSprite, ChariotSprite, CavalrySprite, KnightSprite,
+  CrossbowmanSprite, CatapultSprite, BallistaSprite, CannonSprite, ArtillerySprite, GrenadierSprite,
+  RiflemanSprite, MarineSprite, IroncladSprite,
+  MachineGunnerSprite, InfantrySprite, PreDreadnoughtSprite, TankSprite, SubmarineSprite,
   ObservationBalloonSprite, BiplaneSprite, JetFighterSprite, CarrierSprite,
   AttackHelicopterSprite, MissileSubmarineSprite,
   CombatDroneSprite, AutonomousFrigateSprite, ExosuitInfantrySprite,
@@ -264,7 +264,9 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   axeman:         withMotion('axeman', AxemanSprite),
   spearman:       withMotion('spearman', SpearmanSprite),
   horseman:       withMotion('horseman', HorsemanSprite),
-  chariot:        withMotion('chariot', HorsemanSprite),
+  // De-aliased in #769 batch 1, folding in #708's chariot scope (#708 still owns
+  // beast_handler/war_elephant/cuirassier's bespoke sprites — see comments below).
+  chariot:        withMotion('chariot', ChariotSprite),
   cavalry:        withMotion('cavalry', CavalrySprite),
   // Temporary Tank silhouette; #709 owns Armored Car's distinct final sprite.
   armored_car:    withMotion('armored_car', TankSprite),
@@ -275,12 +277,12 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   catapult:       withMotion('catapult', CatapultSprite),
   ballista:       withMotion('ballista', BallistaSprite),
   cannon:         withMotion('cannon', CannonSprite),
-  // artillery/infantry/bomber reuse existing sprites as placeholders (same pattern as
-  // frigate/destroyer above and stealth_bomber below); bespoke art is a
-  // generate-sprite-prompt follow-up.
-  artillery:      withMotion('artillery', CannonSprite),
+  // bomber still reuses an existing sprite as a placeholder (same pattern as frigate/destroyer
+  // below and stealth_bomber further down); bespoke art is a generate-sprite-prompt follow-up.
+  // artillery/infantry/marine de-aliased in #769 batch 1.
+  artillery:      withMotion('artillery', ArtillerySprite),
   grenadier:      withMotion('grenadier', GrenadierSprite),
-  marine:         withMotion('marine', RiflemanSprite),
+  marine:         withMotion('marine', MarineSprite),
   rifleman:       withMotion('rifleman', RiflemanSprite),
   // frigate/destroyer reuse existing hulls as placeholders (same pattern as stealth_bomber
   // reusing JetFighterSprite below); bespoke sprites are a generate-sprite-prompt follow-up.
@@ -288,7 +290,7 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   ironclad:          withMotion('ironclad', IroncladSprite),
   destroyer:         withMotion('destroyer', IroncladSprite),
   machine_gunner:    withMotion('machine_gunner', MachineGunnerSprite),
-  infantry:          withMotion('infantry', MachineGunnerSprite),
+  infantry:          withMotion('infantry', InfantrySprite),
   pre_dreadnought:   withMotion('pre_dreadnought', PreDreadnoughtSprite),
   tank:              withMotion('tank', TankSprite),
   submarine:         withMotion('submarine', SubmarineSprite),
@@ -331,7 +333,8 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   beast_roc:          withMotion('beast_roc', StormRocSprite),
   beast_hydra:        withMotion('beast_hydra', SwampHydraSprite),
   beast_dragon:       withMotion('beast_dragon', AncientDragonSprite),
-  cyber_unit:         withMotion('cyber_unit', SpyHackerSprite),
+  // De-aliased in #769 batch 1.
+  cyber_unit:         withMotion('cyber_unit', CyberUnitSprite),
   stealth_bomber:     withMotion('stealth_bomber', JetFighterSprite),
 };
 

--- a/src/renderer/sprites/units.tsx
+++ b/src/renderer/sprites/units.tsx
@@ -819,6 +819,66 @@ export function SpyHackerSprite({ palette, svgOnly = false }: UnitSpriteProps): 
   });
 }
 
+// #769 de-alias: cyber_unit previously reused SpyHackerSprite verbatim. It is a distinct
+// unit type — a non-combat economic saboteur (strength 0, capturable) that drains gold from
+// ADJACENT cities from range, so it reads as a STANDING technical specialist with a portable
+// field laptop (glowing screen, backpack radio + antenna) rather than SpyHacker's cloaked infiltrator.
+export function CyberUnitSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  const screen = '#00c8ff';
+  return (
+    <SpriteFrame svgOnly={svgOnly} hexTint="#10202c">
+      <g data-kind="civilian">
+        <Shadow cx={62} cy={100} rx={22} ry={5} />
+        {/* backpack field radio + antenna (the "kit" that makes it a cyber operative) */}
+        <g transform="translate(40 66)">
+          <rect x="-8" y="-8" width="14" height="22" rx="2" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.9" />
+          <rect x="-8" y="-8" width="14" height="4" fill={P.metal.steel} />
+          <rect x="-6" y="1" width="10" height="3" fill={palette.mid} />
+          <line x1="4" y1="-8" x2="10" y2="-30" stroke={P.metal.steel} strokeWidth="1.4" />
+          <circle cx="10" cy="-31" r="2.2" fill={palette.bright} className="cq-glow" />
+        </g>
+        {/* STANDING operative, hunched over a rugged field laptop — bespectacled "army nerd" */}
+        <Humanoid cx={60} cy={80} scale={0.95} cloth={palette.mid} pants="#454b38" accent={palette.dark} skin={P.skin.warm} hair="#2a1a0a"
+          hat={
+            <g>
+              <path d="M-9,-33 Q-9,-39 0,-39 Q9,-39 9,-33 L9,-31 L-9,-31 Z" fill={palette.dark} stroke={P.ink.line} strokeWidth="0.7" />
+              <path d="M-9,-31 L-15,-30 L-9,-28 Z" fill={palette.dark} stroke={P.ink.line} strokeWidth="0.5" />
+              {/* glasses — the "nerd" tell */}
+              <g stroke={P.metal.iron} strokeWidth="0.8" fill="none">
+                <rect x="-6" y="-25.5" width="4.6" height="3.4" rx="0.8" />
+                <rect x="1.4" y="-25.5" width="4.6" height="3.4" rx="0.8" />
+                <line x1="-1.4" y1="-24" x2="1.4" y2="-24" />
+              </g>
+            </g>
+          }
+        />
+        {/* both arms bent forward, cradling the laptop */}
+        <path d="M50,73 Q56,80 63,82" fill="none" stroke={palette.mid} strokeWidth="5" strokeLinecap="round" />
+        <path d="M74,73 Q70,80 66,82" fill="none" stroke={palette.mid} strokeWidth="5" strokeLinecap="round" />
+        {/* rugged portable laptop with a glowing screen */}
+        <g transform="translate(64 82)">
+          <path d="M-16,4 L16,4 L20,10 L-20,10 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.9" />
+          <rect x="-15" y="5.5" width="30" height="2.6" fill={P.stone.dark} />
+          <g transform="rotate(-13 -14 4)">
+            <rect x="-16" y="-14" width="30" height="18" rx="1.5" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.9" />
+            <g className="cq-glow"><rect x="-13" y="-11" width="24" height="12" rx="1" fill={screen} opacity="0.9" /></g>
+            <line x1="-10" y1="-8" x2="6" y2="-8" stroke="#06303f" strokeWidth="1" />
+            <line x1="-10" y1="-5" x2="2" y2="-5" stroke="#06303f" strokeWidth="1" />
+            <line x1="-10" y1="-2" x2="8" y2="-2" stroke="#06303f" strokeWidth="1" />
+          </g>
+          {/* team status LED */}
+          <circle cx="17" cy="7" r="1.4" fill={palette.bright} className="cq-glow" />
+        </g>
+        {/* cable from the laptop to the backpack radio */}
+        <path d="M48,86 Q42,82 44,72" fill="none" stroke={P.ink.soft} strokeWidth="1.6" />
+        {/* hands on the device */}
+        <circle cx="52" cy="83" r="2.4" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.5" />
+        <circle cx="76" cy="83" r="2.4" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.5" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
 /* === Helpers (file-local) === */
 
 function mountedRider({
@@ -953,6 +1013,96 @@ export function HorsemanSprite({ palette, svgOnly = false }: UnitSpriteProps): s
         </g>
       </g>
       <Banner x={42} y={34} palette={palette} scale={0.7} />
+    </SpriteFrame>
+  );
+}
+
+// #708 de-alias: chariot previously reused HorsemanSprite verbatim. A chariot is a
+// two-wheeled cart with a STANDING driver pulled by a harnessed horse — the pair of
+// large spoked wheels is the silhouette differentiator from a single mounted rider.
+export function ChariotSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-kind="melee">
+        <Shadow cx={58} cy={99} rx={46} ry={7} />
+        {/* HORSE in harness — head to the right, pulling the cart (no rider on its back) */}
+        <g transform="translate(88 76)">
+          <rect x="-13" y="4" width="5" height="18" fill="#7a5a3a" stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="9" y="4" width="5" height="18" fill="#7a5a3a" stroke={P.ink.line} strokeWidth="0.6" />
+          <ellipse cx="0" cy="0" rx="25" ry="12" fill="#a07a4a" stroke={P.ink.line} strokeWidth="1" />
+          <ellipse cx="-1" cy="-3" rx="23" ry="8" fill="#b88a5a" />
+          <rect x="-18" y="4" width="5" height="18" fill="#8a6a44" stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="14" y="4" width="5" height="18" fill="#8a6a44" stroke={P.ink.line} strokeWidth="0.6" />
+          <ellipse cx="-15.5" cy="22.5" rx="3.2" ry="1.8" fill="#5e3f24" stroke={P.ink.line} strokeWidth="0.4" />
+          <ellipse cx="16.5" cy="22.5" rx="3.2" ry="1.8" fill="#5e3f24" stroke={P.ink.line} strokeWidth="0.4" />
+          <path d="M-24,-6 Q-33,-3 -30,8" fill="none" stroke="#7a5a3a" strokeWidth="3" strokeLinecap="round" />
+          <path d="M16,-6 Q26,-16 29,-24 L35,-21 Q33,-9 24,-2 Z" fill="#a07a4a" stroke={P.ink.line} strokeWidth="1" />
+          <path d="M28,-25 Q39,-25 41,-17 Q41,-13 35,-12 L28,-14 Z" fill="#a07a4a" stroke={P.ink.line} strokeWidth="1" />
+          <ellipse cx="40" cy="-15" rx="4" ry="3.2" fill="#b88a5a" stroke={P.ink.line} strokeWidth="0.6" />
+          <path d="M29,-24 L30,-31 L33,-24 Z" fill="#8a6a44" stroke={P.ink.line} strokeWidth="0.5" />
+          <path d="M19,-8 Q26,-20 30,-26 L32,-24 Q27,-15 23,-5 Z" fill="#7a5a3a" />
+          <circle cx="36" cy="-18" r="0.8" fill={P.ink.line} />
+          {/* leather harness collar — marks this as a draft horse, not a mount */}
+          <path d="M21,-8 Q29,-14 29,-22" fill="none" stroke={P.wood.dark} strokeWidth="2.2" strokeLinecap="round" />
+          <path d="M19,-1 Q27,-5 29,-13" fill="none" stroke={P.wood.dark} strokeWidth="2" strokeLinecap="round" />
+        </g>
+        {/* TRACES + draft pole from the harness back to the cart */}
+        <line x1="52" y1="72" x2="74" y2="72" stroke={P.wood.mid} strokeWidth="2.2" strokeLinecap="round" />
+        <line x1="54" y1="66" x2="72" y2="64" stroke={P.wood.dark} strokeWidth="1.6" strokeLinecap="round" />
+        <line x1="54" y1="78" x2="72" y2="80" stroke={P.wood.dark} strokeWidth="1.6" strokeLinecap="round" />
+        {/* axle + far wheel (behind the bed, smaller + darker) */}
+        <rect x="26" y="80" width="34" height="3" fill={P.wood.dark} />
+        <g transform="translate(34 84)">
+          <circle r="13" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1.2" />
+          <circle r="13" fill="none" stroke={P.wood.mid} strokeWidth="1.4" />
+          <g className="cq-wheel" style="animation-duration:3s">
+            <line x1="-13" y1="0" x2="13" y2="0" stroke={P.wood.mid} strokeWidth="1" />
+            <line x1="0" y1="-13" x2="0" y2="13" stroke={P.wood.mid} strokeWidth="1" />
+            <line x1="-9.2" y1="-9.2" x2="9.2" y2="9.2" stroke={P.wood.mid} strokeWidth="1" />
+            <line x1="-9.2" y1="9.2" x2="9.2" y2="-9.2" stroke={P.wood.mid} strokeWidth="1" />
+          </g>
+          <circle r="2.5" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+        </g>
+        {/* DRIVER standing in the bed — legs occluded by the basket drawn next */}
+        <Humanoid cx={40} cy={52} scale={0.62} cloth={palette.mid} pants={P.cloth.wool} accent={palette.dark} skin={P.skin.warm} hair="#3a2a1a"
+          hat={<path d="M-9,-34 Q0,-40 9,-34 L9,-30 L-9,-30 Z" fill={P.metal.bronze} stroke={P.ink.line} strokeWidth="0.5" />}
+        />
+        {/* CART BED — geometric basket, wood + bronze trim + curved front hoop */}
+        <path d="M20,58 L52,58 Q57,58 57,64 L57,74 Q57,80 51,80 L26,80 Q20,80 20,74 Z" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="1" />
+        <path d="M20,58 L52,58 Q57,58 57,64 L57,66 L20,66 Z" fill={P.wood.light} />
+        <line x1="23" y1="70" x2="54" y2="70" stroke={P.wood.dark} strokeWidth="0.6" opacity="0.6" />
+        <line x1="23" y1="74" x2="52" y2="74" stroke={P.wood.dark} strokeWidth="0.6" opacity="0.6" />
+        <rect x="20" y="57" width="37" height="2.6" fill={P.metal.bronze} />
+        <path d="M55,58 Q64,54 61,44" fill="none" stroke={P.wood.dark} strokeWidth="2.4" strokeLinecap="round" />
+        {/* small round shield on the cart front — team color */}
+        <g transform="translate(54 68)">
+          <circle r="7" fill={palette.mid} stroke={P.ink.line} strokeWidth="1" />
+          <circle r="7" fill="none" stroke={palette.dark} strokeWidth="1.4" />
+          <circle r="1.8" fill={P.metal.bronze} stroke={P.ink.line} strokeWidth="0.4" />
+        </g>
+        {/* near wheel (front, large) — the key silhouette differentiator vs a mounted rider */}
+        <g transform="translate(48 84)">
+          <circle r="15" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="1.5" />
+          <circle r="15" fill="none" stroke={P.wood.dark} strokeWidth="1.6" />
+          <g className="cq-wheel" style="animation-duration:3s">
+            <line x1="-15" y1="0" x2="15" y2="0" stroke={P.wood.dark} strokeWidth="1.4" />
+            <line x1="0" y1="-15" x2="0" y2="15" stroke={P.wood.dark} strokeWidth="1.4" />
+            <line x1="-10.6" y1="-10.6" x2="10.6" y2="10.6" stroke={P.wood.dark} strokeWidth="1.4" />
+            <line x1="-10.6" y1="10.6" x2="10.6" y2="-10.6" stroke={P.wood.dark} strokeWidth="1.4" />
+          </g>
+          <circle r="3.4" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+          <circle r="1.4" fill={P.metal.steel} />
+        </g>
+        {/* spear raised forward over the team */}
+        <g transform="translate(50 54) rotate(30)">
+          <g className="cq-weapon" style="transform-origin: 50px 54px; transform-box: view-box;">
+            <rect x="-1" y="-30" width="2" height="58" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.5" />
+            <path d="M-3,-30 L3,-30 L4,-40 L0,-46 L-4,-40 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.7" />
+            <rect x="-3" y="-31" width="6" height="2" fill={P.metal.gold} />
+          </g>
+        </g>
+        <Banner x={20} y={44} palette={palette} scale={0.62} />
+      </g>
     </SpriteFrame>
   );
 }
@@ -1239,6 +1389,74 @@ export function CannonSprite({ palette, svgOnly = false }: UnitSpriteProps): str
   );
 }
 
+// #769 de-alias: artillery previously reused CannonSprite verbatim. As a later-era
+// siege piece (bombard range 2 vs cannon's shorter reach) it must read as bigger and
+// more mechanically complex: larger wheeled carriage, a longer slender barrel angled
+// up for indirect fire, a visible elevation screw, and an ammo crate with shells.
+export function ArtillerySprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-kind="ranged">
+        <Shadow cx={66} cy={100} rx={46} ry={7} />
+        {/* trail spade — rear leg of the carriage */}
+        <path d="M16,99 L40,86 L44,90 L22,103 Z" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1" />
+        {/* carriage frame with a team-color band */}
+        <path d="M38,78 L94,78 L98,90 L44,90 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+        <rect x="42" y="80" width="54" height="3" fill={palette.mid} />
+        {/* rear wheel — large spoked, wood + iron rim */}
+        <g transform="translate(52 92)">
+          <circle r="16" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1.6" />
+          <circle r="16" fill="none" stroke={P.metal.iron} strokeWidth="2.4" />
+          <g className="cq-wheel" style="animation-duration:3.6s">
+            <line x1="-16" y1="0" x2="16" y2="0" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="0" y1="-16" x2="0" y2="16" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="-11.3" y1="-11.3" x2="11.3" y2="11.3" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="-11.3" y1="11.3" x2="11.3" y2="-11.3" stroke={P.wood.mid} strokeWidth="1.4" />
+          </g>
+          <circle r="3.6" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+          <circle r="1.4" fill={P.metal.steel} />
+        </g>
+        {/* elevation block + screw — the "more advanced than a muzzle-loader" detail */}
+        <rect x="58" y="66" width="14" height="15" rx="2" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.8" />
+        <line x1="56" y1="82" x2="56" y2="68" stroke={P.metal.steel} strokeWidth="2.2" />
+        <circle cx="56" cy="67" r="2.6" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+        {/* long slender barrel angled up for indirect fire — recoil cylinder + breech */}
+        <g transform="translate(66 74) rotate(-30)">
+          <rect x="-4" y="-9.5" width="42" height="4" rx="2" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="-8" y="-4.5" width="72" height="9" rx="4.5" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+          <rect x="-8" y="-4.5" width="72" height="3.5" rx="3" fill={P.metal.steel} />
+          <rect x="-11" y="-6" width="13" height="12" rx="2" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+          <circle cx="-4" cy="0" r="2.4" fill={P.ink.soft} />
+          <ellipse cx="64" cy="0" rx="4" ry="4.6" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+          <ellipse cx="64" cy="0" rx="2" ry="2.6" fill="#111" />
+        </g>
+        {/* front wheel — drawn over the barrel base for depth */}
+        <g transform="translate(86 92)">
+          <circle r="16" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1.6" />
+          <circle r="16" fill="none" stroke={P.metal.iron} strokeWidth="2.4" />
+          <g className="cq-wheel" style="animation-duration:3.6s">
+            <line x1="-16" y1="0" x2="16" y2="0" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="0" y1="-16" x2="0" y2="16" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="-11.3" y1="-11.3" x2="11.3" y2="11.3" stroke={P.wood.mid} strokeWidth="1.4" />
+            <line x1="-11.3" y1="11.3" x2="11.3" y2="-11.3" stroke={P.wood.mid} strokeWidth="1.4" />
+          </g>
+          <circle r="3.6" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+          <circle r="1.4" fill={P.metal.steel} />
+        </g>
+        {/* muzzle flash at the barrel tip */}
+        <g transform="translate(121 42)"><g className="cq-muzzle-flash"><circle r="6" fill="#ffd966" /><circle r="3" fill="#fff" /></g></g>
+        {/* ammunition crate staged behind the gun (left) */}
+        <g transform="translate(24 99)">
+          <rect x="-9" y="-7" width="18" height="10" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.8" />
+          <path d="M-9,-3 H9 M0,-7 V3" stroke={P.wood.dark} strokeWidth="0.6" />
+          <rect x="-9" y="-7" width="18" height="2.4" fill={P.metal.bronze} opacity="0.7" />
+        </g>
+        <Banner x={40} y={60} palette={palette} scale={0.62} />
+      </g>
+    </SpriteFrame>
+  );
+}
+
 /* === GRENADIER === */
 
 export function GrenadierSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
@@ -1287,6 +1505,60 @@ export function RiflemanSprite({ palette, svgOnly = false }: UnitSpriteProps): s
       {/* bayonet */}
       <line x1="74.5" y1="36" x2="74.5" y2="22" stroke={P.metal.shine} strokeWidth="2.5" strokeLinecap="round" />
       <Banner x={100} y={28} palette={palette} scale={0.7} />
+    </SpriteFrame>
+  );
+}
+
+// #769 de-alias: marine previously reused RiflemanSprite verbatim. Marine is coastal
+// assault infantry with a MELEE attack profile — so it reads as a leaner amphibious
+// trooper in olive combat fatigues lunging with a bayonet-fixed rifle (not the rifleman's
+// static vertical carry), with a flotation/plate-carrier vest signalling "coastal assault."
+export function MarineSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-kind="melee">
+        <Shadow cx={62} cy={100} rx={22} ry={5} />
+        {/* lean, forward-crouched amphibious assault stance in olive combat fatigues */}
+        <g transform="rotate(-9 60 78)">
+          <Humanoid cx={60} cy={78} scale={0.94} cloth="#5b6248" pants="#454b38" accent="#3a3f2c" skin={P.skin.cool} hair="#2a1a0a"
+            hat={
+              <g>
+                {/* rounded amphibious combat helmet with a team-color band + chin strap */}
+                <path d="M-10,-33 Q-10,-44 0,-44 Q10,-44 10,-33 L10,-31 Q0,-34 -10,-31 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.9" />
+                <path d="M-11,-31 Q0,-34 11,-31 L10,-28 Q0,-31 -10,-28 Z" fill={P.ink.soft} />
+                <path d="M-10,-33 Q0,-36 10,-33 L10,-31 Q0,-33.5 -10,-31 Z" fill={palette.mid} />
+                <path d="M-9,-30 Q-8,-25 -4,-24" fill="none" stroke={P.ink.soft} strokeWidth="1" />
+              </g>
+            }
+          />
+          {/* flotation / plate-carrier vest — linen with a team-color trim band */}
+          <g transform="translate(60 68)">
+            <path d="M-11,-8 Q0,-11 11,-8 L12,10 L-12,10 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="0.9" />
+            <rect x="-12" y="-2" width="24" height="2.4" fill={palette.mid} />
+            <line x1="0" y1="-9" x2="0" y2="10" stroke={P.ink.soft} strokeWidth="0.8" />
+            <rect x="-9" y="3" width="6" height="6" rx="1" fill={P.cloth.wool} stroke={P.ink.line} strokeWidth="0.5" />
+            <rect x="3" y="3" width="6" height="6" rx="1" fill={P.cloth.wool} stroke={P.ink.line} strokeWidth="0.5" />
+          </g>
+          {/* sheathed combat knife on the thigh */}
+          <g transform="translate(49 87) rotate(18)"><rect x="-1.4" y="0" width="2.8" height="8" rx="1" fill={P.ink.soft} stroke={P.ink.line} strokeWidth="0.4" /><rect x="-1" y="-3" width="2" height="3" fill={P.metal.shine} /></g>
+        </g>
+        {/* bayonet-fixed rifle thrust FORWARD as a melee weapon (not aimed for fire) */}
+        <g transform="translate(58 76) rotate(-6)">
+          <g className="cq-weapon" style="transform-origin: 58px 76px; transform-box: view-box;">
+            <rect x="-14" y="-2.5" width="16" height="5" rx="1.5" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.7" />
+            <rect x="2" y="-2" width="22" height="4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+            <rect x="24" y="-1.5" width="18" height="3" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.5" />
+            <path d="M42,-1.5 L62,-1 L42,1.5 Z" fill={P.metal.shine} stroke={P.ink.line} strokeWidth="0.6" />
+            <path d="M-2,2 L2,2 L1,8 L-3,8 Z" fill={P.ink.soft} stroke={P.ink.line} strokeWidth="0.5" />
+          </g>
+        </g>
+        {/* bare forearms (sleeves rolled) gripping the rifle */}
+        <path d="M56,71 Q57,75 60,77" fill="none" stroke={P.skin.cool} strokeWidth="3.4" strokeLinecap="round" />
+        <path d="M62,71 Q72,70 78,68" fill="none" stroke={P.skin.cool} strokeWidth="3.4" strokeLinecap="round" />
+        <circle cx="60" cy="77" r="2.4" fill={P.skin.cool} stroke={P.ink.line} strokeWidth="0.5" />
+        <circle cx="79" cy="68" r="2.4" fill={P.skin.cool} stroke={P.ink.line} strokeWidth="0.5" />
+        <Banner x={102} y={34} palette={palette} scale={0.6} />
+      </g>
     </SpriteFrame>
   );
 }
@@ -1437,6 +1709,59 @@ export function MachineGunnerSprite({ palette, svgOnly = false }: UnitSpriteProp
       {/* gunner — prone/crouching silhouette */}
       <Humanoid cx={46} cy={84} scale={0.72} cloth={palette.dark} pants={palette.dark} accent={palette.mid} skin={P.skin.warm} hair="#2a1a0a" />
       <Banner x={100} y={30} palette={palette} scale={0.65} />
+    </SpriteFrame>
+  );
+}
+
+// #769 de-alias: infantry previously reused MachineGunnerSprite verbatim. Per its
+// in-game text ("modern line infantry... current infantry apex") it must read as a
+// LATER-era upgrade: rounded combat helmet + tactical vest, rifle held two-handed at
+// the ready (NOT a tripod-mounted belt-fed gun), standing/mobile — not crouched.
+export function InfantrySprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-kind="ranged">
+        <Shadow cx={62} cy={100} rx={22} ry={5} />
+        <Humanoid cx={60} cy={78} scale={1} cloth={palette.dark} pants="#3a3a2e" accent={palette.mid} skin={P.skin.warm} hair="#2a1a0a"
+          hat={
+            <g>
+              {/* modern rounded combat helmet (not a WWI Brodie/Stahlhelm) */}
+              <path d="M-11,-33 Q-11,-45 0,-45 Q11,-45 11,-33 L11,-31 Q0,-34 -11,-31 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+              <path d="M-11,-33 Q0,-36 11,-33 L11,-31 L-11,-31 Z" fill={P.metal.steel} opacity="0.5" />
+              <path d="M-12,-31 Q0,-34 12,-31 L11,-28 Q0,-31 -11,-28 Z" fill={P.ink.soft} />
+            </g>
+          }
+        />
+        {/* tactical vest with pouches over the torso */}
+        <g transform="translate(60 66)">
+          <rect x="-13" y="-6" width="26" height="20" rx="3" fill={palette.mid} stroke={P.ink.line} strokeWidth="1" />
+          <rect x="-13" y="-6" width="26" height="4" fill={palette.dark} />
+          <rect x="-11" y="2" width="7" height="8" rx="1" fill={palette.dark} stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="-2" y="2" width="7" height="8" rx="1" fill={palette.dark} stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="7" y="2" width="5" height="8" rx="1" fill={palette.dark} stroke={P.ink.line} strokeWidth="0.6" />
+          <path d="M-5,-6 L5,-6 L3,-1 L-3,-1 Z" fill={P.cloth.wool} stroke={P.ink.line} strokeWidth="0.5" />
+        </g>
+        {/* both forearms bent to grip the rifle — connects gun to the body */}
+        <path d="M55,66 Q57,74 60,79" fill="none" stroke={palette.dark} strokeWidth="5" strokeLinecap="round" />
+        <path d="M62,66 Q72,67 80,71" fill="none" stroke={palette.dark} strokeWidth="5" strokeLinecap="round" />
+        {/* RIFLE gripped two-handed, muzzle up — NOT tripod-mounted; recoils + flashes on attack */}
+        <g transform="translate(60 80) rotate(-20)">
+          <g className="cq-weapon" style="transform-origin: 60px 80px; transform-box: view-box;">
+            <rect x="-18" y="-3" width="20" height="6" rx="1.5" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.7" />
+            <rect x="0" y="-4" width="24" height="6" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.7" />
+            <rect x="24" y="-2.5" width="22" height="3" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+            <rect x="46" y="-3" width="4" height="4" rx="1" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.5" />
+            <path d="M6,2 L14,2 L13,13 L7,13 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+            <path d="M-2,2 L2,2 L1,9 L-3,9 Z" fill={P.ink.soft} stroke={P.ink.line} strokeWidth="0.5" />
+            <rect x="16" y="-6" width="2.5" height="3" fill={P.metal.iron} />
+            <g transform="translate(52 -1)"><g className="cq-muzzle-flash"><circle r="5" fill="#ffd966" /><circle r="2.5" fill="#fff" /></g></g>
+          </g>
+        </g>
+        {/* hands on the rifle */}
+        <circle cx="60" cy="80" r="2.6" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.6" />
+        <circle cx="81" cy="72" r="2.6" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.6" />
+        <Banner x={100} y={30} palette={palette} scale={0.65} />
+      </g>
     </SpriteFrame>
   );
 }

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -154,6 +154,67 @@ describe('Era 13 sprites are not aliases of their placeholders (#652)', () => {
   });
 });
 
+// #769: full audit (2026-08-01, `scripts/audit-sprite-aliases.mjs`) of UNIT_SPRITE_CATALOG
+// originally found 17 units still rendering via another unit's exact sprite function — not
+// similar art, literally the same component (distinct from the Era 13 placeholders above,
+// which have all shipped real replacements). This is the audit baseline; batches ship 5 at a
+// time and each row is deleted the moment its unit gets real bespoke art (mirroring the Era 13
+// pattern above) — so a shrinking list here is expected and desired, not a bug.
+//
+// Batch 1 (chariot, infantry, artillery, marine, cyber_unit) shipped 2026-08-01 and is no
+// longer listed below. `chariot` also closed out the overlapping portion of pre-existing issue
+// #708's scope that this issue didn't originally know about (see next paragraph) — #708's
+// comment was updated to reflect that.
+//
+// Reconciled with issue #708 (2026-08-01): #708 is a pre-existing, separately-tracked issue
+// (part of the larger #547 combat-roster initiative) that already owned `beast_handler`,
+// `war_elephant`, and `cuirassier`'s bespoke-sprite work with its own design doc and
+// implementation plan — this issue didn't know about it when originally filed. Per project
+// decision, #769 no longer tracks those 3 units (removed from the batch plan below); #708
+// keeps them. `armored_car` (owned by issue #709) is similarly out of #769's scope. Both
+// `cuirassier` and `armored_car` landed on `main` as new aliased placeholders *after* this
+// baseline was first written — `scripts/audit-sprite-aliases.mjs` will (correctly) still flag
+// them as aliases, since they mechanically are; they're just not this issue's units to fix.
+//
+// Both sides render through their own UNIT_SPRITE_CATALOG entry (not the raw sprite function)
+// with an explicit motion so the wrapper's per-unit `data-motion`/transform injection is
+// identical on both sides — true visual identity is what we're asserting, not incidental
+// string equality from bypassing the wrapper.
+//
+// If a `toBe` assertion below starts failing, the unit already got its own art — delete that
+// row. If a *new* alias appears that isn't listed here, `scripts/audit-sprite-aliases.mjs`
+// will catch it too — run it before starting any new #769 batch in case another agent added a
+// unit that reuses an existing sprite in the meantime. Not every alias the script reports is
+// automatically #769's scope — check whether another issue already owns it first (as happened
+// with #708/#709 above) before adding a row here.
+describe('#769 pending sprite-alias audit baseline', () => {
+  const palette = derivePalette('#4a90d9');
+
+  it('known-pending aliased units still render identically to their donor unit', () => {
+    const pendingAliasPairs: Array<[keyof typeof UNIT_SPRITE_CATALOG, keyof typeof UNIT_SPRITE_CATALOG]> = [
+      // Batch 2 (naval + logistics) — beast_handler/war_elephant removed, owned by #708
+      ['frigate', 'trireme'],
+      ['destroyer', 'ironclad'],
+      ['merchant_wagon', 'caravan'],
+      // Batch 3 (logistics + air)
+      ['freight_convoy', 'caravan'],
+      ['recon_aircraft', 'biplane'],
+      ['air_freighter', 'biplane'],
+      ['bomber', 'jet_fighter'],
+      ['jet_freighter', 'jet_fighter'],
+      // Batch 4 (air, remainder)
+      ['global_air_cargo', 'jet_fighter'],
+      ['stealth_bomber', 'jet_fighter'],
+    ];
+    expect(pendingAliasPairs.length, "baseline count should match #769's remaining scope (17 originally, minus batch 1's 5, minus beast_handler/war_elephant deferred to #708)").toBe(10);
+    for (const [aliasType, donorType] of pendingAliasPairs) {
+      const actual = UNIT_SPRITE_CATALOG[aliasType]({ palette, svgOnly: true, motion: 'idle' });
+      const donor = UNIT_SPRITE_CATALOG[donorType]({ palette, svgOnly: true, motion: 'idle' });
+      expect(actual, `${aliasType} no longer renders identically to ${donorType} — delete this row from the baseline`).toBe(donor);
+    }
+  });
+});
+
 // The completeness tests above only check `typeof fn === 'function'` — they never call the
 // function, so a runtime-only bug (a NaN from a bad coordinate calc, a property access that
 // only fails for a specific palette's derived colors, etc.) would slip through undetected until

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -10,6 +10,7 @@ import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
 import {
   JetFighterSprite, IroncladSprite, MachineGunnerSprite, MissionarySprite, SpyHackerSprite,
+  HorsemanSprite, CannonSprite, RiflemanSprite,
 } from '@/renderer/sprites/units';
 import {
   DataCenterSprite, CyberDefenseCenterSprite, AutomatedPortSprite, SignalsHubSprite,
@@ -150,6 +151,29 @@ describe('Era 13 sprites are not aliases of their placeholders (#652)', () => {
     ];
     for (const [id, placeholderFn] of replacements) {
       expect(BUILDING_SPRITE_CATALOG[id], `${id} still aliases its old placeholder component`).not.toBe(placeholderFn);
+    }
+  });
+});
+
+// #769 batch 1 (2026-08-01): chariot/infantry/artillery/marine/cyber_unit got real, distinct
+// sprites, replacing their donor aliases (HorsemanSprite/MachineGunnerSprite/CannonSprite/
+// RiflemanSprite/SpyHackerSprite). Same pattern and purpose as the Era 13 block above — reject
+// any regression back to rendering byte-identical to the old donor.
+describe('#769 batch 1 sprites are not aliases of their donors', () => {
+  const palette = derivePalette('#4a90d9');
+
+  it('unit sprites render different markup than the donors they replaced', () => {
+    const replacements: Array<[keyof typeof UNIT_SPRITE_CATALOG, (props: { palette: typeof palette; svgOnly: boolean }) => string]> = [
+      ['chariot', HorsemanSprite],
+      ['infantry', MachineGunnerSprite],
+      ['artillery', CannonSprite],
+      ['marine', RiflemanSprite],
+      ['cyber_unit', SpyHackerSprite],
+    ];
+    for (const [type, donorFn] of replacements) {
+      const actual = UNIT_SPRITE_CATALOG[type]({ palette, svgOnly: true });
+      const donor = donorFn({ palette, svgOnly: true });
+      expect(actual, `${type} still renders identically to its old donor sprite`).not.toBe(donor);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Gives `chariot`, `infantry`, `artillery`, `marine`, and `cyber_unit` their own bespoke sprite in `src/renderer/sprites/units.tsx`, instead of silently rendering another unit's exact art (they previously aliased `HorsemanSprite`, `MachineGunnerSprite`, `CannonSprite`, `RiflemanSprite`, and `SpyHackerSprite` respectively — same silhouette, not just similar).
- Adds [`scripts/audit-sprite-aliases.mjs`](scripts/audit-sprite-aliases.mjs), a repeatable, order-independent script that statically re-derives the alias list from `sprite-catalog.ts` (function-name vs. unit-id convention mismatch) — run before starting any future batch to catch drift.
- Adds a CI-enforced regression baseline in `tests/renderer/sprites/sprite-catalog.test.ts` (`describe('#769 pending sprite-alias audit baseline', ...)`) that asserts each still-aliased unit renders byte-identical to its donor; a row is deleted the moment its batch ships real art, which is the mechanical proof of completion (not a prose checkbox).

## Scope reconciliation (found mid-batch)

While preparing this batch, the audit surfaced two things worth recording:

1. **Issue overlap**: pre-existing issue #708 (part of the larger #547 combat-roster initiative) already owned `chariot`'s bespoke-sprite work, with its own design doc and implementation plan, before #769 was filed. Resolved: `chariot` ships here (folding in that slice of #708's scope, #708's comment updated); `beast_handler`/`war_elephant`/`cuirassier` remain #708's alone and were removed from #769's plan.
2. **Concurrent drift**: two new aliased units (`cuirassier`, `armored_car`) landed on `main` from the same #547 initiative while this batch was in flight — exactly the scenario the new audit script exists to catch. They're out of #769's scope (owned by #708 and #709 respectively) and are explicitly excluded from the regression baseline with a comment explaining why.

Issue #769's body and #708 were both updated to reflect this.

## Test plan

- [x] `yarn build` — clean, no type errors
- [x] `yarn test` — full suite, 7271 passed / 3 skipped, 439 files
- [x] `scripts/audit-sprite-aliases.mjs` — reports 14 remaining aliases (down from 19 after rebasing onto main's 10 new commits), matching the doc/issue's stated numbers
- [x] Visually verified all 5 new sprites render distinct SVG markup from their old donors (published comparison as a private Artifact and reviewed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)