### PR TITLE
feat(sprites): #769 batch 2 de-alias (frigate/destroyer/merchant_wagon) + work-state animation fix

### DIFF
--- a/docs/claude-design-sprites-prompt.md
+++ b/docs/claude-design-sprites-prompt.md
@@ -1,9 +1,11 @@
 # Claude Design Prompt: Conquestoria Sprites
 
-**This file has no active prompt right now.** The last one — #769 batch 1 (real, distinct
-live-catalog sprites for `chariot`, `infantry`, `artillery`, `marine`, `cyber_unit`) — shipped
-2026-08-01. All 5 now render their own bespoke `units.tsx` sprite function instead of aliasing
-another unit's exact art.
+**This file has no active prompt right now.** The last one — #769 batch 2 (real, distinct
+live-catalog sprites for `frigate`, `destroyer`, `merchant_wagon`, drafted 2026-08-01 as
+[issue #775](https://github.com/a1flecke/conquestoria/issues/775)) — shipped 2026-08-01. All 3
+now render their own bespoke `units.tsx` sprite function instead of aliasing another unit's exact
+art. The prior batch — #769 batch 1 (`chariot`, `infantry`, `artillery`, `marine`, `cyber_unit`)
+— shipped 2026-08-01 in PR #773 (merged).
 
 ## Durable note: check for other issues owning the same units before scoping a batch
 
@@ -31,34 +33,33 @@ during the same reconciliation) belongs to issue #709, also not #769.
 
 ## Audit before starting every batch
 
-Two new aliases (`cuirassier`, `armored_car`) landed on `main` between batch 1 being filed and
-batch 1 shipping — added by a separate, actively-landing automated initiative (issue #547). This
-is exactly the drift this audit step exists to catch:
-
 ```bash
 bash scripts/run-with-mise.sh yarn node scripts/audit-sprite-aliases.mjs
 ```
 
 This re-derives the alias list directly from `sprite-catalog.ts` (not from this doc or any issue
-body) and exits non-zero while any alias remains. Cross-check its output against:
+body) and exits non-zero while any alias remains. As of batch 2 shipping (2026-08-01) it reports
+11 total: 7 remaining in #769's scope (batch 3's 5, batch 4's 2), plus `beast_handler`/
+`war_elephant`/`cuirassier` (owned by #708) and `armored_car` (owned by #709). Cross-check its
+output against:
 - `tests/renderer/sprites/sprite-catalog.test.ts` → `describe('#769 pending sprite-alias audit
-  baseline', ...)` — the mechanically-enforced remaining-scope list for #769 specifically (10
-  units as of 2026-08-01, batch 1 shipped, beast_handler/war_elephant/cuirassier/armored_car
-  excluded as described above). A unit is only "done" when its row is deleted here — that
-  deletion is the proof, not a checkbox in prose.
+  baseline', ...)` — the mechanically-enforced remaining-scope list for #769 specifically. A unit
+  is only "done" when its row is deleted here — that deletion is the proof, not a checkbox in prose.
 - Issue #769's body, for the batch grouping of whatever's left.
 
 If the audit reports a unit not in either place, don't assume it's #769's — check for another
 owning issue first (see "Durable note" above), then update both the baseline test and #769's plan
 in the same PR.
 
+---
+
 ## When a new sprite/terrain/prompt need comes up
 
 Use the `.claude/skills/generate-sprite-prompt.md` skill for live-catalog (`units.tsx`/
 `buildings.tsx`) sprites, or hand-write a v2-native prompt (see git history for #759 batch 1's
 prompt as a template) for animation-hook rigging work. Append the new prompt to this file the same
-way every prior prompt was — dated, scoped to the specific issue — and prune it back out once
-shipped rather than leaving it to accumulate. Everything that has ever lived in this file (economy
-sprites, terrain tiles, naval transports, legendary beasts, rail segments, both Era 13 batches,
-#759 batch 1, #769 batch 1) was pruned the same way, verified against actual source each time
+way this one was — dated, scoped to the specific issue — and prune it back out once shipped rather
+than leaving it to accumulate. Everything that has ever lived in this file (economy sprites,
+terrain tiles, naval transports, legendary beasts, rail segments, both Era 13 batches, #759 batch
+1, #769 batch 1, #769 batch 2) was pruned the same way, verified against actual source each time
 before removal — the history is in git, not preserved here.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1921,6 +1921,7 @@ export interface GameEvents {
   'advisor:message': { advisor: AdvisorType; message: string; icon: string; tone?: CouncilCallbackTone; memoryKey?: string };
   'trade:route-created': { route: TradeRoute };
   'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' | 'trips-exhausted' | 'unit-captured' };
+  'trade:route-delivered': { unitId: string; routeId: string; toCityId: string };
   'trade:price-changed': { resource: ResourceType; oldPrice: number; newPrice: number };
   'wonder:discovered': { civId: string; wonderId: string; position: HexCoord; isFirstDiscoverer: boolean };
   'wonder:eruption': { wonderId: string; position: HexCoord; tilesAffected: HexCoord[] };

--- a/src/main.ts
+++ b/src/main.ts
@@ -4564,6 +4564,10 @@ bus.on('combat:resolved', event => {
   });
 });
 
+bus.on('trade:route-delivered', ({ unitId }) => {
+  renderLoop.applyDeliveryVisual(unitId);
+});
+
 bus.on('combat:reward-earned', ({ reward }) => {
   routeCombatRewardEarned(gameState, reward, appendToCivLog);
 });

--- a/src/renderer/pirate-sprite-state.ts
+++ b/src/renderer/pirate-sprite-state.ts
@@ -1,6 +1,6 @@
 import type { PirateBehavior } from '@/core/pirate-state';
 
