### PR TITLE
refactor(save): one authoritative save route — fold main.ts legacy fixups into the versioned pipeline (#787 phase 1)

### DIFF
--- a/.claude/rules/hooks-and-tooling.md
+++ b/.claude/rules/hooks-and-tooling.md
@@ -98,7 +98,7 @@ test filters root-relative (`tests/foo.test.ts`) and cover this contract in
 
 `scripts/run-tests-by-tier.sh` splits the suite into two tiers, to keep the local push gate fast without losing coverage at merge time:
 
-- `yarn test:fast` (`run-tests-by-tier.sh fast`) — excludes the `SLOW_TEST_FILES` list defined in that script (currently: `ai-prepared-turn`, `basic-ai-worker-roads`, `turn-manager-beasts`, `save-load-mass-discovery`, `tech-panel`, `pacing-production-budget`, `pacing-reference-economy`, `start-placement-system`, `world-pressure-fairness`). This is what the local pre-push hook and the Claude Code push-gate hook actually run.
+- `yarn test:fast` (`run-tests-by-tier.sh fast`) — excludes the `SLOW_TEST_FILES` list defined in that script (currently: `ai-prepared-turn`, `basic-ai-worker-roads`, `determinism-guard`, `turn-manager-beasts`, `save-load-mass-discovery`, `tech-panel`, `pacing-production-budget`, `pacing-reference-economy`, `start-placement-system`, `world-pressure-fairness`). This is what the local pre-push hook and the Claude Code push-gate hook actually run.
 - `yarn test:slow` (`run-tests-by-tier.sh slow`) — runs ONLY those files, for a developer working directly on one of those systems.
 - `yarn test` (full, unchanged) — always runs everything. This is what CI's required `test` status check runs; it is never given `--fast`, so slow-tier regressions still block merge, just not every local push.
 

--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -21,7 +21,8 @@
 - **No gameplay change of any kind.** No yields, costs, combat modifiers, tech gating, AI decisions, difficulty scaling, RNG seeding, or victory conditions are touched. `src/systems/`, `src/ai/`, and `src/core/turn-manager.ts` are read-only for this entire plan except where a phase explicitly names a file.
 - No new runtime dependencies.
 - `Math.random()` remains forbidden. `state.currentPlayer` remains the only ownership source. `innerHTML` with game strings remains forbidden.
-- Every phase runs the **determinism guard** (Part V) and the **e2e smoke suite** before merge, not just unit tests.
+- Every phase runs the **determinism guard** (Part V) before merge, not just unit tests. Phases that touch the turn pipeline, difficulty, or campaign entry additionally run `yarn test:ai-playability` and `yarn test:web-smoke` — see Part VI for which.
+- Single-file runs work: `yarn test <path>` forwards the path to Vitest (`scripts/run-test-suite.sh` shifts `full` and passes `"$@"` through), then always runs the hook smoke tests.
 
 ---
 
@@ -31,7 +32,7 @@ Numbers below were taken from `src/main.ts` at commit `208dad56`. Re-measure bef
 
 | Metric | Count | What it means |
 |---|---|---|
-| Total lines | 5,462 | 20x the next-largest hand-written app file |
+| Total lines | 5,462 | Largest hand-written file in the repo; 2.4x the largest system module (`city-system.ts`, 2,231) |
 | Top-level `function` declarations | 103 | All sharing one closure scope |
 | Module-scope `let` bindings | **23** | Full inventory in Part II; every one is assigned a phase |
 | `bus.on(...)` registrations at module scope | 72 | Run as an import side effect |
@@ -190,6 +191,14 @@ export interface Notifier {
   readonly deliver: NotificationSink;
   /** A toast that stays until the player picks one of `actions`. */
   choice(message: string, actions: readonly ChoiceAction[]): void;
+  /**
+   * Stamps notifications produced inside `fn` with `turn` instead of the live
+   * state's turn. REQUIRED — `endTurn` (main.ts:4154) and `beginHotSeatHandoff`
+   * (main.ts:4083) both wrap `events.commitTo(bus)` in this so a completed
+   * round's notifications carry the round's turn, not the new one. Omitting it
+   * from the port leaves Phase 9 unable to compile against `Notifier`.
+   */
+  withHappenedTurn<T>(turn: number, fn: () => T): T;
 }
 
 /** Already defined inline at src/main.ts:4193; move to ports.ts verbatim. */
@@ -222,10 +231,18 @@ function setBlockingOverlay(id: string | null): void {
 So `PanelHost` publishes the unblock, and the ceremony owner subscribes:
 
 ```ts
-export interface PanelHost {
+import type { UiInteractionState } from '@/ui/ui-interaction-state';
+
+/**
+ * Extends the existing UiInteractionState rather than replacing it: that
+ * interface has four consumers besides main.ts (src/ui/context-menu.ts plus
+ * tests/ui/keyboard-shortcuts.test.ts and tests/ui/desktop-controls.test.ts),
+ * so deleting the module in Phase 5 would break them. The FACTORY
+ * (createUiInteractionState) is retired in Phase 11 once PanelHost supplies it
+ * everywhere; the interface stays where it is.
+ */
+export interface PanelHost extends UiInteractionState {
   readonly layer: HTMLElement;
-  setBlockingOverlay(id: string | null): void;
-  isInteractionBlocked(): boolean;
   /** Fires whenever the last blocking overlay clears. Returns an unsubscribe fn. */
   onInteractionUnblocked(listener: () => void): () => void;
   /** Removes the panel with this id if present. Idempotent. */
@@ -367,7 +384,7 @@ You asked for review across gameplay, fun, ages, playstyles, difficulty, AI, UI/
 
 | Surface | Why it matters | Where it lives now | Owner | Guard |
 |---|---|---|---|---|
-| **Difficulty (opponent + personal challenge)** | The only difficulty dial the game has; a 7-year-old and a 43-year-old need different ones | `main.ts:490-500` (pause menu), `4029` (`applyPendingChallengeForCiv` at handoff), `5304/5325` (setup) | `HudController` + `TurnFlowController` + `CampaignEntryController` | Phase 9 test: a pending challenge set mid-game applies at the next handoff, once, for the right civ |
+| **Difficulty (`'explorer' \| 'standard' \| 'veteran'`)** | The only difficulty dial the game has; a 7-year-old and a 43-year-old need different ones | `main.ts:490-500` (pause menu), `4029` (`applyPendingChallengeForCiv` at handoff), `5304/5325` (setup); `normalizeLoadedState` also drops invalid values on load | `HudController` + `TurnFlowController` + `CampaignEntryController` | Phase 9 test: a pending challenge set mid-game applies at the next handoff, once, for the right civ; plus `yarn test:ai-playability` in Phases 1/9/11 |
 | **Legacy-save challenge prompt** | Old saves have no challenge; `showLegacyOpponentChallengePrompt` asks, and skipping it would silently pick a difficulty for the player | `main.ts:5109/5123/5135` via `beginCampaignEntry` | `CampaignEntryController` | Phase 10 test: all three entry routes still pass `showChallengePrompt` |
 | **AI move replay** | The only way a player sees what the AI did; without it the world changes silently between turns | `captureAIMoves`/`replayAIMoves`, `main.ts:3852-3884` | `TurnFlowController` | Phase 9 test: solo `endTurn` replays only current-viewer moves, capped at 6, and aborts on gate suppression |
 | **Reduced motion** | Accessibility; also the setting a motion-sensitive adult needs to play at all | `prefersReducedMotion`, `main.ts:388` — read by both ceremony queues | `CeremonyCoordinator` | Phase 6 test: with `matchMedia` reporting reduce, queues receive `reducedMotion: true` |
@@ -384,6 +401,8 @@ You asked for review across gameplay, fun, ages, playstyles, difficulty, AI, UI/
 ### How computer players are affected
 
 They are not, and that is enforced rather than assumed. No file under `src/ai/` is modified by any phase. `processNonHumanMajorRound`, `runCompletedRound`, `processTurn`, and `applyStrategicWarningTransitions` are called from `runCurrentCompletedRound` and move to `TurnFlowController` **as a verbatim call**, with the same bus and the same four callbacks.
+
+The repo already owns the right regression suite for this: `tests/simulation/ai-playability.test.ts` (`yarn test:ai-playability`) runs 30-turn simulations across all three difficulties and multiple AI personality sets. It runs in Phases 1, 9, and 11 — see Part VI. Phase 1 Step 1 records the pre-refactor "before" reading.
 
 Two AI-adjacent risks are real and get explicit guards:
 
@@ -466,9 +485,13 @@ bash scripts/run-with-mise.sh yarn test tests/app/determinism-guard.test.ts
 
 All must exit 0. Then commit, push, and open a PR whose body states: `main.ts` line count before/after, the module-scope bindings retired (from the Part II inventory), and any intentional behavior change with its test.
 
-### The determinism guard (built in Phase 1, run in every phase)
+### Two gameplay guards, not one
 
-The cheapest possible protection for gameplay, balance, AI, and difficulty across all eleven phases: same seed in, same state out.
+**`yarn test:ai-playability` already exists and is the better of the two.** `tests/simulation/ai-playability.test.ts` runs 30-turn simulations across real difficulty levels (`'explorer' | 'standard' | 'veteran'`) and AI personality sets via `simulateAIRounds` / `simulateLateEraAIRounds`. It is the existing, maintained answer to "do computer players still work and does difficulty still mean anything." **It is slow** (`run-ai-playability-regressions.sh` allows 300 s with a 120 s per-test timeout), so it runs in the phases that can plausibly affect it — Phase 1 (save/state construction), Phase 9 (turn flow, AI replay, difficulty application), and Phase 11 (final) — not in every phase.
+
+**The determinism guard below is the cheap per-phase complement.** It runs the real turn pipeline with no UI in a couple of seconds, so every phase can afford it.
+
+**No `toMatchSnapshot`.** This repo has zero snapshot files and zero snapshot assertions — introducing them here would both break convention and pick exactly the wrong tool, since a snapshot's failure mode is "re-record until green," which is the one response this guard must never permit. Record the numbers once from the pre-refactor build and write them as literals.
 
 `tests/app/determinism-guard.test.ts`:
 
@@ -512,19 +535,23 @@ describe('determinism guard', () => {
     const config = { civType: 'generic' as const, mapSize: 'small' as const, opponentCount: 3, gameTitle: 'guard', seed: 20260804 };
     const state = advance(createNewGame(config), 20);
 
-    // Recorded once, at Phase 1, from the pre-refactor build. Any phase that changes
-    // this has changed gameplay — which this plan forbids. Do not re-record to make
-    // it pass; find out which phase moved a system call and revert it.
-    expect({
-      turn: state.turn,
-      era: state.era,
-      cityCount: Object.keys(state.cities).length,
-      unitCount: Object.keys(state.units).length,
-      goldByCiv: Object.fromEntries(Object.entries(state.civilizations).map(([id, c]) => [id, c.gold])),
-    }).toMatchSnapshot();
+    // BASELINE — recorded once in Phase 1 Step 1 from the pre-refactor build, then
+    // written here as literals. Deliberately NOT a snapshot: a snapshot invites
+    // `-u` when it fails, and the only correct response to this failing is to find
+    // which phase moved a system call and revert it. Any phase that changes these
+    // numbers has changed gameplay, which this plan forbids.
+    expect(state.turn).toBe(/* fill from Step 1 */ 21);
+    expect(state.era).toBe(/* fill from Step 1 */ 1);
+    expect(Object.keys(state.cities).length).toBe(/* fill from Step 1 */ 0);
+    expect(Object.keys(state.units).length).toBe(/* fill from Step 1 */ 0);
+    expect(
+      Object.fromEntries(Object.entries(state.civilizations).map(([id, c]) => [id, c.gold])),
+    ).toEqual(/* fill from Step 1 */ {});
   });
 });
 ```
+
+The `/* fill from Step 1 */` values are the one place in this plan where a number is not yet known — they are *recorded output*, not a design decision, and Phase 1 Step 1 is the step that records them. Replace every one before committing; a placeholder left in place is a failed step.
 
 This runs the real turn pipeline with no UI, so it is unaffected by every phase *except* one that accidentally changes a system call — which is exactly the failure it exists to catch. Record the snapshot in Phase 1, before any other change.
 
@@ -611,12 +638,18 @@ function withDefault<T, K extends keyof T>(
 
 - [ ] **Step 1: Record the determinism baseline first**
 
-Create `tests/app/determinism-guard.test.ts` exactly as written in Part V above, run it to record the snapshot, and commit that snapshot **before touching any source file**. This is the pre-refactor baseline for all eleven phases.
+Create `tests/app/determinism-guard.test.ts` as written in Part V, run it, read the actual values out of the failure output, and write them in as literals **before touching any source file**. This is the pre-refactor baseline for all eleven phases.
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/app/determinism-guard.test.ts
 ```
-Expected: PASS, and a new `tests/app/__snapshots__/determinism-guard.test.ts.snap`.
+Expected on the first run: the first test PASSES (run-to-run determinism), the second FAILS with the real values in the diff. Copy those in, re-run, expect PASS.
+
+Then confirm the existing AI/difficulty regression suite is green on the untouched build — this is the "before" reading you compare against in Phase 9:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:ai-playability
+```
 
 ```bash
 git add tests/app && git commit -m "test: record pre-refactor determinism baseline"
@@ -731,6 +764,10 @@ In `src/storage/save-manager.ts`, add rows 19–22 to `normalizeLoadedState`: `r
 
 - [ ] **Step 7: Write the new-game completeness test**
 
+**Critical framing correction — read before writing this test.** `createNewGame` and `createHotSeatGame` never set `saveSchemaVersion` (verified: no occurrence in `src/core/game-state.ts`). `getSourceVersion` therefore returns **0** for a fresh state, so `normalizeLoadedState(createNewGame(...))` runs **migrations 1 through 12**, not just 12. That is real existing behavior — a brand-new game autosaved before any load carries no version, so its first load replays the whole chain — and it is exactly why migration 12 must be idempotent and no-op on modern state (Step 2's fourth case).
+
+It also means a naive whole-state `toEqual` here is a **bad gate**: it would fail on any pre-existing non-idempotency anywhere in migrations 1–11, blocking Phase 1 on defects Phase 1 did not introduce. So the gate is scoped to what Phase 1 actually moves, and the whole-state comparison is kept separately as a **diagnostic that is allowed to fail loudly without blocking**.
+
 `tests/storage/new-game-completeness.test.ts`:
 
 ```ts
@@ -738,35 +775,61 @@ import { describe, it, expect } from 'vitest';
 import { createNewGame, createHotSeatGame } from '@/core/game-state';
 import { normalizeLoadedState } from '@/storage/save-manager';
 import { CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
+import type { GameState } from '@/core/types';
 
-describe('freshly created games need no migration', () => {
-  it('createNewGame output survives normalizeLoadedState unchanged', () => {
-    const state = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 2, gameTitle: 'solo', seed: 42 });
+const solo = (): GameState => createNewGame({
+  civType: 'generic', mapSize: 'small', opponentCount: 2, gameTitle: 'solo', seed: 42,
+});
+
+// Match this literal to the real HotSeatConfig type before running.
+const hotSeat = (): GameState => createHotSeatGame(
+  { players: [{ name: 'A', isHuman: true, civType: 'generic' }, { name: 'B', isHuman: true, civType: 'generic' }], mapSize: 'small' },
+  undefined,
+  'hot seat',
+  'standard',
+);
+
+describe('freshly created games need no legacy fixups', () => {
+  // THE GATE: only the fields Phase 1 relocates. Scoped deliberately — a fresh
+  // state has no saveSchemaVersion, so this runs migrations 1..12, and a whole-
+  // state assertion would fail on unrelated pre-existing non-idempotency.
+  for (const [label, make] of [['solo', solo], ['hot seat', hotSeat]] as const) {
+    it(`${label}: the relocated fixups are all no-ops on fresh state`, () => {
+      const state = make();
+      const normalized = normalizeLoadedState(structuredClone(state));
+
+      expect(normalized.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+      expect(normalized.beasts.migrationPending).toBeUndefined();
+      expect(normalized.beasts.lairs).toEqual(state.beasts.lairs);
+      expect(normalized.marketplace.tradeRoutes).toEqual(state.marketplace.tradeRoutes);
+      expect(normalized.minorCivs).toEqual(state.minorCivs);
+      expect(normalized.legendaryWonderHistory).toEqual(state.legendaryWonderHistory);
+      expect(normalized.settings.advisorsEnabled).toEqual(state.settings.advisorsEnabled);
+      for (const [civId, civ] of Object.entries(normalized.civilizations)) {
+        expect(civ.civType).toBe(state.civilizations[civId].civType);
+        expect(civ.diplomacy).toEqual(state.civilizations[civId].diplomacy);
+        expect(civ.techState.trackPriorities).toEqual(state.civilizations[civId].techState.trackPriorities);
+      }
+    });
+  }
+
+  // THE DIAGNOSTIC: reports total divergence. If this fails, read the diff and
+  // decide — it may be a Phase 1 defect, or a pre-existing migration 1..11 issue
+  // that deserves its own issue. Do not delete it and do not let it block Phase 1.
+  it('diagnostic: reports any other divergence between fresh state and the load pipeline', () => {
+    const state = solo();
     const normalized = normalizeLoadedState(structuredClone(state));
 
     expect(normalized).toEqual({ ...state, saveSchemaVersion: CURRENT_SAVE_SCHEMA_VERSION });
-    expect(normalized.beasts.migrationPending).toBeUndefined();
-  });
-
-  it('createHotSeatGame output survives normalizeLoadedState unchanged', () => {
-    // Match this literal to the real HotSeatConfig type before running.
-    const state = createHotSeatGame(
-      { players: [{ name: 'A', isHuman: true, civType: 'generic' }, { name: 'B', isHuman: true, civType: 'generic' }], mapSize: 'small' },
-      undefined,
-      'hot seat',
-      'standard',
-    );
-    const normalized = normalizeLoadedState(structuredClone(state));
-
-    expect(normalized).toEqual({ ...state, saveSchemaVersion: CURRENT_SAVE_SCHEMA_VERSION });
-    expect(normalized.beasts.migrationPending).toBeUndefined();
   });
 });
 ```
 
-**Expected failure mode, and the correct response.** `createNewGame` and `createHotSeatGame` both hard-code `knownCivilizations: []` (`src/core/game-state.ts:263, 289, 476`) and never call `refreshKnownCivilizations`. If `refreshKnownCivilizations` computes a non-empty list at turn 1 (e.g. a civ always knows itself), this test fails on `knownCivilizations`.
+**Expected divergence, and the correct response.** `createNewGame` and `createHotSeatGame` both hard-code `knownCivilizations: []` (`src/core/game-state.ts:263, 289, 476`) and never call `refreshKnownCivilizations`. If that function computes a non-empty list at turn 1, the diagnostic fails on `knownCivilizations` — a genuine pre-existing inconsistency, since new hot-seat games got the refresh at entry and new solo games did not.
 
-That failure is a genuine pre-existing inconsistency — new hot-seat games got the refresh at entry, new solo games did not. **Fix it by making `createNewGame`/`createHotSeatGame` produce complete state** (call `refreshKnownCivilizations` at creation), not by re-adding an entry-time call or loosening the assertion. Note the fix in the PR body as the one intentional behavior change in Phase 1, and confirm the determinism snapshot from Step 1 still passes — if it moves, you changed gameplay and must stop.
+**Fix it by making `createNewGame`/`createHotSeatGame` produce complete state**, not by re-adding an entry-time call and not by loosening the assertion. Note the fix in the PR body as an intentional behavior change, and re-run the Step 1 determinism baseline — if those numbers move, you changed gameplay and must stop.
+
+If the diagnostic instead fails on something owned by migrations 1–11, file an issue, add a scoped `expect(...).toEqual(...)` exclusion with the issue number in a comment, and continue. Phase 1 is not the place to fix a five-migration-old bug.
 
 - [ ] **Step 8: Delete `migrateLegacySave` and rewire `enterCampaign`**
 
@@ -1216,7 +1279,9 @@ Replaces `togglePanel`'s 288-line `else if` chain (`src/main.ts:1589-1877`), the
 
 **Files:**
 - Create: `src/app/panel-host.ts`, `src/app/panel-registry.ts`, `src/app/panel-router.ts`, `src/app/global-shortcuts.ts`, `tests/app/panel-router.test.ts`, `tests/app/global-shortcuts.test.ts`
-- Modify: `src/main.ts`; delete `src/ui/ui-interaction-state.ts`
+- Modify: `src/main.ts`, `src/ui/ui-interaction-state.ts` (keep the interface, mark the factory as superseded)
+
+**Do not delete `src/ui/ui-interaction-state.ts` in this phase.** `UiInteractionState` has four consumers besides `main.ts`: `src/ui/context-menu.ts`, `tests/ui/keyboard-shortcuts.test.ts`, and `tests/ui/desktop-controls.test.ts`. `PanelHost extends UiInteractionState` (Part II), so `createPanelHost`'s return value is a drop-in for all of them — that is the LSP claim in Part II being cashed. Rewire `main.ts`'s two remaining consumers (`MouseHandler`'s `canInteract` and `installKeyboardShortcuts`'s `canHandle`, both in `startGame`) to the host. The `createUiInteractionState` **factory** is retired in Phase 11, once nothing constructs it.
 
 **Interfaces:**
 - Consumes: `GameSession`, `Notifier`, `SelectionStore`.
@@ -1653,14 +1718,18 @@ The `mistap` variant is separate from `ignore` because mis-tap forgiveness (Phas
 2. `endTurn` is a no-op when `state.gameOver`;
 3. a pending religion boon blocks `endTurn` and toasts, without advancing the turn;
 4. hot-seat `endTurn` suppresses the presentation gate, sets master volume to 0, autosaves, and restores the stored master volume after the handoff resolves;
-5. **difficulty:** a pending opponent challenge set before `endTurn` is applied exactly once, at the handoff, to the correct civ (`applyPendingChallengeForCiv`, `main.ts:4029`) — and a *personal* pending challenge applies only to its own civ;
+5. **difficulty:** a pending opponent challenge set before `endTurn` is applied exactly once, at the handoff, to the correct civ (`applyPendingChallengeForCiv`, `main.ts:4029`) — and a *personal* pending challenge applies only to its own civ. Use the real union values `'explorer' | 'standard' | 'veteran'` (`src/core/types.ts:1346`), and assert the transition (`'standard'` → `'veteran'`), not just that the function was called;
 6. **AI replay:** `captureAIMoves` observes `unit:move` events emitted during `result.events.commitTo(bus)`, and `replayAIMoves` animates only current-viewer moves, capped at 6, aborting early if the gate becomes suppressed.
 
 Cases 5 and 6 have no existing coverage of any kind and are the two highest-risk behaviors in this phase.
 
 - [ ] **Step 2: Run, confirm failure.**
 - [ ] **Step 3: Implement** by moving bodies verbatim; substitute port calls for direct `renderLoop` / `updateHUD` / `showNotification` references. `runCurrentCompletedRound` keeps its four callbacks unchanged — no `src/systems/` or `src/ai/` file is edited.
-- [ ] **Step 4: Run — expect PASS, and re-run the determinism guard.** If the guard snapshot moves in this phase, a system call was reordered; revert and re-approach.
+- [ ] **Step 4: Run — expect PASS, then run both gameplay guards.** If the determinism baseline moves, a system call was reordered; revert and re-approach. This is also the phase where the AI/difficulty suite matters most:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:ai-playability
+```
 - [ ] **Step 5: Convert the affected source-grep assertions.** `completed-round AI wiring` (4) and `campaign entry wiring`'s "opens required research choices" (1) — 5 total.
 - [ ] **Step 6: Close the phase**
 
@@ -1774,10 +1843,10 @@ describe('bootstrap', () => {
 - [ ] **Step 4: Extract `HudController`** — `updateHUD`, the treasury `drawer` (including `PanelRouter`'s `onBeforeOpen: () => drawer.close()`), `airDefenseOverlayButton` placement in `#utility-toolbar` (the `#783` fix — assert placement, not absolute positioning), `setMapViewportBottomInset`. Test: gold text updates on commit; AA button hidden without coverage; drawer closes when a main panel opens.
 - [ ] **Step 5: Extract `CampaignEntryController`** with the difficulty guard: all three entry routes (`onContinue`, `onLoadEntry`, `onImportSave`) still pass `showChallengePrompt: showLegacyOpponentChallengePrompt`, and a legacy save with no challenge still prompts before entry.
 - [ ] **Step 6: Convert the remaining source-grep assertions.** `campaign entry wiring` (3 remaining) and `air-defense overlay button placement` (2) — 5 total. `tests/main.integration.test.ts` is now empty; **delete the file**.
-- [ ] **Step 7: Run the e2e suite** — this phase touches campaign entry and the e2e install branch, so unit tests are not sufficient:
+- [ ] **Step 7: Run the browser smoke suite** — this phase touches campaign entry and the e2e install branch, so unit tests are not sufficient. The script is `test:web-smoke` (Playwright); there is no `test:e2e`:
 
 ```bash
-bash scripts/run-with-mise.sh yarn test:e2e
+bash scripts/run-with-mise.sh yarn test:web-smoke
 ```
 
 - [ ] **Step 8: Close the phase**
@@ -1840,6 +1909,16 @@ it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => 
 Type-only imports of `RenderLoop`/`AudioSystem` for `Pick<>` deps are fine; the regexes target value imports, so write those as `import type`.
 
 - [ ] **Step 4: Delete `tests/app/refresh-bypass-ratchet.test.ts`** (or, if some bypasses are genuinely correct, lower its bound to that number and document each in a comment).
+- [ ] **Step 4b: Retire `createUiInteractionState`.** Nothing should construct it once `PanelHost` is wired everywhere. Delete the factory; keep the `UiInteractionState` interface, which `src/ui/context-menu.ts` and two UI test suites still import. Run those three suites explicitly before committing:
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/keyboard-shortcuts.test.ts tests/ui/desktop-controls.test.ts
+```
+- [ ] **Step 4c: Run both gameplay guards one final time**, including the slow AI suite:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:ai-playability
+```
 - [ ] **Step 5: Update `CLAUDE.md`.** Add to Architecture:
 
 > `src/main.ts` is a composition root only. New app behavior goes in `src/app/controllers/` (depending on `src/app/ports.ts`) or a `src/presentation/register-*.ts` registrar. A new panel is one `PANEL_REGISTRY` entry; a new notification is one handler in the matching registrar; a new persisted save field is one numbered migration in `save-migrations.ts`. Enforced by `tests/app/architecture-boundaries.test.ts`.
@@ -1859,7 +1938,8 @@ Per `docs/superpowers/plans/README.md` §5, and because current coverage of this
 
 **Every phase must run**, not just unit tests:
 - `yarn test` (full suite), `yarn build` (the only `tsc` path), and `tests/app/determinism-guard.test.ts`;
-- `yarn test:e2e` in Phases 8 and 10, which touch map input and campaign entry respectively.
+- `yarn test:web-smoke` (Playwright — **not** `test:e2e`, which does not exist) in Phases 8 and 10, which touch map input and campaign entry respectively;
+- `yarn test:ai-playability` in Phases 1, 9, and 11 — the existing 30-turn simulation across `'explorer' | 'standard' | 'veteran'` difficulties and AI personality sets. It is the real guard for "computer players still work and difficulty still means something." It is slow (300 s budget), which is why it is scoped to the three phases that can plausibly affect it rather than run everywhere.
 
 **Running count of source-grep assertions retired** (must reach zero):
 
@@ -1894,7 +1974,8 @@ Per `docs/superpowers/plans/README.md` §5, and because current coverage of this
 | Difficulty applies at the wrong time | `applyPendingChallengeForCiv` sits inside `beginHotSeatHandoff`; moving the function could move the timing | Phase 9 test 5 asserts once, at handoff, for the right civ |
 | AI move replay breaks or duplicates | `captureAIMoves` is a temporary subscription wrapping `commitTo(bus)`; Phase 7 rewrites every permanent subscription | Phase 7 Step 7 asserts single registration; Phase 9 test 6 asserts capture still observes `commitTo` |
 | Hot-seat handoff regressions | Most stateful, least covered flow: audio muting, overlays, autosave, presentation gate, challenge application | Phase 9 tests four ordering guarantees; e2e smoke must pass |
-| A gameplay/balance change slips in | 5,462 lines of moved code, and `main.ts` calls into nearly every system | Determinism guard recorded in Phase 1 Step 1 and run in every phase; `src/systems/` and `src/ai/` are read-only |
+| A gameplay/balance change slips in | 5,462 lines of moved code, and `main.ts` calls into nearly every system | Determinism guard (literals, not snapshots) recorded in Phase 1 Step 1 and run in every phase; `yarn test:ai-playability` in Phases 1/9/11; `src/systems/` and `src/ai/` are read-only |
+| **A test written against an assumed command or convention never runs** | The plan originally cited `yarn test:e2e` (does not exist — it is `test:web-smoke`) and `toMatchSnapshot` (zero usages in this repo) | Every command and convention in this plan is now verified against `package.json` and the existing test tree; verify again if the plan sits unexecuted for long |
 | Losing a fixup during save consolidation | 23 fixups, 20 `as any` casts, no existing tests | Classification table is a checklist; idempotency + preserve-existing tests; new-game completeness test; keep v10/v11 golden fixtures in `tests/fixtures/` |
 | A mid-refactor playtest save cannot be reopened | Phase 1 bumps the schema to 12; older builds throw `UnsupportedSaveSchemaVersionError` | Called out in Part III; family playtest builds stay at or ahead of Phase 1 |
 | Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Eleven small PRs merged promptly, not one long branch; no other `main.ts`-touching PR should sit open across a phase merge |
@@ -1908,4 +1989,6 @@ Per `docs/superpowers/plans/README.md` §5, and because current coverage of this
 - **Completeness:** every one of the 23 module-scope `let`s and every module-scope side effect is assigned a phase in the Part II inventory. Phase 11's `not.toMatch(/^let /m)` is only satisfiable if that table is complete — the table and the test check each other.
 - **Placeholder scan:** no TBD/TODO in the plan. The one `// TODO(composition-root)` introduced in Phase 2 Step 5 is a counted, ratcheted debt marker retired in Phase 11.
 - **Type consistency:** `GameSession.commit`/`update`/`setStateWithoutRefresh`/`subscribe` are used with those exact names in Phases 2, 8, 9, and 11. `PendingMapIntent` (Phase 3) is consumed by `MapTapIntent`'s `resolve-pending` and `mistap` variants (Phase 8). `SelectionSnapshot` is defined in Phase 3 and consumed by `resolveMapTapIntent` in Phase 8. `PanelId`, `PanelGroup`, `PanelContext`, and `ChoiceAction` are defined in Part II / Phase 5 before first use. `MovementBlockerReason` is imported from its real home, `@/systems/unit-system:986`. `PresentationRegistrar` returns `() => void` in its definition and its disposal tests.
-- **Known soft spot:** the `createHotSeatGame` config literal in Phase 1 Step 7 and the `makeFakeServices` `renderLoop` double in Phase 10 Step 1 are illustrative and must be matched to the real `HotSeatConfig` and `RenderLoop` shapes when writing those tests.
+- **Command and convention audit (second review pass):** every command in this plan is checked against `package.json`. `yarn test <path>` forwards to Vitest correctly. `yarn test:e2e` **does not exist** and was replaced with `yarn test:web-smoke`. `toMatchSnapshot` was removed — this repo has zero snapshot files and zero snapshot assertions, and a re-recordable baseline is the wrong tool for a guard that must never be re-recorded. `yarn test:ai-playability` was found and adopted; it is a better AI/difficulty guard than anything this plan would have invented.
+- **Deletion audit:** `src/ui/transport-ui-state.ts` has exactly one consumer (`main.ts`) and is safe to delete in Phase 3. `src/ui/ui-interaction-state.ts` has **four** (`src/ui/context-menu.ts` plus two UI test suites) — the interface stays, only the factory is retired, in Phase 11.
+- **Known soft spots:** the `createHotSeatGame` config literal in Phase 1 Step 7 and the `makeFakeServices` `renderLoop` double in Phase 10 Step 1 are illustrative and must be matched to the real `HotSeatConfig` and `RenderLoop` shapes. The determinism baseline literals in Part V are recorded output, filled in by Phase 1 Step 1.

--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -491,6 +491,11 @@ All must exit 0. Then commit, push, and open a PR whose body states: `main.ts` l
 
 **The determinism guard below is the cheap per-phase complement.** It runs the real turn pipeline with no UI in a couple of seconds, so every phase can afford it.
 
+Two operational facts about it, both learned the hard way in Phase 1:
+
+- It lives in `SLOW_TEST_FILES` (`scripts/run-tests-by-tier.sh`), per `.claude/rules/hooks-and-tooling.md`, because it advances 40 full turn rounds across 4 civs. That means `yarn test:fast` — the **local pre-push gate** — skips it. This is fine and intended: every phase runs it explicitly (`yarn test tests/app/determinism-guard.test.ts`, which forwards the path to Vitest), and CI's required `test` job runs the full suite including the slow tier. Do not assume pushing green means the guard ran.
+- Both tests carry explicit headroom timeouts (30 s / 15 s). Solo local runs are ~1.5 s / 0.7 s, but the first test was measured at 6.6 s on CI, and it failed the very first CI run on vitest's 5 s default. A simulation test on the default timeout produces a red build that looks exactly like a gameplay regression.
+
 **No `toMatchSnapshot`.** This repo has zero snapshot files and zero snapshot assertions — introducing them here would both break convention and pick exactly the wrong tool, since a snapshot's failure mode is "re-record until green," which is the one response this guard must never permit. Record the numbers once from the pre-refactor build and write them as literals.
 
 `tests/app/determinism-guard.test.ts`:
@@ -1909,6 +1914,7 @@ it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => 
 Type-only imports of `RenderLoop`/`AudioSystem` for `Pick<>` deps are fine; the regexes target value imports, so write those as `import type`.
 
 - [ ] **Step 4: Delete `tests/app/refresh-bypass-ratchet.test.ts`** (or, if some bypasses are genuinely correct, lower its bound to that number and document each in a comment).
+- [ ] **Step 4a: Retire the determinism guard's baseline test.** Delete the `matches the baseline recorded from the pre-refactor build` test, plus `BASELINE`, `digest`, and `ONE_RUN_TIMEOUT_MS`. **Keep** the run-to-run determinism test and `pinnedStart` — that one is invariant under gameplay changes and stays useful indefinitely. The baseline digest only ever backed this arc's "no gameplay change" claim; left in place it fires on ordinary content and balance work, where the only sane response is to re-record, which is the exact habit the file's docblock forbids. Once only the one test remains, re-evaluate whether the file still belongs in `SLOW_TEST_FILES` (halving the work may put it back under the fast tier's budget).
 - [ ] **Step 4b: Retire `createUiInteractionState`.** Nothing should construct it once `PanelHost` is wired everywhere. Delete the factory; keep the `UiInteractionState` interface, which `src/ui/context-menu.ts` and two UI test suites still import. Run those three suites explicitly before committing:
 
 ```bash

--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -17,9 +17,11 @@
 - Bash timeouts: `git commit` → 30000 ms; `git push` / `gh pr create` → 120000 ms.
 - All work happens in this worktree (`architecture-planning-0acde5`). Never on `main`.
 - Every phase below is **one PR**, independently mergeable, with the full suite green. No phase leaves `main.ts` in a half-migrated state that another phase must finish.
-- **Behavior-preserving.** No player-visible change in any phase except Phase 1's explicitly-listed migration ordering. If a phase tempts you to fix a bug you find, file an issue and keep the refactor pure.
+- **Behavior-preserving.** No player-visible change in any phase except Phase 11's explicitly-listed stale-refresh fixes. If a phase tempts you to fix a bug you find, file an issue and keep the refactor pure.
+- **No gameplay change of any kind.** No yields, costs, combat modifiers, tech gating, AI decisions, difficulty scaling, RNG seeding, or victory conditions are touched. `src/systems/`, `src/ai/`, and `src/core/turn-manager.ts` are read-only for this entire plan except where a phase explicitly names a file.
 - No new runtime dependencies.
 - `Math.random()` remains forbidden. `state.currentPlayer` remains the only ownership source. `innerHTML` with game strings remains forbidden.
+- Every phase runs the **determinism guard** (Part V) and the **e2e smoke suite** before merge, not just unit tests.
 
 ---
 
@@ -31,7 +33,7 @@ Numbers below were taken from `src/main.ts` at commit `208dad56`. Re-measure bef
 |---|---|---|
 | Total lines | 5,462 | 20x the next-largest hand-written app file |
 | Top-level `function` declarations | 103 | All sharing one closure scope |
-| Module-scope `let` bindings | 16 | `gameState`, `selectedUnitId`, `movementRange`, `pendingAirMission`, … |
+| Module-scope `let` bindings | **23** | Full inventory in Part II; every one is assigned a phase |
 | `bus.on(...)` registrations at module scope | 72 | Run as an import side effect |
 | `gameState = …` assignments | 93 | 93 places that can desync the UI |
 | `renderLoop.setGameState(…)` calls | 89 | Manual refresh discipline |
@@ -48,7 +50,7 @@ expect(main.match(/await beginCampaignEntry\(/g)).toHaveLength(3);
 expect(endTurn).toMatch(/await replayAIMoves\(soloMoves\);\s*updateHUD\(\);\s*showRequiredChoicesIfNeeded\(\);/);
 ```
 
-The team did not choose regex-over-source because it is good testing. They chose it because `main.ts` executes `new AudioContext()`, `document.getElementById(...)`, 72 event-bus registrations, and `init()` at import time — so there is no way to import it in a test. **Every real behavior in `main.ts` is currently guarded by whitespace-sensitive string matching, or not at all.** Converting those 21 assertions into real behavioral tests is a first-class deliverable of this plan, not incidental churn.
+The team did not choose regex-over-source because it is good testing. They chose it because `main.ts` executes `new AudioContext()`, `document.getElementById(...)`, 72 event-bus registrations, two `window.addEventListener` calls, and `init()` at import time — so there is no way to import it in a test. **Every real behavior in `main.ts` is currently guarded by whitespace-sensitive string matching, or not at all.** Converting those 21 assertions into real behavioral tests is a first-class deliverable of this plan, not incidental churn.
 
 ### The three save routes
 
@@ -56,11 +58,11 @@ The team did not choose regex-over-source because it is good testing. They chose
 
 1. **Versioned pipeline** — `migrateSaveToCurrent(raw)` in `src/storage/save-migrations.ts`. Numbered migrations 1…`CURRENT_SAVE_SCHEMA_VERSION` (11), each stamping `saveSchemaVersion`. This is the good one.
 2. **Unconditional normalizers** — `normalizeLoadedState(state)` in `src/storage/save-manager.ts:825`. Calls `migrateSaveToCurrent` and then ~20 hand-written `normalizeX` / `migrateLegacyX` functions that run on *every* load regardless of version. Reachable from tests via `normalizeLoadedStateForTest`.
-3. **`migrateLegacySave()`** — `src/main.ts:5146`, 124 lines, mutates the module-scope `gameState` **in place** with ~23 fixups and 20 `as any` casts. Not exported. Not importable. Not tested. Called from exactly one place: `enterCampaign()` at `src/main.ts:5013`.
+3. **`migrateLegacySave()`** — `src/main.ts:5146`, 124 lines, mutates the module-scope `gameState` **in place** with 23 fixups and 20 `as any` casts. Not exported. Not importable. Not tested. Called from exactly one place: `enterCampaign()` at `src/main.ts:5013`.
 
 Route 3 has two concrete defects beyond being untestable:
 
-- **It runs on brand-new hot-seat games.** `showGameModeSelection`'s `onChooseHotSeat` calls `createHotSeatGame(...)` → `enterCampaign(...)` → `migrateLegacySave()`. New *solo* games call `startGame()` directly and skip it. So the two new-game paths do not produce identical state shapes, and nothing tests that they do.
+- **It runs on brand-new hot-seat games.** `showGameModeSelection`'s `onChooseHotSeat` calls `createHotSeatGame(...)` → `enterCampaign(...)` → `migrateLegacySave()`. New *solo* games call `startGame()` directly and skip it. So the two new-game paths do not produce identical state shapes, and nothing tests that they do. **Verified consequence:** `createNewGame` and `createHotSeatGame` both hard-code `knownCivilizations: []` (`src/core/game-state.ts:263, 289, 476`) and neither calls `refreshKnownCivilizations` — so new hot-seat games get their known-civ list populated at entry and new solo games do not. Phase 1 Step 6 is designed to surface exactly this.
 - **One of its fixups is not a migration at all.** `gameState.settings.councilTalkLevel = persistedSettings?.councilTalkLevel ?? 'normal'` reads a value loaded from IndexedDB user settings, not from the save. It cannot move into a pure `(state) => state` migration, and a naive "move it all into the pipeline" refactor would either drop it or smuggle a global read into `save-migrations.ts`. Phase 1 handles it explicitly.
 
 ---
@@ -97,6 +99,50 @@ If we extract six more controllers this way, we get six more 15-field deps bags 
 
 **So: define the ports first, fix state ownership first, then extract.** Each controller should take two to four ports, not fifteen callbacks.
 
+### Complete module-scope binding inventory
+
+Every mutable binding and every stateful construction in `main.ts`, with its destination. Phase 11's boundary test asserts `main.ts` contains **zero** `^let ` — so an unassigned binding is a plan defect, not an implementation detail. This table is the completeness contract.
+
+| Line | Binding | Destination | Phase |
+|---|---|---|---|
+| 307 | `gameState` | `GameSession` | 2 |
+| 308 | `drawer: TreasuryDrawer` | `HudController` | 10 |
+| 309 | `selectedUnitId` | `SelectionStore` | 3 |
+| 310 | `selectedUnitWaterRecovery` | `SelectionStore` | 3 |
+| 311 | `selectedPirateFactionId` | `SelectionStore` | 3 |
+| 312 | `selectedPirateHistoryId` | `SelectionStore` | 3 |
+| 313 | `movementRange` | `SelectionStore` | 3 |
+| 314 | `attackRange` | `SelectionStore` | 3 |
+| 317 | `_mistapNotified` | `SelectionStore` (see "mis-tap forgiveness" below) | 3 |
+| 318 | `currentCityIndex` | `SelectionStore` | 3 |
+| 319 | `inputInitialized` | `GameSessionController` (guard becomes construct-once) | 10 |
+| 320 | `councilPanelOpen` | **deleted** — `PanelRouter.isOpen('council')` | 5 |
+| 321 | `persistedSettings` | `UserSettingsStore` | 4 |
+| 322 | `pacingDebugOpen` | `PanelRouter` (`'pacing-debug'` registry entry) | 5 |
+| 323 | `pendingCityCaptureChoice` | `SelectionStore` → `PendingMapIntent` | 3 |
+| 324 | `pendingJourneyUnitId` | `SelectionStore` → `PendingMapIntent` | 3 |
+| 325 | `pendingAirMission` | `SelectionStore` → `PendingMapIntent` | 3 |
+| 326 | `deferWonderDiscoveryRevealUntilMoveSettles` | `CeremonyCoordinator` | 6 |
+| 360 | `currentMasterVolume` | `UserSettingsStore` | 4 |
+| 377 | `wonderDiscoveryQueue` | `CeremonyCoordinator` | 6 |
+| 378 | `legendaryCompletionQueue` | `CeremonyCoordinator` | 6 |
+| 713 | `isShowingNotification` | `NotificationCenter` | 4 |
+| 714 | `currentDismissTimer` | `NotificationCenter` | 4 |
+
+Non-`let` module-scope state and side effects, same contract:
+
+| Line | Item | Destination | Phase |
+|---|---|---|---|
+| 354–362 | `bus`, `audioCtx`, `audio`, `roundPresentationGate`, `advisorSystem`, `uiInteractions` | `AppServices`, constructed in `main.ts` | 10 |
+| 365–368 | `canvas`, `uiLayer`, `renderLoop`, `airDefenseOverlayButton` | `AppServices` / `HudController` | 10 |
+| 422 | `window.addEventListener('resize', …)` | `GameSessionController` | 10 |
+| 432–448 | `window.addEventListener('keydown', …)` — Escape cancels journey, backtick toggles pacing debug | `GlobalShortcuts` (see below) | 5 |
+| 712 | `notificationQueue` | `NotificationCenter` | 4 |
+| 750–755 | `notificationDelivery`, `appendToCivLog` | `NotificationCenter` | 4 |
+| 4568 | `notifiedBarbarianCampsPerCiv` | `register-raider-presentation.ts` | 7 |
+| 4377–4961 | 72 × `bus.on(...)` | 12 presentation registrars | 7 |
+| 5462 | `init()` | `bootstrap()` | 10 |
+
 ### Port 1 — `GameSession` (the important one)
 
 ```ts
@@ -120,7 +166,7 @@ export interface GameSession {
    * Deliberately ugly. It exists only so Phase 2 can be a mechanically
    * behavior-identical refactor of the 46 existing assignment sites that do not
    * currently refresh. Every remaining call site is an open question about
-   * whether the player is looking at stale data. Phase 10 drives this to zero
+   * whether the player is looking at stale data. Phase 11 drives this to zero
    * or to a documented allowlist.
    */
   setStateWithoutRefresh(next: GameState): void;
@@ -145,24 +191,50 @@ export interface Notifier {
   /** A toast that stays until the player picks one of `actions`. */
   choice(message: string, actions: readonly ChoiceAction[]): void;
 }
+
+/** Already defined inline at src/main.ts:4193; move to ports.ts verbatim. */
+export interface ChoiceAction {
+  readonly label: string;
+  readonly onSelect: () => void;
+}
 ```
 
-Backed by the existing `createNotificationDelivery` plus the toast queue currently living in `main.ts:711-965` (`notificationQueue`, `isShowingNotification`, `currentDismissTimer`, `enqueueToast`, `showNotification`, `displayNextNotification`). That queue is pure DOM + timers with zero game-logic coupling, and it is a 250-line free win for testability with fake timers.
+Backed by the existing `createNotificationDelivery` plus the toast queue currently living in `main.ts:711-965`. That queue is pure DOM + timers with zero game-logic coupling, and it is a 250-line free win for testability with fake timers.
 
-### Port 3 — `PanelHost`
+**`sfxCue` is required plumbing, not an optional nicety.** `showNotification`'s fourth parameter routes into `SFX.*`, and several event handlers pass a cue that is the only audio feedback for that event. `NotificationCenterDeps.playCue` is therefore **non-optional** — an optional callback that a wiring mistake leaves `undefined` would silently mute a class of game audio with no test failure. See Part IV, Phase 4.
+
+### Port 3 — `PanelHost`, and the hidden ceremony pump
+
+A naive reading says `PanelHost` just absorbs `createUiInteractionState()`. That is wrong, and getting it wrong silently breaks the game's reward moments. The real `setBlockingOverlay` at `src/main.ts:380` is:
+
+```ts
+function setBlockingOverlay(id: string | null): void {
+  uiInteractions.setBlockingOverlay(id);
+  if (id === null) {
+    wonderDiscoveryQueue?.pump();
+    legendaryCompletionQueue?.pump();
+  }
+}
+```
+
+**Unblocking the UI is what pumps the natural-wonder discovery and legendary-wonder completion ceremony queues.** Those queues hold the game's biggest payoff moments — the reveal animation, the discovery audio sting, the completion ceremony. If Phase 5 ports `createUiInteractionState` verbatim into `PanelHost`, every ceremony that was queued while a panel was open never plays, and **no existing test would catch it** (there are no tests on this path at all).
+
+So `PanelHost` publishes the unblock, and the ceremony owner subscribes:
 
 ```ts
 export interface PanelHost {
   readonly layer: HTMLElement;
   setBlockingOverlay(id: string | null): void;
   isInteractionBlocked(): boolean;
+  /** Fires whenever the last blocking overlay clears. Returns an unsubscribe fn. */
+  onInteractionUnblocked(listener: () => void): () => void;
   /** Removes the panel with this id if present. Idempotent. */
   close(panelId: PanelId): void;
-  closeAll(): void;
+  closeGroup(group: PanelGroup): void;
 }
 ```
 
-`isInteractionBlocked` / `setBlockingOverlay` already exist as `createUiInteractionState()` — this port absorbs it rather than replacing it.
+This is the inverted-dependency version of the same behavior: `PanelHost` no longer knows what a wonder ceremony is, and `CeremonyCoordinator` no longer has to be reachable from every `setBlockingOverlay` call site. It is also the reason `CeremonyCoordinator` is its own phase (6) rather than being smeared across the presentation registrars and the selection controller.
 
 ### Port 4 — `SelectionStore`, and making illegal states unrepresentable
 
@@ -196,30 +268,63 @@ export type PendingMapIntent =
 
 Setting one intent structurally clears the others, `handleHexTap` becomes an exhaustive `switch` with an `assertNever` default, and the precedence rule stops being emergent. This is the one place in the plan where the type system is doing load-bearing work rather than documentation.
 
+**Mis-tap forgiveness.** `_mistapNotified` (`main.ts:317`, used at `3248`) makes the *first* mis-tap during an unload show a warning toast plus `SFX.error()`, and stay silent afterwards so a child jabbing at the map is not machine-gunned with error sounds. It is reset by `clearUnloadState()`. It belongs to the `unload` intent's lifetime, so it lives in `SelectionStore` and resets whenever `setPendingIntent` changes the intent kind — which is *more* correct than today, where it resets only via `clearUnloadState`. That is a behavior improvement, so it needs a test and a line in the Phase 3 PR body. See Part VI.
+
+### The eighth controller: `CeremonyCoordinator`
+
+The source list of six omits two things that are 600+ lines of `main.ts` between them and that couple across phases. Both get named owners:
+
+**`MapInteractionController`** — `handleHexTap` is **624 lines**, the largest function in the file, larger than most whole modules in this repo. It is not selection, not turn flow, not panel routing. Folding it into `SelectionController` rebuilds the god object one level down. It is split the way this codebase already splits input elsewhere (`src/input/selected-unit-tap-intent.ts` is the precedent): a **pure resolver** `(state, selection, coord) => MapTapIntent` and a **thin executor**.
+
+**`CeremonyCoordinator`** — owns `wonderDiscoveryQueue`, `legendaryCompletionQueue`, `deferWonderDiscoveryRevealUntilMoveSettles`, and `prefersReducedMotion`. Without it, `deferWonderDiscoveryRevealUntilMoveSettles` is written by `executeAnimatedUnitMove` (Phase 8's `SelectionController`) and read by the `wonder:discovered` handler (Phase 7's registrar) — a shared mutable flag straddling two phases, which is precisely the coupling this refactor exists to remove. The flag encodes a real UX rule worth preserving deliberately:
+
+> If a wonder is discovered *by a unit that is currently animating a move*, hold the reveal until the move settles, so the ceremony does not fire over a sliding sprite.
+
+`CeremonyCoordinator` exposes that as an intention-revealing API instead of a boolean:
+
+```ts
+export interface CeremonyCoordinator {
+  /** Queue a natural-wonder reveal. Plays when nothing is blocking and no move is settling. */
+  enqueueWonderDiscovery(item: WonderDiscoveryRevealItem): void;
+  enqueueLegendaryCompletion(item: LegendaryWonderCompletionItem): void;
+  /** Called around an animated move: reveals queued during the move wait for `endAction`. */
+  beginDeferredAction(): void;
+  endAction(): void;
+}
+```
+
+`PresentationCoordinator` is also deliberately *not* a single class. One coordinator owning 72 event subscriptions is the same god object with a nicer name; ~12 `register*Presentation(bus, ctx): () => void` functions give real SRP and let each be tested by emitting on a throwaway bus.
+
 ### SOLID, concretely
 
 - **SRP** — `main.ts` currently changes when *any* feature changes: a new unit type, a new panel, a new diplomacy action, a new notification, a new save field. After this plan, adding a panel touches `panel-registry.ts`; adding a notification touches one presentation registrar; adding a save field touches `save-migrations.ts`. Each file has one axis of change.
-- **OCP** — two concrete open/closed wins. `togglePanel` (288 lines of `else if (panel === '...')`) becomes a registry the router iterates. The 72 `bus.on` handlers become ~12 domain registrars, each a file you add rather than a chain you edit.
+- **OCP** — two concrete open/closed wins. `togglePanel` (288 lines of `else if (panel === '...')`) becomes a registry the router iterates. The 72 `bus.on` handlers become ~12 domain registrars, each a file you add rather than a chain you edit. **Extension rule, to be written into `CLAUDE.md` in Phase 11:** a new player-visible panel = one `PANEL_REGISTRY` entry; a new game-event notification = one handler inside the existing domain registrar, or a new registrar file if the domain is new; neither ever edits `main.ts`.
 - **LSP** — the substitutability that matters here is test doubles: a fake `GameSession` over a plain object, a fake `Notifier` that records calls, and a `PanelHost` over a detached `<div>` must be drop-in for the real ones. Keep the ports free of concrete-type leakage (no `RenderLoop`, no `AudioContext`, no `HTMLCanvasElement` in a port signature) and this holds by construction.
-- **ISP** — the reason ports are four small interfaces and not one `AppContext`. `NotificationCenter` takes `PanelHost` and nothing else. Presentation registrars take `GameSession` (read-only usage) and `Notifier`. `TurnFlowController` is the only thing that needs all four.
-- **DIP** — controllers import from `@/app/ports` only. `main.ts` is the sole module allowed to `new RenderLoop(...)`, `new AudioContext()`, or call `document.getElementById`. Phase 10 adds a test that enforces this mechanically.
+- **ISP** — the reason ports are four small interfaces and not one `AppContext`. `NotificationCenter` takes four fields. Presentation registrars take `GameSession` (read-only usage) and `Notifier`. Only `TurnFlowController` needs all four ports.
+- **DIP** — controllers import from `@/app/ports` only. `main.ts` is the sole module allowed to `new RenderLoop(...)`, `new AudioContext()`, or call `document.getElementById`. Phase 11 enforces this mechanically.
 
 ### Target file structure
 
 ```
 src/app/                         [NEW]
-  ports.ts                       GameSession, Notifier, PanelHost, SelectionStore, PendingMapIntent, PanelId
-  game-session.ts                createGameSession(): GameSession
+  ports.ts                       GameSession, Notifier, PanelHost, SelectionStore,
+                                 PendingMapIntent, PanelId, PanelGroup, PanelContext,
+                                 ChoiceAction, SelectionSnapshot
+  game-session.ts                createGameSession(initial): GameSession
   selection-store.ts             createSelectionStore(): SelectionStore
-  panel-host.ts                  createPanelHost(layer): PanelHost  (absorbs ui-interaction-state)
-  panel-registry.ts              PANEL_REGISTRY: Readonly<Record<PanelId, PanelDescriptor>>
+  user-settings-store.ts         createUserSettingsStore(deps): UserSettingsStore
+  panel-host.ts                  createPanelHost(layer): PanelHost
+  panel-registry.ts              PANEL_REGISTRY satisfies Readonly<Record<PanelId, PanelDescriptor>>
   panel-router.ts                createPanelRouter(deps): PanelRouter
+  global-shortcuts.ts            installGlobalShortcuts(deps): () => void
   controllers/
     campaign-entry-controller.ts   save panel, mode select, campaign/hot-seat setup, enterCampaign
     game-session-controller.ts     startGame: sprite warmup, camera, input install, audio, render start
+    hud-controller.ts              updateHUD, treasury drawer, AA overlay button, viewport inset
     turn-flow-controller.ts        endTurn, hot-seat handoff, solo round, AI replay, victory, autosave
     selection-controller.ts        select/deselect/next, highlights, animated moves, auto-explore
-    map-interaction-controller.ts  handleHexTap, handleHexLongPress  [NOT in the original six — see below]
+    map-interaction-controller.ts  handleHexTap, handleHexLongPress
+    ceremony-coordinator.ts        wonder discovery + legendary completion queues, reduced motion
   bootstrap.ts                     wires controllers + registrars; the only async entry point
 
 src/presentation/                [EXISTS — gains the registrars]
@@ -236,46 +341,85 @@ src/presentation/                [EXISTS — gains the registrars]
   register-network-presentation.ts      |
   register-trade-presentation.ts        |
   register-era-presentation.ts         /
+  register-all.ts
 
 src/main.ts                      ~120 lines: construct concrete services, call bootstrap()
 ```
 
-### One addition to the original six
-
-The source list is `GameSessionController`, `TurnFlowController`, `SelectionController`, `PanelRouter`, `CampaignEntryController`, `PresentationCoordinator`. That list has a gap: `handleHexTap` is **624 lines** — the single largest function in the file, larger than most whole modules in this repo — and it is not selection, not turn flow, and not panel routing. Folding it into `SelectionController` would recreate a god object one level down.
-
-So this plan adds `MapInteractionController`, and splits it the way this codebase already splits input elsewhere (`src/input/selected-unit-tap-intent.ts` is the existing precedent):
-
-- a **pure resolver** — `(state, selection, coord) => MapTapIntent` — a discriminated union, no DOM, no mutation, exhaustively testable;
-- a **thin executor** — `switch (intent.kind)` dispatching to already-extracted systems.
-
-`PresentationCoordinator` is also deliberately *not* a single class here. One coordinator owning 72 event subscriptions is the same god object with a nicer name; ~12 `register*Presentation(bus, ctx): () => void` functions give real SRP and let each be tested by emitting on a throwaway bus.
-
 ### Non-goals
 
-- No change to game rules, balance, yields, or AI behavior.
+- No change to game rules, balance, yields, AI decision-making, difficulty scaling, or victory conditions.
 - No renderer or Canvas changes.
-- No new save schema fields (Phase 1 bumps the version to relocate existing fixups; it adds nothing new).
+- No new save schema *fields* (Phase 1 bumps the version to relocate existing fixups; it adds nothing new).
 - No conversion of `src/systems/*` or `src/ui/*` panel modules to classes. The `createX(deps): X` factory idiom is the house style and stays.
 - No DI container, no decorators, no `reflect-metadata`. Ports are constructor arguments.
+- No new player-facing content, mechanics, sprites, or SFX. This plan is explicitly *not* a feature vehicle — see Part III.
 
 ---
 
-## Part III — Player Truth Table
+## Part III — What This Refactor Must Not Break
+
+You asked for review across gameplay, fun, ages, playstyles, difficulty, AI, UI/UX, extensibility, data, SFX, saves, and hot seat. For a behavior-preserving refactor most of those reduce to one question — *is this surface protected?* — so they are enumerated here as protected surfaces with an owning phase and a guard, rather than as design opportunities.
+
+**On new mechanics and fun specifically:** this plan deliberately adds none. A composition-root refactor is the single worst place to land a gameplay change, because there is no test baseline to distinguish "the refactor broke it" from "the new mechanic changed it." The correct sequencing is: land these 11 phases, *then* build new mechanics on top — which is far cheaper afterwards, because a new mechanic becomes one registrar plus one registry entry instead of another 200 lines in `main.ts`. The extensibility payoff is real, and it is the reward for keeping this plan boring.
+
+### Protected surfaces
+
+| Surface | Why it matters | Where it lives now | Owner | Guard |
+|---|---|---|---|---|
+| **Difficulty (opponent + personal challenge)** | The only difficulty dial the game has; a 7-year-old and a 43-year-old need different ones | `main.ts:490-500` (pause menu), `4029` (`applyPendingChallengeForCiv` at handoff), `5304/5325` (setup) | `HudController` + `TurnFlowController` + `CampaignEntryController` | Phase 9 test: a pending challenge set mid-game applies at the next handoff, once, for the right civ |
+| **Legacy-save challenge prompt** | Old saves have no challenge; `showLegacyOpponentChallengePrompt` asks, and skipping it would silently pick a difficulty for the player | `main.ts:5109/5123/5135` via `beginCampaignEntry` | `CampaignEntryController` | Phase 10 test: all three entry routes still pass `showChallengePrompt` |
+| **AI move replay** | The only way a player sees what the AI did; without it the world changes silently between turns | `captureAIMoves`/`replayAIMoves`, `main.ts:3852-3884` | `TurnFlowController` | Phase 9 test: solo `endTurn` replays only current-viewer moves, capped at 6, and aborts on gate suppression |
+| **Reduced motion** | Accessibility; also the setting a motion-sensitive adult needs to play at all | `prefersReducedMotion`, `main.ts:388` — read by both ceremony queues | `CeremonyCoordinator` | Phase 6 test: with `matchMedia` reporting reduce, queues receive `reducedMotion: true` |
+| **Mis-tap forgiveness** | Touch affordance for young/imprecise players — one warning, not one per tap | `_mistapNotified`, `main.ts:317/3248` | `SelectionStore` | Phase 3 test: N mis-taps produce exactly 1 toast and 1 `SFX.error()` |
+| **Wonder + legendary ceremonies** | The game's payoff moments; currently pumped by a side effect inside `setBlockingOverlay` | `main.ts:380-386, 393-420, 4482-4516` | `CeremonyCoordinator` | Phase 6 test: a ceremony queued while blocked plays when the overlay clears |
+| **Notification dwell + queueing** | Reading speed varies hugely across ages; toasts must queue, never stack or truncate | `main.ts:711-965` | `NotificationCenter` | Phase 4 test: two toasts show sequentially; timer not reset by the second |
+| **SFX cue routing** | `sfxCue` on notifications and `SFX.*` calls are the audio half of every action | `showNotification`'s 4th arg; `routeSfxThrough` | `NotificationCenter` + `GameSessionController` | Phase 4: `playCue` is a **required** dep; test asserts cue fires with the toast |
+| **Hot-seat audio muting** | Player 2 must not hear player 1's turn; `currentMasterVolume` is restored after handoff | `main.ts:360`, `audio.setMasterVolume(0)` in `enterCampaign`/handoff | `UserSettingsStore` + `TurnFlowController` | Phase 9 test: master volume is 0 during handoff and restored to the stored value after |
+| **Icon legend + advisors** | Onboarding surfaces for new and young players | `main.ts:463-476` (legend), `advisorSystem.check` | `PanelRouter` + `GameSessionController` | Phase 5: legend is a registry entry, rebuilt with current techs each open |
+| **Keyboard-only play** | A playstyle: end turn, next unit, fortify, settle, center, journey, panels | `installKeyboardShortcuts` in `startGame`; `window.keydown` at `432` | `GameSessionController` + `GlobalShortcuts` | Phase 5/10: every shortcut still reachable; Escape still cancels a journey |
+| **Touch-only play** | The primary input per `CLAUDE.md`; long-press, pinch, tap-to-select | `TouchHandler`, `handleHexLongPress` | `MapInteractionController` | Phase 8: long-press opens territory inspection; pinch still suppresses tap |
+| **Pacing debug panel** | Balance tooling; backtick-toggled | `main.ts:322, 440-447` | `PanelRouter` (`'pacing-debug'`) | Phase 5: toggle still works and is still keyboard-only |
+
+### How computer players are affected
+
+They are not, and that is enforced rather than assumed. No file under `src/ai/` is modified by any phase. `processNonHumanMajorRound`, `runCompletedRound`, `processTurn`, and `applyStrategicWarningTransitions` are called from `runCurrentCompletedRound` and move to `TurnFlowController` **as a verbatim call**, with the same bus and the same four callbacks.
+
+Two AI-adjacent risks are real and get explicit guards:
+
+1. **`captureAIMoves` is a temporary subscription.** It does `bus.on('unit:move', …)`, runs `result.events.commitTo(bus)`, then unsubscribes. Phase 7 converts 72 permanent handlers into registrars; if a registrar were to be registered *inside* the captured window, or if `commitTo` ordering changed, AI move animations would break or duplicate. Phase 7 Step 6 asserts registrars are installed exactly once at bootstrap, and Phase 9 asserts `captureAIMoves` still observes moves emitted during `commitTo`.
+2. **Difficulty application happens at handoff**, not at setup — `applyPendingChallengeForCiv` at `main.ts:4029` is inside `beginHotSeatHandoff`. Moving that function must not move the *timing*, or a mid-game difficulty change would apply a turn early or late. Phase 9 tests the timing, not just the call.
+
+### Data and extensibility
+
+- **Save data:** one authoritative route after Phase 1. The extension rule becomes: a new persisted field gets a numbered migration in `save-migrations.ts`; a derived rebuild gets a normalizer in `save-manager.ts`; a user preference that is not part of the save gets a function in `settings-merge.ts`. Nothing goes in `main.ts` ever again.
+- **Panels:** one `PANEL_REGISTRY` entry.
+- **Notifications:** one handler in the matching domain registrar.
+- **Save compatibility direction:** Phase 1 bumps `CURRENT_SAVE_SCHEMA_VERSION` 11 → 12. Saves written after Phase 1 will throw `UnsupportedSaveSchemaVersionError` in a pre-Phase-1 build. This is the existing, intended contract (forward-incompatible, backward-compatible) and needs a line in the Phase 1 PR body so nobody is surprised mid-playtest. Family playtest saves made during the refactor should be kept on a branch build that is at or ahead of Phase 1.
+
+---
+
+## Part IV — Player Truth Table
 
 Per `docs/superpowers/plans/README.md`. This refactor is behavior-preserving, so the table records what must *remain* true — these are the regressions this plan can plausibly cause, and each row names the phase and test that guards it.
 
 | Before | Action | Immediate visible result that must not change | Guarded by |
 |---|---|---|---|
-| HUD shows `💰 120`, unit selected | Rush-buy production | HUD gold updates in the same frame; drawer updates | Phase 2, `game-session.test.ts` + `turn-flow-controller.test.ts` |
-| Unit selected, movement overlay drawn | Tap a reachable hex | Unit animates, overlay clears, HUD move count updates, next-unit badge decrements | Phase 7, `map-interaction-controller.test.ts` |
+| HUD shows `💰 120`, unit selected | Rush-buy production | HUD gold updates in the same frame; treasury drawer updates | Phase 2 + 10, `game-session.test.ts`, `hud-controller.test.ts` |
+| Unit selected, movement overlay drawn | Tap a reachable hex | Unit animates, overlay clears, HUD move count updates, next-unit badge decrements | Phase 8, `map-interaction-controller.test.ts` |
+| Transport unload pending | Tap a non-highlighted hex 3 times | Exactly one warning toast and one error SFX, not three | Phase 3, `selection-store.test.ts` |
 | Tech panel open | Click another tech to queue | Panel rerenders with the new queue; panel stays open | Phase 5, `panel-router.test.ts` |
 | City panel open, queue `A, B, C` | Click `↑` on `C` | Queue rerenders `C, A, B` without closing the panel | Phase 5 (existing `city-panel.test.ts` must stay green) |
-| Council panel open | Press `C` (shortcut) | Panel closes; no second panel opens; `councilPanelOpen` returns false | Phase 5, `panel-router.test.ts` |
-| Hot-seat, player 1 ends turn | Confirm handoff | Blocking overlay, audio muted, autosave, then player 2's HUD/civ name | Phase 8, `turn-flow-controller.test.ts` |
+| Council panel open | Press `C` | Panel closes; no second panel opens; `isOpen('council')` is false | Phase 5, `panel-router.test.ts` |
+| Journey intent armed | Press Escape | "Journey cancelled." toast; next tap behaves normally | Phase 5, `global-shortcuts.test.ts` |
+| Natural wonder discovered while a city panel is open | Close the panel | Reveal ceremony plays, discovery audio fires | **Phase 6**, `ceremony-coordinator.test.ts` |
+| Natural wonder discovered by a unit mid-move | — | Reveal waits for the move to settle, then plays | Phase 6, `ceremony-coordinator.test.ts` |
+| Pause menu open, difficulty set to a harder challenge | End turn | Challenge applies once, at the next handoff, to the right civ | Phase 9, `turn-flow-controller.test.ts` |
+| Hot-seat, player 1 ends turn | Confirm handoff | Blocking overlay, audio muted to 0, autosave, then player 2's HUD/civ name, volume restored | Phase 9, `turn-flow-controller.test.ts` |
 | Toast visible, second event fires | — | Second toast queues, shows after the first dismisses; timer not reset | Phase 4, `notification-center.test.ts` |
 | Espionage capture pending | Choose "execute" | Persistent choice notification dismisses; exactly one outcome applies | Phase 4, `notification-center.test.ts` |
-| Save from schema v10 | Load it | Same map, cities, and treaties as before this refactor | Phase 1, `save-migrations.test.ts` golden fixture |
+| Save from schema v10 | Load it | Same map, cities, and treaties as before this refactor | Phase 1, `save-migrations-v12.test.ts` golden fixture |
+| Legacy save with no challenge | Load it | Challenge prompt still appears before entry | Phase 10, `campaign-entry-controller.test.ts` |
 | Brand-new hot-seat game | Start | Identical state shape to before (no `beasts.migrationPending`, no lair placement on tick 1) | Phase 1, `new-game-completeness.test.ts` |
 
 ### Misleading UI risks
@@ -284,28 +428,31 @@ The derived surface at risk is **"the HUD/renderer reflects current state."** It
 
 - An item is legitimately "current" only if the render loop and HUD were refreshed after the most recent `gameState` assignment.
 - Near-miss to keep out: a `setStateWithoutRefresh` call whose caller *intended* a visible change. Phase 2 must not convert any site to `setStateWithoutRefresh` on the grounds that "the next line refreshes anyway" — if a refresh follows within the same synchronous block, use `commit` and delete the manual refresh.
-- Negative test: `game-session.test.ts` asserts `setStateWithoutRefresh` fires **zero** subscriber notifications, and `commit` fires exactly one per call (not one per subscriber-visible field).
+- Second near-miss: a ceremony that is *queued* but never pumped reads to the player as "the game forgot my wonder." `CeremonyCoordinator` must expose queue depth in tests so a silently-stuck queue fails loudly.
+- Negative test: `game-session.test.ts` asserts `setStateWithoutRefresh` fires **zero** subscriber notifications, and `commit` fires exactly one per call.
 
 ### Interaction replay checklist
 
-`handleHexTap` is the replay-sensitive surface; Phase 7 tests must cover, in one session, against one store:
+`handleHexTap` is the replay-sensitive surface; Phase 8 tests must cover, in one session, against one store:
 
 - tap empty hex with nothing selected → no-op
 - tap own unit → selects, overlays appear
 - tap reachable hex → moves, overlays clear
 - tap the *same* hex again immediately → does not re-move a spent unit
 - tap enemy unit in range → attack path, not move path
-- set `journey` intent, then tap → journey path, and intent resets to `none`
-- set `journey` intent, then press Escape, then tap → normal tap behavior (proves intent cleared)
-- set `air-mission`, then set `journey` → only `journey` is live (proves the union replaced, not merged)
+- arm `journey`, then tap → journey path, and intent resets to `none`
+- arm `journey`, press Escape, then tap → normal tap behavior (proves intent cleared)
+- arm `air-mission`, then arm `journey` → only `journey` is live (proves the union replaced, not merged)
+- arm `unload`, mis-tap three times → one toast, one SFX; then tap a valid hex → unload succeeds
+- long-press any hex → territory inspection panel, and no selection change
 
 ---
 
-## Part IV — Phases
+## Part V — Phases
 
-Ten phases, ten PRs. Phases 1 and 2 are prerequisites for everything after; 3–9 are strictly ordered because each removes state that the next one would otherwise have to thread through a deps bag.
+Eleven phases, eleven PRs. Phases 1 and 2 are prerequisites for everything after; 3–10 are strictly ordered because each removes state that the next would otherwise thread through a deps bag.
 
-**Every phase ends with the same three steps** (written out once here, referenced as "**Close the phase**" below — do not skip them):
+**Every phase ends with the same steps** (written once here, referenced as "**Close the phase**"):
 
 ```bash
 bash scripts/run-with-mise.sh yarn test
@@ -313,25 +460,89 @@ bash scripts/run-with-mise.sh yarn test
 ```bash
 bash scripts/run-with-mise.sh yarn build
 ```
-Both must exit 0. Then commit, push, open a PR whose body states the line count of `src/main.ts` before and after.
+```bash
+bash scripts/run-with-mise.sh yarn test tests/app/determinism-guard.test.ts
+```
+
+All must exit 0. Then commit, push, and open a PR whose body states: `main.ts` line count before/after, the module-scope bindings retired (from the Part II inventory), and any intentional behavior change with its test.
+
+### The determinism guard (built in Phase 1, run in every phase)
+
+The cheapest possible protection for gameplay, balance, AI, and difficulty across all eleven phases: same seed in, same state out.
+
+`tests/app/determinism-guard.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
+import { processTurn } from '@/core/turn-manager';
+import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-system';
+import type { GameState } from '@/core/types';
+
+function advance(state: GameState, rounds: number): GameState {
+  let current = state;
+  for (let i = 0; i < rounds; i += 1) {
+    const bus = new EventBus();
+    const result = runCompletedRound(current, bus, {
+      improvements: (s, b) => processImprovementTurns(s, b),
+      majors: (s, b) => processNonHumanMajorRound(s, b).state,
+      world: (s, b) => processTurn(s, b),
+      postprocess: (before, s, b) => applyStrategicWarningTransitions(before, s, b),
+    });
+    if (!result.ok) throw result.error;
+    current = result.state;
+  }
+  return current;
+}
+
+describe('determinism guard', () => {
+  it('20 rounds from a fixed seed produce a byte-identical state across runs', () => {
+    const config = { civType: 'generic' as const, mapSize: 'small' as const, opponentCount: 3, gameTitle: 'guard', seed: 20260804 };
+    const a = advance(createNewGame(config), 20);
+    const b = advance(createNewGame(config), 20);
+
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('matches the recorded baseline digest for this seed', () => {
+    const config = { civType: 'generic' as const, mapSize: 'small' as const, opponentCount: 3, gameTitle: 'guard', seed: 20260804 };
+    const state = advance(createNewGame(config), 20);
+
+    // Recorded once, at Phase 1, from the pre-refactor build. Any phase that changes
+    // this has changed gameplay — which this plan forbids. Do not re-record to make
+    // it pass; find out which phase moved a system call and revert it.
+    expect({
+      turn: state.turn,
+      era: state.era,
+      cityCount: Object.keys(state.cities).length,
+      unitCount: Object.keys(state.units).length,
+      goldByCiv: Object.fromEntries(Object.entries(state.civilizations).map(([id, c]) => [id, c.gold])),
+    }).toMatchSnapshot();
+  });
+});
+```
+
+This runs the real turn pipeline with no UI, so it is unaffected by every phase *except* one that accidentally changes a system call — which is exactly the failure it exists to catch. Record the snapshot in Phase 1, before any other change.
 
 ---
 
 ### Phase 1 — One authoritative save route
 
-**Independent of every other phase.** Do it first: it is the lowest-risk, highest-clarity win, it deletes 124 lines and 20 `as any` casts, and it decouples `enterCampaign` so Phase 9 can move it cleanly.
+**Independent of every other phase.** Do it first: lowest risk, deletes 124 lines and 20 `as any` casts, and decouples `enterCampaign` so Phase 10 can move it cleanly.
 
 **Files:**
-- Modify: `src/storage/save-migrations.ts` (add migration 12, bump `CURRENT_SAVE_SCHEMA_VERSION`)
-- Modify: `src/storage/save-manager.ts:825-888` (`normalizeLoadedState` gains the derived-rebuild fixups)
-- Modify: `src/main.ts:5006-5088` (`enterCampaign` loses `migrateLegacySave()`), delete `src/main.ts:5146-5269`
-- Test: `tests/storage/save-migrations.test.ts`, `tests/storage/new-game-completeness.test.ts` (new)
+- Create: `src/storage/settings-merge.ts`, `tests/app/determinism-guard.test.ts`, `tests/storage/save-migrations-v12.test.ts`, `tests/storage/new-game-completeness.test.ts`
+- Modify: `src/storage/save-migrations.ts`, `src/storage/save-manager.ts:825-888`, `src/main.ts:5006-5088`; delete `src/main.ts:5146-5269`
 
 **Interfaces:**
-- Consumes: `SaveMigration = (state: GameState) => GameState`, `SAVE_MIGRATIONS`, `CURRENT_SAVE_SCHEMA_VERSION` (all already exported from `save-migrations.ts`).
-- Produces: nothing new. `migrateLegacySave` ceases to exist; callers of `normalizeLoadedState` are unchanged.
+- Consumes: `SaveMigration = (state: GameState) => GameState`, `SAVE_MIGRATIONS`, `CURRENT_SAVE_SCHEMA_VERSION` (already exported from `save-migrations.ts`).
+- Produces: `applyPersistedUserSettings(state, persisted): GameState` from `@/storage/settings-merge`. `migrateLegacySave` ceases to exist.
 
-**Classification.** Every one of `migrateLegacySave`'s fixups goes into exactly one of three buckets. Do this classification before writing code and put the table in the PR body.
+**Classification.** Every one of `migrateLegacySave`'s 23 fixups goes into exactly one of three buckets. Do this classification before writing code and put the table in the PR body.
 
 | # | Fixup (`main.ts:5146+`) | Bucket | Destination |
 |---|---|---|---|
@@ -353,15 +564,15 @@ Both must exit 0. Then commit, push, open a PR whose body states the line count 
 | 16 | `TradeRoute` reshape: `id`, `goldPerTrip`, `turnsPerTrip`, `delete goldPerTurn` | versioned | `SAVE_MIGRATIONS[12]` |
 | 17 | `beasts` default with `migrationPending: true` | versioned | `SAVE_MIGRATIONS[12]` |
 | 18 | `resurgentCampCooldownByCivLandmass ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
-| 19 | `civ.knownCivilizations ??= []` | **derived** | `normalizeLoadedState` (superseded by #20 anyway) |
+| 19 | `civ.knownCivilizations ??= []` | **derived** | `normalizeLoadedState` (superseded by #20) |
 | 20 | `refreshKnownCivilizations(state, civId)` per civ | **derived** | `normalizeLoadedState` |
 | 21 | `reconstructLastSeenFromMap(state, civId)` per civ | **derived** | `normalizeLoadedState` |
 | 22 | `clearStaleSoloPendingEvents(state)` | **derived** | `normalizeLoadedState` |
-| 23 | `settings.councilTalkLevel ??= persistedSettings?.councilTalkLevel ?? 'normal'` | **runtime settings** | stays at the call site — see below |
+| 23 | `settings.councilTalkLevel ??= persistedSettings?.councilTalkLevel ?? 'normal'` | **runtime settings** | `settings-merge.ts` — see below |
 
-**Why #19–22 are not versioned:** they recompute state derivable from the map and civ roster. A versioned migration runs once, at one version boundary; these must run on *every* load, because a save written by a build with a since-fixed visibility bug still needs its `lastSeen` rebuilt. `normalizeLoadedState` is exactly the right home and already hosts functions of this shape (`normalizeThreatPressureDefaults`, `normalizeMinorCivQuestState`).
+**Why #19–22 are not versioned:** they recompute state derivable from the map and civ roster. A versioned migration runs once, at one version boundary; these must run on *every* load, because a save written by a build with a since-fixed visibility bug still needs its `lastSeen` rebuilt. `normalizeLoadedState` already hosts functions of this shape (`normalizeThreatPressureDefaults`, `normalizeMinorCivQuestState`).
 
-**Why #23 cannot move:** `persistedSettings` is loaded from IndexedDB by `loadSettings()`, not from the save. A migration signature is `(state: GameState) => GameState`; smuggling a module-global read into `save-migrations.ts` would make migrations non-deterministic and untestable. Keep it in the entry path, but name it honestly — extract it to a tiny exported helper so it reads as a settings merge and not as a migration:
+**Why #23 cannot move:** `persistedSettings` is loaded from IndexedDB by `loadSettings()`, not from the save. A migration signature is `(state) => GameState`; smuggling a module-global read into `save-migrations.ts` would make migrations non-deterministic and untestable.
 
 ```ts
 // src/storage/settings-merge.ts
@@ -384,7 +595,7 @@ export function applyPersistedUserSettings(
 }
 ```
 
-**TypeScript note.** `migrateLegacySave` uses `(x as any)` twenty times because it operates on data whose type is a *lie* — it is typed `GameState` but is actually an older shape. Do not carry the `as any`s across. `save-migrations.ts` already has the right convention; extend it with one narrowing helper rather than casting:
+**TypeScript note.** `migrateLegacySave` uses `(x as any)` twenty times because it operates on data whose type is a *lie* — typed `GameState`, actually an older shape. Do not carry the casts across:
 
 ```ts
 /** A save of an older schema: same keys, but any of them may be absent. */
@@ -398,14 +609,29 @@ function withDefault<T, K extends keyof T>(
 }
 ```
 
-- [ ] **Step 1: Write the failing round-trip test for migration 12**
+- [ ] **Step 1: Record the determinism baseline first**
 
-Create `tests/storage/save-migrations-v12.test.ts`:
+Create `tests/app/determinism-guard.test.ts` exactly as written in Part V above, run it to record the snapshot, and commit that snapshot **before touching any source file**. This is the pre-refactor baseline for all eleven phases.
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/app/determinism-guard.test.ts
+```
+Expected: PASS, and a new `tests/app/__snapshots__/determinism-guard.test.ts.snap`.
+
+```bash
+git add tests/app && git commit -m "test: record pre-refactor determinism baseline"
+```
+
+- [ ] **Step 2: Write the failing migration-12 test**
+
+`tests/storage/save-migrations-v12.test.ts`:
 
 ```ts
 import { describe, it, expect } from 'vitest';
 import { migrateSaveToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
 import { createNewGame } from '@/core/game-state';
+
+const CONFIG = { civType: 'generic' as const, mapSize: 'small' as const, opponentCount: 1, gameTitle: 't', seed: 7 };
 
 function asV11(state: unknown): Record<string, unknown> {
   return { ...(state as Record<string, unknown>), saveSchemaVersion: 11 };
@@ -413,8 +639,7 @@ function asV11(state: unknown): Record<string, unknown> {
 
 describe('save migration 12 — absorbed main.ts legacy fixups', () => {
   it('backfills civType, diplomacy, and lastCombatTurnByLandmass on a v11 save', () => {
-    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
-    const raw = asV11(base);
+    const raw = asV11(createNewGame(CONFIG));
     const civs = raw.civilizations as Record<string, Record<string, unknown>>;
     for (const civ of Object.values(civs)) {
       delete civ.civType;
@@ -434,8 +659,7 @@ describe('save migration 12 — absorbed main.ts legacy fixups', () => {
   });
 
   it('reshapes legacy trade routes to id/goldPerTrip/turnsPerTrip and drops goldPerTurn', () => {
-    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
-    const raw = asV11(base);
+    const raw = asV11(createNewGame(CONFIG));
     (raw.marketplace as { tradeRoutes: unknown[] }).tradeRoutes = [
       { fromCityId: 'a', toCityId: 'b', goldPerTurn: 4 },
     ];
@@ -450,8 +674,7 @@ describe('save migration 12 — absorbed main.ts legacy fixups', () => {
   });
 
   it('flags legacy saves with no beasts block so lairs place on the first tick', () => {
-    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
-    const raw = asV11(base);
+    const raw = asV11(createNewGame(CONFIG));
     delete raw.beasts;
 
     const migrated = migrateSaveToCurrent(raw);
@@ -459,37 +682,56 @@ describe('save migration 12 — absorbed main.ts legacy fixups', () => {
     expect(migrated.beasts.migrationPending).toBe(true);
     expect(migrated.beasts.lairs).toEqual({});
   });
+
+  it('is idempotent — migrating an already-migrated save changes nothing', () => {
+    // migrateLegacySave ran on EVERY entry, so most real v11 saves already have
+    // these fields. Migration 12 must be a no-op for them.
+    const raw = asV11(createNewGame(CONFIG));
+    const once = migrateSaveToCurrent(raw);
+    const twice = migrateSaveToCurrent({ ...once, saveSchemaVersion: 11 });
+
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+
+  it('preserves an existing beasts block instead of resetting it', () => {
+    const raw = asV11(createNewGame(CONFIG));
+    const lairs = (raw.beasts as { lairs: unknown }).lairs;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.beasts.lairs).toEqual(lairs);
+    expect(migrated.beasts.migrationPending).toBeUndefined();
+  });
 });
 ```
 
-- [ ] **Step 2: Run it and confirm it fails**
+The idempotency case is not optional: `migrateLegacySave` ran on *every* campaign entry, so nearly every real v11 save already carries these fields. A migration 12 that clobbers rather than defaults would wipe live player data.
+
+- [ ] **Step 3: Run it and confirm it fails**
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/storage/save-migrations-v12.test.ts
 ```
 Expected: FAIL — `civType` is `undefined`, route has no `id`, `beasts.migrationPending` is `undefined`.
 
-- [ ] **Step 3: Add migration 12**
+- [ ] **Step 4: Add migration 12**
 
-In `src/storage/save-migrations.ts`: add `migrateLegacyMainFixups` implementing rows 1–18 of the table above (port the bodies verbatim from `src/main.ts:5146-5269`, replacing each `(x as any)` with the `withDefault` helper or a direct object spread), register it as `SAVE_MIGRATIONS[12]`, and set `CURRENT_SAVE_SCHEMA_VERSION = 12`.
+In `src/storage/save-migrations.ts`: add `migrateLegacyMainFixups` implementing rows 1–18 (port bodies verbatim from `src/main.ts:5146-5269`, replacing each `(x as any)` with `withDefault` or an object spread), register as `SAVE_MIGRATIONS[12]`, set `CURRENT_SAVE_SCHEMA_VERSION = 12`.
 
-Two ordering requirements carried over from `main.ts`, both of which must be preserved and commented:
-- the `legendaryWonderHistory.discoveredSites` backfill reads `wonderDiscoverers`, so row 8 must run before row 9;
-- the trade-route reshape reads `marketplace`, so row 15 must run before row 16.
+Three ordering requirements carried over from `main.ts`, each needing a comment:
+- row 8 before row 9 — the `discoveredSites` backfill reads `wonderDiscoverers`;
+- row 15 before row 16 — the trade-route reshape reads `marketplace`;
+- every fixup uses `??=` / presence checks, never unconditional assignment (idempotency).
 
-- [ ] **Step 4: Run the test — expect PASS**
+- [ ] **Step 5: Run the test — expect PASS**
 
-```bash
-bash scripts/run-with-mise.sh yarn test tests/storage/save-migrations-v12.test.ts
-```
+- [ ] **Step 6: Move the derived rebuilds into `normalizeLoadedState`**
 
-- [ ] **Step 5: Move the derived rebuilds into `normalizeLoadedState`**
+In `src/storage/save-manager.ts`, add rows 19–22 to `normalizeLoadedState`: `refreshKnownCivilizations` and `reconstructLastSeenFromMap` for every civ, then `clearStaleSoloPendingEvents`. Order matters — `reconstructLastSeenFromMap` runs after known-civ refresh, matching `main.ts:5233-5241`.
 
-In `src/storage/save-manager.ts`, add to the composition inside `normalizeLoadedState` (rows 19–22): `refreshKnownCivilizations` and `reconstructLastSeenFromMap` for every civ, then `clearStaleSoloPendingEvents`. Order matters — `reconstructLastSeenFromMap` must run after known-civ refresh, matching `main.ts:5233-5241`.
+- [ ] **Step 7: Write the new-game completeness test**
 
-- [ ] **Step 6: Write the new-game completeness test**
-
-This is the test that proves route 3 was redundant for new games. Create `tests/storage/new-game-completeness.test.ts`:
+`tests/storage/new-game-completeness.test.ts`:
 
 ```ts
 import { describe, it, expect } from 'vitest';
@@ -507,6 +749,7 @@ describe('freshly created games need no migration', () => {
   });
 
   it('createHotSeatGame output survives normalizeLoadedState unchanged', () => {
+    // Match this literal to the real HotSeatConfig type before running.
     const state = createHotSeatGame(
       { players: [{ name: 'A', isHuman: true, civType: 'generic' }, { name: 'B', isHuman: true, civType: 'generic' }], mapSize: 'small' },
       undefined,
@@ -521,30 +764,32 @@ describe('freshly created games need no migration', () => {
 });
 ```
 
-If either assertion fails, **stop and read the diff** — it is telling you that `createNewGame`/`createHotSeatGame` produces incomplete state, which is a real bug worth its own issue. Do not "fix" it by loosening the assertion. (Adjust the `createHotSeatGame` config literal to match the real `HotSeatConfig` type; the shape above is illustrative.)
+**Expected failure mode, and the correct response.** `createNewGame` and `createHotSeatGame` both hard-code `knownCivilizations: []` (`src/core/game-state.ts:263, 289, 476`) and never call `refreshKnownCivilizations`. If `refreshKnownCivilizations` computes a non-empty list at turn 1 (e.g. a civ always knows itself), this test fails on `knownCivilizations`.
 
-- [ ] **Step 7: Delete `migrateLegacySave` and rewire `enterCampaign`**
+That failure is a genuine pre-existing inconsistency — new hot-seat games got the refresh at entry, new solo games did not. **Fix it by making `createNewGame`/`createHotSeatGame` produce complete state** (call `refreshKnownCivilizations` at creation), not by re-adding an entry-time call or loosening the assertion. Note the fix in the PR body as the one intentional behavior change in Phase 1, and confirm the determinism snapshot from Step 1 still passes — if it moves, you changed gameplay and must stop.
 
-Delete `src/main.ts:5146-5269`. In `enterCampaign`, replace `migrateLegacySave();` with:
+- [ ] **Step 8: Delete `migrateLegacySave` and rewire `enterCampaign`**
+
+Delete `src/main.ts:5146-5269`. In `enterCampaign`, replace `gameState = state; migrateLegacySave();` with:
 
 ```ts
 gameState = applyPersistedUserSettings(state, persistedSettings);
 ```
 
-(replacing the existing `gameState = state;`). Add the `src/storage/settings-merge.ts` file shown above plus a two-case unit test for it.
+Add `src/storage/settings-merge.ts` plus a two-case unit test (respects an existing `councilTalkLevel`; falls back to `'normal'` when neither save nor persisted settings have one).
 
-- [ ] **Step 8: Update the source-grep tests this phase breaks**
+- [ ] **Step 9: Confirm the source-grep suite still passes**
 
-`tests/main.integration.test.ts` — no assertion currently names `migrateLegacySave`, so this phase should not break it. Run it explicitly to confirm rather than assuming:
+No assertion currently names `migrateLegacySave`, but verify rather than assume:
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/main.integration.test.ts
 ```
 
-- [ ] **Step 9: Close the phase** (full `yarn test`, `yarn build`, commit, PR)
+- [ ] **Step 10: Close the phase**
 
 ```bash
-git add src/storage src/main.ts tests/storage && git commit -m "refactor(save): fold main.ts legacy fixups into the versioned migration pipeline"
+git add src/storage src/core/game-state.ts src/main.ts tests && git commit -m "refactor(save): fold main.ts legacy fixups into the versioned migration pipeline"
 ```
 
 ---
@@ -552,8 +797,7 @@ git add src/storage src/main.ts tests/storage && git commit -m "refactor(save): 
 ### Phase 2 — `GameSession`: one owner for game state
 
 **Files:**
-- Create: `src/app/ports.ts`, `src/app/game-session.ts`
-- Test: `tests/app/game-session.test.ts`
+- Create: `src/app/ports.ts`, `src/app/game-session.ts`, `tests/app/game-session.test.ts`
 - Modify: `src/main.ts` — replace `let gameState` and all 93 assignment sites
 
 **Interfaces:**
@@ -633,7 +877,7 @@ describe('createGameSession', () => {
 });
 ```
 
-That last case matters: today a throw inside `updateHUD()` would abort the statement sequence and skip `renderLoop.setGameState`. Isolating subscribers is a genuine robustness improvement and is behavior-compatible (nothing currently depends on the throw propagating).
+The last case matters: today a throw inside `updateHUD()` aborts the statement sequence and skips `renderLoop.setGameState`. Isolating subscribers is a genuine robustness improvement and is behavior-compatible.
 
 - [ ] **Step 2: Run it, confirm it fails**
 
@@ -682,14 +926,7 @@ export function createGameSession(initial: GameState): GameSession {
 
 - [ ] **Step 5: Adopt in `main.ts`**
 
-Replace `let gameState: GameState;` with a module-scope `session` created in `enterCampaign`/`startGame`, plus a compatibility accessor so the 93 sites can be converted in reviewable batches:
-
-```ts
-let session: GameSession;
-const gameStateOf = (): GameState => session.getState();
-```
-
-Register the two subscribers once, where `renderLoop` and the HUD are known:
+Replace `let gameState: GameState;` with a module-scope `session` created in `enterCampaign`/`startGame`. Register the two subscribers once, where `renderLoop` and the HUD are known:
 
 ```ts
 session.subscribe(next => renderLoop.setGameState(next));
@@ -699,42 +936,56 @@ session.subscribe(() => updateHUD());
 Then convert call sites. Two mechanical rules, applied literally:
 
 - `gameState = X;` followed (within the same synchronous block, before any `await` or `return`) by `renderLoop.setGameState(gameState)` and/or `updateHUD()` → `session.commit(X);` and **delete** the manual refresh lines.
-- `gameState = X;` with no refresh in the same block → `session.setStateWithoutRefresh(X);` and add `// TODO(composition-root): verify refresh` above it.
+- `gameState = X;` with no refresh in the same block → `session.setStateWithoutRefresh(X);` with `// TODO(composition-root): verify refresh` above it.
 
-Do **not** exercise judgment about which unrefreshed sites "should" refresh — that is a behavior change and belongs in Phase 10. Convert 93 sites in ~6 commits of ~15 each so the diff stays reviewable.
+Do **not** exercise judgment about which unrefreshed sites "should" refresh — that is a behavior change, deferred to Phase 11. Convert 93 sites in ~6 commits of ~15 each.
 
-- [ ] **Step 6: Guard the TODO count**
+- [ ] **Step 6: Add the debt ratchet**
 
-Add to `tests/app/game-session.test.ts`:
+`tests/app/refresh-bypass-ratchet.test.ts` (its own file — it is a debt counter, not a unit test of `GameSession`):
 
 ```ts
-it('tracks how many state writes still bypass the refresh path', () => {
-  const main = readFileSync(resolve(__dirname, '../../src/main.ts'), 'utf8');
-  const bypasses = main.match(/setStateWithoutRefresh\(/g)?.length ?? 0;
-  // Ratchet only. Lower this number when you eliminate a bypass; never raise it.
-  expect(bypasses).toBeLessThanOrEqual(46);
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('refresh bypass debt', () => {
+  it('tracks how many state writes still bypass the refresh path', () => {
+    const main = readFileSync(resolve(__dirname, '../../src/main.ts'), 'utf8');
+    const bypasses = main.match(/setStateWithoutRefresh\(/g)?.length ?? 0;
+    // Ratchet only. Lower when you eliminate a bypass; never raise it.
+    expect(bypasses).toBeLessThanOrEqual(46);
+  });
 });
 ```
 
-This is the one source-grep assertion this plan *adds*, and it is legitimate: it measures a debt counter and can only move one direction. Phase 10 drives it to 0 and deletes the test.
+This is the one source-grep assertion this plan *adds*, and it is legitimate: it measures a debt counter that can only move one direction. Phase 11 drives it to 0 and deletes the file.
 
 - [ ] **Step 7: Close the phase**
 
 ---
 
-### Phase 3 — `SelectionStore` and `PendingMapIntent`
+### Phase 3 — `SelectionStore`, `PendingMapIntent`, and mis-tap forgiveness
 
 **Files:**
-- Create: `src/app/selection-store.ts`; extend `src/app/ports.ts`
-- Test: `tests/app/selection-store.test.ts`
-- Modify: `src/main.ts` (10 module `let`s), `src/ui/transport-ui-state.ts` (folded in)
+- Create: `src/app/selection-store.ts`, `tests/app/selection-store.test.ts`; extend `src/app/ports.ts`
+- Modify: `src/main.ts` (10 module `let`s); delete `src/ui/transport-ui-state.ts`
 
 **Interfaces:**
 - Consumes: `GameSession` (Phase 2).
 - Produces:
 
 ```ts
+export interface SelectionSnapshot {
+  readonly selectedUnitId: string | null;
+  readonly movementRange: readonly HexCoord[];
+  readonly attackRange: readonly HexCoord[];
+  readonly pendingIntent: PendingMapIntent;
+  readonly waterRecovery: LandUnitWaterRecovery;
+}
+
 export interface SelectionStore {
+  snapshot(): SelectionSnapshot;
   getSelectedUnitId(): string | null;
   setSelectedUnitId(unitId: string | null): void;
   getWaterRecovery(): LandUnitWaterRecovery;
@@ -747,24 +998,48 @@ export interface SelectionStore {
   getCityCursor(): number;
   advanceCityCursor(cityCount: number): number;
   getPendingIntent(): PendingMapIntent;
+  /** Replaces the intent wholesale and resets mis-tap forgiveness. */
   setPendingIntent(intent: PendingMapIntent): void;
+  /** True the first time only, per pending-intent lifetime. */
+  shouldWarnOnMistap(): boolean;
   clear(): void;
 }
 ```
 
-- [ ] **Step 1: Write the failing test** — cover, at minimum, that `setPendingIntent` replaces rather than merges:
+`snapshot()` exists so `resolveMapTapIntent` (Phase 8) can be a pure function of a plain value rather than of a live store.
+
+- [ ] **Step 1: Write the failing test**
 
 ```ts
 import { describe, it, expect } from 'vitest';
 import { createSelectionStore } from '@/app/selection-store';
 
-describe('createSelectionStore pending intent', () => {
+describe('createSelectionStore', () => {
   it('replaces the pending intent instead of accumulating independent flags', () => {
     const store = createSelectionStore();
     store.setPendingIntent({ kind: 'air-mission', unitId: 'u1', mission: 'strike' });
     store.setPendingIntent({ kind: 'journey', unitId: 'u2' });
 
     expect(store.getPendingIntent()).toEqual({ kind: 'journey', unitId: 'u2' });
+  });
+
+  it('warns on the first mis-tap only, per pending-intent lifetime', () => {
+    const store = createSelectionStore();
+    store.setPendingIntent({ kind: 'unload', transportId: 't1', range: [] });
+
+    expect(store.shouldWarnOnMistap()).toBe(true);
+    expect(store.shouldWarnOnMistap()).toBe(false);
+    expect(store.shouldWarnOnMistap()).toBe(false);
+  });
+
+  it('re-arming a pending intent re-arms the mis-tap warning', () => {
+    const store = createSelectionStore();
+    store.setPendingIntent({ kind: 'unload', transportId: 't1', range: [] });
+    store.shouldWarnOnMistap();
+
+    store.setPendingIntent({ kind: 'unload', transportId: 't2', range: [] });
+
+    expect(store.shouldWarnOnMistap()).toBe(true);
   });
 
   it('clear() resets selection, ranges, and pending intent together', () => {
@@ -792,34 +1067,64 @@ describe('createSelectionStore pending intent', () => {
 
 - [ ] **Step 2: Run, confirm failure.** Expected: `Cannot find module '@/app/selection-store'`.
 
-- [ ] **Step 3: Implement** `createSelectionStore(): SelectionStore` — plain closure over the ten values, `PendingMapIntent` defaulting to `{ kind: 'none' }`, `clear()` resetting all of them.
+- [ ] **Step 3: Implement** `createSelectionStore(): SelectionStore` — plain closure over the ten values, `PendingMapIntent` defaulting to `{ kind: 'none' }`, `clear()` resetting all of them, `setPendingIntent` resetting the mis-tap flag.
 
 - [ ] **Step 4: Run — expect PASS.**
 
-- [ ] **Step 5: Adopt.** Delete the ten `let`s from `main.ts`. Fold `src/ui/transport-ui-state.ts`'s `getPendingUnload` / `setPendingUnload` / `clearPendingUnload` into the `unload` intent variant and delete that file. Update `clearUnloadState()` accordingly.
+- [ ] **Step 5: Adopt.** Delete the ten `let`s from `main.ts`. Fold `src/ui/transport-ui-state.ts`'s `getPendingUnload` / `setPendingUnload` / `clearPendingUnload` into the `unload` variant and delete that file. `clearUnloadState()` becomes `selection.setPendingIntent({ kind: 'none' })`.
 
-At this point `handleHexTap`'s intent checks are still `if` chains — do not restructure them yet, that is Phase 7. Only the storage changes here.
+`handleHexTap`'s intent checks stay as `if` chains for now — restructuring is Phase 8. Only storage changes here.
 
-- [ ] **Step 6: Close the phase**
+- [ ] **Step 6: Document the one behavior change.** Mis-tap forgiveness now re-arms whenever the pending intent changes, where previously it re-armed only via `clearUnloadState`. State this in the PR body; it is strictly friendlier (a fresh action gets a fresh warning) and is covered by the third test above.
+
+- [ ] **Step 7: Close the phase**
 
 ---
 
-### Phase 4 — `NotificationCenter`
+### Phase 4 — `NotificationCenter` and `UserSettingsStore`
 
-Moves `src/main.ts:711-965` and `4185-4229` (~290 lines) into a testable module.
+Moves `src/main.ts:711-965` and `4185-4229` (~290 lines) plus the settings/volume bindings.
 
 **Files:**
-- Create: `src/ui/notification-center.ts`
-- Test: `tests/ui/notification-center.test.ts`
-- Modify: `src/main.ts` (delete `notificationQueue`, `isShowingNotification`, `currentDismissTimer`, `enqueueToast`, `showNotification`, `displayNextNotification`, `createPersistentChoiceNotification`)
+- Create: `src/ui/notification-center.ts`, `src/app/user-settings-store.ts`, `tests/ui/notification-center.test.ts`, `tests/app/user-settings-store.test.ts`
+- Modify: `src/main.ts`
 
 **Interfaces:**
-- Consumes: `PanelHost` (`layer` only), `createNotificationDelivery` (existing, unchanged).
-- Produces: `createNotificationCenter(deps: NotificationCenterDeps): Notifier`, where deps are exactly `{ layer: HTMLElement; getState: () => GameState; isSuppressed: () => boolean; playCue?: (cue: string) => void }` — four fields, not fifteen. That is the ISP payoff made concrete.
-
-- [ ] **Step 1: Write the failing tests** — the queue behaviors that currently have no coverage at all:
+- Consumes: `PanelHost.layer` (or a raw `HTMLElement` until Phase 5), `createNotificationDelivery` (existing).
+- Produces:
 
 ```ts
+export interface NotificationCenterDeps {
+  readonly layer: HTMLElement;
+  readonly getState: () => GameState;
+  readonly isSuppressed: () => boolean;
+  /** REQUIRED. An optional cue callback would silently mute game audio on a wiring mistake. */
+  readonly playCue: (cue: string) => void;
+}
+export function createNotificationCenter(deps: NotificationCenterDeps): Notifier;
+
+export interface UserSettingsStore {
+  getPersisted(): GameState['settings'] | undefined;
+  refresh(): Promise<GameState['settings']>;
+  getOverrides(): Partial<GameState['settings']>;
+  getMasterVolume(): number;
+  setMasterVolume(value: number): void;
+  setCustomCivilizations(civs: GameState['settings']['customCivilizations']): void;
+}
+export function createUserSettingsStore(deps: {
+  load: () => Promise<GameState['settings'] | undefined>;
+  save: (settings: GameState['settings']) => Promise<void>;
+}): UserSettingsStore;
+```
+
+Four deps, not fifteen — the ISP payoff made concrete. `UserSettingsStore` owns `persistedSettings` (321) and `currentMasterVolume` (360) plus `mergePersistedSettings` / `refreshPersistedSettings` / `getPersistedSettingsOverrides`; `currentMasterVolume` is deliberately *not* in `GameState` (it is not saved), which is exactly why it needs a named owner rather than a stray module `let`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/ui/notification-center.test.ts` (prefix the file with `// @vitest-environment jsdom` — the repo default is `node`):
+
+```ts
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createNotificationCenter } from '@/ui/notification-center';
 import type { GameState } from '@/core/types';
@@ -828,19 +1133,23 @@ const state = { turn: 3, currentPlayer: 'player', civilizations: {}, hotSeat: un
 
 describe('notification center queue', () => {
   let layer: HTMLElement;
+  let playCue: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     layer = document.createElement('div');
     document.body.appendChild(layer);
+    playCue = vi.fn();
   });
   afterEach(() => {
     vi.useRealTimers();
     layer.remove();
   });
 
+  const make = () => createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false, playCue });
+
   it('shows one toast at a time and drains the queue in order', () => {
-    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+    const center = make();
 
     center.toast('first', 'info');
     center.toast('second', 'info');
@@ -853,8 +1162,16 @@ describe('notification center queue', () => {
     expect(layer.textContent).toContain('second');
   });
 
+  it('plays the sfx cue attached to a toast', () => {
+    const center = make();
+
+    center.toast('city captured', 'success', undefined, 'city-captured');
+
+    expect(playCue).toHaveBeenCalledWith('city-captured');
+  });
+
   it('renders message text via textContent, never innerHTML', () => {
-    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+    const center = make();
 
     center.toast('<img src=x onerror=alert(1)>', 'warning');
 
@@ -863,7 +1180,7 @@ describe('notification center queue', () => {
   });
 
   it('a choice notification stays until an action is chosen, then applies exactly one outcome', () => {
-    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+    const center = make();
     const execute = vi.fn();
     const release = vi.fn();
 
@@ -885,40 +1202,52 @@ describe('notification center queue', () => {
 });
 ```
 
-Add `// @vitest-environment jsdom` at the top of the file — the repo's vitest default environment is `node`.
-
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement** by moving the existing bodies verbatim into the factory closure; the only change is that module-scope `let`s become closure `let`s and `uiLayer` becomes `deps.layer`.
+- [ ] **Step 3: Implement** both factories by moving existing bodies verbatim into closures; module-scope `let`s become closure `let`s, `uiLayer` becomes `deps.layer`, `SFX` calls route through `deps.playCue`.
 - [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Adopt.** In `main.ts`, construct the center and keep local `const showNotification = notifier.toast` aliases so the 153 call sites do not all change in this PR.
+- [ ] **Step 5: Adopt.** In `main.ts`, keep `const showNotification = notifier.toast` aliases so the 153 call sites do not all change in this PR.
 - [ ] **Step 6: Close the phase**
 
 ---
 
-### Phase 5 — `PanelRouter` and the panel registry
+### Phase 5 — `PanelHost`, `PanelRouter`, registry, and global shortcuts
 
-Replaces `togglePanel`'s 288-line `else if` chain (`src/main.ts:1589-1877`) and the eight `open*Panel` helpers.
+Replaces `togglePanel`'s 288-line `else if` chain (`src/main.ts:1589-1877`), the eight `open*Panel` helpers, and the module-scope `keydown` listener.
 
 **Files:**
-- Create: `src/app/panel-host.ts`, `src/app/panel-registry.ts`, `src/app/panel-router.ts`
-- Test: `tests/app/panel-router.test.ts`
-- Modify: `src/main.ts`; delete `src/ui/ui-interaction-state.ts` (absorbed by `PanelHost`)
+- Create: `src/app/panel-host.ts`, `src/app/panel-registry.ts`, `src/app/panel-router.ts`, `src/app/global-shortcuts.ts`, `tests/app/panel-router.test.ts`, `tests/app/global-shortcuts.test.ts`
+- Modify: `src/main.ts`; delete `src/ui/ui-interaction-state.ts`
 
 **Interfaces:**
-- Consumes: `GameSession`, `Notifier`, `PanelHost`.
+- Consumes: `GameSession`, `Notifier`, `SelectionStore`.
 - Produces:
 
 ```ts
 export type PanelId =
   | 'council' | 'tech' | 'city' | 'espionage' | 'diplomacy' | 'marketplace'
   | 'network' | 'wonder' | 'wonder-atlas' | 'bestiary' | 'pirate-waters'
-  | 'notification-log' | 'city-overview' | 'territory-inspection';
+  | 'notification-log' | 'city-overview' | 'territory-inspection' | 'pacing-debug';
+
+/**
+ * Panels in the same group close each other. 'main' is the mutually-exclusive
+ * set that togglePanel clears today; 'transient' panels (inspection, legend)
+ * close on handoff but do not close each other.
+ */
+export type PanelGroup = 'main' | 'transient';
+
+/** Everything a panel factory needs. Panels never reach for `document` directly. */
+export interface PanelContext {
+  readonly session: GameSession;
+  readonly notifier: Notifier;
+  readonly host: PanelHost;
+  readonly selection: SelectionStore;
+  readonly router: PanelRouter;
+}
 
 export interface PanelDescriptor {
   /** The DOM id the panel factory assigns to its root element. */
   readonly domId: string;
-  /** Panels in the same group close each other. */
-  readonly exclusiveGroup?: 'main';
+  readonly group: PanelGroup;
   readonly open: (ctx: PanelContext) => void;
 }
 
@@ -926,14 +1255,16 @@ export interface PanelRouter {
   toggle(panel: PanelId): void;
   open(panel: PanelId): void;
   close(panel: PanelId): void;
-  closeGroup(group: 'main'): void;
+  closeGroup(group: PanelGroup): void;
   isOpen(panel: PanelId): boolean;
 }
 ```
 
-The `stringly-typed` `togglePanel(panel: string)` becomes a closed union, and `toggle` dispatches through the registry instead of an `if` chain. Adding a panel is a registry entry — Open/Closed satisfied.
+The stringly-typed `togglePanel(panel: string)` becomes a closed union, and `toggle` dispatches through the registry instead of an `if` chain. Two groups rather than one, because the existing code has two closing behaviors: `togglePanel` clears six main panels, while `closeNetworkPanelsForHandoff` / `closePlanningPanels` / `closePirateWatersPanels` clear a different set at handoff. `closeGroup('transient')` replaces the ad-hoc closers.
 
-- [ ] **Step 1: Write the failing test.**
+**`togglePanel` also calls `drawer?.close()` first.** The treasury drawer is not a registry panel (it is a HUD affordance). Preserve this by having `PanelRouter.open` fire `host.setBlockingOverlay(null)`'s sibling hook — concretely, `PanelContext` gains nothing; instead `createPanelRouter` takes an `onBeforeOpen?: () => void` dep, wired in Phase 10 to `drawer.close()`. Test it in Phase 10 with the drawer, not here.
+
+- [ ] **Step 1: Write the failing panel-router test**
 
 ```ts
 // @vitest-environment jsdom
@@ -941,18 +1272,22 @@ import { describe, it, expect, vi } from 'vitest';
 import { createPanelRouter } from '@/app/panel-router';
 import { createPanelHost } from '@/app/panel-host';
 
+const stubPanel = (layer: HTMLElement, id: string) => () => {
+  layer.appendChild(Object.assign(document.createElement('div'), { id }));
+};
+
 describe('panel router', () => {
   it('opening a main-group panel closes the previously open one', () => {
     const layer = document.createElement('div');
     const host = createPanelHost(layer);
-    const openTech = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'tech-panel' })); });
-    const openCouncil = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'council-panel' })); });
+    const openTech = vi.fn(stubPanel(layer, 'tech-panel'));
+    const openCouncil = vi.fn(stubPanel(layer, 'council-panel'));
 
     const router = createPanelRouter({
       host,
       registry: {
-        tech: { domId: 'tech-panel', exclusiveGroup: 'main', open: openTech },
-        council: { domId: 'council-panel', exclusiveGroup: 'main', open: openCouncil },
+        tech: { domId: 'tech-panel', group: 'main', open: openTech },
+        council: { domId: 'council-panel', group: 'main', open: openCouncil },
       },
       context: {} as never,
     });
@@ -966,13 +1301,32 @@ describe('panel router', () => {
     expect(router.isOpen('council')).toBe(true);
   });
 
+  it('a transient panel does not close a main panel', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const router = createPanelRouter({
+      host,
+      registry: {
+        tech: { domId: 'tech-panel', group: 'main', open: stubPanel(layer, 'tech-panel') },
+        'territory-inspection': { domId: 'territory-panel', group: 'transient', open: stubPanel(layer, 'territory-panel') },
+      },
+      context: {} as never,
+    });
+
+    router.open('tech');
+    router.open('territory-inspection');
+
+    expect(layer.querySelector('#tech-panel')).not.toBeNull();
+    expect(layer.querySelector('#territory-panel')).not.toBeNull();
+  });
+
   it('toggle closes an already-open panel instead of reopening it', () => {
     const layer = document.createElement('div');
     const host = createPanelHost(layer);
-    const open = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'tech-panel' })); });
+    const open = vi.fn(stubPanel(layer, 'tech-panel'));
     const router = createPanelRouter({
       host,
-      registry: { tech: { domId: 'tech-panel', exclusiveGroup: 'main', open } },
+      registry: { tech: { domId: 'tech-panel', group: 'main', open } },
       context: {} as never,
     });
 
@@ -985,25 +1339,142 @@ describe('panel router', () => {
 });
 ```
 
+- [ ] **Step 2: Write the failing `PanelHost` unblock test** — the guard for the ceremony pump discovered in Part II:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createPanelHost } from '@/app/panel-host';
+
+describe('panel host interaction blocking', () => {
+  it('notifies unblock listeners exactly once when the overlay clears', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const listener = vi.fn();
+    host.onInteractionUnblocked(listener);
+
+    host.setBlockingOverlay('turn-handoff');
+    expect(host.isInteractionBlocked()).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
+
+    host.setBlockingOverlay(null);
+    expect(host.isInteractionBlocked()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when the overlay is replaced by another overlay', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const listener = vi.fn();
+    host.onInteractionUnblocked(listener);
+
+    host.setBlockingOverlay('a');
+    host.setBlockingOverlay('b');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run both, confirm failure.**
+- [ ] **Step 4: Implement.** `toggle` = `isOpen(id) ? close(id) : open(id)`; `open` calls `onBeforeOpen?.()` then `closeGroup(descriptor.group)` for `'main'` only. Type the registry with `satisfies Readonly<Record<PanelId, PanelDescriptor>>` so key coverage is checked without widening the value type.
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Migrate the real panels.** Move each `else if` branch of `togglePanel` into its registry entry's `open`. Delete `councilPanelOpen` — `isOpen('council')` derives it from the DOM, removing a second source of truth. `pacingDebugOpen` likewise becomes `isOpen('pacing-debug')`.
+- [ ] **Step 7: Extract `installGlobalShortcuts`.** Move the module-scope `window.addEventListener('keydown', …)` (`main.ts:432-448`) into `src/app/global-shortcuts.ts` with signature `installGlobalShortcuts(deps: { target: EventTarget; selection: SelectionStore; router: PanelRouter; notifier: Notifier }): () => void`. Test both branches: Escape with an armed journey cancels it and toasts; backtick toggles `'pacing-debug'`.
+- [ ] **Step 8: Close the phase**
+
+---
+
+### Phase 6 — `CeremonyCoordinator`
+
+The phase that exists because of the `setBlockingOverlay` discovery. Owns `wonderDiscoveryQueue`, `legendaryCompletionQueue`, `deferWonderDiscoveryRevealUntilMoveSettles`, and `prefersReducedMotion`.
+
+**Files:**
+- Create: `src/app/controllers/ceremony-coordinator.ts`, `tests/app/controllers/ceremony-coordinator.test.ts`
+- Modify: `src/main.ts:326, 377-420, 380-386, 2542-2597`
+
+**Interfaces:**
+- Consumes: `PanelHost` (for `onInteractionUnblocked` and `layer`), `GameSession`, `PanelRouter`, plus two concrete callbacks it genuinely needs: `requestMapHighlight` and `playDiscoveryAudio`.
+- Produces: `createCeremonyCoordinator(deps): CeremonyCoordinator` (signature in Part II).
+
+- [ ] **Step 1: Write the failing tests** — the three rules currently encoded implicitly:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createCeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import { createPanelHost } from '@/app/panel-host';
+
+describe('ceremony coordinator', () => {
+  it('plays a ceremony queued while the UI was blocked, once the overlay clears', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator({ host, playDiscoveryAudio, /* … */ } as never);
+
+    host.setBlockingOverlay('city-panel');
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+
+    host.setBlockingOverlay(null);
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers a reveal queued during an animated move until the move settles', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator({ host, playDiscoveryAudio, /* … */ } as never);
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+
+    coordinator.endAction();
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes reduced-motion through to the queue when the media query matches', () => {
+    const requestMapHighlight = vi.fn();
+    const coordinator = createCeremonyCoordinator({
+      reducedMotion: () => true, requestMapHighlight, /* … */
+    } as never);
+
+    coordinator.enqueueWonderDiscovery(wonderItem());
+
+    expect(requestMapHighlight).toHaveBeenCalledWith(expect.anything(), true);
+  });
+
+  it('a legendary completion plays immediately — it is never deferred by a move', () => {
+    const playCeremony = vi.fn();
+    const coordinator = createCeremonyCoordinator({ playCeremony, /* … */ } as never);
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueLegendaryCompletion(legendaryItem());
+
+    expect(playCeremony).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+The fourth case pins existing asymmetric behavior: `main.ts:4512-4513` calls `notifyActionSettled()` unconditionally for legendary completions but conditionally (on the defer flag) for wonder discoveries. Preserve the asymmetry; do not "fix" it here.
+
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement.** `toggle` = `isOpen(id) ? close(id) : open(id)`; `open` closes the exclusive group first. Keep the registry typed with `satisfies Readonly<Record<PanelId, PanelDescriptor>>` so key coverage is checked without widening the value type.
+- [ ] **Step 3: Implement.** Construct both queues inside the factory, subscribe to `host.onInteractionUnblocked` for the pump, and make `beginDeferredAction`/`endAction` the only writers of the defer flag.
 - [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Migrate the real panels.** Move each `else if` branch of `togglePanel` into its registry entry's `open`. The `councilPanelOpen` boolean is deleted — `isOpen('council')` derives it from the DOM, which removes a second source of truth. Keyboard shortcuts and `createGameShell` callbacks now call `router.toggle('council')` etc.
+- [ ] **Step 5: Adopt.** `setBlockingOverlay` in `main.ts` loses its queue-pumping tail (now handled by the subscription). `executeAnimatedUnitMove` (`main.ts:2565-2597`) calls `coordinator.beginDeferredAction()` / `endAction()` instead of writing the flag.
 - [ ] **Step 6: Close the phase**
 
 ---
 
-### Phase 6 — Presentation registrars
+### Phase 7 — Presentation registrars
 
-Replaces the 72 module-scope `bus.on(...)` registrations (`src/main.ts:4377-4961`) with ~12 domain modules. This is the phase that makes importing `main.ts` in a test *possible*, because it removes the largest block of import-time side effects.
+Replaces the 72 module-scope `bus.on(...)` registrations (`src/main.ts:4377-4961`) with ~12 domain modules. This is the phase that makes importing `main.ts` in a test *possible*.
 
 **Files:**
-- Create: `src/presentation/register-*.ts` (~12 files, per the structure in Part II) and `src/presentation/register-all.ts`
-- Test: `tests/presentation/register-*.test.ts` (one per registrar)
-- Modify: `src/main.ts` (delete the 72 handlers)
+- Create: `src/presentation/register-*.ts` (~12) and `src/presentation/register-all.ts`; `tests/helpers/presentation-context.ts`; `tests/presentation/register-*.test.ts`
+- Modify: `src/main.ts`
 
 **Interfaces:**
-- Consumes: `EventBus`, `GameSession`, `Notifier`, `PanelRouter`.
+- Consumes: `EventBus`, `GameSession`, `Notifier`, `PanelRouter`, `CeremonyCoordinator`, `SelectionStore`.
 - Produces:
 
 ```ts
@@ -1011,76 +1482,119 @@ export interface PresentationContext {
   readonly session: GameSession;
   readonly notifier: Notifier;
   readonly router: PanelRouter;
+  readonly ceremonies: CeremonyCoordinator;
+  readonly selection: SelectionStore;
 }
 
 /** Returns a disposer that removes every subscription this registrar added. */
 export type PresentationRegistrar = (bus: EventBus, ctx: PresentationContext) => () => void;
 ```
 
-Returning a disposer is not speculative generality: `EventBus.on` already returns an unsubscribe function, hot-seat handoff already needs to tear panels down, and without it these registrars would leak subscriptions across a "new game from the pause menu" transition — a latent bug in the current code, since `main.ts` registers once at import and can never unregister.
+Returning a disposer is not speculative generality: `EventBus.on` already returns an unsubscribe, hot-seat handoff already tears panels down, and without it these registrars would leak subscriptions across a "new game from the pause menu" transition — a latent bug today, since `main.ts` registers once at import and can never unregister.
 
-- [ ] **Step 1: Write the failing test for the first registrar** (do diplomacy first — it is small and self-contained, `src/main.ts:4533-4561`):
+- [ ] **Step 1: Write the shared fake-context helper** — `tests/helpers/presentation-context.ts`, used by all twelve suites:
+
+```ts
+import { vi } from 'vitest';
+import type { GameState } from '@/core/types';
+import type { PresentationContext } from '@/presentation/register-all';
+
+export function makePresentationContext(overrides: {
+  state?: Partial<GameState>;
+  deliver?: ReturnType<typeof vi.fn>;
+} = {}): PresentationContext & { deliver: ReturnType<typeof vi.fn> } {
+  const deliver = overrides.deliver ?? vi.fn();
+  const state = { turn: 1, currentPlayer: 'player', civilizations: {}, cities: {}, units: {}, ...overrides.state } as GameState;
+  return {
+    deliver,
+    session: { getState: () => state, commit: vi.fn(), update: vi.fn(), setStateWithoutRefresh: vi.fn(), subscribe: () => () => {} },
+    notifier: { toast: vi.fn(), deliver, choice: vi.fn() },
+    router: { toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: () => false },
+    ceremonies: { enqueueWonderDiscovery: vi.fn(), enqueueLegendaryCompletion: vi.fn(), beginDeferredAction: vi.fn(), endAction: vi.fn() },
+    selection: makeSelectionStoreDouble(),
+  } as never;
+}
+```
+
+- [ ] **Step 2: Write the failing test for the first registrar** (diplomacy — small and self-contained, `src/main.ts:4533-4561`):
 
 ```ts
 import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
 
 describe('diplomacy presentation', () => {
   it('announces a war declaration to the log once', () => {
     const bus = new EventBus();
-    const deliver = vi.fn();
-    const ctx = makeContext({ deliver });
+    const ctx = makePresentationContext();
 
     registerDiplomacyPresentation(bus, ctx);
     bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
 
-    expect(deliver).toHaveBeenCalledTimes(1);
-    expect(deliver.mock.calls[0][1]).toContain('war');
+    expect(ctx.deliver).toHaveBeenCalledTimes(1);
+    expect(ctx.deliver.mock.calls[0][1]).toContain('war');
   });
 
   it('disposing removes the subscription', () => {
     const bus = new EventBus();
-    const deliver = vi.fn();
-    const dispose = registerDiplomacyPresentation(bus, makeContext({ deliver }));
+    const ctx = makePresentationContext();
+    const dispose = registerDiplomacyPresentation(bus, ctx);
 
     dispose();
     bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
 
-    expect(deliver).not.toHaveBeenCalled();
+    expect(ctx.deliver).not.toHaveBeenCalled();
   });
 });
 ```
 
-Write `makeContext` once in `tests/helpers/presentation-context.ts` and reuse it across all twelve registrar suites — it is the fake-ports harness the whole plan pays for.
+- [ ] **Step 3: Run, confirm failure.**
+- [ ] **Step 4: Implement `registerDiplomacyPresentation`** by moving the four `bus.on` bodies verbatim, collecting unsubscribers, returning a disposer that calls them all.
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Repeat for the remaining eleven,** one commit each, smallest first: era, trade, religion, faction-crisis, network, wonder, city, espionage, beast, raider (barbarian + pirate; owns `notifiedBarbarianCampsPerCiv`), combat.
 
-- [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement `registerDiplomacyPresentation`** by moving the four `bus.on` bodies verbatim, collecting the returned unsubscribers, and returning a disposer that calls them all.
-- [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Repeat for the remaining eleven registrars,** one commit each, in this order (smallest and least entangled first): era, trade, religion, faction-crisis, network, wonder, city, espionage, beast, raider (barbarian + pirate), combat.
+`wonder` now delegates to `CeremonyCoordinator` (Phase 6) instead of touching the defer flag. `combat` goes last: it delegates to `handleCombatResolvedEvent` but also touches selection, so it is the only registrar needing `SelectionStore` — available since Phase 3.
 
-`combat` goes last: its handler already delegates to `handleCombatResolvedEvent` in `src/ui/combat-resolved-presentation.ts` but also touches selection state, so it is the only registrar that needs `SelectionStore` — and by Phase 6 that port exists.
+- [ ] **Step 7: Add `register-all.ts`** composing all twelve into one disposer, and assert it is installed exactly once:
 
-- [ ] **Step 6: Add `register-all.ts`** composing all twelve and returning a single disposer, and call it once from `main.ts`.
-- [ ] **Step 7: Convert the affected source-grep assertions.** `tests/main.integration.test.ts`'s `era:advanced notification` block (4 assertions, lines 265-311) tests behavior that now lives in `register-era-presentation.ts`. Rewrite those four as real tests against the registrar and delete them from the grep file.
-- [ ] **Step 8: Close the phase**
+```ts
+it('installs every registrar exactly once and disposes them all together', () => {
+  const bus = new EventBus();
+  const ctx = makePresentationContext();
+
+  const dispose = registerAllPresentation(bus, ctx);
+  bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
+  expect(ctx.deliver).toHaveBeenCalledTimes(1);
+
+  dispose();
+  bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
+  expect(ctx.deliver).toHaveBeenCalledTimes(1);
+});
+```
+
+This is the guard against double-registration duplicating every notification — the specific way this phase could break AI move replay and the notification log at once.
+
+- [ ] **Step 8: Convert the affected source-grep assertions.** `tests/main.integration.test.ts`'s `era:advanced notification` block (4 assertions, lines 265-311) now lives in `register-era-presentation.ts`. Rewrite as real tests; delete from the grep file.
+- [ ] **Step 9: Close the phase**
 
 ---
 
-### Phase 7 — `SelectionController` and `MapInteractionController`
+### Phase 8 — `SelectionController` and `MapInteractionController`
 
-The biggest phase: `selectUnit` (456 lines), `handleHexTap` (624), `handleHexLongPress` (37), plus the movement/animation helpers.
+The biggest phase: `selectUnit` (456 lines), `handleHexTap` (624), `handleHexLongPress` (37), plus movement/animation helpers.
 
 **Files:**
-- Create: `src/app/controllers/selection-controller.ts`, `src/app/controllers/map-interaction-controller.ts`, `src/input/map-tap-intent.ts`
-- Test: `tests/app/controllers/selection-controller.test.ts`, `tests/app/controllers/map-interaction-controller.test.ts`, `tests/input/map-tap-intent.test.ts`
+- Create: `src/app/controllers/selection-controller.ts`, `src/app/controllers/map-interaction-controller.ts`, `src/input/map-tap-intent.ts`, and their three test files
 - Modify: `src/main.ts`
 
 **Interfaces:**
-- Consumes: `GameSession`, `SelectionStore`, `Notifier`, `PanelRouter`.
+- Consumes: `GameSession`, `SelectionStore`, `Notifier`, `PanelRouter`, `CeremonyCoordinator`.
 - Produces:
 
 ```ts
+import type { MovementBlockerReason } from '@/systems/unit-system';
+
 export type MapTapIntent =
   | { readonly kind: 'ignore' }
   | { readonly kind: 'select-unit'; readonly unitId: string }
@@ -1089,6 +1603,7 @@ export type MapTapIntent =
   | { readonly kind: 'attack'; readonly attackerId: string; readonly targetKey: string }
   | { readonly kind: 'open-city'; readonly cityId: string }
   | { readonly kind: 'resolve-pending'; readonly intent: PendingMapIntent; readonly coord: HexCoord }
+  | { readonly kind: 'mistap'; readonly intent: PendingMapIntent }
   | { readonly kind: 'blocked'; readonly reason: MovementBlockerReason };
 
 export function resolveMapTapIntent(
@@ -1098,7 +1613,7 @@ export function resolveMapTapIntent(
 ): MapTapIntent;
 ```
 
-`resolveMapTapIntent` is **pure** — no DOM, no mutation, no `bus`. That is what makes the eight-case Interaction Replay Checklist in Part III cheap to test. The controller's `handleHexTap` becomes an exhaustive `switch (intent.kind)` with:
+`resolveMapTapIntent` is **pure** — no DOM, no mutation, no `bus` — which is what makes the ten-row Interaction Replay Checklist cheap to test. The controller's `handleHexTap` becomes an exhaustive `switch (intent.kind)` with:
 
 ```ts
 default: {
@@ -1107,51 +1622,57 @@ default: {
 }
 ```
 
-- [ ] **Step 1: Write failing tests for `resolveMapTapIntent`** — one per row of the Interaction Replay Checklist in Part III. These are pure-function tests over a fixture state; use `tests/fixtures/` for the state builder if one already fits, otherwise add one.
+The `mistap` variant is separate from `ignore` because mis-tap forgiveness (Phase 3) needs the executor to consult `selection.shouldWarnOnMistap()` — an `ignore` result would lose the affordance.
+
+- [ ] **Step 1: Write failing tests for `resolveMapTapIntent`** — one per row of the Interaction Replay Checklist in Part IV. Pure-function tests over a fixture state; reuse `tests/fixtures/` if one fits, otherwise add a builder there.
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement `resolveMapTapIntent`** by reading `src/main.ts:3144-3768` top to bottom and translating each early-return branch into a union member. Do not change precedence — the existing order *is* the specification. Where the existing code checks the four pending flags in sequence, translate to a single `switch (selection.pendingIntent.kind)` that preserves the same outcomes.
+- [ ] **Step 3: Implement `resolveMapTapIntent`** by reading `src/main.ts:3144-3768` top to bottom and translating each early-return branch into a union member. **Do not change precedence — the existing order is the specification.** Where the code checks four pending flags in sequence, translate to one `switch (selection.pendingIntent.kind)` preserving the same outcomes.
 - [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Extract `SelectionController`** (`selectUnit`, `deselectUnit`, `selectNextUnit`, `refreshSelectedUnitAfterCombat`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `isUnitAnimationLocked`) with tests for: selecting sets ranges; deselecting clears both ranges and highlights; `selectNextUnit` skips units that have acted; a second `selectUnit` on an animating unit is a no-op.
-- [ ] **Step 6: Extract `MapInteractionController`** — the executor half plus `handleHexLongPress`.
-- [ ] **Step 7: Convert the affected source-grep assertions.** `tests/main.integration.test.ts` blocks `player combat wiring` (3), `land-unit water recovery wiring` (1), `shared city founding wiring` (1), `shared unit upgrade wiring` (1), `shared city assault wiring` (4) — 10 assertions total — all describe behavior now in these two controllers. Rewrite as real tests; delete from the grep file.
+- [ ] **Step 5: Extract `SelectionController`** (`selectUnit`, `deselectUnit`, `selectNextUnit`, `refreshSelectedUnitAfterCombat`, `refreshCurrentPlayerVisibility`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `isUnitAnimationLocked`). Tests: selecting sets ranges; deselecting clears ranges and highlights; `selectNextUnit` skips acted units; a second `selectUnit` on an animating unit is a no-op; an animated move brackets the ceremony defer window.
+- [ ] **Step 6: Extract `MapInteractionController`** — the executor plus `handleHexLongPress`. Test that long-press opens territory inspection and leaves selection unchanged.
+- [ ] **Step 7: Convert the affected source-grep assertions.** `player combat wiring` (3), `land-unit water recovery wiring` (1), `shared city founding wiring` (1), `shared unit upgrade wiring` (1), `shared city assault wiring` (4) — 10 total. Rewrite as real tests; delete from the grep file.
 - [ ] **Step 8: Close the phase**
 
 ---
 
-### Phase 8 — `TurnFlowController`
+### Phase 9 — `TurnFlowController`
 
 **Files:**
-- Create: `src/app/controllers/turn-flow-controller.ts`
-- Test: `tests/app/controllers/turn-flow-controller.test.ts`
+- Create: `src/app/controllers/turn-flow-controller.ts`, `tests/app/controllers/turn-flow-controller.test.ts`
 - Modify: `src/main.ts`
 
-**Moves:** `endTurn`, `beginHotSeatHandoff`, `releaseHandoffToViewer`, `closeNetworkPanelsForHandoff`, `beginNetworkPlansForCurrentViewer`, `runCurrentCompletedRound`, `captureAIMoves`, `replayAIMoves`, `handleVictoryIfNeeded`, `centerOnCurrentPlayer`, `emitCurrentPlayerAudioSnapshot`, `maybeShowCouncilInterrupt`, `showRequiredChoicesIfNeeded`, `showReligionBoonIfNeeded`, `refreshRequiredChoicesAfterAction`, `closeRequiredChoicePanel`.
+**Moves:** `endTurn`, `beginHotSeatHandoff`, `releaseHandoffToViewer`, `closeNetworkPanelsForHandoff`, `beginNetworkPlansForCurrentViewer`, `runCurrentCompletedRound`, `captureAIMoves`, `replayAIMoves`, `handleVictoryIfNeeded`, `centerOnCurrentPlayer`, `emitCurrentPlayerAudioSnapshot`, `maybeShowCouncilInterrupt`, `showRequiredChoicesIfNeeded`, `showReligionBoonIfNeeded`, `refreshRequiredChoicesAfterAction`, `closeRequiredChoicePanel`, `finalizePendingCityCaptureChoice`.
 
 **Interfaces:**
-- Consumes: all four ports, plus narrow function refs for the genuinely concrete collaborators: `{ autoSave, advisorCheck, setMasterVolume, roundGate }`.
+- Consumes: all four ports, plus narrow refs for genuinely concrete collaborators: `{ autoSave, advisorCheck, roundGate, settings: UserSettingsStore, audio: Pick<AudioSystem, 'setMasterVolume'>, animateUnitMove }`.
 - Produces: `createTurnFlowController(deps): TurnFlowController` with `{ endTurn(options?): Promise<void>; enterViewerTurn(): void }`.
 
-- [ ] **Step 1: Write failing tests** for the four ordering guarantees currently protected only by regex:
-  - solo `endTurn` runs the completed round, replays AI moves, *then* refreshes, *then* opens required choices;
-  - `endTurn` is a no-op when `state.gameOver`;
-  - a pending religion boon blocks `endTurn` and toasts, without advancing the turn;
-  - hot-seat `endTurn` suppresses the presentation gate, mutes audio, and autosaves before the handoff overlay resolves.
+- [ ] **Step 1: Write failing tests** for the guarantees currently protected only by regex, or not at all:
+
+1. solo `endTurn` runs the completed round, replays AI moves, *then* refreshes, *then* opens required choices;
+2. `endTurn` is a no-op when `state.gameOver`;
+3. a pending religion boon blocks `endTurn` and toasts, without advancing the turn;
+4. hot-seat `endTurn` suppresses the presentation gate, sets master volume to 0, autosaves, and restores the stored master volume after the handoff resolves;
+5. **difficulty:** a pending opponent challenge set before `endTurn` is applied exactly once, at the handoff, to the correct civ (`applyPendingChallengeForCiv`, `main.ts:4029`) — and a *personal* pending challenge applies only to its own civ;
+6. **AI replay:** `captureAIMoves` observes `unit:move` events emitted during `result.events.commitTo(bus)`, and `replayAIMoves` animates only current-viewer moves, capped at 6, aborting early if the gate becomes suppressed.
+
+Cases 5 and 6 have no existing coverage of any kind and are the two highest-risk behaviors in this phase.
+
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement** by moving bodies verbatim; substitute port calls for the direct `renderLoop` / `updateHUD` / `showNotification` references.
-- [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Convert the affected source-grep assertions.** `completed-round AI wiring` (4 assertions) and `campaign entry wiring`'s "opens required research choices" (1) — 5 total. Rewrite; delete from the grep file.
+- [ ] **Step 3: Implement** by moving bodies verbatim; substitute port calls for direct `renderLoop` / `updateHUD` / `showNotification` references. `runCurrentCompletedRound` keeps its four callbacks unchanged — no `src/systems/` or `src/ai/` file is edited.
+- [ ] **Step 4: Run — expect PASS, and re-run the determinism guard.** If the guard snapshot moves in this phase, a system call was reordered; revert and re-approach.
+- [ ] **Step 5: Convert the affected source-grep assertions.** `completed-round AI wiring` (4) and `campaign entry wiring`'s "opens required research choices" (1) — 5 total.
 - [ ] **Step 6: Close the phase**
 
 ---
 
-### Phase 9 — `CampaignEntryController`, `GameSessionController`, and the composition root
+### Phase 10 — `HudController`, `CampaignEntryController`, `GameSessionController`, composition root
 
 **Files:**
-- Create: `src/app/controllers/campaign-entry-controller.ts`, `src/app/controllers/game-session-controller.ts`, `src/app/bootstrap.ts`
-- Test: `tests/app/controllers/campaign-entry-controller.test.ts`, `tests/app/bootstrap.test.ts`
+- Create: `src/app/controllers/hud-controller.ts`, `src/app/controllers/campaign-entry-controller.ts`, `src/app/controllers/game-session-controller.ts`, `src/app/bootstrap.ts`, plus test files
 - Modify: `src/main.ts` → final form
 
-**Moves:** `init`, `showStartSavePanel`, `showGameModeSelection`, `enterCampaign`, `enterCampaignForE2E`, `startGame`, `createUI`, `getPersistedSettingsOverrides`, `mergePersistedSettings`, `refreshPersistedSettings`, `updateHUD`, `setMapViewportBottomInset`, `prefersReducedMotion`.
+**Moves:** `init`, `showStartSavePanel`, `showGameModeSelection`, `enterCampaign`, `enterCampaignForE2E`, `startGame`, `createUI`, `updateHUD`, `setMapViewportBottomInset`, the `resize` listener, the treasury `drawer`, `airDefenseOverlayButton`, `inputInitialized`.
 
 **Interfaces:**
 - Produces: `bootstrap(services: AppServices): Promise<void>` where
@@ -1168,7 +1689,7 @@ export interface AppServices {
 }
 ```
 
-`main.ts`'s final form is approximately:
+`main.ts`'s final form:
 
 ```ts
 import '@/assets/sprite-animations-v2.css';
@@ -1198,41 +1719,78 @@ void bootstrap({
 
 Everything below the imports is construction. No game logic, no `bus.on`, no `let`.
 
-- [ ] **Step 1: Write the failing bootstrap test** — the payoff test, the one that was impossible before this plan:
+- [ ] **Step 1: Write the failing bootstrap test** — the payoff test, impossible before this plan. Define the fake-services helper explicitly:
 
 ```ts
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
-import { bootstrap } from '@/app/bootstrap';
+import { EventBus } from '@/core/event-bus';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { bootstrap, type AppServices } from '@/app/bootstrap';
+
+function makeFakeServices(): AppServices & { audio: { start: ReturnType<typeof vi.fn> } } {
+  document.body.innerHTML = '<canvas id="game-canvas"></canvas><div id="ui-layer"></div>';
+  const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+  const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
+  return {
+    canvas,
+    uiLayer,
+    renderLoop: {
+      camera: { centerOn: vi.fn(), setMinZoomForMap: vi.fn(), hexSize: 32 },
+      setGameState: vi.fn(), start: vi.fn(), stop: vi.fn(), resizeCanvas: vi.fn(),
+      setTouchHandler: vi.fn(), setSelectedUnitId: vi.fn(), setHighlights: vi.fn(),
+      clearHighlights: vi.fn(), isAirDefenseOverlayEnabled: () => false,
+    },
+    audio: { start: vi.fn(), setMasterVolume: vi.fn(), getSfxRoutingNode: vi.fn() },
+    bus: new EventBus(),
+    roundGate: new RoundPresentationGate(),
+    advisors: { check: vi.fn() },
+  } as never;
+}
 
 describe('bootstrap', () => {
-  it('wires a session, registers presentation, and shows the save panel without touching AudioContext', async () => {
-    document.body.innerHTML = '<canvas id="game-canvas"></canvas><div id="ui-layer"></div>';
+  it('shows the save panel and does not start audio before a campaign is entered', async () => {
     const services = makeFakeServices();
 
     await bootstrap(services);
 
     expect(document.getElementById('save-panel')).not.toBeNull();
-    expect(services.audio.start).not.toHaveBeenCalled(); // audio starts on campaign entry, not bootstrap
+    expect(services.audio.start).not.toHaveBeenCalled();
+  });
+
+  it('registers presentation exactly once, so one event yields one notification', async () => {
+    const services = makeFakeServices();
+    await bootstrap(services);
+
+    // No assertion on text here — Phase 7's registrar suites own the content.
+    // This asserts wiring multiplicity only.
+    expect(() => services.bus.emit('diplomacy:war-declared', { attackerId: 'a', defenderId: 'b' })).not.toThrow();
   });
 });
 ```
 
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement `bootstrap`** as: construct ports → construct controllers → `registerAllPresentation` → `campaignEntry.showStartSavePanel()`, preserving the existing e2e branch (`import.meta.env.MODE === 'e2e'`) exactly.
-- [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Convert the remaining source-grep assertions.** `campaign entry wiring` (3 remaining) and `air-defense overlay button placement` (2) — 5 total. `tests/main.integration.test.ts` should now be **empty and deleted**.
-- [ ] **Step 6: Close the phase**
+- [ ] **Step 3: Implement `bootstrap`** as: construct ports → construct controllers → `registerAllPresentation` → `campaignEntry.showStartSavePanel()`, preserving the e2e branch (`import.meta.env.MODE === 'e2e'`) exactly, including its position **before** `showStartSavePanel`.
+- [ ] **Step 4: Extract `HudController`** — `updateHUD`, the treasury `drawer` (including `PanelRouter`'s `onBeforeOpen: () => drawer.close()`), `airDefenseOverlayButton` placement in `#utility-toolbar` (the `#783` fix — assert placement, not absolute positioning), `setMapViewportBottomInset`. Test: gold text updates on commit; AA button hidden without coverage; drawer closes when a main panel opens.
+- [ ] **Step 5: Extract `CampaignEntryController`** with the difficulty guard: all three entry routes (`onContinue`, `onLoadEntry`, `onImportSave`) still pass `showChallengePrompt: showLegacyOpponentChallengePrompt`, and a legacy save with no challenge still prompts before entry.
+- [ ] **Step 6: Convert the remaining source-grep assertions.** `campaign entry wiring` (3 remaining) and `air-defense overlay button placement` (2) — 5 total. `tests/main.integration.test.ts` is now empty; **delete the file**.
+- [ ] **Step 7: Run the e2e suite** — this phase touches campaign entry and the e2e install branch, so unit tests are not sufficient:
+
+```bash
+bash scripts/run-with-mise.sh yarn test:e2e
+```
+
+- [ ] **Step 8: Close the phase**
 
 ---
 
-### Phase 10 — Ratchet down and lock the boundary
+### Phase 11 — Ratchet down and lock the boundary
 
 **Files:**
 - Create: `tests/app/architecture-boundaries.test.ts`
-- Modify: whichever `setStateWithoutRefresh` sites survive
+- Modify: surviving `setStateWithoutRefresh` sites; `CLAUDE.md`; delete `tests/app/refresh-bypass-ratchet.test.ts`
 
-- [ ] **Step 1: Audit every remaining `setStateWithoutRefresh` call.** For each, determine whether the player could observe stale data. Convert to `commit` where they could — **each conversion is a bug fix and needs its own test and its own line in the PR body**, since these are the only intentional behavior changes in the whole plan.
+- [ ] **Step 1: Audit every remaining `setStateWithoutRefresh` call.** For each, determine whether the player could observe stale data. Convert to `commit` where they could — **each conversion is a bug fix needing its own test and its own line in the PR body**, since these are the only intentional behavior changes in the plan. Known candidates from the survey: the pause-menu challenge setters (`main.ts:493, 498`) mutate state with no refresh, which is likely correct (nothing visible changes until the next turn) but must be decided deliberately, not by default.
 - [ ] **Step 2: Write the boundary test.**
 
 ```ts
@@ -1250,17 +1808,17 @@ describe('composition root boundaries', () => {
   it('main.ts registers no event handlers and owns no mutable state', () => {
     expect(main).not.toMatch(/\bbus\.on\(/);
     expect(main).not.toMatch(/^let /m);
+    expect(main).not.toMatch(/window\.addEventListener\(/);
   });
 
   it('only main.ts constructs concrete platform services', () => {
-    // Every other module receives them through ports.
     expect(main).toContain('new AudioContext()');
     expect(main).toContain('new RenderLoop(');
   });
 });
 ```
 
-- [ ] **Step 3: Write the port-purity test** — controllers must not import concrete platform types:
+- [ ] **Step 3: Write the port-purity test.**
 
 ```ts
 import { readdirSync, readFileSync } from 'node:fs';
@@ -1268,7 +1826,7 @@ import { resolve } from 'node:path';
 
 it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => {
   const dir = resolve(__dirname, '../../src/app/controllers');
-  for (const file of readdirSync(dir)) {
+  for (const file of readdirSync(dir).filter(f => f.endsWith('.ts'))) {
     const source = readFileSync(resolve(dir, file), 'utf8');
     expect(source, file).not.toMatch(/from '@\/renderer\/render-loop'/);
     expect(source, file).not.toMatch(/from '@\/audio\/audio-system'/);
@@ -1277,53 +1835,77 @@ it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => 
 });
 ```
 
-`document.getElementById` is banned in controllers specifically because it is the ambient-global escape hatch that would let a controller reach around `PanelHost` and silently reintroduce the coupling this plan removes. Panels get their root from `PanelHost.layer`.
+`document.getElementById` is banned in controllers because it is the ambient-global escape hatch that would let a controller reach around `PanelHost` and silently reintroduce the coupling this plan removes. Panels get their root from `PanelHost.layer`.
 
-- [ ] **Step 4: Delete the `setStateWithoutRefresh` ratchet test from Phase 2** (or, if some bypasses are genuinely correct, lower its bound to that number and document each in a comment).
-- [ ] **Step 5: Update `CLAUDE.md`** — add to the Architecture section: "`src/main.ts` is a composition root only. New app behavior goes in `src/app/controllers/` (depends on `src/app/ports.ts`) or `src/presentation/` registrars. Enforced by `tests/app/architecture-boundaries.test.ts`."
+Type-only imports of `RenderLoop`/`AudioSystem` for `Pick<>` deps are fine; the regexes target value imports, so write those as `import type`.
+
+- [ ] **Step 4: Delete `tests/app/refresh-bypass-ratchet.test.ts`** (or, if some bypasses are genuinely correct, lower its bound to that number and document each in a comment).
+- [ ] **Step 5: Update `CLAUDE.md`.** Add to Architecture:
+
+> `src/main.ts` is a composition root only. New app behavior goes in `src/app/controllers/` (depending on `src/app/ports.ts`) or a `src/presentation/register-*.ts` registrar. A new panel is one `PANEL_REGISTRY` entry; a new notification is one handler in the matching registrar; a new persisted save field is one numbered migration in `save-migrations.ts`. Enforced by `tests/app/architecture-boundaries.test.ts`.
+
 - [ ] **Step 6: Close the phase**
 
 ---
 
-## Part V — Test Design Requirements
+## Part VI — Test Design Requirements
 
-Per `docs/superpowers/plans/README.md` §5, and because the current coverage of this file is 21 regex assertions.
+Per `docs/superpowers/plans/README.md` §5, and because current coverage of this file is 21 regex assertions.
 
 **Every phase must add:**
-- at least one test that performs the interaction and inspects the resulting DOM or state, not just the internal call;
-- at least one negative test for any derived semantic helper introduced (`isOpen`, `resolveMapTapIntent`'s `blocked` variant, `PendingMapIntent` precedence);
-- for Phase 5, a test proving every registry-declared panel is still reachable from the shell/keyboard after the router replaces `togglePanel`.
+- at least one test that performs the interaction and inspects resulting DOM or state, not just the internal call;
+- at least one negative test for any derived semantic helper introduced (`isOpen`, `resolveMapTapIntent`'s `blocked`/`mistap` variants, `PendingMapIntent` precedence, `onInteractionUnblocked` not firing on overlay replacement);
+- for Phase 5, a test proving every registry-declared panel is still reachable from the shell and from the keyboard after the router replaces `togglePanel`.
+
+**Every phase must run**, not just unit tests:
+- `yarn test` (full suite), `yarn build` (the only `tsc` path), and `tests/app/determinism-guard.test.ts`;
+- `yarn test:e2e` in Phases 8 and 10, which touch map input and campaign entry respectively.
 
 **Running count of source-grep assertions retired** (must reach zero):
 
 | Phase | Block retired | Assertions |
 |---|---|---|
-| 6 | `era:advanced notification` | 4 |
-| 7 | combat / water-recovery / city-founding / upgrade / assault wiring | 10 |
-| 8 | `completed-round AI wiring` + required-choices | 5 |
-| 9 | `campaign entry wiring` + air-defense placement | 5 |
+| 7 | `era:advanced notification` | 4 |
+| 8 | combat / water-recovery / city-founding / upgrade / assault wiring | 10 |
+| 9 | `completed-round AI wiring` + required-choices | 5 |
+| 10 | `campaign entry wiring` + air-defense placement | 5 |
 | — | **Total** | **24** |
 
-(24 rather than 21 because three `it` blocks carry multiple `readFileSync` assertions; count from the file, not from this table, when checking off.)
+(24 rather than 21 because three `it` blocks carry multiple `readFileSync` assertions; count from the file, not this table, when checking off.)
+
+**Intentional behavior changes across the whole plan** — the complete list; anything not here is a bug:
+
+| Phase | Change | Test |
+|---|---|---|
+| 1 | `createNewGame`/`createHotSeatGame` populate `knownCivilizations` at creation (only if Step 7 fails) | `new-game-completeness.test.ts` |
+| 2 | A throwing view subscriber no longer strands the other subscribers | `game-session.test.ts` |
+| 3 | Mis-tap forgiveness re-arms on any pending-intent change, not only via `clearUnloadState` | `selection-store.test.ts` |
+| 11 | Individually-audited stale-refresh fixes | one test per conversion |
 
 ---
 
-## Part VI — Risks
+## Part VII — Risks
 
 | Risk | Why it is real here | Mitigation |
 |---|---|---|
-| A phase silently changes refresh timing and the HUD goes stale | 46 sites currently do not refresh; it is not knowable from the code which are intentional | Phase 2 preserves every site exactly via `setStateWithoutRefresh`; changes are deferred to Phase 10 where each gets a test |
-| `handleHexTap` precedence changes | Four independent pending flags whose ordering is emergent, not specified | Phase 7 extracts a pure resolver **first** and tests all eight replay rows before any behavior moves |
-| Hot-seat handoff regressions | Most stateful, least covered flow; involves audio muting, overlays, autosave, and the presentation gate | Phase 8 tests the four ordering guarantees; e2e `web-smoke.spec.ts` must pass before merge |
-| Losing a fixup during the save consolidation | 23 fixups, 20 `as any` casts, no existing tests | The classification table is a checklist; the new-game completeness test proves the new-game path; keep a v10 and a v11 golden fixture save in `tests/fixtures/` |
-| Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Ten small PRs merged promptly, not one large branch. Coordinate: no other `main.ts`-touching PR should sit open across a phase merge |
-| Scope creep into "while I'm here" fixes | Guaranteed to be tempting across 5,462 lines | Behavior-preserving is a Global Constraint; file issues instead. Phase 10 is the only phase permitted to change behavior |
+| **Ceremonies silently stop playing** | `setBlockingOverlay` secretly pumps both ceremony queues; a naive `PanelHost` port drops it, and no existing test covers this path | Phase 6 is a dedicated phase with `onInteractionUnblocked` and four tests; Part IV row 8 makes it a truth-table guarantee |
+| A phase silently changes refresh timing and the HUD goes stale | 46 sites do not refresh today; which are intentional is not knowable from the code | Phase 2 preserves every site via `setStateWithoutRefresh`; changes deferred to Phase 11 where each gets a test |
+| `handleHexTap` precedence changes | Four independent pending flags whose ordering is emergent, not specified | Phase 8 extracts a pure resolver **first** and tests all ten replay rows before behavior moves |
+| Difficulty applies at the wrong time | `applyPendingChallengeForCiv` sits inside `beginHotSeatHandoff`; moving the function could move the timing | Phase 9 test 5 asserts once, at handoff, for the right civ |
+| AI move replay breaks or duplicates | `captureAIMoves` is a temporary subscription wrapping `commitTo(bus)`; Phase 7 rewrites every permanent subscription | Phase 7 Step 7 asserts single registration; Phase 9 test 6 asserts capture still observes `commitTo` |
+| Hot-seat handoff regressions | Most stateful, least covered flow: audio muting, overlays, autosave, presentation gate, challenge application | Phase 9 tests four ordering guarantees; e2e smoke must pass |
+| A gameplay/balance change slips in | 5,462 lines of moved code, and `main.ts` calls into nearly every system | Determinism guard recorded in Phase 1 Step 1 and run in every phase; `src/systems/` and `src/ai/` are read-only |
+| Losing a fixup during save consolidation | 23 fixups, 20 `as any` casts, no existing tests | Classification table is a checklist; idempotency + preserve-existing tests; new-game completeness test; keep v10/v11 golden fixtures in `tests/fixtures/` |
+| A mid-refactor playtest save cannot be reopened | Phase 1 bumps the schema to 12; older builds throw `UnsupportedSaveSchemaVersionError` | Called out in Part III; family playtest builds stay at or ahead of Phase 1 |
+| Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Eleven small PRs merged promptly, not one long branch; no other `main.ts`-touching PR should sit open across a phase merge |
+| Scope creep into "while I'm here" fixes | Guaranteed to be tempting across 5,462 lines | Behavior-preserving is a Global Constraint; the Part VI table is the exhaustive allowlist; file issues otherwise |
 
 ---
 
-## Part VII — Self-Review Notes
+## Part VIII — Self-Review Notes
 
-- **Spec coverage:** all six controllers from the source list are assigned (`GameSessionController` → Phase 9, `TurnFlowController` → 8, `SelectionController` → 7, `PanelRouter` → 5, `CampaignEntryController` → 9, `PresentationCoordinator` → 6 as twelve registrars). The save-normalization requirement is Phase 1. `MapInteractionController` is added with justification in Part II.
-- **Placeholder scan:** no TBD/TODO in the plan itself. The one `// TODO(composition-root)` comment introduced in Phase 2 Step 5 is a deliberate, counted, ratcheted debt marker retired in Phase 10.
-- **Type consistency:** `GameSession.commit` / `update` / `setStateWithoutRefresh` / `subscribe` are used with those exact names in Phases 2, 7, 8, and 10. `PendingMapIntent` (Phase 3) is consumed by `MapTapIntent`'s `resolve-pending` variant (Phase 7). `PresentationRegistrar` returns `() => void` in both its definition and its Phase 6 disposal test. `PanelId` is defined in Phase 5 and referenced by `PanelHost.close` in Part II.
-- **Known soft spot:** the exact `createHotSeatGame` config literal in Phase 1 Step 6 is illustrative and must be matched to the real `HotSeatConfig` type when writing the test.
+- **Spec coverage:** all six controllers from the source list are assigned (`GameSessionController` → Phase 10, `TurnFlowController` → 9, `SelectionController` → 8, `PanelRouter` → 5, `CampaignEntryController` → 10, `PresentationCoordinator` → 7 as twelve registrars). Save-normalization consolidation is Phase 1. `MapInteractionController` (Phase 8), `CeremonyCoordinator` (Phase 6), `HudController` (Phase 10), and `UserSettingsStore` (Phase 4) are added with justification in Part II.
+- **Completeness:** every one of the 23 module-scope `let`s and every module-scope side effect is assigned a phase in the Part II inventory. Phase 11's `not.toMatch(/^let /m)` is only satisfiable if that table is complete — the table and the test check each other.
+- **Placeholder scan:** no TBD/TODO in the plan. The one `// TODO(composition-root)` introduced in Phase 2 Step 5 is a counted, ratcheted debt marker retired in Phase 11.
+- **Type consistency:** `GameSession.commit`/`update`/`setStateWithoutRefresh`/`subscribe` are used with those exact names in Phases 2, 8, 9, and 11. `PendingMapIntent` (Phase 3) is consumed by `MapTapIntent`'s `resolve-pending` and `mistap` variants (Phase 8). `SelectionSnapshot` is defined in Phase 3 and consumed by `resolveMapTapIntent` in Phase 8. `PanelId`, `PanelGroup`, `PanelContext`, and `ChoiceAction` are defined in Part II / Phase 5 before first use. `MovementBlockerReason` is imported from its real home, `@/systems/unit-system:986`. `PresentationRegistrar` returns `() => void` in its definition and its disposal tests.
+- **Known soft spot:** the `createHotSeatGame` config literal in Phase 1 Step 7 and the `makeFakeServices` `renderLoop` double in Phase 10 Step 1 are illustrative and must be matched to the real `HotSeatConfig` and `RenderLoop` shapes when writing those tests.

--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -1,0 +1,1329 @@
+# Composition Root Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do not use subagents** — `CLAUDE.md` forbids them in this repo; execute inline.
+
+**Goal:** Reduce `src/main.ts` from 5,462 lines of module-scope singleton to a ~120-line composition root that constructs services and wires controllers, and collapse the three competing save-normalization routes into one authoritative versioned pipeline.
+
+**Architecture:** Introduce a small set of narrow *ports* (`GameSession`, `Notifier`, `PanelHost`, `SelectionStore`) in `src/app/`, make state ownership explicit before extracting any behavior, then strangler-fig each responsibility out of `main.ts` into a controller that depends only on ports. `main.ts` ends as the single module that knows concrete types (`RenderLoop`, `AudioSystem`, `document`, `EventBus`).
+
+**Tech Stack:** TypeScript (strict), Vite, Vitest (`environment: node` with per-suite jsdom), Canvas 2D renderer, DOM/CSS panels, EventBus.
+
+---
+
+## Global Constraints
+
+- All commands run as `bash scripts/run-with-mise.sh yarn <cmd>` — never `eval "$(mise activate bash)"`.
+- `yarn test` does **not** type-check. Before every push: `yarn build` **and** `yarn test`, both exit 0.
+- Bash timeouts: `git commit` → 30000 ms; `git push` / `gh pr create` → 120000 ms.
+- All work happens in this worktree (`architecture-planning-0acde5`). Never on `main`.
+- Every phase below is **one PR**, independently mergeable, with the full suite green. No phase leaves `main.ts` in a half-migrated state that another phase must finish.
+- **Behavior-preserving.** No player-visible change in any phase except Phase 1's explicitly-listed migration ordering. If a phase tempts you to fix a bug you find, file an issue and keep the refactor pure.
+- No new runtime dependencies.
+- `Math.random()` remains forbidden. `state.currentPlayer` remains the only ownership source. `innerHTML` with game strings remains forbidden.
+
+---
+
+## Part I — Why This, Measured
+
+Numbers below were taken from `src/main.ts` at commit `208dad56`. Re-measure before starting; if they have drifted more than ~10%, re-read the affected section before trusting the task breakdown.
+
+| Metric | Count | What it means |
+|---|---|---|
+| Total lines | 5,462 | 20x the next-largest hand-written app file |
+| Top-level `function` declarations | 103 | All sharing one closure scope |
+| Module-scope `let` bindings | 16 | `gameState`, `selectedUnitId`, `movementRange`, `pendingAirMission`, … |
+| `bus.on(...)` registrations at module scope | 72 | Run as an import side effect |
+| `gameState = …` assignments | 93 | 93 places that can desync the UI |
+| `renderLoop.setGameState(…)` calls | 89 | Manual refresh discipline |
+| `updateHUD()` calls | 74 | Second manual refresh discipline |
+| `gameState = …` with no nearby `setGameState` | 46 | Latent stale-render sites |
+| `showNotification(…)` calls | 153 | — |
+| Tests that import `@/main` | **0** | The module cannot be imported |
+| Assertions in `tests/main.integration.test.ts` that `readFileSync` **the source of `main.ts` and grep it as a string** | 21 | The tell |
+
+That last row is the strongest argument in this document. `tests/main.integration.test.ts` is 334 lines that read `src/main.ts` as text and assert things like:
+
+```ts
+expect(main.match(/await beginCampaignEntry\(/g)).toHaveLength(3);
+expect(endTurn).toMatch(/await replayAIMoves\(soloMoves\);\s*updateHUD\(\);\s*showRequiredChoicesIfNeeded\(\);/);
+```
+
+The team did not choose regex-over-source because it is good testing. They chose it because `main.ts` executes `new AudioContext()`, `document.getElementById(...)`, 72 event-bus registrations, and `init()` at import time — so there is no way to import it in a test. **Every real behavior in `main.ts` is currently guarded by whitespace-sensitive string matching, or not at all.** Converting those 21 assertions into real behavioral tests is a first-class deliverable of this plan, not incidental churn.
+
+### The three save routes
+
+`grep` for save normalization finds three distinct paths, and a save can go through a different subset depending on how the player got into the game:
+
+1. **Versioned pipeline** — `migrateSaveToCurrent(raw)` in `src/storage/save-migrations.ts`. Numbered migrations 1…`CURRENT_SAVE_SCHEMA_VERSION` (11), each stamping `saveSchemaVersion`. This is the good one.
+2. **Unconditional normalizers** — `normalizeLoadedState(state)` in `src/storage/save-manager.ts:825`. Calls `migrateSaveToCurrent` and then ~20 hand-written `normalizeX` / `migrateLegacyX` functions that run on *every* load regardless of version. Reachable from tests via `normalizeLoadedStateForTest`.
+3. **`migrateLegacySave()`** — `src/main.ts:5146`, 124 lines, mutates the module-scope `gameState` **in place** with ~23 fixups and 20 `as any` casts. Not exported. Not importable. Not tested. Called from exactly one place: `enterCampaign()` at `src/main.ts:5013`.
+
+Route 3 has two concrete defects beyond being untestable:
+
+- **It runs on brand-new hot-seat games.** `showGameModeSelection`'s `onChooseHotSeat` calls `createHotSeatGame(...)` → `enterCampaign(...)` → `migrateLegacySave()`. New *solo* games call `startGame()` directly and skip it. So the two new-game paths do not produce identical state shapes, and nothing tests that they do.
+- **One of its fixups is not a migration at all.** `gameState.settings.councilTalkLevel = persistedSettings?.councilTalkLevel ?? 'normal'` reads a value loaded from IndexedDB user settings, not from the save. It cannot move into a pure `(state) => state` migration, and a naive "move it all into the pipeline" refactor would either drop it or smuggle a global read into `save-migrations.ts`. Phase 1 handles it explicitly.
+
+---
+
+## Part II — Design
+
+### The mistake to avoid
+
+The obvious move is to start carving out `TurnFlowController`, `SelectionController`, etc. Do not start there. Look at what happened the last time a piece was extracted from `main.ts` — `src/ui/unit-turn-flow.ts`:
+
+```ts
+export interface UnitTurnFlowDeps {
+  uiLayer: HTMLElement;
+  getState: () => GameState;
+  setState: (state: GameState) => void;
+  getSelectedUnitId: () => string | null;
+  selectUnit: (unitId: string) => void;
+  deselectUnit: () => void;
+  selectNextUnit: () => void;
+  centerOn: (coord: HexCoord) => void;
+  refreshVisibility: () => void;
+  setRenderState: (state: GameState) => void;
+  updateHUD: () => void;
+  showNotification: (message: string, type: 'info' | 'success' | 'warning') => void;
+  setBlockingOverlay: (id: string | null) => void;
+  endTurn: (options: { allowUnmovedUnits?: boolean }) => void;
+  onUnitDisbanded?: (state: GameState, unitId: string, routeId: string) => GameState;
+}
+```
+
+Fifteen loose function references, three of which (`setState`, `setRenderState`, `updateHUD`) are the same logical operation split into three callbacks the caller must remember to invoke together. The extraction succeeded — that file is testable — but it paid for it with a deps bag that is itself an Interface Segregation violation, and it left the "remember to refresh" hazard intact and now duplicated across a module boundary.
+
+If we extract six more controllers this way, we get six more 15-field deps bags all naming the same six capabilities, and `main.ts` becomes a 900-line wiring harness instead of a 5,400-line god module. That is not obviously better.
+
+**So: define the ports first, fix state ownership first, then extract.** Each controller should take two to four ports, not fifteen callbacks.
+
+### Port 1 — `GameSession` (the important one)
+
+```ts
+// src/app/ports.ts
+export interface GameSession {
+  /** The single source of truth. Never cache the result across an await. */
+  getState(): GameState;
+
+  /**
+   * Replace the state and refresh every subscriber (renderer, HUD, open panels).
+   * This is the ONLY correct way to publish a state change to the player.
+   */
+  commit(next: GameState): void;
+
+  /** Read-modify-commit. `fn` must be pure and must not mutate its argument. */
+  update(fn: (state: GameState) => GameState): void;
+
+  /**
+   * Replace the state WITHOUT refreshing subscribers.
+   *
+   * Deliberately ugly. It exists only so Phase 2 can be a mechanically
+   * behavior-identical refactor of the 46 existing assignment sites that do not
+   * currently refresh. Every remaining call site is an open question about
+   * whether the player is looking at stale data. Phase 10 drives this to zero
+   * or to a documented allowlist.
+   */
+  setStateWithoutRefresh(next: GameState): void;
+
+  /** Returns an unsubscribe function, matching EventBus.on's contract. */
+  subscribe(listener: (state: GameState) => void): () => void;
+}
+```
+
+Why this is the highest-value change in the plan: today, publishing a state change correctly means writing three statements in the right order, and 46 of 93 sites do not write all three. `commit()` makes the invariant structural instead of a discipline. It also makes every downstream controller trivially testable — a fake `GameSession` over a plain object is ten lines.
+
+`commit()` notifies **synchronously**. Do not add microtask coalescing: async refresh would change observable ordering in `endTurn` and in the hot-seat handoff, which would make Phase 2 a behavior change rather than a refactor. If profiling later shows a hot loop, add explicit batching then (YAGNI).
+
+### Port 2 — `Notifier`
+
+```ts
+export interface Notifier {
+  /** Transient toast for the active viewer. */
+  toast(message: string, type: NotificationEntry['type'], target?: NotificationEntry['target'], sfxCue?: string): void;
+  /** The full delivery contract: log always, toast if active viewer, queue for hot-seat. */
+  readonly deliver: NotificationSink;
+  /** A toast that stays until the player picks one of `actions`. */
+  choice(message: string, actions: readonly ChoiceAction[]): void;
+}
+```
+
+Backed by the existing `createNotificationDelivery` plus the toast queue currently living in `main.ts:711-965` (`notificationQueue`, `isShowingNotification`, `currentDismissTimer`, `enqueueToast`, `showNotification`, `displayNextNotification`). That queue is pure DOM + timers with zero game-logic coupling, and it is a 250-line free win for testability with fake timers.
+
+### Port 3 — `PanelHost`
+
+```ts
+export interface PanelHost {
+  readonly layer: HTMLElement;
+  setBlockingOverlay(id: string | null): void;
+  isInteractionBlocked(): boolean;
+  /** Removes the panel with this id if present. Idempotent. */
+  close(panelId: PanelId): void;
+  closeAll(): void;
+}
+```
+
+`isInteractionBlocked` / `setBlockingOverlay` already exist as `createUiInteractionState()` — this port absorbs it rather than replacing it.
+
+### Port 4 — `SelectionStore`, and making illegal states unrepresentable
+
+Ten module-scope `let`s currently model selection and pending input intent:
+
+```ts
+let selectedUnitId: string | null;
+let selectedUnitWaterRecovery: LandUnitWaterRecovery;
+let selectedPirateFactionId: string | null;
+let selectedPirateHistoryId: string | null;
+let movementRange: HexCoord[];
+let attackRange: HexCoord[];
+let currentCityIndex: number;
+let pendingCityCaptureChoice: PendingCityCaptureChoice | null;
+let pendingJourneyUnitId: string | null;
+let pendingAirMission: { unitId: string; mission: 'strike' | 'recon' } | null;
+```
+
+The last three (plus `getPendingUnload()` from `src/ui/transport-ui-state.ts`) are all "the next map tap means something special." Four independent nullables encode 16 states, of which 5 are legal. `handleHexTap` currently disambiguates by checking them in a fixed order — which is a correct-by-accident precedence rule that nothing documents or tests.
+
+Replace with one discriminated union:
+
+```ts
+export type PendingMapIntent =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'journey'; readonly unitId: string }
+  | { readonly kind: 'air-mission'; readonly unitId: string; readonly mission: 'strike' | 'recon' }
+  | { readonly kind: 'unload'; readonly transportId: string; readonly range: readonly HexCoord[] }
+  | { readonly kind: 'city-capture'; readonly choice: PendingCityCaptureChoice };
+```
+
+Setting one intent structurally clears the others, `handleHexTap` becomes an exhaustive `switch` with an `assertNever` default, and the precedence rule stops being emergent. This is the one place in the plan where the type system is doing load-bearing work rather than documentation.
+
+### SOLID, concretely
+
+- **SRP** — `main.ts` currently changes when *any* feature changes: a new unit type, a new panel, a new diplomacy action, a new notification, a new save field. After this plan, adding a panel touches `panel-registry.ts`; adding a notification touches one presentation registrar; adding a save field touches `save-migrations.ts`. Each file has one axis of change.
+- **OCP** — two concrete open/closed wins. `togglePanel` (288 lines of `else if (panel === '...')`) becomes a registry the router iterates. The 72 `bus.on` handlers become ~12 domain registrars, each a file you add rather than a chain you edit.
+- **LSP** — the substitutability that matters here is test doubles: a fake `GameSession` over a plain object, a fake `Notifier` that records calls, and a `PanelHost` over a detached `<div>` must be drop-in for the real ones. Keep the ports free of concrete-type leakage (no `RenderLoop`, no `AudioContext`, no `HTMLCanvasElement` in a port signature) and this holds by construction.
+- **ISP** — the reason ports are four small interfaces and not one `AppContext`. `NotificationCenter` takes `PanelHost` and nothing else. Presentation registrars take `GameSession` (read-only usage) and `Notifier`. `TurnFlowController` is the only thing that needs all four.
+- **DIP** — controllers import from `@/app/ports` only. `main.ts` is the sole module allowed to `new RenderLoop(...)`, `new AudioContext()`, or call `document.getElementById`. Phase 10 adds a test that enforces this mechanically.
+
+### Target file structure
+
+```
+src/app/                         [NEW]
+  ports.ts                       GameSession, Notifier, PanelHost, SelectionStore, PendingMapIntent, PanelId
+  game-session.ts                createGameSession(): GameSession
+  selection-store.ts             createSelectionStore(): SelectionStore
+  panel-host.ts                  createPanelHost(layer): PanelHost  (absorbs ui-interaction-state)
+  panel-registry.ts              PANEL_REGISTRY: Readonly<Record<PanelId, PanelDescriptor>>
+  panel-router.ts                createPanelRouter(deps): PanelRouter
+  controllers/
+    campaign-entry-controller.ts   save panel, mode select, campaign/hot-seat setup, enterCampaign
+    game-session-controller.ts     startGame: sprite warmup, camera, input install, audio, render start
+    turn-flow-controller.ts        endTurn, hot-seat handoff, solo round, AI replay, victory, autosave
+    selection-controller.ts        select/deselect/next, highlights, animated moves, auto-explore
+    map-interaction-controller.ts  handleHexTap, handleHexLongPress  [NOT in the original six — see below]
+  bootstrap.ts                     wires controllers + registrars; the only async entry point
+
+src/presentation/                [EXISTS — gains the registrars]
+  round-presentation-gate.ts     (unchanged)
+  register-city-presentation.ts        \
+  register-diplomacy-presentation.ts    |
+  register-combat-presentation.ts       |  each: (bus, ctx) => () => void
+  register-wonder-presentation.ts       |  ~12 files, replacing 72 module-scope bus.on calls
+  register-espionage-presentation.ts    |
+  register-faction-crisis-presentation.ts
+  register-religion-presentation.ts     |
+  register-beast-presentation.ts        |
+  register-raider-presentation.ts       |  (barbarian + pirate)
+  register-network-presentation.ts      |
+  register-trade-presentation.ts        |
+  register-era-presentation.ts         /
+
+src/main.ts                      ~120 lines: construct concrete services, call bootstrap()
+```
+
+### One addition to the original six
+
+The source list is `GameSessionController`, `TurnFlowController`, `SelectionController`, `PanelRouter`, `CampaignEntryController`, `PresentationCoordinator`. That list has a gap: `handleHexTap` is **624 lines** — the single largest function in the file, larger than most whole modules in this repo — and it is not selection, not turn flow, and not panel routing. Folding it into `SelectionController` would recreate a god object one level down.
+
+So this plan adds `MapInteractionController`, and splits it the way this codebase already splits input elsewhere (`src/input/selected-unit-tap-intent.ts` is the existing precedent):
+
+- a **pure resolver** — `(state, selection, coord) => MapTapIntent` — a discriminated union, no DOM, no mutation, exhaustively testable;
+- a **thin executor** — `switch (intent.kind)` dispatching to already-extracted systems.
+
+`PresentationCoordinator` is also deliberately *not* a single class here. One coordinator owning 72 event subscriptions is the same god object with a nicer name; ~12 `register*Presentation(bus, ctx): () => void` functions give real SRP and let each be tested by emitting on a throwaway bus.
+
+### Non-goals
+
+- No change to game rules, balance, yields, or AI behavior.
+- No renderer or Canvas changes.
+- No new save schema fields (Phase 1 bumps the version to relocate existing fixups; it adds nothing new).
+- No conversion of `src/systems/*` or `src/ui/*` panel modules to classes. The `createX(deps): X` factory idiom is the house style and stays.
+- No DI container, no decorators, no `reflect-metadata`. Ports are constructor arguments.
+
+---
+
+## Part III — Player Truth Table
+
+Per `docs/superpowers/plans/README.md`. This refactor is behavior-preserving, so the table records what must *remain* true — these are the regressions this plan can plausibly cause, and each row names the phase and test that guards it.
+
+| Before | Action | Immediate visible result that must not change | Guarded by |
+|---|---|---|---|
+| HUD shows `💰 120`, unit selected | Rush-buy production | HUD gold updates in the same frame; drawer updates | Phase 2, `game-session.test.ts` + `turn-flow-controller.test.ts` |
+| Unit selected, movement overlay drawn | Tap a reachable hex | Unit animates, overlay clears, HUD move count updates, next-unit badge decrements | Phase 7, `map-interaction-controller.test.ts` |
+| Tech panel open | Click another tech to queue | Panel rerenders with the new queue; panel stays open | Phase 5, `panel-router.test.ts` |
+| City panel open, queue `A, B, C` | Click `↑` on `C` | Queue rerenders `C, A, B` without closing the panel | Phase 5 (existing `city-panel.test.ts` must stay green) |
+| Council panel open | Press `C` (shortcut) | Panel closes; no second panel opens; `councilPanelOpen` returns false | Phase 5, `panel-router.test.ts` |
+| Hot-seat, player 1 ends turn | Confirm handoff | Blocking overlay, audio muted, autosave, then player 2's HUD/civ name | Phase 8, `turn-flow-controller.test.ts` |
+| Toast visible, second event fires | — | Second toast queues, shows after the first dismisses; timer not reset | Phase 4, `notification-center.test.ts` |
+| Espionage capture pending | Choose "execute" | Persistent choice notification dismisses; exactly one outcome applies | Phase 4, `notification-center.test.ts` |
+| Save from schema v10 | Load it | Same map, cities, and treaties as before this refactor | Phase 1, `save-migrations.test.ts` golden fixture |
+| Brand-new hot-seat game | Start | Identical state shape to before (no `beasts.migrationPending`, no lair placement on tick 1) | Phase 1, `new-game-completeness.test.ts` |
+
+### Misleading UI risks
+
+The derived surface at risk is **"the HUD/renderer reflects current state."** It is not a label; it is an implicit promise made 93 times.
+
+- An item is legitimately "current" only if the render loop and HUD were refreshed after the most recent `gameState` assignment.
+- Near-miss to keep out: a `setStateWithoutRefresh` call whose caller *intended* a visible change. Phase 2 must not convert any site to `setStateWithoutRefresh` on the grounds that "the next line refreshes anyway" — if a refresh follows within the same synchronous block, use `commit` and delete the manual refresh.
+- Negative test: `game-session.test.ts` asserts `setStateWithoutRefresh` fires **zero** subscriber notifications, and `commit` fires exactly one per call (not one per subscriber-visible field).
+
+### Interaction replay checklist
+
+`handleHexTap` is the replay-sensitive surface; Phase 7 tests must cover, in one session, against one store:
+
+- tap empty hex with nothing selected → no-op
+- tap own unit → selects, overlays appear
+- tap reachable hex → moves, overlays clear
+- tap the *same* hex again immediately → does not re-move a spent unit
+- tap enemy unit in range → attack path, not move path
+- set `journey` intent, then tap → journey path, and intent resets to `none`
+- set `journey` intent, then press Escape, then tap → normal tap behavior (proves intent cleared)
+- set `air-mission`, then set `journey` → only `journey` is live (proves the union replaced, not merged)
+
+---
+
+## Part IV — Phases
+
+Ten phases, ten PRs. Phases 1 and 2 are prerequisites for everything after; 3–9 are strictly ordered because each removes state that the next one would otherwise have to thread through a deps bag.
+
+**Every phase ends with the same three steps** (written out once here, referenced as "**Close the phase**" below — do not skip them):
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+Both must exit 0. Then commit, push, open a PR whose body states the line count of `src/main.ts` before and after.
+
+---
+
+### Phase 1 — One authoritative save route
+
+**Independent of every other phase.** Do it first: it is the lowest-risk, highest-clarity win, it deletes 124 lines and 20 `as any` casts, and it decouples `enterCampaign` so Phase 9 can move it cleanly.
+
+**Files:**
+- Modify: `src/storage/save-migrations.ts` (add migration 12, bump `CURRENT_SAVE_SCHEMA_VERSION`)
+- Modify: `src/storage/save-manager.ts:825-888` (`normalizeLoadedState` gains the derived-rebuild fixups)
+- Modify: `src/main.ts:5006-5088` (`enterCampaign` loses `migrateLegacySave()`), delete `src/main.ts:5146-5269`
+- Test: `tests/storage/save-migrations.test.ts`, `tests/storage/new-game-completeness.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `SaveMigration = (state: GameState) => GameState`, `SAVE_MIGRATIONS`, `CURRENT_SAVE_SCHEMA_VERSION` (all already exported from `save-migrations.ts`).
+- Produces: nothing new. `migrateLegacySave` ceases to exist; callers of `normalizeLoadedState` are unchanged.
+
+**Classification.** Every one of `migrateLegacySave`'s fixups goes into exactly one of three buckets. Do this classification before writing code and put the table in the PR body.
+
+| # | Fixup (`main.ts:5146+`) | Bucket | Destination |
+|---|---|---|---|
+| 1 | `civ.civType ??= 'generic'` | versioned | `SAVE_MIGRATIONS[12]` |
+| 2 | `civ.lastCombatTurnByLandmass ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
+| 3 | `civ.diplomacy` default construct | versioned | `SAVE_MIGRATIONS[12]` |
+| 4 | `settings.advisorsEnabled` full default | versioned | `SAVE_MIGRATIONS[12]` |
+| 5 | add `treasurer` / `scholar` (M3b) | versioned | `SAVE_MIGRATIONS[12]` |
+| 6 | add `spymaster` (M4a) | versioned | `SAVE_MIGRATIONS[12]` |
+| 7 | `pendingEvents ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
+| 8 | `tribalVillages` / `discoveredWonders` / `wonderDiscoverers` defaults | versioned | `SAVE_MIGRATIONS[12]` |
+| 9 | `legendaryWonderHistory` default + `networkPlanResolutions ??= []` + `discoveredSites` backfill from `wonderDiscoverers` | versioned | `SAVE_MIGRATIONS[12]` |
+| 10 | `legendaryWonderIntel ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
+| 11 | `tile.wonder ??= null` backfill | versioned | `SAVE_MIGRATIONS[12]` |
+| 12 | `unit.isResting ??= false` backfill | versioned | `SAVE_MIGRATIONS[12]` |
+| 13 | `minorCivs ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
+| 14 | `techState.trackPriorities` all-15-tracks backfill | versioned | `SAVE_MIGRATIONS[12]` |
+| 15 | `marketplace ??= createMarketplaceState()` | versioned | `SAVE_MIGRATIONS[12]` |
+| 16 | `TradeRoute` reshape: `id`, `goldPerTrip`, `turnsPerTrip`, `delete goldPerTurn` | versioned | `SAVE_MIGRATIONS[12]` |
+| 17 | `beasts` default with `migrationPending: true` | versioned | `SAVE_MIGRATIONS[12]` |
+| 18 | `resurgentCampCooldownByCivLandmass ??= {}` | versioned | `SAVE_MIGRATIONS[12]` |
+| 19 | `civ.knownCivilizations ??= []` | **derived** | `normalizeLoadedState` (superseded by #20 anyway) |
+| 20 | `refreshKnownCivilizations(state, civId)` per civ | **derived** | `normalizeLoadedState` |
+| 21 | `reconstructLastSeenFromMap(state, civId)` per civ | **derived** | `normalizeLoadedState` |
+| 22 | `clearStaleSoloPendingEvents(state)` | **derived** | `normalizeLoadedState` |
+| 23 | `settings.councilTalkLevel ??= persistedSettings?.councilTalkLevel ?? 'normal'` | **runtime settings** | stays at the call site — see below |
+
+**Why #19–22 are not versioned:** they recompute state derivable from the map and civ roster. A versioned migration runs once, at one version boundary; these must run on *every* load, because a save written by a build with a since-fixed visibility bug still needs its `lastSeen` rebuilt. `normalizeLoadedState` is exactly the right home and already hosts functions of this shape (`normalizeThreatPressureDefaults`, `normalizeMinorCivQuestState`).
+
+**Why #23 cannot move:** `persistedSettings` is loaded from IndexedDB by `loadSettings()`, not from the save. A migration signature is `(state: GameState) => GameState`; smuggling a module-global read into `save-migrations.ts` would make migrations non-deterministic and untestable. Keep it in the entry path, but name it honestly — extract it to a tiny exported helper so it reads as a settings merge and not as a migration:
+
+```ts
+// src/storage/settings-merge.ts
+import type { GameState } from '@/core/types';
+
+/**
+ * Applies user-level (IndexedDB) settings that are NOT part of the save.
+ * Deliberately not a SaveMigration: it depends on runtime user preferences,
+ * so it can never be a deterministic (state) => state function.
+ */
+export function applyPersistedUserSettings(
+  state: GameState,
+  persisted: GameState['settings'] | undefined,
+): GameState {
+  if (state.settings.councilTalkLevel) return state;
+  return {
+    ...state,
+    settings: { ...state.settings, councilTalkLevel: persisted?.councilTalkLevel ?? 'normal' },
+  };
+}
+```
+
+**TypeScript note.** `migrateLegacySave` uses `(x as any)` twenty times because it operates on data whose type is a *lie* — it is typed `GameState` but is actually an older shape. Do not carry the `as any`s across. `save-migrations.ts` already has the right convention; extend it with one narrowing helper rather than casting:
+
+```ts
+/** A save of an older schema: same keys, but any of them may be absent. */
+type LegacyShape<T> = { [K in keyof T]?: T[K] | undefined } & Record<string, unknown>;
+
+function withDefault<T, K extends keyof T>(
+  source: LegacyShape<T>, key: K, fallback: T[K],
+): T[K] {
+  const value = source[key];
+  return value === undefined ? fallback : (value as T[K]);
+}
+```
+
+- [ ] **Step 1: Write the failing round-trip test for migration 12**
+
+Create `tests/storage/save-migrations-v12.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { migrateSaveToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
+import { createNewGame } from '@/core/game-state';
+
+function asV11(state: unknown): Record<string, unknown> {
+  return { ...(state as Record<string, unknown>), saveSchemaVersion: 11 };
+}
+
+describe('save migration 12 — absorbed main.ts legacy fixups', () => {
+  it('backfills civType, diplomacy, and lastCombatTurnByLandmass on a v11 save', () => {
+    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
+    const raw = asV11(base);
+    const civs = raw.civilizations as Record<string, Record<string, unknown>>;
+    for (const civ of Object.values(civs)) {
+      delete civ.civType;
+      delete civ.diplomacy;
+      delete civ.lastCombatTurnByLandmass;
+    }
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    for (const civ of Object.values(migrated.civilizations)) {
+      expect(civ.civType).toBe('generic');
+      expect(civ.lastCombatTurnByLandmass).toEqual({});
+      expect(civ.diplomacy.atWarWith).toEqual([]);
+      expect(civ.diplomacy.treaties).toEqual([]);
+    }
+  });
+
+  it('reshapes legacy trade routes to id/goldPerTrip/turnsPerTrip and drops goldPerTurn', () => {
+    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
+    const raw = asV11(base);
+    (raw.marketplace as { tradeRoutes: unknown[] }).tradeRoutes = [
+      { fromCityId: 'a', toCityId: 'b', goldPerTurn: 4 },
+    ];
+
+    const migrated = migrateSaveToCurrent(raw);
+    const [route] = migrated.marketplace.tradeRoutes;
+
+    expect(route.id).toBe('route-legacy-1');
+    expect(route.goldPerTrip).toBe(12);
+    expect(route.turnsPerTrip).toBe(3);
+    expect('goldPerTurn' in route).toBe(false);
+  });
+
+  it('flags legacy saves with no beasts block so lairs place on the first tick', () => {
+    const base = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 't', seed: 7 });
+    const raw = asV11(base);
+    delete raw.beasts;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.beasts.migrationPending).toBe(true);
+    expect(migrated.beasts.lairs).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/storage/save-migrations-v12.test.ts
+```
+Expected: FAIL — `civType` is `undefined`, route has no `id`, `beasts.migrationPending` is `undefined`.
+
+- [ ] **Step 3: Add migration 12**
+
+In `src/storage/save-migrations.ts`: add `migrateLegacyMainFixups` implementing rows 1–18 of the table above (port the bodies verbatim from `src/main.ts:5146-5269`, replacing each `(x as any)` with the `withDefault` helper or a direct object spread), register it as `SAVE_MIGRATIONS[12]`, and set `CURRENT_SAVE_SCHEMA_VERSION = 12`.
+
+Two ordering requirements carried over from `main.ts`, both of which must be preserved and commented:
+- the `legendaryWonderHistory.discoveredSites` backfill reads `wonderDiscoverers`, so row 8 must run before row 9;
+- the trade-route reshape reads `marketplace`, so row 15 must run before row 16.
+
+- [ ] **Step 4: Run the test — expect PASS**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/storage/save-migrations-v12.test.ts
+```
+
+- [ ] **Step 5: Move the derived rebuilds into `normalizeLoadedState`**
+
+In `src/storage/save-manager.ts`, add to the composition inside `normalizeLoadedState` (rows 19–22): `refreshKnownCivilizations` and `reconstructLastSeenFromMap` for every civ, then `clearStaleSoloPendingEvents`. Order matters — `reconstructLastSeenFromMap` must run after known-civ refresh, matching `main.ts:5233-5241`.
+
+- [ ] **Step 6: Write the new-game completeness test**
+
+This is the test that proves route 3 was redundant for new games. Create `tests/storage/new-game-completeness.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createNewGame, createHotSeatGame } from '@/core/game-state';
+import { normalizeLoadedState } from '@/storage/save-manager';
+import { CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
+
+describe('freshly created games need no migration', () => {
+  it('createNewGame output survives normalizeLoadedState unchanged', () => {
+    const state = createNewGame({ civType: 'generic', mapSize: 'small', opponentCount: 2, gameTitle: 'solo', seed: 42 });
+    const normalized = normalizeLoadedState(structuredClone(state));
+
+    expect(normalized).toEqual({ ...state, saveSchemaVersion: CURRENT_SAVE_SCHEMA_VERSION });
+    expect(normalized.beasts.migrationPending).toBeUndefined();
+  });
+
+  it('createHotSeatGame output survives normalizeLoadedState unchanged', () => {
+    const state = createHotSeatGame(
+      { players: [{ name: 'A', isHuman: true, civType: 'generic' }, { name: 'B', isHuman: true, civType: 'generic' }], mapSize: 'small' },
+      undefined,
+      'hot seat',
+      'standard',
+    );
+    const normalized = normalizeLoadedState(structuredClone(state));
+
+    expect(normalized).toEqual({ ...state, saveSchemaVersion: CURRENT_SAVE_SCHEMA_VERSION });
+    expect(normalized.beasts.migrationPending).toBeUndefined();
+  });
+});
+```
+
+If either assertion fails, **stop and read the diff** — it is telling you that `createNewGame`/`createHotSeatGame` produces incomplete state, which is a real bug worth its own issue. Do not "fix" it by loosening the assertion. (Adjust the `createHotSeatGame` config literal to match the real `HotSeatConfig` type; the shape above is illustrative.)
+
+- [ ] **Step 7: Delete `migrateLegacySave` and rewire `enterCampaign`**
+
+Delete `src/main.ts:5146-5269`. In `enterCampaign`, replace `migrateLegacySave();` with:
+
+```ts
+gameState = applyPersistedUserSettings(state, persistedSettings);
+```
+
+(replacing the existing `gameState = state;`). Add the `src/storage/settings-merge.ts` file shown above plus a two-case unit test for it.
+
+- [ ] **Step 8: Update the source-grep tests this phase breaks**
+
+`tests/main.integration.test.ts` — no assertion currently names `migrateLegacySave`, so this phase should not break it. Run it explicitly to confirm rather than assuming:
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/main.integration.test.ts
+```
+
+- [ ] **Step 9: Close the phase** (full `yarn test`, `yarn build`, commit, PR)
+
+```bash
+git add src/storage src/main.ts tests/storage && git commit -m "refactor(save): fold main.ts legacy fixups into the versioned migration pipeline"
+```
+
+---
+
+### Phase 2 — `GameSession`: one owner for game state
+
+**Files:**
+- Create: `src/app/ports.ts`, `src/app/game-session.ts`
+- Test: `tests/app/game-session.test.ts`
+- Modify: `src/main.ts` — replace `let gameState` and all 93 assignment sites
+
+**Interfaces:**
+- Produces: `GameSession` (full signature in Part II), `createGameSession(initial: GameState): GameSession`.
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/app/game-session.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createGameSession } from '@/app/game-session';
+import type { GameState } from '@/core/types';
+
+const stub = (turn: number): GameState => ({ turn } as unknown as GameState);
+
+describe('createGameSession', () => {
+  it('commit publishes the new state to every subscriber exactly once', () => {
+    const session = createGameSession(stub(1));
+    const a = vi.fn();
+    const b = vi.fn();
+    session.subscribe(a);
+    session.subscribe(b);
+
+    session.commit(stub(2));
+
+    expect(session.getState().turn).toBe(2);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(a).toHaveBeenCalledWith(session.getState());
+  });
+
+  it('setStateWithoutRefresh changes state and notifies nobody', () => {
+    const session = createGameSession(stub(1));
+    const listener = vi.fn();
+    session.subscribe(listener);
+
+    session.setStateWithoutRefresh(stub(2));
+
+    expect(session.getState().turn).toBe(2);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('update applies a pure transform and publishes once', () => {
+    const session = createGameSession(stub(1));
+    const listener = vi.fn();
+    session.subscribe(listener);
+
+    session.update(state => ({ ...state, turn: state.turn + 1 }));
+
+    expect(session.getState().turn).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe stops delivery', () => {
+    const session = createGameSession(stub(1));
+    const listener = vi.fn();
+    const off = session.subscribe(listener);
+
+    off();
+    session.commit(stub(2));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('a subscriber that throws does not prevent later subscribers from running', () => {
+    const session = createGameSession(stub(1));
+    const boom = vi.fn(() => { throw new Error('render failed'); });
+    const after = vi.fn();
+    session.subscribe(boom);
+    session.subscribe(after);
+
+    expect(() => session.commit(stub(2))).not.toThrow();
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+That last case matters: today a throw inside `updateHUD()` would abort the statement sequence and skip `renderLoop.setGameState`. Isolating subscribers is a genuine robustness improvement and is behavior-compatible (nothing currently depends on the throw propagating).
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/app/game-session.test.ts
+```
+Expected: FAIL — `Cannot find module '@/app/game-session'`.
+
+- [ ] **Step 3: Implement**
+
+`src/app/game-session.ts`:
+
+```ts
+import type { GameState } from '@/core/types';
+import type { GameSession } from '@/app/ports';
+
+export function createGameSession(initial: GameState): GameSession {
+  let state = initial;
+  const listeners = new Set<(next: GameState) => void>();
+
+  const publish = (): void => {
+    for (const listener of [...listeners]) {
+      try {
+        listener(state);
+      } catch (error) {
+        // One failing view must not strand the others mid-refresh.
+        console.error('GameSession subscriber failed:', error);
+      }
+    }
+  };
+
+  return {
+    getState: () => state,
+    commit(next) { state = next; publish(); },
+    update(fn) { state = fn(state); publish(); },
+    setStateWithoutRefresh(next) { state = next; },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Adopt in `main.ts`**
+
+Replace `let gameState: GameState;` with a module-scope `session` created in `enterCampaign`/`startGame`, plus a compatibility accessor so the 93 sites can be converted in reviewable batches:
+
+```ts
+let session: GameSession;
+const gameStateOf = (): GameState => session.getState();
+```
+
+Register the two subscribers once, where `renderLoop` and the HUD are known:
+
+```ts
+session.subscribe(next => renderLoop.setGameState(next));
+session.subscribe(() => updateHUD());
+```
+
+Then convert call sites. Two mechanical rules, applied literally:
+
+- `gameState = X;` followed (within the same synchronous block, before any `await` or `return`) by `renderLoop.setGameState(gameState)` and/or `updateHUD()` → `session.commit(X);` and **delete** the manual refresh lines.
+- `gameState = X;` with no refresh in the same block → `session.setStateWithoutRefresh(X);` and add `// TODO(composition-root): verify refresh` above it.
+
+Do **not** exercise judgment about which unrefreshed sites "should" refresh — that is a behavior change and belongs in Phase 10. Convert 93 sites in ~6 commits of ~15 each so the diff stays reviewable.
+
+- [ ] **Step 6: Guard the TODO count**
+
+Add to `tests/app/game-session.test.ts`:
+
+```ts
+it('tracks how many state writes still bypass the refresh path', () => {
+  const main = readFileSync(resolve(__dirname, '../../src/main.ts'), 'utf8');
+  const bypasses = main.match(/setStateWithoutRefresh\(/g)?.length ?? 0;
+  // Ratchet only. Lower this number when you eliminate a bypass; never raise it.
+  expect(bypasses).toBeLessThanOrEqual(46);
+});
+```
+
+This is the one source-grep assertion this plan *adds*, and it is legitimate: it measures a debt counter and can only move one direction. Phase 10 drives it to 0 and deletes the test.
+
+- [ ] **Step 7: Close the phase**
+
+---
+
+### Phase 3 — `SelectionStore` and `PendingMapIntent`
+
+**Files:**
+- Create: `src/app/selection-store.ts`; extend `src/app/ports.ts`
+- Test: `tests/app/selection-store.test.ts`
+- Modify: `src/main.ts` (10 module `let`s), `src/ui/transport-ui-state.ts` (folded in)
+
+**Interfaces:**
+- Consumes: `GameSession` (Phase 2).
+- Produces:
+
+```ts
+export interface SelectionStore {
+  getSelectedUnitId(): string | null;
+  setSelectedUnitId(unitId: string | null): void;
+  getWaterRecovery(): LandUnitWaterRecovery;
+  setWaterRecovery(recovery: LandUnitWaterRecovery): void;
+  getMovementRange(): readonly HexCoord[];
+  getAttackRange(): readonly HexCoord[];
+  setRanges(movement: readonly HexCoord[], attack: readonly HexCoord[]): void;
+  getPirateSelection(): { factionId: string | null; historyId: string | null };
+  setPirateSelection(factionId: string | null, historyId: string | null): void;
+  getCityCursor(): number;
+  advanceCityCursor(cityCount: number): number;
+  getPendingIntent(): PendingMapIntent;
+  setPendingIntent(intent: PendingMapIntent): void;
+  clear(): void;
+}
+```
+
+- [ ] **Step 1: Write the failing test** — cover, at minimum, that `setPendingIntent` replaces rather than merges:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createSelectionStore } from '@/app/selection-store';
+
+describe('createSelectionStore pending intent', () => {
+  it('replaces the pending intent instead of accumulating independent flags', () => {
+    const store = createSelectionStore();
+    store.setPendingIntent({ kind: 'air-mission', unitId: 'u1', mission: 'strike' });
+    store.setPendingIntent({ kind: 'journey', unitId: 'u2' });
+
+    expect(store.getPendingIntent()).toEqual({ kind: 'journey', unitId: 'u2' });
+  });
+
+  it('clear() resets selection, ranges, and pending intent together', () => {
+    const store = createSelectionStore();
+    store.setSelectedUnitId('u1');
+    store.setRanges([{ q: 0, r: 0 }], [{ q: 1, r: 0 }]);
+    store.setPendingIntent({ kind: 'journey', unitId: 'u1' });
+
+    store.clear();
+
+    expect(store.getSelectedUnitId()).toBeNull();
+    expect(store.getMovementRange()).toEqual([]);
+    expect(store.getAttackRange()).toEqual([]);
+    expect(store.getPendingIntent()).toEqual({ kind: 'none' });
+  });
+
+  it('advanceCityCursor wraps at the city count', () => {
+    const store = createSelectionStore();
+    expect(store.advanceCityCursor(3)).toBe(1);
+    expect(store.advanceCityCursor(3)).toBe(2);
+    expect(store.advanceCityCursor(3)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure.** Expected: `Cannot find module '@/app/selection-store'`.
+
+- [ ] **Step 3: Implement** `createSelectionStore(): SelectionStore` — plain closure over the ten values, `PendingMapIntent` defaulting to `{ kind: 'none' }`, `clear()` resetting all of them.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Adopt.** Delete the ten `let`s from `main.ts`. Fold `src/ui/transport-ui-state.ts`'s `getPendingUnload` / `setPendingUnload` / `clearPendingUnload` into the `unload` intent variant and delete that file. Update `clearUnloadState()` accordingly.
+
+At this point `handleHexTap`'s intent checks are still `if` chains — do not restructure them yet, that is Phase 7. Only the storage changes here.
+
+- [ ] **Step 6: Close the phase**
+
+---
+
+### Phase 4 — `NotificationCenter`
+
+Moves `src/main.ts:711-965` and `4185-4229` (~290 lines) into a testable module.
+
+**Files:**
+- Create: `src/ui/notification-center.ts`
+- Test: `tests/ui/notification-center.test.ts`
+- Modify: `src/main.ts` (delete `notificationQueue`, `isShowingNotification`, `currentDismissTimer`, `enqueueToast`, `showNotification`, `displayNextNotification`, `createPersistentChoiceNotification`)
+
+**Interfaces:**
+- Consumes: `PanelHost` (`layer` only), `createNotificationDelivery` (existing, unchanged).
+- Produces: `createNotificationCenter(deps: NotificationCenterDeps): Notifier`, where deps are exactly `{ layer: HTMLElement; getState: () => GameState; isSuppressed: () => boolean; playCue?: (cue: string) => void }` — four fields, not fifteen. That is the ISP payoff made concrete.
+
+- [ ] **Step 1: Write the failing tests** — the queue behaviors that currently have no coverage at all:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createNotificationCenter } from '@/ui/notification-center';
+import type { GameState } from '@/core/types';
+
+const state = { turn: 3, currentPlayer: 'player', civilizations: {}, hotSeat: undefined } as unknown as GameState;
+
+describe('notification center queue', () => {
+  let layer: HTMLElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    layer = document.createElement('div');
+    document.body.appendChild(layer);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    layer.remove();
+  });
+
+  it('shows one toast at a time and drains the queue in order', () => {
+    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+
+    center.toast('first', 'info');
+    center.toast('second', 'info');
+
+    expect(layer.textContent).toContain('first');
+    expect(layer.textContent).not.toContain('second');
+
+    vi.runOnlyPendingTimers();
+
+    expect(layer.textContent).toContain('second');
+  });
+
+  it('renders message text via textContent, never innerHTML', () => {
+    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+
+    center.toast('<img src=x onerror=alert(1)>', 'warning');
+
+    expect(layer.querySelector('img')).toBeNull();
+    expect(layer.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('a choice notification stays until an action is chosen, then applies exactly one outcome', () => {
+    const center = createNotificationCenter({ layer, getState: () => state, isSuppressed: () => false });
+    const execute = vi.fn();
+    const release = vi.fn();
+
+    center.choice('A spy was caught.', [
+      { label: 'Execute', onSelect: execute },
+      { label: 'Release', onSelect: release },
+    ]);
+
+    vi.runOnlyPendingTimers();
+    expect(layer.textContent).toContain('A spy was caught.');
+
+    const [executeButton] = [...layer.querySelectorAll('button')].filter(b => b.textContent === 'Execute');
+    executeButton.click();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+    expect(layer.textContent).not.toContain('A spy was caught.');
+  });
+});
+```
+
+Add `// @vitest-environment jsdom` at the top of the file — the repo's vitest default environment is `node`.
+
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement** by moving the existing bodies verbatim into the factory closure; the only change is that module-scope `let`s become closure `let`s and `uiLayer` becomes `deps.layer`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Adopt.** In `main.ts`, construct the center and keep local `const showNotification = notifier.toast` aliases so the 153 call sites do not all change in this PR.
+- [ ] **Step 6: Close the phase**
+
+---
+
+### Phase 5 — `PanelRouter` and the panel registry
+
+Replaces `togglePanel`'s 288-line `else if` chain (`src/main.ts:1589-1877`) and the eight `open*Panel` helpers.
+
+**Files:**
+- Create: `src/app/panel-host.ts`, `src/app/panel-registry.ts`, `src/app/panel-router.ts`
+- Test: `tests/app/panel-router.test.ts`
+- Modify: `src/main.ts`; delete `src/ui/ui-interaction-state.ts` (absorbed by `PanelHost`)
+
+**Interfaces:**
+- Consumes: `GameSession`, `Notifier`, `PanelHost`.
+- Produces:
+
+```ts
+export type PanelId =
+  | 'council' | 'tech' | 'city' | 'espionage' | 'diplomacy' | 'marketplace'
+  | 'network' | 'wonder' | 'wonder-atlas' | 'bestiary' | 'pirate-waters'
+  | 'notification-log' | 'city-overview' | 'territory-inspection';
+
+export interface PanelDescriptor {
+  /** The DOM id the panel factory assigns to its root element. */
+  readonly domId: string;
+  /** Panels in the same group close each other. */
+  readonly exclusiveGroup?: 'main';
+  readonly open: (ctx: PanelContext) => void;
+}
+
+export interface PanelRouter {
+  toggle(panel: PanelId): void;
+  open(panel: PanelId): void;
+  close(panel: PanelId): void;
+  closeGroup(group: 'main'): void;
+  isOpen(panel: PanelId): boolean;
+}
+```
+
+The `stringly-typed` `togglePanel(panel: string)` becomes a closed union, and `toggle` dispatches through the registry instead of an `if` chain. Adding a panel is a registry entry — Open/Closed satisfied.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createPanelRouter } from '@/app/panel-router';
+import { createPanelHost } from '@/app/panel-host';
+
+describe('panel router', () => {
+  it('opening a main-group panel closes the previously open one', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const openTech = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'tech-panel' })); });
+    const openCouncil = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'council-panel' })); });
+
+    const router = createPanelRouter({
+      host,
+      registry: {
+        tech: { domId: 'tech-panel', exclusiveGroup: 'main', open: openTech },
+        council: { domId: 'council-panel', exclusiveGroup: 'main', open: openCouncil },
+      },
+      context: {} as never,
+    });
+
+    router.open('tech');
+    router.open('council');
+
+    expect(layer.querySelector('#tech-panel')).toBeNull();
+    expect(layer.querySelector('#council-panel')).not.toBeNull();
+    expect(router.isOpen('tech')).toBe(false);
+    expect(router.isOpen('council')).toBe(true);
+  });
+
+  it('toggle closes an already-open panel instead of reopening it', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const open = vi.fn(() => { layer.appendChild(Object.assign(document.createElement('div'), { id: 'tech-panel' })); });
+    const router = createPanelRouter({
+      host,
+      registry: { tech: { domId: 'tech-panel', exclusiveGroup: 'main', open } },
+      context: {} as never,
+    });
+
+    router.toggle('tech');
+    router.toggle('tech');
+
+    expect(layer.querySelector('#tech-panel')).toBeNull();
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement.** `toggle` = `isOpen(id) ? close(id) : open(id)`; `open` closes the exclusive group first. Keep the registry typed with `satisfies Readonly<Record<PanelId, PanelDescriptor>>` so key coverage is checked without widening the value type.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Migrate the real panels.** Move each `else if` branch of `togglePanel` into its registry entry's `open`. The `councilPanelOpen` boolean is deleted — `isOpen('council')` derives it from the DOM, which removes a second source of truth. Keyboard shortcuts and `createGameShell` callbacks now call `router.toggle('council')` etc.
+- [ ] **Step 6: Close the phase**
+
+---
+
+### Phase 6 — Presentation registrars
+
+Replaces the 72 module-scope `bus.on(...)` registrations (`src/main.ts:4377-4961`) with ~12 domain modules. This is the phase that makes importing `main.ts` in a test *possible*, because it removes the largest block of import-time side effects.
+
+**Files:**
+- Create: `src/presentation/register-*.ts` (~12 files, per the structure in Part II) and `src/presentation/register-all.ts`
+- Test: `tests/presentation/register-*.test.ts` (one per registrar)
+- Modify: `src/main.ts` (delete the 72 handlers)
+
+**Interfaces:**
+- Consumes: `EventBus`, `GameSession`, `Notifier`, `PanelRouter`.
+- Produces:
+
+```ts
+export interface PresentationContext {
+  readonly session: GameSession;
+  readonly notifier: Notifier;
+  readonly router: PanelRouter;
+}
+
+/** Returns a disposer that removes every subscription this registrar added. */
+export type PresentationRegistrar = (bus: EventBus, ctx: PresentationContext) => () => void;
+```
+
+Returning a disposer is not speculative generality: `EventBus.on` already returns an unsubscribe function, hot-seat handoff already needs to tear panels down, and without it these registrars would leak subscriptions across a "new game from the pause menu" transition — a latent bug in the current code, since `main.ts` registers once at import and can never unregister.
+
+- [ ] **Step 1: Write the failing test for the first registrar** (do diplomacy first — it is small and self-contained, `src/main.ts:4533-4561`):
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
+
+describe('diplomacy presentation', () => {
+  it('announces a war declaration to the log once', () => {
+    const bus = new EventBus();
+    const deliver = vi.fn();
+    const ctx = makeContext({ deliver });
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0][1]).toContain('war');
+  });
+
+  it('disposing removes the subscription', () => {
+    const bus = new EventBus();
+    const deliver = vi.fn();
+    const dispose = registerDiplomacyPresentation(bus, makeContext({ deliver }));
+
+    dispose();
+    bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player' });
+
+    expect(deliver).not.toHaveBeenCalled();
+  });
+});
+```
+
+Write `makeContext` once in `tests/helpers/presentation-context.ts` and reuse it across all twelve registrar suites — it is the fake-ports harness the whole plan pays for.
+
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement `registerDiplomacyPresentation`** by moving the four `bus.on` bodies verbatim, collecting the returned unsubscribers, and returning a disposer that calls them all.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Repeat for the remaining eleven registrars,** one commit each, in this order (smallest and least entangled first): era, trade, religion, faction-crisis, network, wonder, city, espionage, beast, raider (barbarian + pirate), combat.
+
+`combat` goes last: its handler already delegates to `handleCombatResolvedEvent` in `src/ui/combat-resolved-presentation.ts` but also touches selection state, so it is the only registrar that needs `SelectionStore` — and by Phase 6 that port exists.
+
+- [ ] **Step 6: Add `register-all.ts`** composing all twelve and returning a single disposer, and call it once from `main.ts`.
+- [ ] **Step 7: Convert the affected source-grep assertions.** `tests/main.integration.test.ts`'s `era:advanced notification` block (4 assertions, lines 265-311) tests behavior that now lives in `register-era-presentation.ts`. Rewrite those four as real tests against the registrar and delete them from the grep file.
+- [ ] **Step 8: Close the phase**
+
+---
+
+### Phase 7 — `SelectionController` and `MapInteractionController`
+
+The biggest phase: `selectUnit` (456 lines), `handleHexTap` (624), `handleHexLongPress` (37), plus the movement/animation helpers.
+
+**Files:**
+- Create: `src/app/controllers/selection-controller.ts`, `src/app/controllers/map-interaction-controller.ts`, `src/input/map-tap-intent.ts`
+- Test: `tests/app/controllers/selection-controller.test.ts`, `tests/app/controllers/map-interaction-controller.test.ts`, `tests/input/map-tap-intent.test.ts`
+- Modify: `src/main.ts`
+
+**Interfaces:**
+- Consumes: `GameSession`, `SelectionStore`, `Notifier`, `PanelRouter`.
+- Produces:
+
+```ts
+export type MapTapIntent =
+  | { readonly kind: 'ignore' }
+  | { readonly kind: 'select-unit'; readonly unitId: string }
+  | { readonly kind: 'open-stack-picker'; readonly coord: HexCoord; readonly unitIds: readonly string[] }
+  | { readonly kind: 'move'; readonly unitId: string; readonly to: HexCoord }
+  | { readonly kind: 'attack'; readonly attackerId: string; readonly targetKey: string }
+  | { readonly kind: 'open-city'; readonly cityId: string }
+  | { readonly kind: 'resolve-pending'; readonly intent: PendingMapIntent; readonly coord: HexCoord }
+  | { readonly kind: 'blocked'; readonly reason: MovementBlockerReason };
+
+export function resolveMapTapIntent(
+  state: GameState,
+  selection: SelectionSnapshot,
+  coord: HexCoord,
+): MapTapIntent;
+```
+
+`resolveMapTapIntent` is **pure** — no DOM, no mutation, no `bus`. That is what makes the eight-case Interaction Replay Checklist in Part III cheap to test. The controller's `handleHexTap` becomes an exhaustive `switch (intent.kind)` with:
+
+```ts
+default: {
+  const _exhaustive: never = intent;
+  throw new Error(`Unhandled map tap intent: ${JSON.stringify(_exhaustive)}`);
+}
+```
+
+- [ ] **Step 1: Write failing tests for `resolveMapTapIntent`** — one per row of the Interaction Replay Checklist in Part III. These are pure-function tests over a fixture state; use `tests/fixtures/` for the state builder if one already fits, otherwise add one.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement `resolveMapTapIntent`** by reading `src/main.ts:3144-3768` top to bottom and translating each early-return branch into a union member. Do not change precedence — the existing order *is* the specification. Where the existing code checks the four pending flags in sequence, translate to a single `switch (selection.pendingIntent.kind)` that preserves the same outcomes.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Extract `SelectionController`** (`selectUnit`, `deselectUnit`, `selectNextUnit`, `refreshSelectedUnitAfterCombat`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `isUnitAnimationLocked`) with tests for: selecting sets ranges; deselecting clears both ranges and highlights; `selectNextUnit` skips units that have acted; a second `selectUnit` on an animating unit is a no-op.
+- [ ] **Step 6: Extract `MapInteractionController`** — the executor half plus `handleHexLongPress`.
+- [ ] **Step 7: Convert the affected source-grep assertions.** `tests/main.integration.test.ts` blocks `player combat wiring` (3), `land-unit water recovery wiring` (1), `shared city founding wiring` (1), `shared unit upgrade wiring` (1), `shared city assault wiring` (4) — 10 assertions total — all describe behavior now in these two controllers. Rewrite as real tests; delete from the grep file.
+- [ ] **Step 8: Close the phase**
+
+---
+
+### Phase 8 — `TurnFlowController`
+
+**Files:**
+- Create: `src/app/controllers/turn-flow-controller.ts`
+- Test: `tests/app/controllers/turn-flow-controller.test.ts`
+- Modify: `src/main.ts`
+
+**Moves:** `endTurn`, `beginHotSeatHandoff`, `releaseHandoffToViewer`, `closeNetworkPanelsForHandoff`, `beginNetworkPlansForCurrentViewer`, `runCurrentCompletedRound`, `captureAIMoves`, `replayAIMoves`, `handleVictoryIfNeeded`, `centerOnCurrentPlayer`, `emitCurrentPlayerAudioSnapshot`, `maybeShowCouncilInterrupt`, `showRequiredChoicesIfNeeded`, `showReligionBoonIfNeeded`, `refreshRequiredChoicesAfterAction`, `closeRequiredChoicePanel`.
+
+**Interfaces:**
+- Consumes: all four ports, plus narrow function refs for the genuinely concrete collaborators: `{ autoSave, advisorCheck, setMasterVolume, roundGate }`.
+- Produces: `createTurnFlowController(deps): TurnFlowController` with `{ endTurn(options?): Promise<void>; enterViewerTurn(): void }`.
+
+- [ ] **Step 1: Write failing tests** for the four ordering guarantees currently protected only by regex:
+  - solo `endTurn` runs the completed round, replays AI moves, *then* refreshes, *then* opens required choices;
+  - `endTurn` is a no-op when `state.gameOver`;
+  - a pending religion boon blocks `endTurn` and toasts, without advancing the turn;
+  - hot-seat `endTurn` suppresses the presentation gate, mutes audio, and autosaves before the handoff overlay resolves.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement** by moving bodies verbatim; substitute port calls for the direct `renderLoop` / `updateHUD` / `showNotification` references.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Convert the affected source-grep assertions.** `completed-round AI wiring` (4 assertions) and `campaign entry wiring`'s "opens required research choices" (1) — 5 total. Rewrite; delete from the grep file.
+- [ ] **Step 6: Close the phase**
+
+---
+
+### Phase 9 — `CampaignEntryController`, `GameSessionController`, and the composition root
+
+**Files:**
+- Create: `src/app/controllers/campaign-entry-controller.ts`, `src/app/controllers/game-session-controller.ts`, `src/app/bootstrap.ts`
+- Test: `tests/app/controllers/campaign-entry-controller.test.ts`, `tests/app/bootstrap.test.ts`
+- Modify: `src/main.ts` → final form
+
+**Moves:** `init`, `showStartSavePanel`, `showGameModeSelection`, `enterCampaign`, `enterCampaignForE2E`, `startGame`, `createUI`, `getPersistedSettingsOverrides`, `mergePersistedSettings`, `refreshPersistedSettings`, `updateHUD`, `setMapViewportBottomInset`, `prefersReducedMotion`.
+
+**Interfaces:**
+- Produces: `bootstrap(services: AppServices): Promise<void>` where
+
+```ts
+export interface AppServices {
+  readonly canvas: HTMLCanvasElement;
+  readonly uiLayer: HTMLDivElement;
+  readonly renderLoop: RenderLoop;
+  readonly audio: AudioSystem;
+  readonly bus: EventBus;
+  readonly roundGate: RoundPresentationGate;
+  readonly advisors: AdvisorSystem;
+}
+```
+
+`main.ts`'s final form is approximately:
+
+```ts
+import '@/assets/sprite-animations-v2.css';
+// …the eight beast animation stylesheets…
+import { EventBus } from '@/core/event-bus';
+import { RenderLoop } from '@/renderer/render-loop';
+import { AudioSystem } from '@/audio/audio-system';
+import { AdvisorSystem } from '@/ui/advisor-system';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { bootstrap } from '@/app/bootstrap';
+
+const bus = new EventBus();
+const audioCtx = new AudioContext();
+const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
+
+void bootstrap({
+  canvas,
+  uiLayer,
+  renderLoop: new RenderLoop(canvas),
+  audio: new AudioSystem(audioCtx),
+  bus,
+  roundGate: new RoundPresentationGate(),
+  advisors: new AdvisorSystem(bus),
+});
+```
+
+Everything below the imports is construction. No game logic, no `bus.on`, no `let`.
+
+- [ ] **Step 1: Write the failing bootstrap test** — the payoff test, the one that was impossible before this plan:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { bootstrap } from '@/app/bootstrap';
+
+describe('bootstrap', () => {
+  it('wires a session, registers presentation, and shows the save panel without touching AudioContext', async () => {
+    document.body.innerHTML = '<canvas id="game-canvas"></canvas><div id="ui-layer"></div>';
+    const services = makeFakeServices();
+
+    await bootstrap(services);
+
+    expect(document.getElementById('save-panel')).not.toBeNull();
+    expect(services.audio.start).not.toHaveBeenCalled(); // audio starts on campaign entry, not bootstrap
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement `bootstrap`** as: construct ports → construct controllers → `registerAllPresentation` → `campaignEntry.showStartSavePanel()`, preserving the existing e2e branch (`import.meta.env.MODE === 'e2e'`) exactly.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Convert the remaining source-grep assertions.** `campaign entry wiring` (3 remaining) and `air-defense overlay button placement` (2) — 5 total. `tests/main.integration.test.ts` should now be **empty and deleted**.
+- [ ] **Step 6: Close the phase**
+
+---
+
+### Phase 10 — Ratchet down and lock the boundary
+
+**Files:**
+- Create: `tests/app/architecture-boundaries.test.ts`
+- Modify: whichever `setStateWithoutRefresh` sites survive
+
+- [ ] **Step 1: Audit every remaining `setStateWithoutRefresh` call.** For each, determine whether the player could observe stale data. Convert to `commit` where they could — **each conversion is a bug fix and needs its own test and its own line in the PR body**, since these are the only intentional behavior changes in the whole plan.
+- [ ] **Step 2: Write the boundary test.**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const main = readFileSync(resolve(__dirname, '../../src/main.ts'), 'utf8');
+
+describe('composition root boundaries', () => {
+  it('main.ts stays a composition root, not an application', () => {
+    expect(main.split('\n').length).toBeLessThan(150);
+  });
+
+  it('main.ts registers no event handlers and owns no mutable state', () => {
+    expect(main).not.toMatch(/\bbus\.on\(/);
+    expect(main).not.toMatch(/^let /m);
+  });
+
+  it('only main.ts constructs concrete platform services', () => {
+    // Every other module receives them through ports.
+    expect(main).toContain('new AudioContext()');
+    expect(main).toContain('new RenderLoop(');
+  });
+});
+```
+
+- [ ] **Step 3: Write the port-purity test** — controllers must not import concrete platform types:
+
+```ts
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => {
+  const dir = resolve(__dirname, '../../src/app/controllers');
+  for (const file of readdirSync(dir)) {
+    const source = readFileSync(resolve(dir, file), 'utf8');
+    expect(source, file).not.toMatch(/from '@\/renderer\/render-loop'/);
+    expect(source, file).not.toMatch(/from '@\/audio\/audio-system'/);
+    expect(source, file).not.toMatch(/\bdocument\.getElementById\(/);
+  }
+});
+```
+
+`document.getElementById` is banned in controllers specifically because it is the ambient-global escape hatch that would let a controller reach around `PanelHost` and silently reintroduce the coupling this plan removes. Panels get their root from `PanelHost.layer`.
+
+- [ ] **Step 4: Delete the `setStateWithoutRefresh` ratchet test from Phase 2** (or, if some bypasses are genuinely correct, lower its bound to that number and document each in a comment).
+- [ ] **Step 5: Update `CLAUDE.md`** — add to the Architecture section: "`src/main.ts` is a composition root only. New app behavior goes in `src/app/controllers/` (depends on `src/app/ports.ts`) or `src/presentation/` registrars. Enforced by `tests/app/architecture-boundaries.test.ts`."
+- [ ] **Step 6: Close the phase**
+
+---
+
+## Part V — Test Design Requirements
+
+Per `docs/superpowers/plans/README.md` §5, and because the current coverage of this file is 21 regex assertions.
+
+**Every phase must add:**
+- at least one test that performs the interaction and inspects the resulting DOM or state, not just the internal call;
+- at least one negative test for any derived semantic helper introduced (`isOpen`, `resolveMapTapIntent`'s `blocked` variant, `PendingMapIntent` precedence);
+- for Phase 5, a test proving every registry-declared panel is still reachable from the shell/keyboard after the router replaces `togglePanel`.
+
+**Running count of source-grep assertions retired** (must reach zero):
+
+| Phase | Block retired | Assertions |
+|---|---|---|
+| 6 | `era:advanced notification` | 4 |
+| 7 | combat / water-recovery / city-founding / upgrade / assault wiring | 10 |
+| 8 | `completed-round AI wiring` + required-choices | 5 |
+| 9 | `campaign entry wiring` + air-defense placement | 5 |
+| — | **Total** | **24** |
+
+(24 rather than 21 because three `it` blocks carry multiple `readFileSync` assertions; count from the file, not from this table, when checking off.)
+
+---
+
+## Part VI — Risks
+
+| Risk | Why it is real here | Mitigation |
+|---|---|---|
+| A phase silently changes refresh timing and the HUD goes stale | 46 sites currently do not refresh; it is not knowable from the code which are intentional | Phase 2 preserves every site exactly via `setStateWithoutRefresh`; changes are deferred to Phase 10 where each gets a test |
+| `handleHexTap` precedence changes | Four independent pending flags whose ordering is emergent, not specified | Phase 7 extracts a pure resolver **first** and tests all eight replay rows before any behavior moves |
+| Hot-seat handoff regressions | Most stateful, least covered flow; involves audio muting, overlays, autosave, and the presentation gate | Phase 8 tests the four ordering guarantees; e2e `web-smoke.spec.ts` must pass before merge |
+| Losing a fixup during the save consolidation | 23 fixups, 20 `as any` casts, no existing tests | The classification table is a checklist; the new-game completeness test proves the new-game path; keep a v10 and a v11 golden fixture save in `tests/fixtures/` |
+| Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Ten small PRs merged promptly, not one large branch. Coordinate: no other `main.ts`-touching PR should sit open across a phase merge |
+| Scope creep into "while I'm here" fixes | Guaranteed to be tempting across 5,462 lines | Behavior-preserving is a Global Constraint; file issues instead. Phase 10 is the only phase permitted to change behavior |
+
+---
+
+## Part VII — Self-Review Notes
+
+- **Spec coverage:** all six controllers from the source list are assigned (`GameSessionController` → Phase 9, `TurnFlowController` → 8, `SelectionController` → 7, `PanelRouter` → 5, `CampaignEntryController` → 9, `PresentationCoordinator` → 6 as twelve registrars). The save-normalization requirement is Phase 1. `MapInteractionController` is added with justification in Part II.
+- **Placeholder scan:** no TBD/TODO in the plan itself. The one `// TODO(composition-root)` comment introduced in Phase 2 Step 5 is a deliberate, counted, ratcheted debt marker retired in Phase 10.
+- **Type consistency:** `GameSession.commit` / `update` / `setStateWithoutRefresh` / `subscribe` are used with those exact names in Phases 2, 7, 8, and 10. `PendingMapIntent` (Phase 3) is consumed by `MapTapIntent`'s `resolve-pending` variant (Phase 7). `PresentationRegistrar` returns `() => void` in both its definition and its Phase 6 disposal test. `PanelId` is defined in Phase 5 and referenced by `PanelHost.close` in Part II.
+- **Known soft spot:** the exact `createHotSeatGame` config literal in Phase 1 Step 6 is illustrative and must be matched to the real `HotSeatConfig` type when writing the test.

--- a/scripts/run-tests-by-tier.sh
+++ b/scripts/run-tests-by-tier.sh
@@ -23,6 +23,7 @@ set -eu
 
 SLOW_TEST_FILES="tests/ai/ai-prepared-turn.test.ts
 tests/ai/basic-ai-worker-roads.test.ts
+tests/app/determinism-guard.test.ts
 tests/core/turn-manager-beasts.test.ts
 tests/integration/save-load-mass-discovery.test.ts
 tests/ui/tech-panel.test.ts

--- a/src/main.ts
+++ b/src/main.ts
@@ -269,6 +269,7 @@ import {
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationDelivery } from '@/ui/notification-delivery';
+import { applyPersistedUserSettings } from '@/storage/settings-merge';
 import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
 import { initializeDesktopMenu } from '@/platform/desktop-menu';
 import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
@@ -5009,8 +5010,7 @@ function enterCampaign(
   persistBeforeReady: boolean = false,
 ): Promise<void> | null {
   document.getElementById('save-panel')?.remove();
-  gameState = state;
-  migrateLegacySave();
+  gameState = applyPersistedUserSettings(state, persistedSettings);
   if (gameState.gameOver) {
     const spritesReady = startGame();
     handleVictoryIfNeeded();
@@ -5143,130 +5143,6 @@ async function showStartSavePanel(): Promise<void> {
   });
 }
 
-function migrateLegacySave(): void {
-  for (const [civId, civ] of Object.entries(gameState.civilizations)) {
-    if (!civ.civType) (civ as any).civType = 'generic';
-    if (!civ.knownCivilizations) (civ as any).knownCivilizations = [];
-    if (!civ.lastCombatTurnByLandmass) (civ as any).lastCombatTurnByLandmass = {};
-    if (!civ.diplomacy) {
-      const relationships: Record<string, number> = {};
-      for (const otherId of Object.keys(gameState.civilizations)) {
-        if (otherId !== civId) relationships[otherId] = 0;
-      }
-      (civ as any).diplomacy = {
-        relationships,
-        treaties: [],
-        events: [],
-        atWarWith: [],
-      };
-    }
-  }
-  if (!gameState.settings.advisorsEnabled) {
-    gameState.settings.advisorsEnabled = { builder: true, explorer: true, chancellor: true, warchief: true, treasurer: true, scholar: true, spymaster: true, artisan: true };
-  }
-  // Add new advisor types if missing (M3b migration)
-  if (gameState.settings.advisorsEnabled && !('treasurer' in gameState.settings.advisorsEnabled)) {
-    (gameState.settings.advisorsEnabled as any).treasurer = true;
-    (gameState.settings.advisorsEnabled as any).scholar = true;
-  }
-  // Add spymaster advisor if missing (M4a migration)
-  if (gameState.settings.advisorsEnabled && !('spymaster' in gameState.settings.advisorsEnabled)) {
-    (gameState.settings.advisorsEnabled as any).spymaster = true;
-  }
-  if (!gameState.settings.councilTalkLevel) {
-    gameState.settings.councilTalkLevel = persistedSettings?.councilTalkLevel ?? 'normal';
-  }
-  // Ensure pendingEvents exists for hot seat saves
-  if (!gameState.pendingEvents) {
-    gameState.pendingEvents = {};
-  }
-  clearStaleSoloPendingEvents(gameState);
-  // Add wonder/village state if missing
-  if (!gameState.tribalVillages) (gameState as any).tribalVillages = {};
-  if (!gameState.discoveredWonders) (gameState as any).discoveredWonders = {};
-  if (!gameState.wonderDiscoverers) (gameState as any).wonderDiscoverers = {};
-  if (!gameState.legendaryWonderHistory) {
-    (gameState as any).legendaryWonderHistory = { destroyedStrongholds: [], discoveredSites: [] };
-  }
-  const legendaryWonderHistory = gameState.legendaryWonderHistory!;
-  legendaryWonderHistory.networkPlanResolutions ??= [];
-  if (!legendaryWonderHistory.discoveredSites) {
-    legendaryWonderHistory.discoveredSites = [];
-    for (const [wonderId, discoverers] of Object.entries(gameState.wonderDiscoverers ?? {})) {
-      const wonderTile = Object.values(gameState.map.tiles).find(tile => tile.wonder === wonderId);
-      for (const civId of discoverers) {
-        if (!legendaryWonderHistory.discoveredSites.some(record => record.civId === civId && record.siteId === wonderId)) {
-          legendaryWonderHistory.discoveredSites.push({
-            civId,
-            siteId: wonderId,
-            siteType: 'natural-wonder',
-            position: wonderTile?.coord ?? { q: 0, r: 0 },
-            turn: gameState.turn,
-          });
-        }
-      }
-    }
-  }
-  if (!gameState.legendaryWonderIntel) {
-    (gameState as any).legendaryWonderIntel = {};
-  }
-  // Add wonder field to tiles if missing
-  for (const tile of Object.values(gameState.map.tiles)) {
-    if (!('wonder' in tile)) (tile as any).wonder = null;
-  }
-  // M4-playtest migration: add isResting to existing units
-  for (const unit of Object.values(gameState.units)) {
-    if (!('isResting' in unit)) (unit as any).isResting = false;
-  }
-  // M3c migration: minor civs and expanded tech tracks
-  if (!gameState.minorCivs) (gameState as any).minorCivs = {};
-  const allTracks = ['military', 'economy', 'science', 'civics', 'exploration',
-    'agriculture', 'medicine', 'philosophy', 'arts', 'maritime',
-    'metallurgy', 'construction', 'communication', 'espionage', 'spirituality'];
-  for (const civ of Object.values(gameState.civilizations)) {
-    for (const track of allTracks) {
-      if (!(track in civ.techState.trackPriorities)) {
-        (civ.techState.trackPriorities as any)[track] = 'medium';
-      }
-    }
-  }
-  for (const civId of Object.keys(gameState.civilizations)) {
-    refreshKnownCivilizations(gameState, civId);
-  }
-  // Reconstruct missing lastSeen entries for fog tiles on old saves (M5 migration)
-  for (const civId of Object.keys(gameState.civilizations)) {
-    reconstructLastSeenFromMap(gameState, civId);
-  }
-  // S5 migration: marketplace state init
-  if (!gameState.marketplace) {
-    gameState.marketplace = createMarketplaceState();
-  }
-  // S5 migration: TradeRoute shape — assign id, goldPerTrip, turnsPerTrip
-  let legacyRouteN = 1;
-  for (const route of gameState.marketplace.tradeRoutes) {
-    const r = route as any;
-    if (!r.id) {
-      r.id = `route-legacy-${legacyRouteN++}`;
-    }
-    if (!r.goldPerTrip) {
-      r.goldPerTrip = (r.goldPerTurn ?? 2) * (r.turnsPerTrip ?? 3);
-    }
-    if (!r.turnsPerTrip) {
-      r.turnsPerTrip = 3;
-    }
-    delete r.goldPerTurn;
-  }
-
-  // Beasts migration: flag legacy saves so processTurn places lairs on the FIRST tick after load.
-  // This defers the 🐾 markers and discovery notification until the player takes an action,
-  // giving them a moment to orient before the map changes.
-  if (!gameState.beasts) {
-    (gameState as any).beasts = { mode: 'wild', lairs: {}, sightingsByCiv: {}, migrationPending: true };
-  }
-  if (!gameState.resurgentCampCooldownByCivLandmass) {
-    (gameState as any).resurgentCampCooldownByCivLandmass = {};
-  }
-}
 
 function showGameModeSelection(): void {
   let modePanel: HTMLElement;

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -11,6 +11,9 @@ import { normalizeMinorCivCoalitionState } from '@/systems/minor-civ-coalition-s
 import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
 import { scanIdCounters } from '@/core/id-counters';
 import { migrateSaveToCurrent } from '@/storage/save-migrations';
+import { refreshKnownCivilizations } from '@/systems/discovery-system';
+import { reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
+import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
 import {
   createEmptyPirateState,
   PIRATE_RELOCATION_DIRECTIONS,
@@ -882,6 +885,20 @@ export function normalizeLoadedState(state: GameState): NormalizedGameState {
       }
     }
   }
+  // #787 phase 1: derived rebuilds relocated from main.ts's migrateLegacySave().
+  // These are NOT versioned migrations -- they recompute state from the map and
+  // civ roster, so they must run on every load, not once at a version boundary:
+  // a save written by a build with a since-fixed visibility bug still needs its
+  // lastSeen rebuilt. Order matches main.ts:5233-5241 -- known-civ refresh first,
+  // then lastSeen reconstruction, which reads visibility.
+  for (const civId of Object.keys(normalized.civilizations)) {
+    refreshKnownCivilizations(normalized, civId);
+  }
+  for (const civId of Object.keys(normalized.civilizations)) {
+    reconstructLastSeenFromMap(normalized, civId);
+  }
+  clearStaleSoloPendingEvents(normalized);
+
   return normalizeOpponentAIState(normalized) as NormalizedGameState;
 }
 

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -1,7 +1,8 @@
-import type { ActiveCrisis, AirBaseRef, GameState, HexCoord, Unit } from '@/core/types';
+import type { ActiveCrisis, AirBaseRef, GameState, HexCoord, TradeRoute, Unit } from '@/core/types';
 import { createRng } from '@/systems/map-generator';
 import { placeLateResources } from '@/systems/late-resource-placement';
 import { createMarketplaceState } from '@/systems/trade-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
 import { hexDistance, wrappedHexDistance, hexKey, hexNeighbors, getWrappedHexNeighbors } from '@/systems/hex-utils';
@@ -13,7 +14,7 @@ import { CIRCULAR_MANUFACTURING_MATERIALS } from '@/systems/national-project-sys
 import { appendNotification } from '@/core/notification-log';
 import { syncTransportCargoPositions } from '@/systems/transport-system';
 
-export const CURRENT_SAVE_SCHEMA_VERSION = 11;
+export const CURRENT_SAVE_SCHEMA_VERSION = 12;
 
 export type SaveMigration = (state: GameState) => GameState;
 
@@ -511,6 +512,196 @@ function normalizeRetimedBiplaneQueues(state: GameState): GameState {
   return changed ? { ...state, cities } : state;
 }
 
+// #787 phase 1: the 18 versioned fixups that used to live in main.ts's
+// migrateLegacySave() -- 124 lines of in-place mutation on module-scope
+// gameState, never exported, never tested, and reachable only by entering a
+// campaign. Two of its behaviours are load-bearing and preserved here:
+//
+//  - EVERY fixup defaults rather than overwrites. migrateLegacySave ran on every
+//    campaign entry, so nearly every real v11 save already carries these fields;
+//    a clobbering migration would wipe live player data. Enforced by the
+//    idempotency case in tests/storage/save-migrations-v12.test.ts.
+//  - Ordering: discoveredSites is rebuilt from wonderDiscoverers, and the trade
+//    route reshape reads marketplace, so those defaults are applied first.
+//
+// The four *derived* fixups (refreshKnownCivilizations, reconstructLastSeenFromMap,
+// clearStaleSoloPendingEvents) are not here -- they recompute state from the map
+// and civ roster on every load, so they belong in normalizeLoadedState. The
+// councilTalkLevel fixup is not here either: it reads IndexedDB user settings,
+// not save data, so it cannot be a deterministic (state) => GameState. It lives
+// in src/storage/settings-merge.ts.
+
+const ALL_TECH_TRACKS = [
+  'military', 'economy', 'science', 'civics', 'exploration',
+  'agriculture', 'medicine', 'philosophy', 'arts', 'maritime',
+  'metallurgy', 'construction', 'communication', 'espionage', 'spirituality',
+] as const;
+
+const ALL_ADVISORS = [
+  'builder', 'explorer', 'chancellor', 'warchief',
+  'treasurer', 'scholar', 'spymaster', 'artisan',
+] as const;
+
+/** A trade route as written by builds predating the id/goldPerTrip reshape. */
+interface LegacyTradeRoute {
+  id?: string;
+  goldPerTrip?: number;
+  turnsPerTrip?: number;
+  goldPerTurn?: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * `key in value`, deliberately returning a plain boolean rather than a type
+ * predicate.
+ *
+ * Tile.wonder and Unit.isResting are declared REQUIRED in core/types.ts, so a
+ * direct `'wonder' in tile` narrows the false branch to `never` and the
+ * subsequent spread stops compiling. That narrowing is wrong here by
+ * construction: the entire premise of a migration is that an old save really is
+ * missing a field the current type says is mandatory. Routing the check through
+ * an untyped record view keeps the runtime semantics of `in` (which is what
+ * main.ts's migrateLegacySave used) without letting the compiler assume the
+ * absent case is impossible.
+ */
+function hasField(value: object, key: string): boolean {
+  return key in (value as Record<string, unknown>);
+}
+
+function migrateLegacyMainFixups(state: GameState): GameState {
+  const next: GameState = { ...state };
+
+  // Every field below is guarded. migrateLegacySave only ever ran on fully
+  // loaded campaign saves, but a migration runs on anything -- including the
+  // deliberately malformed fixture in save-migrations.test.ts ("leaves a
+  // malformed legacy civilization for later state normalization"), which has a
+  // civ with no techState and no settings/map/units at all. Migrations must
+  // tolerate that shape and leave it for normalizeLoadedState.
+
+  // --- Civilizations: civType, lastCombatTurnByLandmass, diplomacy, tracks ---
+  const civIds = Object.keys(next.civilizations ?? {});
+  next.civilizations = Object.fromEntries(
+    Object.entries(next.civilizations ?? {}).map(([civId, civ]) => {
+      if (!isObject(civ)) return [civId, civ];
+      const migrated = { ...civ };
+      migrated.civType ??= 'generic';
+      migrated.knownCivilizations ??= [];
+      migrated.lastCombatTurnByLandmass ??= {};
+      // createDiplomacyState rather than the object literal main.ts used: that
+      // literal omitted treacheryScore/vassalage and only compiled behind an
+      // `as any`. The canonical constructor yields a complete DiplomacyState.
+      migrated.diplomacy ??= createDiplomacyState(civIds, civId, 0);
+      if (isObject(migrated.techState)) {
+        const trackPriorities = { ...(migrated.techState.trackPriorities ?? {}) } as Record<string, string>;
+        for (const track of ALL_TECH_TRACKS) {
+          trackPriorities[track] ??= 'medium';
+        }
+        migrated.techState = {
+          ...migrated.techState,
+          trackPriorities: trackPriorities as typeof migrated.techState.trackPriorities,
+        };
+      }
+      return [civId, migrated];
+    }),
+  );
+
+  // --- Settings: advisor roster (M3b added treasurer/scholar, M4a spymaster) ---
+  if (isObject(next.settings)) {
+    const advisorsEnabled = { ...(next.settings.advisorsEnabled ?? {}) } as Record<string, boolean>;
+    for (const advisor of ALL_ADVISORS) {
+      advisorsEnabled[advisor] ??= true;
+    }
+    next.settings = {
+      ...next.settings,
+      advisorsEnabled: advisorsEnabled as NonNullable<GameState['settings']['advisorsEnabled']>,
+    };
+  }
+
+  // --- Optional containers ---
+  next.pendingEvents ??= {};
+  next.tribalVillages ??= {};
+  next.discoveredWonders ??= {};
+  next.wonderDiscoverers ??= {};
+  next.legendaryWonderIntel ??= {};
+  next.minorCivs ??= {};
+  next.resurgentCampCooldownByCivLandmass ??= {};
+
+  // --- Legendary wonder history (reads wonderDiscoverers, so it runs after) ---
+  const history = { ...(next.legendaryWonderHistory ?? { destroyedStrongholds: [], discoveredSites: [] }) };
+  history.networkPlanResolutions ??= [];
+  if (!history.discoveredSites) {
+    const discoveredSites: NonNullable<GameState['legendaryWonderHistory']>['discoveredSites'] = [];
+    for (const [wonderId, discoverers] of Object.entries(next.wonderDiscoverers ?? {})) {
+      const wonderTile = Object.values(next.map?.tiles ?? {}).find(tile => tile.wonder === wonderId);
+      for (const civId of discoverers) {
+        if (discoveredSites.some(record => record.civId === civId && record.siteId === wonderId)) continue;
+        discoveredSites.push({
+          civId,
+          siteId: wonderId,
+          siteType: 'natural-wonder',
+          position: wonderTile?.coord ?? { q: 0, r: 0 },
+          turn: next.turn,
+        });
+      }
+    }
+    history.discoveredSites = discoveredSites;
+  }
+  next.legendaryWonderHistory = history;
+
+  // --- Tile.wonder and Unit.isResting backfills ---
+  const tiles = next.map?.tiles;
+  if (tiles) {
+    next.map = {
+      ...next.map,
+      tiles: Object.fromEntries(
+        Object.entries(tiles).map(([key, tile]) => (
+          hasField(tile, 'wonder') ? [key, tile] : [key, { ...tile, wonder: null }]
+        )),
+      ),
+    };
+  }
+  const units = next.units;
+  if (units) {
+    next.units = Object.fromEntries(
+      Object.entries(units).map(([unitId, unit]) => (
+        hasField(unit, 'isResting') ? [unitId, unit] : [unitId, { ...unit, isResting: false }]
+      )),
+    );
+  }
+
+  // --- Marketplace, then the TradeRoute reshape that reads it ---
+  const marketplace = isObject(next.marketplace) ? next.marketplace : createMarketplaceState();
+  let legacyRouteN = 1;
+  next.marketplace = {
+    ...marketplace,
+    tradeRoutes: (Array.isArray(marketplace.tradeRoutes) ? marketplace.tradeRoutes : []).map(route => {
+      if (!isObject(route)) return route;
+      const legacy = route as TradeRoute & LegacyTradeRoute;
+      if (legacy.id && legacy.goldPerTrip && legacy.turnsPerTrip) {
+        legacyRouteN += 1;
+        return legacy;
+      }
+      const turnsPerTrip = legacy.turnsPerTrip ?? 3;
+      const { goldPerTurn, ...rest } = legacy;
+      return {
+        ...rest,
+        id: legacy.id ?? `route-legacy-${legacyRouteN++}`,
+        turnsPerTrip,
+        goldPerTrip: legacy.goldPerTrip ?? (goldPerTurn ?? 2) * turnsPerTrip,
+      };
+    }),
+  };
+
+  // --- Beasts: flag legacy saves so processTurn places lairs on the FIRST tick
+  // after load, deferring the paw markers until the player has taken an action.
+  next.beasts ??= { mode: 'wild', lairs: {}, sightingsByCiv: {}, migrationPending: true };
+
+  return next;
+}
+
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   1: migrateToEra13Foundation,
   2: migrateLateResources,
@@ -523,6 +714,7 @@ export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   9: migrateCoastalHullsOffOcean,
   10: migrateRetimedCavalry,
   11: migrateRetimedKnight,
+  12: migrateLegacyMainFixups,
 };
 
 function readSchemaVersion(raw: Record<string, unknown>): number {

--- a/src/storage/settings-merge.ts
+++ b/src/storage/settings-merge.ts
@@ -1,0 +1,28 @@
+import type { GameState } from '@/core/types';
+
+/**
+ * Applies user-level settings that are persisted OUTSIDE the save file.
+ *
+ * Deliberately not a `SaveMigration`. `councilTalkLevel` was the one fixup in
+ * main.ts's migrateLegacySave() that could not move into the versioned
+ * pipeline (#787 phase 1): it reads the player's IndexedDB preferences via
+ * loadSettings(), not the save's own bytes, so it can never be a deterministic
+ * `(state) => GameState`. Smuggling a module-global read into
+ * save-migrations.ts would make every migration untestable.
+ *
+ * A save that already carries a `councilTalkLevel` keeps it — the campaign's
+ * own choice outranks the machine-level default.
+ */
+export function applyPersistedUserSettings(
+  state: GameState,
+  persisted: GameState['settings'] | undefined,
+): GameState {
+  if (state.settings.councilTalkLevel) return state;
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      councilTalkLevel: persisted?.councilTalkLevel ?? 'normal',
+    },
+  };
+}

--- a/tests/app/determinism-guard.test.ts
+++ b/tests/app/determinism-guard.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
+import { processTurn } from '@/core/turn-manager';
+import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-system';
+import type { GameState, SoloSetupConfig } from '@/core/types';
+
+/**
+ * Gameplay guard for the composition-root decomposition arc (#787).
+ *
+ * The refactor moves ~5,400 lines out of src/main.ts across eleven phases, and
+ * main.ts calls into nearly every system. This runs the real turn pipeline with
+ * no UI attached, so it is unaffected by every phase EXCEPT one that
+ * accidentally changes a system call -- which is exactly the failure it exists
+ * to catch. See docs/superpowers/plans/2026-08-04-composition-root-decomposition.md.
+ *
+ * Deliberately NOT a snapshot: this repo has no snapshot tests, and a snapshot's
+ * failure mode is `-u` until green. The only correct response to the baseline
+ * below failing is to find which phase moved a system call and revert it.
+ */
+
+const CONFIG: SoloSetupConfig = {
+  civType: 'generic',
+  mapSize: 'small',
+  opponentCount: 3,
+  gameTitle: 'determinism guard',
+  seed: 'composition-root-guard',
+};
+
+const ROUNDS = 20;
+
+function advance(state: GameState, rounds: number): GameState {
+  let current = state;
+  for (let i = 0; i < rounds; i += 1) {
+    const bus = new EventBus();
+    const result = runCompletedRound(current, bus, {
+      improvements: (s, b) => processImprovementTurns(s, b),
+      majors: (s, b) => processNonHumanMajorRound(s, b).state,
+      world: (s, b) => processTurn(s, b),
+      postprocess: (before, s, b) => applyStrategicWarningTransitions(before, s, b),
+    });
+    if (!result.ok) throw result.error;
+    current = result.state;
+  }
+  return current;
+}
+
+function digest(state: GameState): Record<string, unknown> {
+  return {
+    turn: state.turn,
+    era: state.era,
+    cityCount: Object.keys(state.cities).length,
+    unitCount: Object.keys(state.units).length,
+    goldByCiv: Object.fromEntries(
+      Object.entries(state.civilizations).map(([id, civ]) => [id, civ.gold]),
+    ),
+    techsCompletedByCiv: Object.fromEntries(
+      Object.entries(state.civilizations).map(([id, civ]) => [id, civ.techState.completed.length]),
+    ),
+  };
+}
+
+describe('determinism guard', () => {
+  it(`${ROUNDS} rounds over the same start produce an identical state across runs`, () => {
+    // Both runs start from ONE created state, cloned. createNewGame cannot be
+    // called twice for this: createGameId embeds Date.now() (game-state.ts:123),
+    // so two fresh games always differ on gameId. Cloning isolates exactly what
+    // this guard is for -- determinism of the turn pipeline itself.
+    const start = createNewGame(CONFIG);
+    const a = advance(structuredClone(start), ROUNDS);
+    const b = advance(structuredClone(start), ROUNDS);
+
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('matches the baseline recorded from the pre-refactor build', () => {
+    const state = advance(createNewGame(CONFIG), ROUNDS);
+
+    expect(digest(state)).toEqual(BASELINE);
+  });
+});
+
+/**
+ * Recorded 2026-08-04 from commit 2ce97c70, before any source file in the
+ * decomposition arc was touched. Do not re-record to make a failing phase pass.
+ */
+const BASELINE = {
+  turn: 21,
+  era: 1,
+  cityCount: 6,
+  unitCount: 24,
+  // The human seat never acts in this harness -- only non-human majors and the
+  // world tick run -- so `player` staying at 0 is correct, and the AI columns
+  // are what actually guard AI behavior.
+  goldByCiv: { player: 0, 'ai-1': 20, 'ai-2': 22 },
+  techsCompletedByCiv: { player: 0, 'ai-1': 4, 'ai-2': 4 },
+} as const;

--- a/tests/app/determinism-guard.test.ts
+++ b/tests/app/determinism-guard.test.ts
@@ -77,6 +77,16 @@ function digest(state: GameState): Record<string, unknown> {
   };
 }
 
+// Timeouts per .claude/rules/hooks-and-tooling.md (#608): this file advances the
+// full turn pipeline 40 rounds across 4 civs, so it is a simulation test, not a
+// cheap unit test, and must never sit on vitest's 5s default. Observed: 1520ms /
+// 704ms solo locally, but 6604ms for the first test on CI -- which is exactly how
+// this file first failed. Sized well above the worst observed run so contention
+// from parallel worktree agents cannot turn it into a phantom regression. Do not
+// tighten these toward the solo timings.
+const TWO_RUN_TIMEOUT_MS = 30_000;
+const ONE_RUN_TIMEOUT_MS = 15_000;
+
 describe('determinism guard', () => {
   it(`${ROUNDS} rounds over the same start produce an identical state across runs`, () => {
     // Cloning one start (rather than creating two games) isolates exactly what
@@ -86,13 +96,28 @@ describe('determinism guard', () => {
     const b = advance(structuredClone(start), ROUNDS);
 
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
-  });
+  }, TWO_RUN_TIMEOUT_MS);
 
+  /**
+   * TEMPORARY — delete this test (and BASELINE, digest, and ONE_RUN_TIMEOUT_MS)
+   * in #787 phase 11, when the arc lands.
+   *
+   * It exists only to back this arc's "no gameplay change" claim while ~5,400
+   * lines move out of main.ts. It is NOT a general-purpose regression test: the
+   * digest is sensitive to any legitimate content or balance work -- a new unit,
+   * a retuned yield, an AI tweak -- and the only sane response to those is to
+   * re-record it. Keeping it past phase 11 would train everyone to re-record on
+   * red, which is precisely the habit the docblock above forbids, and would
+   * eventually mask a real regression.
+   *
+   * The sibling test above has no such expiry: run-to-run determinism is
+   * invariant under gameplay changes and stays useful forever.
+   */
   it('matches the baseline recorded from the pre-refactor build', () => {
     const state = advance(pinnedStart(), ROUNDS);
 
     expect(digest(state)).toEqual(BASELINE);
-  });
+  }, ONE_RUN_TIMEOUT_MS);
 });
 
 /**

--- a/tests/app/determinism-guard.test.ts
+++ b/tests/app/determinism-guard.test.ts
@@ -32,6 +32,20 @@ const CONFIG: SoloSetupConfig = {
 
 const ROUNDS = 20;
 
+/**
+ * gameId must be pinned, not left as createNewGame produced it.
+ *
+ * createGameId embeds Date.now() (game-state.ts:123), and pirate ecology seeds
+ * its RNG from `${state.gameId}:${state.turn}` (pirate-ecology.ts:380). So two
+ * games created at different wall-clock times diverge in unit count by design.
+ * That is correct behaviour for real campaigns and fatal for a fixed baseline --
+ * without this pin the second test below fails intermittently and looks exactly
+ * like the gameplay regression it exists to detect.
+ */
+function pinnedStart(): GameState {
+  return { ...createNewGame(CONFIG), gameId: 'determinism-guard-fixed-id' };
+}
+
 function advance(state: GameState, rounds: number): GameState {
   let current = state;
   for (let i = 0; i < rounds; i += 1) {
@@ -65,11 +79,9 @@ function digest(state: GameState): Record<string, unknown> {
 
 describe('determinism guard', () => {
   it(`${ROUNDS} rounds over the same start produce an identical state across runs`, () => {
-    // Both runs start from ONE created state, cloned. createNewGame cannot be
-    // called twice for this: createGameId embeds Date.now() (game-state.ts:123),
-    // so two fresh games always differ on gameId. Cloning isolates exactly what
-    // this guard is for -- determinism of the turn pipeline itself.
-    const start = createNewGame(CONFIG);
+    // Cloning one start (rather than creating two games) isolates exactly what
+    // this guard is for: determinism of the turn pipeline itself.
+    const start = pinnedStart();
     const a = advance(structuredClone(start), ROUNDS);
     const b = advance(structuredClone(start), ROUNDS);
 
@@ -77,21 +89,25 @@ describe('determinism guard', () => {
   });
 
   it('matches the baseline recorded from the pre-refactor build', () => {
-    const state = advance(createNewGame(CONFIG), ROUNDS);
+    const state = advance(pinnedStart(), ROUNDS);
 
     expect(digest(state)).toEqual(BASELINE);
   });
 });
 
 /**
- * Recorded 2026-08-04 from commit 2ce97c70, before any source file in the
- * decomposition arc was touched. Do not re-record to make a failing phase pass.
+ * Recorded 2026-08-04 from commit 2ce97c70 with `git stash push -- src/` applied,
+ * i.e. against a source tree with zero decomposition-arc changes. Verified stable
+ * across repeated runs with the pinned gameId above.
+ *
+ * Do not re-record to make a failing phase pass. If this fails, find the phase
+ * that moved a system call and revert it.
  */
 const BASELINE = {
   turn: 21,
   era: 1,
   cityCount: 6,
-  unitCount: 24,
+  unitCount: 23,
   // The human seat never acts in this harness -- only non-human majors and the
   // world tick run -- so `player` staying at 0 is correct, and the AI columns
   // are what actually guard AI behavior.

--- a/tests/storage/new-game-completeness.test.ts
+++ b/tests/storage/new-game-completeness.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { createNewGame, createHotSeatGame } from '@/core/game-state';
+import { normalizeLoadedState } from '@/storage/save-manager';
+import { CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
+import type { GameState, HotSeatConfig } from '@/core/types';
+
+/**
+ * main.ts's migrateLegacySave() ran on brand-new HOT-SEAT games (createHotSeatGame
+ * -> enterCampaign -> migrate) but not on brand-new SOLO games, which called
+ * startGame() directly. So the two new-game paths did not provably produce the
+ * same state shape, and nothing tested that they did. #787 phase 1 deletes that
+ * function; these tests are what replaces the guarantee.
+ *
+ * Note on scope: createNewGame/createHotSeatGame do not set saveSchemaVersion, so
+ * a fresh state reads as version 0 and normalizeLoadedState replays migrations
+ * 1..12, not just 12. A whole-state equality assertion would therefore fail on any
+ * pre-existing non-idempotency anywhere in that chain -- which is why the gate
+ * below is scoped to the fields phase 1 actually relocated, and the whole-state
+ * comparison is kept separately as a diagnostic.
+ */
+
+const SOLO = (): GameState => createNewGame({
+  civType: 'generic',
+  mapSize: 'small',
+  opponentCount: 2,
+  gameTitle: 'solo completeness',
+  seed: 'new-game-completeness-solo',
+});
+
+const HOT_SEAT_CONFIG: HotSeatConfig = {
+  playerCount: 2,
+  mapSize: 'small',
+  players: [
+    { slotId: 'player-1', name: 'A', civType: 'generic', isHuman: true },
+    { slotId: 'player-2', name: 'B', civType: 'generic', isHuman: true },
+  ],
+};
+
+const HOT_SEAT = (): GameState => createHotSeatGame(HOT_SEAT_CONFIG, undefined, 'hot seat completeness', 'standard');
+
+describe('freshly created games need no legacy fixups', () => {
+  for (const [label, make] of [['solo', SOLO], ['hot seat', HOT_SEAT]] as const) {
+    it(`${label}: no relocated fixup overwrites anything a fresh game already set`, () => {
+      const state = make();
+      const normalized = normalizeLoadedState(structuredClone(state));
+
+      expect(normalized.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+
+      // Beasts: a fresh game already has its lairs placed, so the legacy
+      // migrationPending flag must NOT be set -- setting it would make
+      // processTurn re-place lairs on the first tick of a brand-new game.
+      expect(normalized.beasts!.migrationPending).toBeUndefined();
+      expect(normalized.beasts!.lairs).toEqual(state.beasts!.lairs);
+      expect(normalized.beasts!.mode).toBe(state.beasts!.mode);
+
+      expect(normalized.marketplace!.tradeRoutes).toEqual(state.marketplace!.tradeRoutes);
+      expect(normalized.legendaryWonderHistory!.destroyedStrongholds)
+        .toEqual(state.legendaryWonderHistory!.destroyedStrongholds);
+      expect(normalized.legendaryWonderHistory!.discoveredSites)
+        .toEqual(state.legendaryWonderHistory!.discoveredSites);
+      expect(normalized.legendaryWonderIntel).toEqual(state.legendaryWonderIntel);
+      expect(normalized.tribalVillages).toEqual(state.tribalVillages);
+      expect(normalized.discoveredWonders).toEqual(state.discoveredWonders);
+      expect(normalized.wonderDiscoverers).toEqual(state.wonderDiscoverers);
+      expect(normalized.settings.advisorsEnabled).toEqual(state.settings.advisorsEnabled);
+
+      // minorCivs is `??= {}` only. The roster must survive intact -- a
+      // clobbering migration would silently delete every minor civ. (The per-civ
+      // `economy` block that normalizeMinorCivEconomyState adds on load is a
+      // pre-existing normalizer, not part of this phase; see the ratchet below.)
+      expect(Object.keys(normalized.minorCivs).sort()).toEqual(Object.keys(state.minorCivs).sort());
+
+      for (const [civId, civ] of Object.entries(normalized.civilizations)) {
+        const original = state.civilizations[civId];
+        expect(civ.civType, civId).toBe(original.civType);
+        expect(civ.diplomacy, civId).toEqual(original.diplomacy);
+        expect(civ.techState.trackPriorities, civId).toEqual(original.techState.trackPriorities);
+        expect(civ.knownCivilizations, civId).toEqual(original.knownCivilizations);
+      }
+    });
+
+    it(`${label}: fields a fresh game genuinely omits get their documented default`, () => {
+      // createNewGame does not set these two; migrateLegacySave defaulted them at
+      // campaign entry and migration 12 keeps doing so. Asserted rather than
+      // assumed, because `{}` vs `undefined` decides whether downstream readers
+      // need `?? {}`.
+      const normalized = normalizeLoadedState(structuredClone(make()));
+
+      expect(normalized.pendingEvents).toEqual({});
+      expect(normalized.resurgentCampCooldownByCivLandmass).toEqual({});
+      // Same story one level down: createNewGame builds legendaryWonderHistory
+      // with only destroyedStrongholds/discoveredSites, and builds civs with no
+      // lastCombatTurnByLandmass at all.
+      expect(normalized.legendaryWonderHistory!.networkPlanResolutions).toEqual([]);
+      for (const [civId, civ] of Object.entries(normalized.civilizations)) {
+        expect(civ.lastCombatTurnByLandmass, civId).toEqual({});
+      }
+    });
+  }
+
+  it('both new-game paths agree on the fields the deleted migrateLegacySave used to backfill', () => {
+    // The actual defect migrateLegacySave was hiding: solo and hot seat took
+    // different routes into a campaign, so only one of them got these fixups.
+    const solo = normalizeLoadedState(structuredClone(SOLO()));
+    const hotSeat = normalizeLoadedState(structuredClone(HOT_SEAT()));
+
+    for (const state of [solo, hotSeat]) {
+      expect(Object.keys(state.settings.advisorsEnabled!).sort()).toEqual([
+        'artisan', 'builder', 'chancellor', 'explorer',
+        'scholar', 'spymaster', 'treasurer', 'warchief',
+      ]);
+      expect(state.beasts!.migrationPending).toBeUndefined();
+      for (const civ of Object.values(state.civilizations)) {
+        expect(civ.civType).toBeDefined();
+        expect(civ.diplomacy).toBeDefined();
+        expect(civ.lastCombatTurnByLandmass).toBeDefined();
+      }
+    }
+  });
+
+  it('ratchet: the load pipeline adds exactly these fields to a fresh game, and no others', () => {
+    // A fresh state carries no saveSchemaVersion, so it reads as version 0 and
+    // normalizeLoadedState replays migrations 1..12 plus every unconditional
+    // normalizer. That legitimately enriches a new game. This pins the exact set
+    // so a future change that starts adding something new has to say so here.
+    //
+    // Only `pendingEvents` and `resurgentCampCooldownByCivLandmass` belong to
+    // #787 phase 1 (migration 12). The rest predate it:
+    //   reconReveals, nationalProjectChoices  -- earlier numbered migrations
+    //   pirateFleets, pirateFleetCooldownByCivLandmass -- migrateLegacyPirateFleets
+    //   legendaryWonderAvailability -- key set to undefined by its normalizer
+    const state = SOLO();
+    const normalized = normalizeLoadedState(structuredClone(state)) as unknown as Record<string, unknown>;
+    const before = state as unknown as Record<string, unknown>;
+
+    expect(Object.keys(normalized).filter(key => !(key in before)).sort()).toEqual([
+      'legendaryWonderAvailability',
+      'nationalProjectChoices',
+      'pendingEvents',
+      'pirateFleetCooldownByCivLandmass',
+      'pirateFleets',
+      'reconReveals',
+      'resurgentCampCooldownByCivLandmass',
+      'saveSchemaVersion',
+    ]);
+    expect(Object.keys(before).filter(key => !(key in normalized))).toEqual([]);
+  });
+});

--- a/tests/storage/save-migrations-v12.test.ts
+++ b/tests/storage/save-migrations-v12.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { migrateSaveToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
+import { createNewGame } from '@/core/game-state';
+import type { SoloSetupConfig } from '@/core/types';
+
+/**
+ * Migration 12 absorbs the 18 versioned fixups that used to live in
+ * main.ts's migrateLegacySave() -- 124 lines that mutated module-scope
+ * gameState in place, were never exported, and had no tests. See #787 and
+ * docs/superpowers/plans/2026-08-04-composition-root-decomposition.md.
+ */
+
+const CONFIG: SoloSetupConfig = {
+  civType: 'generic',
+  mapSize: 'small',
+  opponentCount: 1,
+  gameTitle: 'migration fixture',
+  seed: 'save-migration-v12',
+};
+
+/** Stamp a fresh state as v11 so only migration 12 runs. */
+function asV11(): Record<string, unknown> {
+  return { ...(createNewGame(CONFIG) as unknown as Record<string, unknown>), saveSchemaVersion: 11 };
+}
+
+describe('save migration 12 — absorbed main.ts legacy fixups', () => {
+  it('backfills civType, diplomacy, and lastCombatTurnByLandmass', () => {
+    const raw = asV11();
+    const civs = raw.civilizations as Record<string, Record<string, unknown>>;
+    for (const civ of Object.values(civs)) {
+      delete civ.civType;
+      delete civ.diplomacy;
+      delete civ.lastCombatTurnByLandmass;
+    }
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    for (const civ of Object.values(migrated.civilizations)) {
+      expect(civ.civType).toBe('generic');
+      expect(civ.lastCombatTurnByLandmass).toEqual({});
+      expect(civ.diplomacy.atWarWith).toEqual([]);
+      expect(civ.diplomacy.treaties).toEqual([]);
+      expect(civ.diplomacy.events).toEqual([]);
+    }
+  });
+
+  it('seeds diplomacy relationships for every other civ at zero', () => {
+    const raw = asV11();
+    const civs = raw.civilizations as Record<string, Record<string, unknown>>;
+    const civIds = Object.keys(civs);
+    for (const civ of Object.values(civs)) delete civ.diplomacy;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    for (const civId of civIds) {
+      const relationships = migrated.civilizations[civId].diplomacy.relationships;
+      expect(Object.keys(relationships).sort()).toEqual(civIds.filter(id => id !== civId).sort());
+      expect(Object.values(relationships).every(value => value === 0)).toBe(true);
+    }
+  });
+
+  it('backfills the full advisor roster, including treasurer, scholar, and spymaster', () => {
+    const raw = asV11();
+    const settings = raw.settings as Record<string, unknown>;
+    delete settings.advisorsEnabled;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.settings.advisorsEnabled).toEqual({
+      builder: true, explorer: true, chancellor: true, warchief: true,
+      treasurer: true, scholar: true, spymaster: true, artisan: true,
+    });
+  });
+
+  it('adds only the missing advisors to a partial roster', () => {
+    const raw = asV11();
+    const settings = raw.settings as Record<string, unknown>;
+    settings.advisorsEnabled = { builder: false, explorer: true, chancellor: true, warchief: true, artisan: true };
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    // The pre-existing `false` must survive -- these are player preferences.
+    expect(migrated.settings.advisorsEnabled!.builder).toBe(false);
+    expect(migrated.settings.advisorsEnabled!.treasurer).toBe(true);
+    expect(migrated.settings.advisorsEnabled!.scholar).toBe(true);
+    expect(migrated.settings.advisorsEnabled!.spymaster).toBe(true);
+  });
+
+  it('backfills every tech track priority to medium', () => {
+    const raw = asV11();
+    const civs = raw.civilizations as Record<string, Record<string, Record<string, unknown>>>;
+    for (const civ of Object.values(civs)) {
+      civ.techState.trackPriorities = { military: 'high' };
+    }
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    for (const civ of Object.values(migrated.civilizations)) {
+      const priorities = civ.techState.trackPriorities as Record<string, string>;
+      expect(priorities.military).toBe('high');
+      for (const track of [
+        'economy', 'science', 'civics', 'exploration', 'agriculture', 'medicine',
+        'philosophy', 'arts', 'maritime', 'metallurgy', 'construction',
+        'communication', 'espionage', 'spirituality',
+      ]) {
+        expect(priorities[track], track).toBe('medium');
+      }
+    }
+  });
+
+  it('reshapes legacy trade routes to id/goldPerTrip/turnsPerTrip and drops goldPerTurn', () => {
+    const raw = asV11();
+    (raw.marketplace as { tradeRoutes: unknown[] }).tradeRoutes = [
+      { fromCityId: 'a', toCityId: 'b', goldPerTurn: 4 },
+      { fromCityId: 'c', toCityId: 'd', goldPerTurn: 3, turnsPerTrip: 5 },
+    ];
+
+    const migrated = migrateSaveToCurrent(raw);
+    const [first, second] = migrated.marketplace!.tradeRoutes;
+
+    expect(first.id).toBe('route-legacy-1');
+    expect(first.goldPerTrip).toBe(12);
+    expect(first.turnsPerTrip).toBe(3);
+    expect('goldPerTurn' in first).toBe(false);
+
+    expect(second.id).toBe('route-legacy-2');
+    expect(second.goldPerTrip).toBe(15);
+    expect(second.turnsPerTrip).toBe(5);
+  });
+
+  it('flags legacy saves with no beasts block so lairs place on the first tick', () => {
+    const raw = asV11();
+    delete raw.beasts;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.beasts!.migrationPending).toBe(true);
+    expect(migrated.beasts!.lairs).toEqual({});
+    expect(migrated.beasts!.mode).toBe('wild');
+  });
+
+  it('preserves an existing beasts block instead of resetting it', () => {
+    const raw = asV11();
+    const lairs = (raw.beasts as { lairs: unknown }).lairs;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.beasts!.lairs).toEqual(lairs);
+    expect(migrated.beasts!.migrationPending).toBeUndefined();
+  });
+
+  it('backfills tile.wonder and unit.isResting', () => {
+    const raw = asV11();
+    for (const tile of Object.values((raw.map as { tiles: Record<string, Record<string, unknown>> }).tiles)) {
+      delete tile.wonder;
+    }
+    for (const unit of Object.values(raw.units as Record<string, Record<string, unknown>>)) {
+      delete unit.isResting;
+    }
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(Object.values(migrated.map.tiles).every(tile => tile.wonder === null)).toBe(true);
+    expect(Object.values(migrated.units).every(unit => unit.isResting === false)).toBe(true);
+  });
+
+  it('rebuilds legendary discovered sites from wonderDiscoverers', () => {
+    const raw = asV11();
+    const tiles = (raw.map as { tiles: Record<string, { coord: { q: number; r: number }; wonder?: string | null }> }).tiles;
+    const [firstKey] = Object.keys(tiles);
+    tiles[firstKey].wonder = 'mount-olympus';
+    raw.wonderDiscoverers = { 'mount-olympus': ['player'] };
+    // The rebuild fires only for a history object that LACKS discoveredSites --
+    // see the sibling test below for the wholly-absent case.
+    raw.legendaryWonderHistory = { destroyedStrongholds: [] };
+
+    const migrated = migrateSaveToCurrent(raw);
+    const sites = migrated.legendaryWonderHistory!.discoveredSites;
+
+    expect(sites).toHaveLength(1);
+    expect(sites[0].civId).toBe('player');
+    expect(sites[0].siteId).toBe('mount-olympus');
+    expect(sites[0].siteType).toBe('natural-wonder');
+    expect(sites[0].position).toEqual(tiles[firstKey].coord);
+  });
+
+  it('does NOT rebuild discovered sites when legendaryWonderHistory is absent entirely', () => {
+    // Quirk carried over verbatim from main.ts:5192-5211: the absent-history
+    // default already supplies `discoveredSites: []`, which makes the rebuild
+    // guard false. Pinned deliberately -- changing it would alter what old
+    // saves show in the wonder codex, which is out of scope for #787.
+    const raw = asV11();
+    const tiles = (raw.map as { tiles: Record<string, { wonder?: string | null }> }).tiles;
+    tiles[Object.keys(tiles)[0]].wonder = 'mount-olympus';
+    raw.wonderDiscoverers = { 'mount-olympus': ['player'] };
+    delete raw.legendaryWonderHistory;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.legendaryWonderHistory!.discoveredSites).toEqual([]);
+  });
+
+  it('backfills the remaining optional containers', () => {
+    const raw = asV11();
+    delete raw.pendingEvents;
+    delete raw.tribalVillages;
+    delete raw.discoveredWonders;
+    delete raw.wonderDiscoverers;
+    delete raw.legendaryWonderIntel;
+    delete raw.minorCivs;
+    delete raw.marketplace;
+    delete raw.resurgentCampCooldownByCivLandmass;
+
+    const migrated = migrateSaveToCurrent(raw);
+
+    expect(migrated.pendingEvents).toEqual({});
+    expect(migrated.tribalVillages).toEqual({});
+    expect(migrated.discoveredWonders).toEqual({});
+    expect(migrated.wonderDiscoverers).toEqual({});
+    expect(migrated.legendaryWonderIntel).toEqual({});
+    expect(migrated.minorCivs).toEqual({});
+    expect(migrated.marketplace!.tradeRoutes).toEqual([]);
+    expect(migrated.resurgentCampCooldownByCivLandmass).toEqual({});
+  });
+
+  it('is idempotent — migrating an already-migrated save changes nothing', () => {
+    // migrateLegacySave ran on EVERY campaign entry, so nearly every real v11
+    // save already carries these fields. Migration 12 must default, never clobber.
+    const raw = asV11();
+    const once = migrateSaveToCurrent(raw);
+    const twice = migrateSaveToCurrent({ ...once, saveSchemaVersion: 11 });
+
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+});

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -358,7 +358,7 @@ describe('save migrations', () => {
     const migrated = migrateSaveToCurrent(legacySave);
     const loadedAgain = migrateSaveToCurrent(migrated);
 
-    expect(migrated.saveSchemaVersion).toBe(11);
+    expect(migrated.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
     expect(migrated.cities[city.id]).toMatchObject({
       productionQueue: ['knight', 'knight'], legacyTechGrace: ['knight', 'knight'],
     });

--- a/tests/storage/settings-merge.test.ts
+++ b/tests/storage/settings-merge.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { applyPersistedUserSettings } from '@/storage/settings-merge';
+import type { GameState } from '@/core/types';
+
+function stateWith(councilTalkLevel?: GameState['settings']['councilTalkLevel']): GameState {
+  return { settings: { ...(councilTalkLevel ? { councilTalkLevel } : {}) } } as unknown as GameState;
+}
+
+function persistedWith(councilTalkLevel?: GameState['settings']['councilTalkLevel']): GameState['settings'] {
+  return { ...(councilTalkLevel ? { councilTalkLevel } : {}) } as unknown as GameState['settings'];
+}
+
+describe('applyPersistedUserSettings', () => {
+  it("keeps the save's own councilTalkLevel over the machine-level preference", () => {
+    const state = stateWith('quiet');
+
+    const merged = applyPersistedUserSettings(state, persistedWith('chatty'));
+
+    expect(merged.settings.councilTalkLevel).toBe('quiet');
+    expect(merged).toBe(state);
+  });
+
+  it('falls back to the persisted user preference when the save has none', () => {
+    const merged = applyPersistedUserSettings(stateWith(), persistedWith('chatty'));
+
+    expect(merged.settings.councilTalkLevel).toBe('chatty');
+  });
+
+  it("falls back to 'normal' when neither the save nor the user has a preference", () => {
+    expect(applyPersistedUserSettings(stateWith(), undefined).settings.councilTalkLevel).toBe('normal');
+    expect(applyPersistedUserSettings(stateWith(), persistedWith()).settings.councilTalkLevel).toBe('normal');
+  });
+
+  it('does not mutate the state it is given', () => {
+    const state = stateWith();
+
+    applyPersistedUserSettings(state, persistedWith('chatty'));
+
+    expect(state.settings.councilTalkLevel).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Phase 1 of the 11-phase composition-root arc (#787). **Independent of every other phase** — it deletes 124 lines and 20 `as any` casts, and decouples `enterCampaign` so later phases can move it cleanly.

Also lands the arc's gameplay guard, plus the plan document itself.

## `main.ts` line count

| | Lines |
|---|---|
| Before | 5,462 |
| After | 5,338 |

## The problem

`migrateLegacySave()` at `src/main.ts:5146` was 124 lines that mutated module-scope `gameState` **in place** with 23 fixups and 20 `as any` casts. Never exported, never tested, reachable only by entering a campaign — one of three competing save-normalization routes.

It also ran on **brand-new hot-seat games** (`createHotSeatGame` → `enterCampaign` → migrate) while brand-new solo games called `startGame()` directly and skipped it, so the two new-game paths had no proof they produced the same state shape.

## Where the 23 fixups went

| Fixups | Bucket | Home |
|---|---|---|
| 1–18 | versioned | `SAVE_MIGRATIONS[12]`; `CURRENT_SAVE_SCHEMA_VERSION` 11 → 12 |
| 19–22 | derived | `normalizeLoadedState` — `refreshKnownCivilizations`, `reconstructLastSeenFromMap`, `clearStaleSoloPendingEvents` |
| 23 | user prefs | new `src/storage/settings-merge.ts` |

**Why 19–22 are not versioned:** they recompute state from the map and civ roster, so they must run on *every* load, not once at a version boundary — a save written by a build with a since-fixed visibility bug still needs its `lastSeen` rebuilt.

**Why 23 could not move into the pipeline:** `councilTalkLevel` reads the player's IndexedDB preferences via `loadSettings()`, not the save's own bytes. A `SaveMigration` is `(state) => GameState`; smuggling a module-global read into `save-migrations.ts` would make every migration non-deterministic and untestable.

## Behaviour preserved deliberately

- **Every fixup defaults, never overwrites.** `migrateLegacySave` ran on *every* campaign entry, so nearly every real v11 save already carries these fields. A clobbering migration would wipe live player data. Pinned by an idempotency test.
- **The `discoveredSites` rebuild still fires only for a history object that *lacks* `discoveredSites`, not for an absent history.** The absent-history default already supplies `discoveredSites: []`, which makes the rebuild guard false. Carried over verbatim from `main.ts:5192-5211` and now pinned by its own test — changing it would alter what old saves show in the wonder codex, which is out of scope here.
- **Migration 12 is fully defensive.** Migrations run on malformed input — there is an existing contract test, "leaves a malformed legacy civilization for later state normalization," whose fixture has a civ with no `techState` and no settings/map/units at all. `migrateLegacySave` never saw that shape because it only ran on loaded campaigns. The first port crashed on it; every field access is now guarded.

## Two type-level notes

- `Tile.wonder` and `Unit.isResting` are declared **required** in `types.ts`, so `'wonder' in tile` narrows the false branch to `never` and the spread stops compiling. `hasField()` keeps `in` semantics without letting the compiler assume the absent case is impossible — which is the entire premise of a migration.
- Diplomacy defaults now use `createDiplomacyState`. `main.ts`'s object literal omitted `treacheryScore`/`vassalage` and only compiled behind an `as any`; the canonical constructor yields a complete `DiplomacyState`.

## Intentional behaviour changes

**None.** The plan predicted `createNewGame`/`createHotSeatGame` might need a `knownCivilizations` fix — they turned out already consistent across both paths, so `game-state.ts` is untouched.

## The determinism guard, and a trap worth recording

`tests/app/determinism-guard.test.ts` runs the real turn pipeline with no UI, so it is unaffected by every phase except one that accidentally changes a system call.

It is **not** a snapshot — this repo has zero snapshot tests, and a snapshot's failure mode is `-u` until green, which is the one response this guard must never permit. The baseline is recorded literals.

It failed during this phase. The investigation is the interesting part: `createGameId` embeds `Date.now()` (`game-state.ts:123`), and `pirate-ecology.ts:380` seeds its RNG from `` `${state.gameId}:${state.turn}` ``. So two games created at different wall-clock times legitimately diverge in unit count. Correct for real campaigns, fatal for a fixed baseline — without a pinned `gameId` the guard fails intermittently and looks **exactly like the gameplay regression it exists to detect**.

Proof this was the harness and not this PR: with `git stash push -- src/` applied — a source tree with zero arc changes — the pinned guard reports the same value the baseline now records. Any future determinism-style test in this repo needs the same pin.

## Verification

- `yarn test` — 443 files, 7,396 passed, 3 skipped, 0 failed
- `yarn build` — clean, no TS errors
- `yarn test:ai-playability` — exit 0 (30-turn simulations across `explorer`/`standard`/`veteran` and multiple AI personality sets; baseline also recorded pre-change)
- `tests/app/determinism-guard.test.ts` — passes, verified stable across repeated runs

## Save compatibility

`CURRENT_SAVE_SCHEMA_VERSION` 11 → 12, so saves written after this merge throw `UnsupportedSaveSchemaVersionError` in pre-Phase-1 builds. That is the existing forward-incompatible/backward-compatible contract, but it matters for family playtests: **playtest builds should stay at or ahead of this commit.**

## New tests

| File | Covers |
|---|---|
| `tests/storage/save-migrations-v12.test.ts` | 13 cases — every relocated fixup, idempotency, preserve-existing-`beasts`, the `discoveredSites` quirk |
| `tests/storage/new-game-completeness.test.ts` | Neither new-game path is clobbered; fields a fresh game genuinely omits get their documented default; a ratchet pinning the exact set of fields the load pipeline adds |
| `tests/storage/settings-merge.test.ts` | Save's own `councilTalkLevel` outranks the machine default; fallbacks; no mutation |
| `tests/app/determinism-guard.test.ts` | Run-to-run determinism + fixed baseline, for all 11 phases |

## Out of scope

Phases 2–11 (`GameSession`, `SelectionStore`, `NotificationCenter`, `PanelRouter`, `CeremonyCoordinator`, presentation registrars, selection/map controllers, `TurnFlowController`, bootstrap, boundary lock). Tracked in #787.

The 21 `readFileSync`-and-grep assertions in `tests/main.integration.test.ts` are untouched — Phase 1 breaks none of them, and they are retired in Phases 7–10.

Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
