### PR TITLE
fix(ui): stop AA overlay toggle overlapping the HUD, gate it on built coverage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/s
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, findPath } from '@/systems/unit-system';
 import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owner-kind';
 import { BUILDINGS, getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
+import { civHasAirDefenseCoverage } from '@/systems/air-defense-system';
 import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
 import { usePropagandistAction } from '@/systems/propagandist-system';
 import { foundCityInState } from '@/systems/city-founding-system';
@@ -366,14 +367,13 @@ const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
 const airDefenseOverlayButton = createGameButton('🛡 Anti-aircraft coverage', 'secondary');
 airDefenseOverlayButton.id = 'btn-air-defense-overlay';
-airDefenseOverlayButton.style.cssText += ';position:absolute;right:12px;top:64px;z-index:12;min-height:44px;';
+airDefenseOverlayButton.hidden = true; // shown once the current civ has built AA coverage — see updateHUD()
 airDefenseOverlayButton.setAttribute('aria-pressed', 'false');
 airDefenseOverlayButton.addEventListener('click', () => {
   const enabled = renderLoop.toggleAirDefenseOverlay();
   airDefenseOverlayButton.setAttribute('aria-pressed', String(enabled));
   airDefenseOverlayButton.textContent = enabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
 });
-uiLayer.appendChild(airDefenseOverlayButton);
 let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
 let legendaryCompletionQueue: ReturnType<typeof createLegendaryWonderCompletionQueue> | null = null;
 
@@ -527,6 +527,16 @@ function createUI(): void {
       });
     },
   });
+
+  // Join the utility toolbar's flex row instead of an independent absolute position —
+  // a second, uncoordinated top-right anchor overlapped the HUD and the toolbar's own
+  // icon buttons (#783).
+  const utilityToolbar = document.getElementById('utility-toolbar');
+  const pauseMenuButton = document.getElementById('btn-pause-menu');
+  if (utilityToolbar) {
+    if (pauseMenuButton) utilityToolbar.insertBefore(airDefenseOverlayButton, pauseMenuButton);
+    else utilityToolbar.appendChild(airDefenseOverlayButton);
+  }
 }
 
 function openBestiary(): void {
@@ -603,12 +613,13 @@ function currentCiv() {
 }
 
 function updateHUD(): void {
+  const civ = currentCiv();
+  airDefenseOverlayButton.hidden = !civHasAirDefenseCoverage(gameState, civ.id);
   const airDefenseEnabled = renderLoop.isAirDefenseOverlayEnabled(gameState.currentPlayer);
   airDefenseOverlayButton.setAttribute('aria-pressed', String(airDefenseEnabled));
   airDefenseOverlayButton.textContent = airDefenseEnabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
   const hud = document.getElementById('hud');
   if (!hud) return;
-  const civ = currentCiv();
 
   // Sum yields across all cities
   let totalFood = 0, totalProd = 0, totalScience = 0;

--- a/src/systems/air-defense-system.ts
+++ b/src/systems/air-defense-system.ts
@@ -25,6 +25,15 @@ function providersForOwner(state: GameState, ownerId: string): ResolvedAirDefens
   });
   return [...cityProviders, ...unitProviders];
 }
+/**
+ * Whether a civ currently has at least one built AA-providing building or unit anywhere
+ * on the map. Deliberately stricter than a tech-unlock check: researching `air-superiority`
+ * alone does not count until the civ actually places a battery or Mobile AA, so the overlay
+ * toggle stays hidden through the (potentially long) gap between unlocking and building one.
+ */
+export function civHasAirDefenseCoverage(state: GameState, civId: string): boolean {
+  return providersForOwner(state, civId).length > 0;
+}
 function providersFor(state: GameState, defender: Unit): ResolvedAirDefenseProvider[] {
   return providersForOwner(state, defender.owner).filter(provider => distance(state, provider.position, defender.position) <= provider.radius);
 }

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -308,3 +308,27 @@ describe('era:advanced notification', () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+describe('air-defense overlay button placement (#783)', () => {
+  it('joins the utility toolbar flex row instead of an independent absolute position', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const createUI = main.slice(main.indexOf('function createUI(): void {'), main.indexOf('function openBestiary('));
+
+    // Regression for #783: this button used to carry its own
+    // `position:absolute;right:12px;top:64px` and land directly on `uiLayer`, which put it
+    // on top of the utility toolbar's own icon buttons and the HUD's turn/era text at the
+    // same screen coordinates. It must not reintroduce a competing absolute anchor.
+    expect(main).not.toMatch(/airDefenseOverlayButton\.style\.cssText[^;]*position:\s*absolute/);
+    expect(createUI).toContain("document.getElementById('utility-toolbar')");
+    expect(createUI).toMatch(/utilityToolbar\.(insertBefore|appendChild)\(airDefenseOverlayButton/);
+  });
+
+  it('only shows the button once the current civ has built AA coverage', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    // Starts hidden so it never flashes visible before the first updateHUD() call.
+    expect(main).toContain('airDefenseOverlayButton.hidden = true;');
+    const updateHud = main.slice(main.indexOf('function updateHUD(): void {'), main.indexOf('\nfunction ', main.indexOf('function updateHUD(): void {') + 1));
+    expect(updateHud).toContain('airDefenseOverlayButton.hidden = !civHasAirDefenseCoverage(gameState, civ.id);');
+  });
+});