-export type PirateSpriteState = 'idle' | 'walk' | 'attack' | 'hurt' | 'death';
+export type PirateSpriteState = 'idle' | 'walk' | 'attack' | 'hurt' | 'death' | 'work';
 export type PirateSpriteMode = 'patrol' | 'raid' | 'blockade' | 'relocating';
 
 export interface PirateSpriteVisualState {
@@ -23,6 +23,7 @@ export type PirateSpriteVisualEvent =
   | { type: 'destroyed'; entityId: string }
   | { type: 'attack'; entityId: string }
   | { type: 'hurt'; entityId: string }
+  | { type: 'work'; entityId: string }
   | { type: 'relocation-started'; entityId: string }
   | { type: 'relocation-finished'; entityId: string };
 
@@ -30,6 +31,10 @@ type PersistentVisualState = Omit<PirateSpriteVisualState, 'state' | 'expiresAtM
 
 const COMBAT_STATE_MS = 420;
 const DEATH_STATE_MS = 1_200;
+// A brief "just performed its civilian action" pulse (e.g. a trade unit delivering
+// goods) -- long enough to see the cq-deliver/cq-work-bob loop play at least once
+// (their keyframes run ~1.1s), matching COMBAT_STATE_MS's role for attack/hurt.
+const WORK_STATE_MS = 1_400;
 
 interface TransientState {
   state: PirateSpriteState;
@@ -86,6 +91,9 @@ export class PirateSpriteStateController {
       case 'attack':
       case 'hurt':
         this.transients.set(event.entityId, { state: event.type, expiresAtMs: nowMs + COMBAT_STATE_MS });
+        return;
+      case 'work':
+        this.transients.set(event.entityId, { state: 'work', expiresAtMs: nowMs + WORK_STATE_MS });
         return;
       case 'relocation-started':
         this.transients.set(event.entityId, { state: 'walk', mode: 'relocating' });

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -114,13 +114,17 @@ export function buildUnitEntities(
     // everyone else so the transient doesn't just expire unread.
     const combatState = visual?.state
       ?? pirateSpriteState.resolveTransientState(presentation.leadUnitId, nowMs);
+    // A unit mid-way through a multi-turn improvement build shows a sustained "work" pose
+    // (matching cq-work-bob/.cq-tool's infinite loop) whenever nothing more urgent (an
+    // active combat transient) is already claiming its state -- combat always wins.
+    const entityState = combatState === 'idle' && presentation.leadUnit.workerTask ? 'work' as const : combatState;
     return {
       id: presentation.leadUnitId,
       memberIds: presentation.memberIds,
       kind: 'unit' as const,
       subtype: presentation.leadUnit.type,
       coord: presentation.coord,
-      state: combatState,
+      state: entityState,
       faction: presentation.faction,
       damage: visual?.damage ?? presentation.damage,
       stackCount: presentation.stackCount,
@@ -295,6 +299,13 @@ export class RenderLoop {
 
   setSelectedPirateFactionId(factionId: string | null): void {
     this.selectedPirateFactionId = factionId;
+  }
+
+  /** Brief "work" pulse for a unit that just performed its civilian action (e.g. a
+   * trade-line unit delivering goods on route arrival) -- same transient mechanism
+   * as applyCombatVisual's attack/hurt, just a different trigger. */
+  applyDeliveryVisual(unitId: string, nowMs = performance.now()): void {
+    this.pirateSpriteState.apply({ type: 'work', entityId: unitId }, nowMs);
   }
 
   applyCombatVisual(result: CombatResult, nowMs = performance.now()): void {

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -43,7 +43,7 @@ export interface SpriteEntity {
    * v2 animation state — NOT the same as UnitMotionState ('move-a' | 'move-b').
    * RenderLoop translates: 'move-a' | 'move-b' → 'walk'.
    */
-  state:   'idle' | 'walk' | 'attack' | 'hurt' | 'death';
+  state:   'idle' | 'walk' | 'attack' | 'hurt' | 'death' | 'work';
   /** Sprite palette name derived from owner's civType via civTypeToFaction() — e.g. 'imperials', 'pharaohs', 'vikings'. */
   faction: string;
   /**

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -18,6 +18,7 @@ import {
   CaravanSprite, ExpeditionSprite,
   CarrackSprite, GalleonSprite, SteamshipSprite, TroopTransportSprite,
   NavalTraderSprite, SteamshipTraderSprite, CargoFreighterSprite, ContainerShipSprite,
+  FrigateSprite, DestroyerSprite, MerchantWagonSprite,
 } from './units';
 import {
   GranarySprite, HerbalistSprite, AqueductSprite,
@@ -286,11 +287,10 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   grenadier:      withMotion('grenadier', GrenadierSprite),
   marine:         withMotion('marine', MarineSprite),
   rifleman:       withMotion('rifleman', RiflemanSprite),
-  // frigate/destroyer reuse existing hulls as placeholders (same pattern as stealth_bomber
-  // reusing JetFighterSprite below); bespoke sprites are a generate-sprite-prompt follow-up.
-  frigate:           withMotion('frigate', TriremeSprite),
+  // frigate/destroyer de-aliased in #769 batch 2.
+  frigate:           withMotion('frigate', FrigateSprite),
   ironclad:          withMotion('ironclad', IroncladSprite),
-  destroyer:         withMotion('destroyer', IroncladSprite),
+  destroyer:         withMotion('destroyer', DestroyerSprite),
   machine_gunner:    withMotion('machine_gunner', MachineGunnerSprite),
   infantry:          withMotion('infantry', InfantrySprite),
   pre_dreadnought:   withMotion('pre_dreadnought', PreDreadnoughtSprite),
@@ -315,8 +315,10 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   drone_controller: withMotion('drone_controller', DroneControllerSprite),
   caravan:           withMotion('caravan', CaravanSprite),
   // Trade Routes Overhaul (#553 MR2/4) — Land trade line successors to Caravan.
-  // Placeholder: reuses CaravanSprite (closest silhouette) until bespoke sprites ship.
-  merchant_wagon:    withMotion('merchant_wagon', CaravanSprite),
+  // merchant_wagon de-aliased in #769 batch 2.
+  merchant_wagon:    withMotion('merchant_wagon', MerchantWagonSprite),
+  // freight_convoy still a placeholder reusing CaravanSprite — out of scope for #769 batch 2,
+  // remains #769 batch 3's to de-alias.
   freight_convoy:    withMotion('freight_convoy', CaravanSprite),
   // Trade Routes Overhaul (#553 MR1/4) — Naval Trader line, bespoke sprites
   naval_trader:      withMotion('naval_trader', NavalTraderSprite),

--- a/src/renderer/sprites/units.tsx
+++ b/src/renderer/sprites/units.tsx
@@ -41,11 +41,19 @@ export function WorkerSprite({ palette, svgOnly = false }: UnitSpriteProps): str
       <Humanoid cx={64} cy={70} scale={1} cloth={P.cloth.tunic} pants={P.cloth.wool} accent={palette.mid} hair="#5a3a20"
         hat={<ellipse cx="0" cy="-40" rx="12" ry="3" fill={P.thatch.straw} stroke={P.ink.line} strokeWidth="0.6" />}
       />
+      {/* PICKAXE over the right shoulder — .cq-tool digs down on the work action,
+         grip pivot at (82,30). NOT .cq-weapon: civilians never do a combat swing. */}
       <g transform="translate(82 30) rotate(28)">
-        <rect x="-1" y="0" width="2.4" height="46" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.6" />
-        <path d="M-5,46 L5,46 L4,58 L-4,58 Z" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.8" />
+        <g className="cq-tool" style="transform-origin: 82px 30px; transform-box: view-box;">
+          <rect x="-1" y="0" width="2.4" height="46" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.6" />
+          <path d="M-5,46 L5,46 L4,58 L-4,58 Z" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.8" />
+        </g>
       </g>
+      {/* dirt mound where the pick strikes; dust kicked up on the work action (.cq-work-dust) */}
       <rect x="58" y="74" width="8" height="6" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.5" />
+      <g className="cq-work-dust">
+        <ellipse cx="62" cy="76" rx="6" ry="2.6" fill={P.ground.dirt} />
+      </g>
     </SpriteFrame>
   );
 }

--- a/src/renderer/sprites/units.tsx
+++ b/src/renderer/sprites/units.tsx
@@ -349,6 +349,69 @@ export function TriremeSprite({ palette, svgOnly = false }: UnitSpriteProps): st
   );
 }
 
+// #769 de-alias: frigate previously reused TriremeSprite verbatim. Frigate is an
+// era-6 age-of-sail warship — three-masted, square-rigged, with a painted gunport
+// stripe and cannon along the hull and a bowsprit at the bow, so it reads as a real
+// sailing warship rather than an ancient oared galley.
+export function FrigateSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly} hexTint={P.ground.water}>
+      <g data-kind="naval">
+        <Shadow cx={64} cy={100} rx={48} ry={7} />
+        {/* BOWSPRIT — spar projecting forward from the bow (left); a jib sail
+            rides it. A silhouette element the Trireme does not have. */}
+        <line x1="18" y1="84" x2="-2" y2="70" stroke={P.wood.dark} strokeWidth="2.4" strokeLinecap="round" />
+        <line x1="1" y1="70" x2="40" y2="26" stroke={P.wood.dark} strokeWidth="0.8" opacity="0.7" />
+        <path className="cq-sail" d="M2,71 L28,50 L15,79 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="0.8" />
+        {/* HULL — a real sailing hull, no oar rows / oar blades */}
+        <path d="M14,86 Q64,78 114,84 Q112,104 64,106 Q18,104 14,86 Z" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1.2" />
+        <path d="M20,82 Q64,76 110,82 L106,92 Q64,97 24,92 Z" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="1" />
+        <path d="M18,90 Q64,96 110,90" fill="none" stroke={P.wood.dark} strokeWidth="1" opacity="0.6" />
+        {/* painted GUNPORT STRIPE — faction-accent band */}
+        <rect x="24" y="83.5" width="84" height="6" fill={palette.mid} opacity="0.9" />
+        {/* gunports — alternating dark squares */}
+        <rect x="30" y="84" width="5" height="5" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.5" />
+        <rect x="42" y="84" width="5" height="5" fill={P.ink.line} />
+        <rect x="54" y="84" width="5" height="5" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.5" />
+        <rect x="66" y="84" width="5" height="5" fill={P.ink.line} />
+        <rect x="78" y="84" width="5" height="5" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.5" />
+        <rect x="90" y="84" width="5" height="5" fill={P.ink.line} />
+        {/* cannon barrel tips (iron) poking through the ports */}
+        <rect x="33" y="88.6" width="4" height="2.4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        <rect x="49" y="88.9" width="4" height="2.4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        <rect x="65" y="89" width="4" height="2.4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        <rect x="81" y="88.9" width="4" height="2.4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        <rect x="97" y="88.6" width="4" height="2.4" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        {/* THREE MASTS — fore, main (tallest), mizzen */}
+        <line x1="40" y1="82" x2="40" y2="24" stroke={P.wood.dark} strokeWidth="2.2" />
+        <line x1="64" y1="82" x2="64" y2="12" stroke={P.wood.dark} strokeWidth="2.5" />
+        <line x1="88" y1="80" x2="88" y2="30" stroke={P.wood.dark} strokeWidth="2" />
+        {/* yards */}
+        <line x1="28" y1="30" x2="52" y2="30" stroke={P.wood.dark} strokeWidth="1.6" strokeLinecap="round" />
+        <line x1="49" y1="20" x2="79" y2="20" stroke={P.wood.dark} strokeWidth="1.8" strokeLinecap="round" />
+        <line x1="78" y1="38" x2="98" y2="38" stroke={P.wood.dark} strokeWidth="1.5" strokeLinecap="round" />
+        {/* SQUARE-RIGGED SAILS — cq-sail billow, mainmast tallest */}
+        <path className="cq-sail" d="M28,31 Q40,34 52,31 L50,58 Q40,61 30,58 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="1" />
+        <path className="cq-sail" d="M49,21 Q64,26 79,21 L76,62 Q64,66 52,62 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="1" />
+        <path className="cq-sail" d="M78,39 Q88,41 98,39 L96,60 Q88,63 80,60 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="1" />
+        {/* faction reef-band across the mainsail */}
+        <path d="M51,40 Q64,44 77,40 L76,50 Q64,54 52,50 Z" fill={palette.mid} opacity="0.85" />
+        {/* raised QUARTERDECK at the stern (right) */}
+        <path d="M97,72 L116,74 L114,84 L99,82 Z" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="1" />
+        <path d="M97,72 L116,74 L116,76 L97,74 Z" fill={P.wood.mid} />
+        <line x1="99" y1="74" x2="114" y2="76" stroke={P.ink.soft} strokeWidth="0.6" opacity="0.5" />
+        {/* faction Banner mounted on the quarterdeck */}
+        <Banner x={101} y={72} palette={palette} scale={0.8} />
+        {/* stern ENSIGN — spanker gaff off the mizzen, palette.trim, cq-cape flutter */}
+        <line x1="88" y1="34" x2="104" y2="44" stroke={P.wood.dark} strokeWidth="1.2" />
+        <path className="cq-cape" d="M88,40 L104,44 L102,52 L88,49 Z" fill={palette.trim} stroke={palette.dark} strokeWidth="0.6" />
+        {/* bronze cathead at the prow (left) */}
+        <path d="M14,88 L4,92 L14,95 Z" fill={P.metal.bronze} stroke={P.ink.line} strokeWidth="0.6" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
 export function TransportSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
   return (
     <SpriteFrame svgOnly={svgOnly} hexTint={P.ground.water}>
@@ -1588,6 +1651,68 @@ export function IroncladSprite({ palette, svgOnly = false }: UnitSpriteProps): s
   );
 }
 
+// #769 de-alias: destroyer previously reused IroncladSprite verbatim. Destroyer is
+// an era-10 modern warship — long, low, lean welded-steel hull, enclosed forward gun
+// turret, radar lattice mast, and torpedo tubes, so it reads as decades past the
+// riveted, boxy Ironclad rather than a recolor of it.
+export function DestroyerSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly} hexTint={P.ground.water}>
+      <g data-kind="naval">
+        <Shadow cx={64} cy={100} rx={52} ry={6.5} />
+        {/* HULL — long, low, lean with real freeboard; smooth welded plating,
+            a continuous deck edge at ~y80 (no rivet lines) */}
+        <path d="M6,84 L114,79 Q123,84 121,92 L116,99 L20,100 Q7,98 6,89 Z" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1.2" />
+        <path d="M12,82 L112,78 L109,82 L15,85 Z" fill={P.metal.iron} />
+        <path d="M9,93 Q64,98 118,92" fill="none" stroke={P.metal.iron} strokeWidth="2.4" opacity="0.7" />
+        {/* faction pennant-number stripe near the bow */}
+        <rect x="20" y="86" width="18" height="3.2" fill={palette.mid} />
+        <rect x="24" y="86.6" width="2" height="2" fill={palette.trim} />
+        <rect x="29" y="86.6" width="2" height="2" fill={palette.trim} />
+        {/* continuous 01-DECK — the base every superstructure fitting mounts on */}
+        <path d="M28,72 L102,72 L100,80 L30,80 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.9" />
+        <rect x="30" y="72" width="70" height="1.6" fill={P.metal.steel} />
+        {/* forward enclosed GUN TURRET on the foredeck, barrel over the bow */}
+        <rect x="20" y="73" width="15" height="7" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+        <path d="M20,73 Q27.5,67 35,73 Z" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.9" />
+        <rect x="6" y="74.6" width="16" height="2.8" rx="1.2" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        {/* BRIDGE superstructure on the 01-deck */}
+        <rect x="48" y="58" width="20" height="14" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1" />
+        <rect x="52" y="51" width="12" height="7" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="0.8" />
+        <rect x="50" y="61" width="16" height="2.4" fill={P.ink.line} opacity="0.75" />
+        <rect x="53" y="53" width="10" height="2" fill={P.ink.line} opacity="0.6" />
+        {/* RADAR LATTICE MAST rising from the bridge top */}
+        <line x1="58" y1="51" x2="58" y2="30" stroke={P.metal.iron} strokeWidth="1.6" />
+        <path d="M54,50 L62,43 M62,50 L54,43 M54,43 L62,36 M62,43 L54,36 M55,36 L61,31" fill="none" stroke={P.metal.iron} strokeWidth="0.7" />
+        <rect x="50" y="29" width="16" height="2.2" rx="1" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.4" />
+        <circle cx="58" cy="26" r="1.6" fill={palette.bright} />
+        {/* single thin raked FUNNEL, base flush with the 01-deck */}
+        <path d="M74,72 L82,72 L86,55 L80,55 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+        <path d="M80,55 L86,55 L86.6,52 L80.6,52 Z" fill={P.metal.bronze} stroke={P.ink.line} strokeWidth="0.4" />
+        {/* turbine exhaust — cq-smoke wisp */}
+        <g transform="translate(83 51)">
+          <ellipse className="cq-smoke" cx="0" cy="0" rx="4" ry="3" fill={P.stone.light} opacity="0.6" />
+          <ellipse className="cq-smoke cq-smoke--b" cx="2" cy="-1" rx="5" ry="4" fill={P.stone.mid} opacity="0.4" />
+          <ellipse className="cq-smoke cq-smoke--c" cx="-1" cy="0" rx="3" ry="2.4" fill={P.stone.light} opacity="0.5" />
+        </g>
+        {/* angled TORPEDO TUBES resting on the 01-deck, aft */}
+        <g transform="translate(93 73)">
+          <rect x="-9" y="0" width="20" height="2.6" rx="1.3" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.5" />
+          <rect x="-9" y="3" width="20" height="2.6" rx="1.3" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.5" />
+          <circle cx="11" cy="1.3" r="1" fill={P.ink.line} />
+          <circle cx="11" cy="4.3" r="1" fill={P.ink.line} />
+        </g>
+        {/* faction Banner on a short jackstaff, base on the foredeck */}
+        <Banner x={39} y={72} palette={palette} scale={0.5} />
+        {/* stern ENSIGN — staff rises from the deck, flag hugging the staff
+            (palette.trim, cq-cape flutter) */}
+        <line x1="110" y1="80" x2="110" y2="62" stroke={P.metal.iron} strokeWidth="1.4" />
+        <path className="cq-cape" d="M110,63 L122,66 L116,70 L121,74 L110,73 Z" fill={palette.trim} stroke={palette.dark} strokeWidth="0.5" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
 /* === CARAVAN === */
 
 export function CaravanSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
@@ -1643,6 +1768,101 @@ export function CaravanSprite({ palette, svgOnly = false }: UnitSpriteProps): st
         <ellipse cx="24" cy="90" rx="4.5" ry="1.8" fill={P.metal.gold} stroke={P.ink.line} strokeWidth="0.5" />
         <ellipse cx="24" cy="87.8" rx="4.5" ry="1.8" fill="#e8c64a" stroke={P.ink.line} strokeWidth="0.5" />
         <ellipse cx="34" cy="91" rx="3.4" ry="1.4" fill={P.metal.gold} stroke={P.ink.line} strokeWidth="0.4" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
+// #769 de-alias: merchant_wagon previously reused CaravanSprite verbatim. Merchant
+// Wagon is the wheeled successor to the walking pack-donkey Caravan — two large
+// spoked wheels (the silhouette Caravan lacks entirely), a harnessed draft horse
+// pulling ahead of the cart, and a driver seated on a raised bench holding the reins
+// instead of walking alongside.
+export function MerchantWagonSprite({ palette, svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-kind="civilian">
+        <Shadow cx={62} cy={96} rx={46} ry={6} />
+        {/* DRAFT HORSE in harness, ahead of the cart (right), pulling forward */}
+        <g transform="translate(94 60)">
+          <rect x="-7" y="14" width="4.5" height="21" fill="#6b4f2f" stroke={P.ink.line} strokeWidth="0.5" />
+          <rect x="9" y="14" width="4.5" height="21" fill="#6b4f2f" stroke={P.ink.line} strokeWidth="0.5" />
+          <path d="M-17,-1 Q-24,5 -22,17 L-18,16 Q-19,6 -14,1 Z" fill="#4a341c" stroke={P.ink.line} strokeWidth="0.5" />
+          <ellipse cx="0" cy="4" rx="18" ry="11" fill="#7a5a34" stroke={P.ink.line} strokeWidth="1" />
+          <ellipse cx="-1" cy="1" rx="16" ry="7" fill="#8a6a3a" />
+          <path d="M13,-1 Q21,-9 21,-17 L15,-19 Q9,-9 7,-2 Z" fill="#7a5a34" stroke={P.ink.line} strokeWidth="1" />
+          <path d="M16,-17 Q25,-21 28,-16 L26,-6 Q19,-6 15,-11 Z" fill="#7a5a34" stroke={P.ink.line} strokeWidth="1" />
+          <ellipse cx="27" cy="-12" rx="3.6" ry="2.6" fill="#8a6a3a" stroke={P.ink.line} strokeWidth="0.6" />
+          <circle cx="25" cy="-14" r="0.8" fill={P.ink.line} />
+          <path d="M15,-18 L16,-24 L20,-19 Z" fill="#6b4f2f" stroke={P.ink.line} strokeWidth="0.5" />
+          <path d="M11,-14 Q15,-21 20,-19 Q14,-10 13,-1 Z" fill="#4a341c" />
+          <rect x="-3" y="14" width="5" height="22" fill="#7a5a34" stroke={P.ink.line} strokeWidth="0.6" />
+          <rect x="7" y="14" width="5" height="22" fill="#7a5a34" stroke={P.ink.line} strokeWidth="0.6" />
+          <ellipse cx="-0.5" cy="36" rx="3" ry="1.6" fill="#3a2a18" />
+          <ellipse cx="9.5" cy="36" rx="3" ry="1.6" fill="#3a2a18" />
+          {/* harness collar — faction accent */}
+          <path d="M9,-2 Q15,-7 16,-15" fill="none" stroke={palette.mid} strokeWidth="2.6" />
+        </g>
+        {/* harness traces / draw-shaft linking horse to cart */}
+        <line x1="76" y1="70" x2="90" y2="62" stroke={P.wood.dark} strokeWidth="1.8" />
+        <line x1="76" y1="76" x2="92" y2="68" stroke={P.wood.dark} strokeWidth="1.8" />
+        {/* wooden AXLE / undercarriage */}
+        <rect x="24" y="80" width="48" height="3.6" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.5" />
+        {/* two large spoked WHEELS (wood.dark rims) — Caravan has none */}
+        <g transform="translate(30 82)">
+          <circle r="13" fill="none" stroke={P.wood.dark} strokeWidth="3.4" />
+          <circle r="10" fill="none" stroke={P.wood.dark} strokeWidth="1" />
+          <line x1="-12" y1="0" x2="12" y2="0" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="0" y1="-12" x2="0" y2="12" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="-8.5" y1="-8.5" x2="8.5" y2="8.5" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="-8.5" y1="8.5" x2="8.5" y2="-8.5" stroke={P.wood.dark} strokeWidth="1.4" />
+          <circle r="2.6" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.6" />
+        </g>
+        <g transform="translate(66 82)">
+          <circle r="13" fill="none" stroke={P.wood.dark} strokeWidth="3.4" />
+          <circle r="10" fill="none" stroke={P.wood.dark} strokeWidth="1" />
+          <line x1="-12" y1="0" x2="12" y2="0" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="0" y1="-12" x2="0" y2="12" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="-8.5" y1="-8.5" x2="8.5" y2="8.5" stroke={P.wood.dark} strokeWidth="1.4" />
+          <line x1="-8.5" y1="8.5" x2="8.5" y2="-8.5" stroke={P.wood.dark} strokeWidth="1.4" />
+          <circle r="2.6" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.6" />
+        </g>
+        {/* CART BODY */}
+        <path d="M18,79 L74,79 L72,58 L22,58 Z" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="1" />
+        <path d="M22,58 L72,58 L72,62 L22,62 Z" fill={P.wood.light} />
+        <line x1="20" y1="71" x2="73" y2="71" stroke={P.wood.dark} strokeWidth="0.6" opacity="0.6" />
+        <line x1="34" y1="62" x2="33" y2="79" stroke={P.wood.dark} strokeWidth="0.5" opacity="0.5" />
+        <line x1="48" y1="62" x2="48" y2="79" stroke={P.wood.dark} strokeWidth="0.5" opacity="0.5" />
+        <line x1="60" y1="62" x2="61" y2="79" stroke={P.wood.dark} strokeWidth="0.5" opacity="0.5" />
+        {/* CARGO BED — crates (wood.light) + linen sack: 3 stacked shapes */}
+        <rect x="26" y="46" width="15" height="14" fill={P.wood.light} stroke={P.ink.line} strokeWidth="0.8" />
+        <path d="M26,52 H41 M33.5,46 V60" stroke={P.wood.dark} strokeWidth="0.6" opacity="0.7" />
+        <rect x="42" y="44" width="13" height="16" fill={P.wood.light} stroke={P.ink.line} strokeWidth="0.8" />
+        <path d="M42,52 H55 M48.5,44 V60" stroke={P.wood.dark} strokeWidth="0.6" opacity="0.7" />
+        <path d="M56,60 L56,52 Q56,45 63,45 Q70,45 70,52 L70,60 Z" fill={P.cloth.linen} stroke={P.ink.line} strokeWidth="0.8" />
+        <path d="M60,45 Q63,49 66,45" fill="none" stroke={P.ink.soft} strokeWidth="0.5" opacity="0.6" />
+        {/* WORK = delivering goods: coin glint at the cargo bed (.cq-deliver) */}
+        <g className="cq-deliver">
+          <ellipse cx="47" cy="40" rx="4.5" ry="1.8" fill={P.metal.gold} stroke={P.ink.line} strokeWidth="0.5" />
+          <ellipse cx="47" cy="37.8" rx="4.5" ry="1.8" fill="#e8c64a" stroke={P.ink.line} strokeWidth="0.5" />
+          <ellipse cx="55" cy="41" rx="3.2" ry="1.4" fill={P.metal.gold} stroke={P.ink.line} strokeWidth="0.4" />
+        </g>
+        {/* DRIVER'S BENCH raised at the front */}
+        <rect x="65" y="52" width="11" height="6" fill={P.wood.dark} stroke={P.ink.line} strokeWidth="0.8" />
+        {/* DRIVER seated on the bench, holding the reins */}
+        <g transform="translate(69 44)">
+          <path d="M0,4 L9,7 L9,10 L1,10 Z" fill={P.cloth.wool} stroke={P.ink.line} strokeWidth="0.5" />
+          <path d="M-3,-8 Q4,-10 6,-3 L5,6 L-4,6 Z" fill={P.cloth.tunic} stroke={P.ink.line} strokeWidth="0.8" />
+          <path d="M-3,-6 L6,-3" fill="none" stroke={palette.mid} strokeWidth="2" />
+          <path d="M4,-4 Q10,-3 13,0" fill="none" stroke={P.cloth.tunic} strokeWidth="3" strokeLinecap="round" />
+          <circle cx="13.4" cy="0.6" r="1.6" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.5" />
+          <circle cx="0" cy="-13" r="5.4" fill={P.skin.warm} stroke={P.ink.line} strokeWidth="0.8" />
+          <path d="M-7,-15 Q0,-20 7,-15 Q4,-13 0,-13 Q-4,-13 -7,-15 Z" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="0.6" />
+        </g>
+        {/* reins from the driver's hand to the horse's mouth */}
+        <path d="M83,45 Q100,42 119,48" fill="none" stroke="#3a2a18" strokeWidth="1" opacity="0.85" />
+        {/* faction Banner on a short staff at the wagon rear (left) */}
+        <Banner x={20} y={56} palette={palette} scale={0.62} />
       </g>
     </SpriteFrame>
   );

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -438,6 +438,7 @@ function processCaravanArrival(
   bus?: EventBus,
 ): GameState {
   if (arrivedAtToCity) {
+    bus?.emit('trade:route-delivered', { unitId: caravanId, routeId: route.id, toCityId: route.toCityId });
     return {
       ...state,
       units: {

--- a/tests/renderer/pirate-sprite-state.test.ts
+++ b/tests/renderer/pirate-sprite-state.test.ts
@@ -102,4 +102,12 @@ describe('resolveTransientState', () => {
     expect(controller.resolveTransientState('musketeer-2', 1_500)).toBe('death');
     expect(controller.resolveTransientState('musketeer-2', 2_300)).toBe('idle');
   });
+
+  it('supports a work one-shot (e.g. a trade unit delivering goods) that expires back to idle', () => {
+    const controller = new PirateSpriteStateController();
+    controller.apply({ type: 'work', entityId: 'merchant-wagon-1' }, 1_000);
+
+    expect(controller.resolveTransientState('merchant-wagon-1', 1_100)).toBe('work');
+    expect(controller.resolveTransientState('merchant-wagon-1', 1_000 + 10_000)).toBe('idle');
+  });
 });

--- a/tests/renderer/render-loop-combat-sprite-state.test.ts
+++ b/tests/renderer/render-loop-combat-sprite-state.test.ts
@@ -140,3 +140,132 @@ describe('render-loop — non-pirate combat sprite state', () => {
     vi.restoreAllMocks();
   });
 });
+
+describe('render-loop — trade unit delivery sprite state', () => {
+  it('reflects a work data-state for a unit right after applyDeliveryVisual', () => {
+    const { canvas, mount } = createMountedCanvas();
+    const loop = new RenderLoop(canvas);
+
+    const wagon = {
+      id: 'wagon-1', type: 'merchant_wagon', owner: 'player', position: { q: 0, r: 0 },
+      movementPointsLeft: 0, health: 100, experience: 0, hasMoved: false, hasActed: true,
+      isResting: false,
+    } as unknown as Unit;
+
+    loop.setGameState({
+      turn: 5,
+      currentPlayer: 'player',
+      map: { width: 5, height: 5, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      tribalVillages: {},
+      minorCivs: {},
+      cities: {},
+      units: { [wagon.id]: wagon },
+      civilizations: { player: { color: '#4a90d9', visibility: { tiles: { '0,0': 'visible' } } } },
+    } as unknown as GameState);
+    loop.camera.isHexVisible = () => true;
+
+    loop.applyDeliveryVisual(wagon.id);
+    (loop as unknown as { render: () => void }).render();
+
+    const wagonWrap = mount.querySelector(`[data-entity-id="${wagon.id}"]`)?.firstElementChild;
+    expect(wagonWrap?.getAttribute('data-state')).toBe('work');
+  });
+
+  it('returns to idle after the work pulse window expires', () => {
+    const { canvas, mount } = createMountedCanvas();
+    const loop = new RenderLoop(canvas);
+
+    const wagon = {
+      id: 'wagon-1', type: 'merchant_wagon', owner: 'player', position: { q: 0, r: 0 },
+      movementPointsLeft: 0, health: 100, experience: 0, hasMoved: false, hasActed: true,
+      isResting: false,
+    } as unknown as Unit;
+
+    loop.setGameState({
+      turn: 5,
+      currentPlayer: 'player',
+      map: { width: 5, height: 5, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      tribalVillages: {},
+      minorCivs: {},
+      cities: {},
+      units: { [wagon.id]: wagon },
+      civilizations: { player: { color: '#4a90d9', visibility: { tiles: { '0,0': 'visible' } } } },
+    } as unknown as GameState);
+    loop.camera.isHexVisible = () => true;
+
+    const nowMs = 20_000;
+    loop.applyDeliveryVisual(wagon.id, nowMs);
+
+    vi.spyOn(performance, 'now').mockReturnValue(nowMs + 2_000); // past WORK_STATE_MS (1400ms)
+    (loop as unknown as { render: () => void }).render();
+
+    const wagonWrap = mount.querySelector(`[data-entity-id="${wagon.id}"]`)?.firstElementChild;
+    expect(wagonWrap?.getAttribute('data-state')).toBe('idle');
+    vi.restoreAllMocks();
+  });
+});
+
+describe('render-loop — sustained work state for an active workerTask', () => {
+  function buildWorkerState(worker: Unit): GameState {
+    return {
+      turn: 5,
+      currentPlayer: 'player',
+      map: { width: 5, height: 5, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      tribalVillages: {},
+      minorCivs: {},
+      cities: {},
+      units: { [worker.id]: worker },
+      civilizations: { player: { color: '#4a90d9', visibility: { tiles: { '0,0': 'visible' } } } },
+    } as unknown as GameState;
+  }
+
+  it('renders data-state="work" for a unit with an active workerTask and no combat transient', () => {
+    const { canvas, mount } = createMountedCanvas();
+    const loop = new RenderLoop(canvas);
+
+    const worker = {
+      id: 'worker-1', type: 'worker', owner: 'player', position: { q: 0, r: 0 },
+      movementPointsLeft: 0, health: 100, experience: 0, hasMoved: false, hasActed: true,
+      isResting: false,
+      workerTask: { action: 'build-farm', coord: { q: 0, r: 0 } },
+    } as unknown as Unit;
+
+    loop.setGameState(buildWorkerState(worker));
+    loop.camera.isHexVisible = () => true;
+    (loop as unknown as { render: () => void }).render();
+
+    const workerWrap = mount.querySelector(`[data-entity-id="${worker.id}"]`)?.firstElementChild;
+    expect(workerWrap?.getAttribute('data-state')).toBe('work');
+  });
+
+  it('lets an active combat transient take priority over a sustained workerTask', () => {
+    const { canvas, mount } = createMountedCanvas();
+    const loop = new RenderLoop(canvas);
+
+    const worker = {
+      id: 'worker-1', type: 'worker', owner: 'player', position: { q: 0, r: 0 },
+      movementPointsLeft: 0, health: 60, experience: 0, hasMoved: false, hasActed: true,
+      isResting: false,
+      workerTask: { action: 'build-farm', coord: { q: 0, r: 0 } },
+    } as unknown as Unit;
+
+    loop.setGameState(buildWorkerState(worker));
+    loop.camera.isHexVisible = () => true;
+    loop.applyCombatVisual({
+      attackerId: 'enemy-1',
+      defenderId: worker.id,
+      attackerDamage: 0,
+      defenderDamage: 40,
+      attackerSurvived: true,
+      defenderSurvived: true,
+      attackerStrength: 10,
+      defenderStrength: 0,
+      attackerPosition: { q: 1, r: 0 },
+      defenderPosition: worker.position,
+    } as unknown as CombatResult);
+    (loop as unknown as { render: () => void }).render();
+
+    const workerWrap = mount.querySelector(`[data-entity-id="${worker.id}"]`)?.firstElementChild;
+    expect(workerWrap?.getAttribute('data-state')).toBe('hurt');
+  });
+});

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -11,7 +11,7 @@ import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
 import {
   JetFighterSprite, IroncladSprite, MachineGunnerSprite, MissionarySprite, SpyHackerSprite,
   HorsemanSprite, CannonSprite, RiflemanSprite,
-  TriremeSprite, CaravanSprite,
+  TriremeSprite, CaravanSprite, WorkerSprite,
 } from '@/renderer/sprites/units';
 import {
   DataCenterSprite, CyberDefenseCenterSprite, AutomatedPortSprite, SignalsHubSprite,
@@ -295,5 +295,18 @@ describe('every catalog sprite renders without throwing, across multiple faction
         expect(svg!.length, `${id} produced suspiciously short markup for faction color ${civColor}`).toBeGreaterThan(100);
       }
     }
+  });
+});
+
+// A worker with an active workerTask now renders data-state="work" (see render-loop.ts),
+// which drives [data-state="work"] .cq-tool / .cq-work-dust in sprite-animations-v2.css --
+// but only if WorkerSprite's own markup actually carries those classes. ExpeditionSprite's
+// prospecting pickaxe already does this correctly; WorkerSprite's pickaxe didn't.
+describe("WorkerSprite carries the work-action animation hooks", () => {
+  it('has a cq-tool class on its pickaxe and a cq-work-dust element', () => {
+    const palette = derivePalette('#4a90d9');
+    const svg = WorkerSprite({ palette, svgOnly: true });
+    expect(svg, 'WorkerSprite is missing the cq-tool class on its pickaxe').toContain('cq-tool');
+    expect(svg, 'WorkerSprite is missing a cq-work-dust element').toContain('cq-work-dust');
   });
 });

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -11,6 +11,7 @@ import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
 import {
   JetFighterSprite, IroncladSprite, MachineGunnerSprite, MissionarySprite, SpyHackerSprite,
   HorsemanSprite, CannonSprite, RiflemanSprite,
+  TriremeSprite, CaravanSprite,
 } from '@/renderer/sprites/units';
 import {
   DataCenterSprite, CyberDefenseCenterSprite, AutomatedPortSprite, SignalsHubSprite,
@@ -178,6 +179,26 @@ describe('#769 batch 1 sprites are not aliases of their donors', () => {
   });
 });
 