--- a/tests/systems/air-defense-system.test.ts
+++ b/tests/systems/air-defense-system.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { GameState, Unit } from '@/core/types';
 import {
+  civHasAirDefenseCoverage,
   getKnownAirDefenseProviders,
   resolveAirDefenseCoverage,
   selectStrongestAirDefenseProviders,
@@ -83,6 +84,36 @@ describe('resolveAirDefenseCoverage', () => {
     } as unknown as GameState['units'];
 
     expect(resolveAirDefenseCoverage(next, { ...defender, position: { q: 2, r: 0 } }, 'defender').flatDefenseModifier).toBe(0);
+  });
+});
+
+describe('civHasAirDefenseCoverage', () => {
+  it('is true for a civ with an Anti-Air Battery already built (#783 follow-up)', () => {
+    expect(civHasAirDefenseCoverage(state(), 'defender')).toBe(true);
+  });
+
+  it('is true for a civ with a Mobile AA unit on the map', () => {
+    const next = state();
+    next.units = {
+      aa: { id: 'aa', owner: 'attacker', type: 'mobile_aa', position: { q: 0, r: 0 } },
+    } as unknown as GameState['units'];
+
+    expect(civHasAirDefenseCoverage(next, 'attacker')).toBe(true);
+  });
+
+  it('is false for a civ with no AA-providing building or unit built', () => {
+    expect(civHasAirDefenseCoverage(state(), 'attacker')).toBe(false);
+  });
+
+  it('stays false for a civ that has researched the unlocking tech but built nothing yet', () => {
+    const next = state();
+    next.civilizations.attacker!.techState.completed = ['air-superiority'];
+
+    expect(civHasAirDefenseCoverage(next, 'attacker')).toBe(false);
+  });
+
+  it('is false for an unknown civ id', () => {
+    expect(civHasAirDefenseCoverage(state(), 'nobody')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- The "🛡 Anti-aircraft coverage" toolbar button carried its own hardcoded `position:absolute;right:12px;top:64px` and was appended directly to `#ui-layer`, landing on top of the utility toolbar's own icon buttons and the HUD's turn/era text at the same screen coordinates. It now joins the toolbar's existing flex row (`insertBefore` the pause-menu button) instead of competing with it.
- The button used to be shown unconditionally regardless of era or tech, which read as evidence of AA capability a civ didn't have. Added `civHasAirDefenseCoverage()` (catalog-driven off the same `airDefenseProvider` flag the coverage resolver itself reads) and wired it into `updateHUD()` so the button stays hidden until the current civ has an Anti-Air Battery or Mobile AA actually built somewhere on the map — not merely the unlocking tech researched.

## Why this is safe to merge
- Purely additive/repositioning UI wiring — no combat math, coverage radius, or stacking-group logic changed. `resolveAirDefenseCoverage`/`selectStrongestAirDefenseProviders` (the actual +8 defense-strength modifier applied against air attackers) are untouched.
- Verified live in-browser: fresh game correctly starts with the button hidden; toolbar DOM order is `next-unit, notif-log, icon-legend, wonder-atlas, pirate-waters, air-defense, pause-menu` with no inline `right:`/`top:` positioning left on the button.

## Test plan
- [x] `tests/main.integration.test.ts` — source-grep regression proving the button is appended into `#utility-toolbar` (not a competing absolute anchor) and that visibility is gated by `civHasAirDefenseCoverage(gameState, civ.id)`.
- [x] `tests/systems/air-defense-system.test.ts` — unit coverage for `civHasAirDefenseCoverage`: true with a built battery, true with a Mobile AA unit, false with neither, false when the tech is researched but nothing is built yet, false for an unknown civ id.
- [x] `yarn test` (439 files, 7362 passed, 3 skipped) and `yarn build` both pass.

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)