+// #769 batch 2 (naval + logistics, shipped 2026-08-01) — same permanent regression as batch 1
+// above, for frigate/destroyer/merchant_wagon (previously TriremeSprite/IroncladSprite/
+// CaravanSprite verbatim).
+describe('#769 batch 2 sprites are not aliases of their donors', () => {
+  const palette = derivePalette('#4a90d9');
+
+  it('unit sprites render different markup than the donors they replaced', () => {
+    const replacements: Array<[keyof typeof UNIT_SPRITE_CATALOG, (props: { palette: typeof palette; svgOnly: boolean }) => string]> = [
+      ['frigate', TriremeSprite],
+      ['destroyer', IroncladSprite],
+      ['merchant_wagon', CaravanSprite],
+    ];
+    for (const [type, donorFn] of replacements) {
+      const actual = UNIT_SPRITE_CATALOG[type]({ palette, svgOnly: true });
+      const donor = donorFn({ palette, svgOnly: true });
+      expect(actual, `${type} still renders identically to its old donor sprite`).not.toBe(donor);
+    }
+  });
+});
+
 // #769: full audit (2026-08-01, `scripts/audit-sprite-aliases.mjs`) of UNIT_SPRITE_CATALOG
 // originally found 17 units still rendering via another unit's exact sprite function — not
 // similar art, literally the same component (distinct from the Era 13 placeholders above,
@@ -189,6 +210,9 @@ describe('#769 batch 1 sprites are not aliases of their donors', () => {
 // longer listed below. `chariot` also closed out the overlapping portion of pre-existing issue
 // #708's scope that this issue didn't originally know about (see next paragraph) — #708's
 // comment was updated to reflect that.
+//
+// Batch 2 (frigate, destroyer, merchant_wagon) shipped 2026-08-01 (issue #775's Claude Design
+// prompt) and is no longer listed below either — see the permanent regression block above.
 //
 // Reconciled with issue #708 (2026-08-01): #708 is a pre-existing, separately-tracked issue
 // (part of the larger #547 combat-roster initiative) that already owned `beast_handler`,
@@ -216,10 +240,6 @@ describe('#769 pending sprite-alias audit baseline', () => {
 
   it('known-pending aliased units still render identically to their donor unit', () => {
     const pendingAliasPairs: Array<[keyof typeof UNIT_SPRITE_CATALOG, keyof typeof UNIT_SPRITE_CATALOG]> = [
-      // Batch 2 (naval + logistics) — beast_handler/war_elephant removed, owned by #708
-      ['frigate', 'trireme'],
-      ['destroyer', 'ironclad'],
-      ['merchant_wagon', 'caravan'],
       // Batch 3 (logistics + air)
       ['freight_convoy', 'caravan'],
       ['recon_aircraft', 'biplane'],
@@ -230,7 +250,7 @@ describe('#769 pending sprite-alias audit baseline', () => {
       ['global_air_cargo', 'jet_fighter'],
       ['stealth_bomber', 'jet_fighter'],
     ];
-    expect(pendingAliasPairs.length, "baseline count should match #769's remaining scope (17 originally, minus batch 1's 5, minus beast_handler/war_elephant deferred to #708)").toBe(10);
+    expect(pendingAliasPairs.length, "baseline count should match #769's remaining scope (17 originally, minus batch 1's 5, minus batch 2's 3, minus beast_handler/war_elephant deferred to #708)").toBe(7);
     for (const [aliasType, donorType] of pendingAliasPairs) {
       const actual = UNIT_SPRITE_CATALOG[aliasType]({ palette, svgOnly: true, motion: 'idle' });
       const donor = UNIT_SPRITE_CATALOG[donorType]({ palette, svgOnly: true, motion: 'idle' });

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -1228,6 +1228,34 @@ describe('trade-system', () => {
       expect(caravan.tripsRemaining).toBe(3);
     });
 
+    it('emits trade:route-delivered when a route runner arrives at toCityId', () => {
+      const state = makeS6bState({
+        caravanPos: { q: 2, r: 0 },
+        routeDirection: 'outbound',
+        tripsRemaining: 3,
+      });
+      const bus = { emit: vi.fn(), on: vi.fn(), off: vi.fn() } as any;
+      advanceRouteRunners(state, bus);
+
+      expect(bus.emit).toHaveBeenCalledWith('trade:route-delivered', {
+        unitId: 'caravan1',
+        routeId: 'route1',
+        toCityId: 'city2',
+      });
+    });
+
+    it('does not emit trade:route-delivered on the inbound (return) leg', () => {
+      const state = makeS6bState({
+        caravanPos: { q: 0, r: 0 },
+        routeDirection: 'inbound',
+        tripsRemaining: 3,
+      });
+      const bus = { emit: vi.fn(), on: vi.fn(), off: vi.fn() } as any;
+      advanceRouteRunners(state, bus);
+
+      expect(bus.emit).not.toHaveBeenCalledWith('trade:route-delivered', expect.anything());
+    });
+
     it('flips routeDirection to outbound and decrements tripsRemaining on arrival at fromCityId', () => {
       const state = makeS6bState({
         caravanPos: { q: 0, r: 0 },


### PR DESCRIPTION
## Summary

- **#769 batch 2**: gives `frigate`, `destroyer`, and `merchant_wagon` their own bespoke sprites instead of silently rendering another unit's exact art (`TriremeSprite`, `IroncladSprite`, `CaravanSprite` respectively). Sprites authored via Claude Design from the prompt in [issue #775](https://github.com/a1flecke/conquestoria/issues/775), diffed against the repo before integrating, and verified with an independent before/after render (build, tests, and a published comparison artifact).
- **Animation fix (found during review)**: `sprite-animations-v2.css` already had `[data-state="work"]` rules for `.cq-tool` (dig swing), `.cq-work-dust`, and `.cq-deliver` (trade coin-glint), but `SpriteEntity.state` never had a `'work'` value — these animations have been dead code since they were authored, affecting `CaravanSprite`/`MerchantWagonSprite`'s coin-glint and every worker-type unit's dig animation. Wired end-to-end via TDD:
  - Sustained `'work'` state for any unit with an active `workerTask` (combat transients still take priority).
  - Transient `'work'` pulse via a new `trade:route-delivered` event, emitted the moment a trade-route runner arrives at its destination city (not the return leg).
  - Gave `WorkerSprite` the `cq-tool`/`cq-work-dust` markup it was missing (`ExpeditionSprite`'s prospecting pickaxe already had it correctly).

## Test plan

- [x] `yarn build` — clean, 0 errors
- [x] `yarn test` — full suite passing (7318/7318, 3 skipped/unrelated)
- [x] `scripts/audit-sprite-aliases.mjs` baseline shrunk from 14 → 11 (batch 2's 3 removed); permanent regression tests added for both the sprite de-alias (mirrors batch 1's pattern) and the new `'work'` state (RED→GREEN for every step)
- [x] Rebased onto latest `main` post-push; re-ran the alias audit to confirm no regression from concurrent work (found unrelated new drift — `anti_tank_gun`/`wwii_fighter` — flagged on issue #769, not in this PR's scope)
- [x] Visual verification: [before/after comparison artifact](https://claude.ai/code/artifact/020c95c0-8094-45cd-95c3-1d9fb37e5cae) rendered from the actual wired-in repo code

## Out of scope

- `ironclad` and `freight_convoy` are untouched — `freight_convoy` remains batch 3's unit to de-alias.
- The newly-discovered `anti_tank_gun`/`wwii_fighter` aliases are flagged on issue #769 but not scoped into any batch yet — pending a decision on where they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)