### PR TITLE
refactor(app): PanelHost + PanelRouter + registry + GlobalShortcuts (#787 phase 5)

### DIFF
--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -1,0 +1,47 @@
+/**
+ * Replaces `main.ts`'s module-scope `window.addEventListener('keydown', ...)`
+ * (#787 phase 5). Two branches, unchanged from the original listener:
+ *
+ * - Escape cancels an armed journey and toasts, but only when a journey is
+ *   actually pending -- it must not swallow Escape for any other purpose.
+ * - Backtick toggles the pacing-debug panel. `main.ts` used to track this
+ *   with its own `pacingDebugOpen` module-scope `let`; `PanelRouter.toggle`
+ *   makes that redundant since `isOpen` is DOM-derived.
+ *
+ * Uses `notifier.toast` rather than `main.ts`'s `showNotification` wrapper,
+ * so the "Journey cancelled." toast is not appended to the persistent
+ * notification log the way it is today -- `Notifier` (the port this phase
+ * has to depend on) only exposes the pure toast, not the log-writing
+ * wrapper. Deliberate, documented deviation: this is transient feedback for
+ * the acting player's own keypress, not a game-consequence event, so losing
+ * its log entry does not affect replayable game history.
+ */
+import type { Notifier, SelectionStore } from '@/app/ports';
+import type { PanelRouter } from '@/app/panel-router';
+
+export interface GlobalShortcutsDeps {
+  readonly target: EventTarget;
+  readonly selection: SelectionStore;
+  readonly router: PanelRouter;
+  readonly notifier: Notifier;
+}
+
+export function installGlobalShortcuts(deps: GlobalShortcutsDeps): () => void {
+  const { target, selection, router, notifier } = deps;
+
+  const handler = (event: Event): void => {
+    const keyboardEvent = event as KeyboardEvent;
+    if (keyboardEvent.key === 'Escape' && selection.getPendingIntent().kind === 'journey') {
+      selection.setPendingIntent({ kind: 'none' });
+      notifier.toast('Journey cancelled.', 'info');
+      return;
+    }
+    if (keyboardEvent.key !== '`') {
+      return;
+    }
+    router.toggle('pacing-debug');
+  };
+
+  target.addEventListener('keydown', handler);
+  return () => target.removeEventListener('keydown', handler);
+}

--- a/src/app/panel-host.ts
+++ b/src/app/panel-host.ts
@@ -1,0 +1,48 @@
+/**
+ * Owns the DOM layer panels render into, plus the interaction-blocking
+ * overlay flag that used to live in `main.ts`'s module-scope
+ * `createUiInteractionState()` instance (#787 phase 5).
+ *
+ * `PanelHost` extends `UiInteractionState` so it is a drop-in for every
+ * existing consumer of that interface (`context-menu.ts`,
+ * `keyboard-shortcuts.test.ts`, `desktop-controls.test.ts`) -- the LSP claim
+ * from the arc's Architecture section. `createUiInteractionState`'s factory
+ * itself is retired in Phase 11, once nothing constructs it directly.
+ *
+ * `onInteractionUnblocked` is new: `setBlockingOverlay` in `main.ts` today
+ * directly pumps the wonder-discovery and legendary-completion ceremony
+ * queues whenever the overlay clears. Phase 6's `CeremonyCoordinator` is the
+ * intended consumer of this hook; Phase 5 only builds and tests the
+ * capability, it does not rewire the ceremony queues to it yet.
+ */
+import { createUiInteractionState, type UiInteractionState } from '@/ui/ui-interaction-state';
+
+export interface PanelHost extends UiInteractionState {
+  readonly layer: HTMLElement;
+  /** Fires exactly once per transition from blocked to unblocked -- never on overlay-to-overlay swaps. */
+  onInteractionUnblocked(listener: () => void): void;
+}
+
+export function createPanelHost(layer: HTMLElement): PanelHost {
+  const inner = createUiInteractionState();
+  const listeners = new Set<() => void>();
+  let wasBlocked = false;
+
+  return {
+    layer,
+    setBlockingOverlay(id: string | null): void {
+      inner.setBlockingOverlay(id);
+      const isBlocked = inner.isInteractionBlocked();
+      if (wasBlocked && !isBlocked) {
+        for (const listener of listeners) listener();
+      }
+      wasBlocked = isBlocked;
+    },
+    isInteractionBlocked(): boolean {
+      return inner.isInteractionBlocked();
+    },
+    onInteractionUnblocked(listener: () => void): void {
+      listeners.add(listener);
+    },
+  };
+}

--- a/src/app/panel-registry.ts
+++ b/src/app/panel-registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Panel routing types shared by `panel-router.ts` and the real registry
+ * `main.ts` builds from them (#787 phase 5).
+ *
+ * See docs/superpowers/plans/2026-08-04-composition-root-decomposition.md,
+ * "Phase 5 — PanelHost, PanelRouter, registry, and global shortcuts".
+ */
+import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
+import type { PanelHost } from '@/app/panel-host';
+import type { PanelRouter } from '@/app/panel-router';
+
+export type PanelId =
+  | 'council' | 'tech' | 'city' | 'espionage' | 'diplomacy' | 'marketplace'
+  | 'network' | 'wonder' | 'wonder-atlas' | 'bestiary' | 'pirate-waters'
+  | 'notification-log' | 'city-overview' | 'territory-inspection' | 'pacing-debug';
+
+/**
+ * Panels in the same group close each other. 'main' is the mutually-exclusive
+ * set that `togglePanel` cleared before this phase; 'transient' panels close
+ * on their own and do not force-close a 'main' panel or each other.
+ */
+export type PanelGroup = 'main' | 'transient';
+
+/** Everything a panel factory needs. Panels never reach for `document` directly. */
+export interface PanelContext {
+  readonly session: GameSession;
+  readonly notifier: Notifier;
+  readonly host: PanelHost;
+  readonly selection: SelectionStore;
+  readonly router: PanelRouter;
+}
+
+export interface PanelDescriptor {
+  /** The DOM id the panel factory assigns to its root element. */
+  readonly domId: string;
+  readonly group: PanelGroup;
+  readonly open: (ctx: PanelContext) => void;
+}
+
+export type PanelRegistry = Readonly<Record<PanelId, PanelDescriptor>>;

--- a/src/app/panel-router.ts
+++ b/src/app/panel-router.ts
@@ -1,0 +1,87 @@
+/**
+ * Dispatches panel opens/closes through a `PanelRegistry` instead of the
+ * 288-line `else if` chain `togglePanel` used to be in `main.ts` (#787 phase 5).
+ *
+ * `isOpen`/`close`/`closeGroup` are DOM-derived (querying `host.layer` by
+ * each descriptor's `domId`), not internally tracked booleans -- that keeps
+ * them correct regardless of whether a panel's DOM was created through
+ * `open()` or through one of the parameterized helpers (`openWonderPanelForCityId`,
+ * `openCityPanelForCity`, `openTerritoryInspectionPanel`) that still create
+ * their panel directly, since `PanelDescriptor.open(ctx)` takes no per-call
+ * arguments and those three genuinely need one (a city id or a hex coord).
+ * Their registry entries exist so `closeGroup`/`isOpen`/`close` behave
+ * correctly against them; their `open` is never invoked by any real call site
+ * and throws if it ever is.
+ */
+import type { PanelHost } from '@/app/panel-host';
+import type { PanelContext, PanelGroup, PanelId, PanelRegistry } from '@/app/panel-registry';
+
+export interface PanelRouter {
+  toggle(panel: PanelId): void;
+  open(panel: PanelId): void;
+  close(panel: PanelId): void;
+  closeGroup(group: PanelGroup): void;
+  isOpen(panel: PanelId): boolean;
+}
+
+export interface PanelRouterDeps {
+  readonly host: PanelHost;
+  /**
+   * Partial so isolated unit tests can exercise the router against a
+   * two-or-three-entry fixture registry instead of the full 15-panel one
+   * `main.ts` builds. `open`/`close`/`isOpen`/`closeGroup` all assume the
+   * caller only ever passes a `PanelId` present in `registry` -- true for
+   * every real call site, since `main.ts`'s registry `satisfies PanelRegistry`
+   * (all keys present).
+   */
+  readonly registry: Partial<PanelRegistry>;
+  readonly context: PanelContext;
+  /**
+   * Fires before every `open()`. Wired in Phase 10 to `drawer.close()` --
+   * `togglePanel` called `drawer?.close()` as its first line today. Phase 5
+   * leaves the existing scattered `drawer?.close()` calls inside the
+   * migrated panel-open functions in place rather than wiring this, so this
+   * stays optional and unused until the composition root passes it.
+   */
+  readonly onBeforeOpen?: () => void;
+}
+
+export function createPanelRouter(deps: PanelRouterDeps): PanelRouter {
+  const { host, registry, context, onBeforeOpen } = deps;
+
+  const descriptorFor = (panel: PanelId) => {
+    const descriptor = registry[panel];
+    if (!descriptor) throw new Error(`No panel registered for '${panel}'.`);
+    return descriptor;
+  };
+
+  const isOpen = (panel: PanelId): boolean =>
+    host.layer.querySelector(`#${descriptorFor(panel).domId}`) !== null;
+
+  const close = (panel: PanelId): void => {
+    host.layer.querySelector(`#${descriptorFor(panel).domId}`)?.remove();
+  };
+
+  const closeGroup = (group: PanelGroup): void => {
+    for (const panel of Object.keys(registry) as PanelId[]) {
+      if (registry[panel]?.group === group) close(panel);
+    }
+  };
+
+  const open = (panel: PanelId): void => {
+    onBeforeOpen?.();
+    // Only 'main' panels mutually exclude on open -- 'transient' panels
+    // (network, wonder-atlas, bestiary, pirate-waters, notification-log,
+    // pacing-debug, ...) coexist freely, matching current behavior where
+    // opening the Wonder Atlas does not silently close the notification log.
+    if (descriptorFor(panel).group === 'main') closeGroup('main');
+    descriptorFor(panel).open(context);
+  };
+
+  const toggle = (panel: PanelId): void => {
+    if (isOpen(panel)) close(panel);
+    else open(panel);
+  };
+
+  return { toggle, open, close, closeGroup, isOpen };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,6 @@ import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
 import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
-import { createUiInteractionState } from '@/ui/ui-interaction-state';
 import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
 import { createReligionBoonModal } from '@/ui/religion-boon-modal';
 import { chooseBoon } from '@/systems/religion-system';
@@ -302,6 +301,10 @@ import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-sy
 import { createCityOverviewPanel } from '@/ui/city-overview-panel';
 import type { GameSession } from '@/app/ports';
 import { createGameSession } from '@/app/game-session';
+import { createPanelHost, type PanelHost } from '@/app/panel-host';
+import { createPanelRouter, type PanelRouter } from '@/app/panel-router';
+import type { PanelContext, PanelRegistry } from '@/app/panel-registry';
+import { installGlobalShortcuts } from '@/app/global-shortcuts';
 
 // --- App State ---
 /**
@@ -320,8 +323,6 @@ const session: GameSession = createGameSession(undefined as unknown as GameState
 const selection = createSelectionStore();
 let drawer: TreasuryDrawer;
 let inputInitialized = false;
-let councilPanelOpen = false;
-let pacingDebugOpen = false;
 let deferWonderDiscoveryRevealUntilMoveSettles = false;
 /** Owns persisted A/V settings + master volume, moved out of module scope (#787 phase 4). */
 const userSettingsStore = createUserSettingsStore({ load: loadSettings });
@@ -357,12 +358,33 @@ const audioCtx = new AudioContext();
 const audio = new AudioSystem(audioCtx);
 const roundPresentationGate = new RoundPresentationGate();
 const advisorSystem = new AdvisorSystem(bus);
-const uiInteractions = createUiInteractionState();
 
 // --- Canvas Setup ---
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
+
+/**
+ * Owns the panel DOM layer and the interaction-blocking overlay flag,
+ * replacing `createUiInteractionState()` (#787 phase 5).
+ */
+const host: PanelHost = createPanelHost(uiLayer);
+
+/**
+ * `router` and `panelContext` are circular by construction (a panel's
+ * `open(ctx)` reads `ctx.router` to potentially chain-open another panel),
+ * so `panelContext` is built first with `notifier`/`router` behind getters
+ * that resolve to the live module-scope bindings once they exist -- the
+ * same deferred-but-eager pattern `notifier` itself already uses.
+ */
+let router: PanelRouter;
+const panelContext: PanelContext = {
+  session,
+  get notifier() { return notifier; },
+  host,
+  selection,
+  get router() { return router; },
+};
 
 // The two refreshes `session.commit()` performs on every state publication.
 // Registered once, here, rather than repeated as a three-statement discipline
@@ -383,7 +405,7 @@ let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | 
 let legendaryCompletionQueue: ReturnType<typeof createLegendaryWonderCompletionQueue> | null = null;
 
 function setBlockingOverlay(id: string | null): void {
-  uiInteractions.setBlockingOverlay(id);
+  host.setBlockingOverlay(id);
   if (id === null) {
     wonderDiscoveryQueue?.pump();
     legendaryCompletionQueue?.pump();
@@ -397,7 +419,7 @@ function prefersReducedMotion(): boolean {
 
 wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
   container: uiLayer,
-  isInteractionBlocked: () => uiInteractions.isInteractionBlocked(),
+  isInteractionBlocked: () => host.isInteractionBlocked(),
   requestMapHighlight: (item, reducedMotion) => {
     renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
   },
@@ -411,7 +433,7 @@ wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
 
 legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
   container: uiLayer,
-  isInteractionBlocked: () => uiInteractions.isInteractionBlocked(),
+  isInteractionBlocked: () => host.isInteractionBlocked(),
   reducedMotion: prefersReducedMotion,
   openCity: cityId => {
     const city = session.getState().cities[cityId];
@@ -434,35 +456,33 @@ function setMapViewportBottomInset(height: number): void {
   renderLoop.resizeCanvas();
 }
 
-window.addEventListener('keydown', event => {
-  if (event.key === 'Escape' && selection.getPendingIntent().kind === 'journey') {
-    selection.setPendingIntent({ kind: 'none' });
-    showNotification('Journey cancelled.', 'info');
-    return;
-  }
-  if (event.key !== '`') {
-    return;
-  }
+/**
+ * `createPacingDebugPanel` self-removes any prior instance from `uiLayer`,
+ * so the router's own DOM-derived `isOpen`/`close` need no extra bookkeeping
+ * here (#787 phase 5).
+ */
+function openPacingDebugPanel(): void {
+  if (session.getState()) createPacingDebugPanel(uiLayer, session.getState());
+}
 
-  pacingDebugOpen = !pacingDebugOpen;
-  document.getElementById('pacing-debug-panel')?.remove();
-  if (pacingDebugOpen && session.getState()) {
-    createPacingDebugPanel(uiLayer, session.getState());
-  }
-});
+// Escape-cancels-journey and backtick-toggles-pacing-debug used to live in a
+// module-scope `window.addEventListener('keydown', ...)` here. Moved to
+// `installGlobalShortcuts` (called from `init()`, once `notifier` exists) so
+// it can depend on the real `Notifier`/`PanelRouter` ports instead of
+// reaching into module-scope closures directly (#787 phase 5).
 
 function createUI(): void {
   createGameShell(uiLayer, {
-    onOpenCouncil: () => togglePanel('council'),
-    onOpenTech: () => togglePanel('tech'),
-    onOpenCity: () => togglePanel('city'),
-    onOpenEspionage: () => togglePanel('espionage'),
-    onOpenDiplomacy: () => togglePanel('diplomacy'),
-    onOpenMarketplace: () => togglePanel('marketplace'),
+    onOpenCouncil: () => router.open('council'),
+    onOpenTech: () => router.open('tech'),
+    onOpenCity: () => router.open('city-overview'),
+    onOpenEspionage: () => router.open('espionage'),
+    onOpenDiplomacy: () => router.open('diplomacy'),
+    onOpenMarketplace: () => router.open('marketplace'),
     onEndTurn: () => endTurn(),
     onNextUnit: () => selectNextUnit(),
-    onOpenNotificationLog: () => toggleNotificationLog(),
-    onOpenPirateWaters: () => openPirateWaters(),
+    onOpenNotificationLog: () => router.toggle('notification-log'),
+    onOpenPirateWaters: () => router.open('pirate-waters'),
     onToggleIconLegend: () => {
       const existing = document.getElementById('icon-legend');
       if (existing && existing.style.display !== 'none') {
@@ -478,7 +498,7 @@ function createUI(): void {
       const overlay = createIconLegendOverlay(viewerTechs);
       uiLayer.appendChild(overlay);
     },
-    onOpenWonderAtlas: () => openWonderAtlas(),
+    onOpenWonderAtlas: () => router.open('wonder-atlas'),
     onBottomBarHeightChange: setMapViewportBottomInset,
     onOpenMenu: () => {
       showPauseMenu(uiLayer, {
@@ -491,7 +511,7 @@ function createUI(): void {
         },
         onNewGame: () => showGameModeSelection(),
         autoSave: () => autoSave(session.getState()),
-        onOpenBestiary: () => openBestiary(),
+        onOpenBestiary: () => router.open('bestiary'),
         opponentChallenge: resolveOpponentChallenge(session.getState()),
         pendingOpponentChallenge: session.getState().pendingOpponentChallenge,
         onOpponentChallengeChange: (challenge) => {
@@ -672,7 +692,7 @@ function updateHUD(): void {
     networkButton.type = 'button';
     networkButton.style.cssText = 'background:transparent;color:inherit;border:1px solid rgba(232,193,112,0.45);border-radius:6px;font:inherit;padding:4px 8px;min-height:44px;';
     networkButton.textContent = getNetworkPanelModel(session.getState(), civ.id).statusText;
-    networkButton.addEventListener('click', () => openNetworkPanel());
+    networkButton.addEventListener('click', () => router.open('network'));
     yieldsRow.appendChild(networkButton);
   }
 
@@ -898,13 +918,12 @@ function openPirateHeadquartersAssault(factionId: string, unitId: string): void 
   });
 }
 
-function toggleNotificationLog(): void {
-  const existing = document.getElementById('notification-log');
-  if (existing) { existing.remove(); return; }
-
-  const ul = document.getElementById('ui-layer');
-  if (!ul) return;
-
+/**
+ * The "close if already open" behavior moved to `router.toggle('notification-log')`
+ * (#787 phase 5) -- `isOpen`/`close` are DOM-derived, so this only needs to
+ * build and append the panel now.
+ */
+function openNotificationLog(): void {
   const entries = session.getState()
     ? getNotificationsForPlayer(session.getState().notificationLog ?? {}, session.getState().currentPlayer)
     : [];
@@ -938,7 +957,7 @@ function toggleNotificationLog(): void {
     },
   });
 
-  ul.appendChild(panel);
+  uiLayer.appendChild(panel);
 
   setTimeout(() => {
     const handler = (e: Event) => {
@@ -1479,7 +1498,7 @@ function showRequiredChoicesIfNeeded(): boolean {
     },
     onOpenTech: () => {
       closeRequiredChoicePanel();
-      togglePanel('tech');
+      router.open('tech');
     },
     onOpenCity: (cityId) => {
       const city = session.getState().cities[cityId];
@@ -1492,65 +1511,57 @@ function showRequiredChoicesIfNeeded(): boolean {
   return true;
 }
 
-function togglePanel(panel: string): void {
+function openCouncilPanel(): void {
   drawer?.close();
-  // Remove any existing panel
-  document.getElementById('tech-panel')?.remove();
-  document.getElementById('city-panel')?.remove();
-  document.getElementById('espionage-panel')?.remove();
-  document.getElementById('diplomacy-panel')?.remove();
-  document.getElementById('marketplace-panel')?.remove();
-  document.getElementById('council-panel')?.remove();
-  councilPanelOpen = false;
+  createCouncilPanel(uiLayer, session.getState(), {
+    onClose: () => {
+      document.getElementById('council-panel')?.remove();
+    },
+    onTalkLevelChange: (level) => {
+      session.getState().settings.councilTalkLevel = level;
+      void saveSettings(session.getState().settings);
+    },
+  });
+}
 
-  if (panel === 'council') {
-    createCouncilPanel(uiLayer, session.getState(), {
-      onClose: () => {
-        document.getElementById('council-panel')?.remove();
-        councilPanelOpen = false;
-      },
-      onTalkLevelChange: (level) => {
-        session.getState().settings.councilTalkLevel = level;
-        void saveSettings(session.getState().settings);
-      },
-    });
-    councilPanelOpen = true;
-  } else if (panel === 'tech') {
-    createTechPanel(uiLayer, session.getState(), {
-      onQueueResearch: (techId) => {
-        try {
-          currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'Queue limit reached';
-          showNotification(message, 'warning');
-          return;
-        }
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        showNotification(`Queued research: ${techId}`, 'info');
-      },
-      onMoveQueuedResearch: (fromIndex, toIndex) => {
-        currentCiv().techState = {
-          ...currentCiv().techState,
-          researchQueue: moveQueuedId(currentCiv().techState.researchQueue, fromIndex, toIndex),
-        };
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-      },
-      onRemoveQueuedResearch: (index) => {
-        currentCiv().techState = {
-          ...currentCiv().techState,
-          researchQueue: removeQueuedId(currentCiv().techState.researchQueue, index),
-        };
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-      },
-      onClose: () => {},
-    });
-  } else if (panel === 'city') {
-    openCityOverviewPanel();
-  } else if (panel === 'espionage') {
-    const chooseForeignCityTarget = (): { civId: string; cityId: string; position: HexCoord } | null => {
+function openTechPanel(): void {
+  drawer?.close();
+  createTechPanel(uiLayer, session.getState(), {
+    onQueueResearch: (techId) => {
+      try {
+        currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Queue limit reached';
+        showNotification(message, 'warning');
+        return;
+      }
+      renderLoop.setGameState(session.getState());
+      updateHUD();
+      showNotification(`Queued research: ${techId}`, 'info');
+    },
+    onMoveQueuedResearch: (fromIndex, toIndex) => {
+      currentCiv().techState = {
+        ...currentCiv().techState,
+        researchQueue: moveQueuedId(currentCiv().techState.researchQueue, fromIndex, toIndex),
+      };
+      renderLoop.setGameState(session.getState());
+      updateHUD();
+    },
+    onRemoveQueuedResearch: (index) => {
+      currentCiv().techState = {
+        ...currentCiv().techState,
+        researchQueue: removeQueuedId(currentCiv().techState.researchQueue, index),
+      };
+      renderLoop.setGameState(session.getState());
+      updateHUD();
+    },
+    onClose: () => {},
+  });
+}
+
+function openEspionagePanel(): void {
+  drawer?.close();
+  const chooseForeignCityTarget = (): { civId: string; cityId: string; position: HexCoord } | null => {
       const choices = Object.values(session.getState().cities)
         .filter(city => city.owner !== session.getState().currentPlayer)
         .sort((a, b) => a.name.localeCompare(b.name));
@@ -1632,7 +1643,7 @@ function togglePanel(panel: string): void {
             session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== spyId);
         }
         renderLoop.setGameState(session.getState());
-        togglePanel('espionage');
+        router.open('espionage');
         const cityName = session.getState().cities[target.cityId]?.name ?? target.cityId;
         showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
       },
@@ -1658,7 +1669,7 @@ function togglePanel(panel: string): void {
           targetCityId,
         );
         renderLoop.setGameState(session.getState());
-        togglePanel('espionage');
+        router.open('espionage');
         showNotification(`Mission ${mission} started.`, 'info');
       },
       onRecall: (spyId) => {
@@ -1667,7 +1678,7 @@ function togglePanel(panel: string): void {
           spyId,
         );
         renderLoop.setGameState(session.getState());
-        togglePanel('espionage');
+        router.open('espionage');
         showNotification('Spy recalled.', 'info');
       },
       onVerifyAgent: (spyId) => {
@@ -1676,7 +1687,7 @@ function togglePanel(panel: string): void {
           spyId,
         );
         renderLoop.setGameState(session.getState());
-        togglePanel('espionage');
+        router.open('espionage');
         showNotification('Agent verified and cleared.', 'success');
       },
       onExfiltrate: (spyId) => {
@@ -1717,7 +1728,7 @@ function togglePanel(panel: string): void {
         renderLoop.setGameState(session.getState());
         // Refresh panel in place
         document.getElementById('espionage-panel')?.remove();
-        togglePanel('espionage');
+        router.open('espionage');
         showNotification('Spy exfiltrated. Available again in 8 turns.', 'info');
       },
       onToggleCooldownMode: (spyId) => {
@@ -1737,7 +1748,7 @@ function togglePanel(panel: string): void {
           },
         });
         document.getElementById('espionage-panel')?.remove();
-        togglePanel('espionage');
+        router.open('espionage');
       },
       onUnembed: (spyId) => {
         const ownerEsp = session.getState().espionage?.[session.getState().currentPlayer];
@@ -1754,7 +1765,7 @@ function togglePanel(panel: string): void {
         session.getState().espionage![session.getState().currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
         renderLoop.setGameState(session.getState());
         document.getElementById('espionage-panel')?.remove();
-        togglePanel('espionage');
+        router.open('espionage');
         showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
       },
       onSweep: (spyId) => {
@@ -1770,15 +1781,60 @@ function togglePanel(panel: string): void {
         }
         renderLoop.setGameState(session.getState());
         document.getElementById('espionage-panel')?.remove();
-        togglePanel('espionage');
+        router.open('espionage');
       },
     }));
-  } else if (panel === 'diplomacy') {
-    openDiplomacyPanel();
-  } else if (panel === 'marketplace') {
-    openMarketplacePanel();
-  }
 }
+
+/**
+ * Replaces `togglePanel`'s 288-line `else if` chain (#787 phase 5). Panels
+ * that require a specific target -- a city id, a hex coord -- have no
+ * parameterless "open the current one" call, so their `open` throws; they
+ * still need a registry entry so `closeGroup`/`isOpen`/`close` (all
+ * DOM-derived off `domId`) behave correctly when a 'main' or 'transient'
+ * sweep runs. Their real entry points (`openCityPanelForCity`,
+ * `openWonderPanelForCityId`, `openTerritoryInspectionPanel`) stay
+ * directly-callable functions, untouched by this phase.
+ */
+const panelRegistry = {
+  council: { domId: 'council-panel', group: 'main', open: () => openCouncilPanel() },
+  tech: { domId: 'tech-panel', group: 'main', open: () => openTechPanel() },
+  city: {
+    domId: 'city-panel',
+    group: 'main',
+    open: () => {
+      throw new Error("'city' is parameterized -- call openCityPanelForCity(city) directly, not router.open('city').");
+    },
+  },
+  espionage: { domId: 'espionage-panel', group: 'main', open: () => openEspionagePanel() },
+  diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => openDiplomacyPanel() },
+  marketplace: { domId: 'marketplace-panel', group: 'main', open: () => openMarketplacePanel() },
+  network: { domId: 'network-panel', group: 'transient', open: () => openNetworkPanel() },
+  wonder: {
+    domId: 'wonder-panel',
+    group: 'transient',
+    open: () => {
+      throw new Error("'wonder' is parameterized -- call openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
+    },
+  },
+  'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => openWonderAtlas() },
+  bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => openBestiary() },
+  'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => openPirateWaters() },
+  'notification-log': { domId: 'notification-log', group: 'transient', open: () => openNotificationLog() },
+  'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => openCityOverviewPanel() },
+  'territory-inspection': {
+    domId: 'territory-inspection-panel',
+    group: 'transient',
+    open: () => {
+      throw new Error(
+        "'territory-inspection' is parameterized -- call openTerritoryInspectionPanel(coord) directly, not router.open('territory-inspection').",
+      );
+    },
+  },
+  'pacing-debug': { domId: 'pacing-debug-panel', group: 'transient', open: () => openPacingDebugPanel() },
+} satisfies PanelRegistry;
+
+router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });
 
 function maybeShowCouncilInterrupt(): void {
   const state = session.getState();
@@ -2514,7 +2570,7 @@ function openUnitContextMenu(unitId: string): void {
   createContextMenu(panel, session.getState(), { unitId }, {
     onStartAutoExplore: id => startAutoExplore(id),
     onCancelAutoExplore: id => cancelAutoExplore(id),
-  }, uiInteractions);
+  }, host);
 }
 
 function selectNextUnit(): void {
@@ -3818,7 +3874,7 @@ function releaseHandoffToViewer(nextSlotId: string): void {
 
 /** These player-owned surfaces may contain strategic targets; never carry them across a hot-seat veil. */
 function closeNetworkPanelsForHandoff(): void {
-  document.getElementById('network-panel')?.remove();
+  router.close('network');
   document.querySelector('[aria-label="Network intent"]')?.remove();
 }
 
@@ -4816,6 +4872,9 @@ async function init(): Promise<void> {
     },
     onFocusTarget: focusNotificationTarget,
   });
+  // Needs the real `notifier`, so deferred here alongside it rather than
+  // installed eagerly at module scope (#787 phase 5).
+  installGlobalShortcuts({ target: window, selection, router, notifier });
   await userSettingsStore.refresh();
 
   if (import.meta.env.MODE === 'e2e') {
@@ -5109,11 +5168,11 @@ function startGame(): Promise<void> {
     const touchHandler = new TouchHandler(canvas, renderLoop.camera, callbacks);
     renderLoop.setTouchHandler(touchHandler);
     new MouseHandler(canvas, renderLoop.camera, callbacks, {
-      canInteract: () => !uiInteractions.isInteractionBlocked(),
+      canInteract: () => !host.isInteractionBlocked(),
     });
     installKeyboardShortcuts(document, {
-      onOpenCouncil: () => togglePanel('council'),
-      onOpenTech: () => togglePanel('tech'),
+      onOpenCouncil: () => router.open('council'),
+      onOpenTech: () => router.open('tech'),
       onEndTurn: () => { void endTurn(); },
       getSelectedUnitId: () => selection.getSelectedUnitId(),
       onCenterUnit: () => {
@@ -5153,7 +5212,7 @@ function startGame(): Promise<void> {
         showNotification('Tap a destination for this unit. Press Escape to cancel.', 'info');
       },
     }, {
-      canHandle: () => !uiInteractions.isInteractionBlocked(),
+      canHandle: () => !host.isInteractionBlocked(),
     });
     inputInitialized = true;
   }

--- a/tests/app/global-shortcuts.test.ts
+++ b/tests/app/global-shortcuts.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { installGlobalShortcuts } from '@/app/global-shortcuts';
+import type { SelectionStore } from '@/app/ports';
+import type { PanelRouter } from '@/app/panel-router';
+import type { Notifier } from '@/app/ports';
+
+function createSelectionStub(pendingIntent: SelectionStore['getPendingIntent']): SelectionStore {
+  return {
+    snapshot: () => ({
+      selectedUnitId: null,
+      movementRange: [],
+      attackRange: [],
+      pendingIntent: pendingIntent(),
+      waterRecovery: { state: 'none' } as never,
+    }),
+    getSelectedUnitId: () => null,
+    setSelectedUnitId: () => {},
+    getWaterRecovery: () => ({ state: 'none' }) as never,
+    setWaterRecovery: () => {},
+    getMovementRange: () => [],
+    getAttackRange: () => [],
+    setRanges: () => {},
+    getPirateSelection: () => ({ factionId: null, historyId: null }),
+    setPirateSelection: () => {},
+    getPendingIntent: pendingIntent,
+    setPendingIntent: vi.fn(),
+    shouldWarnOnMistap: () => false,
+    clear: vi.fn(),
+  } as unknown as SelectionStore;
+}
+
+describe('installGlobalShortcuts', () => {
+  it('Escape with an armed journey cancels it and toasts', () => {
+    const selection = createSelectionStub(() => ({ kind: 'journey', unitId: 'u1' }));
+    const router: PanelRouter = {
+      toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: vi.fn(() => false),
+    };
+    const notifier = { toast: vi.fn() } as unknown as Notifier;
+    const target = document.createElement('div');
+
+    installGlobalShortcuts({ target, selection, router, notifier });
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(selection.setPendingIntent).toHaveBeenCalledWith({ kind: 'none' });
+    expect(notifier.toast).toHaveBeenCalledWith('Journey cancelled.', 'info');
+    expect(router.toggle).not.toHaveBeenCalled();
+  });
+
+  it('Escape with no pending journey does nothing', () => {
+    const selection = createSelectionStub(() => ({ kind: 'none' }));
+    const router: PanelRouter = {
+      toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: vi.fn(() => false),
+    };
+    const notifier = { toast: vi.fn() } as unknown as Notifier;
+    const target = document.createElement('div');
+
+    installGlobalShortcuts({ target, selection, router, notifier });
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(selection.setPendingIntent).not.toHaveBeenCalled();
+    expect(notifier.toast).not.toHaveBeenCalled();
+  });
+
+  it('backtick toggles pacing-debug', () => {
+    const selection = createSelectionStub(() => ({ kind: 'none' }));
+    const router: PanelRouter = {
+      toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: vi.fn(() => false),
+    };
+    const notifier = { toast: vi.fn() } as unknown as Notifier;
+    const target = document.createElement('div');
+
+    installGlobalShortcuts({ target, selection, router, notifier });
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: '`' }));
+
+    expect(router.toggle).toHaveBeenCalledWith('pacing-debug');
+  });
+
+  it('the returned disposer removes the listener', () => {
+    const selection = createSelectionStub(() => ({ kind: 'none' }));
+    const router: PanelRouter = {
+      toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: vi.fn(() => false),
+    };
+    const notifier = { toast: vi.fn() } as unknown as Notifier;
+    const target = document.createElement('div');
+
+    const dispose = installGlobalShortcuts({ target, selection, router, notifier });
+    dispose();
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: '`' }));
+
+    expect(router.toggle).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/panel-host.test.ts
+++ b/tests/app/panel-host.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createPanelHost } from '@/app/panel-host';
+
+describe('panel host interaction blocking', () => {
+  it('notifies unblock listeners exactly once when the overlay clears', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const listener = vi.fn();
+    host.onInteractionUnblocked(listener);
+
+    host.setBlockingOverlay('turn-handoff');
+    expect(host.isInteractionBlocked()).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
+
+    host.setBlockingOverlay(null);
+    expect(host.isInteractionBlocked()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when the overlay is replaced by another overlay', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const listener = vi.fn();
+    host.onInteractionUnblocked(listener);
+
+    host.setBlockingOverlay('a');
+    host.setBlockingOverlay('b');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/panel-router.test.ts
+++ b/tests/app/panel-router.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createPanelRouter } from '@/app/panel-router';
+import { createPanelHost } from '@/app/panel-host';
+
+const stubPanel = (layer: HTMLElement, id: string) => () => {
+  layer.appendChild(Object.assign(document.createElement('div'), { id }));
+};
+
+describe('panel router', () => {
+  it('opening a main-group panel closes the previously open one', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const openTech = vi.fn(stubPanel(layer, 'tech-panel'));
+    const openCouncil = vi.fn(stubPanel(layer, 'council-panel'));
+
+    const router = createPanelRouter({
+      host,
+      registry: {
+        tech: { domId: 'tech-panel', group: 'main', open: openTech },
+        council: { domId: 'council-panel', group: 'main', open: openCouncil },
+      },
+      context: {} as never,
+    });
+
+    router.open('tech');
+    router.open('council');
+
+    expect(layer.querySelector('#tech-panel')).toBeNull();
+    expect(layer.querySelector('#council-panel')).not.toBeNull();
+    expect(router.isOpen('tech')).toBe(false);
+    expect(router.isOpen('council')).toBe(true);
+  });
+
+  it('a transient panel does not close a main panel', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const router = createPanelRouter({
+      host,
+      registry: {
+        tech: { domId: 'tech-panel', group: 'main', open: stubPanel(layer, 'tech-panel') },
+        'territory-inspection': { domId: 'territory-panel', group: 'transient', open: stubPanel(layer, 'territory-panel') },
+      },
+      context: {} as never,
+    });
+
+    router.open('tech');
+    router.open('territory-inspection');
+
+    expect(layer.querySelector('#tech-panel')).not.toBeNull();
+    expect(layer.querySelector('#territory-panel')).not.toBeNull();
+  });
+
+  it('toggle closes an already-open panel instead of reopening it', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const open = vi.fn(stubPanel(layer, 'tech-panel'));
+    const router = createPanelRouter({
+      host,
+      registry: { tech: { domId: 'tech-panel', group: 'main', open } },
+      context: {} as never,
+    });
+
+    router.toggle('tech');
+    router.toggle('tech');
+
+    expect(layer.querySelector('#tech-panel')).toBeNull();
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app/panel-router.test.ts
+++ b/tests/app/panel-router.test.ts
@@ -51,6 +51,45 @@ describe('panel router', () => {
     expect(layer.querySelector('#territory-panel')).not.toBeNull();
   });
 
+  it('two transient panels coexist -- opening one does not close the other', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const router = createPanelRouter({
+      host,
+      registry: {
+        'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: stubPanel(layer, 'wonder-codex-panel') },
+        'notification-log': { domId: 'notification-log', group: 'transient', open: stubPanel(layer, 'notification-log') },
+      },
+      context: {} as never,
+    });
+
+    router.open('notification-log');
+    router.open('wonder-atlas');
+
+    expect(layer.querySelector('#notification-log')).not.toBeNull();
+    expect(layer.querySelector('#wonder-codex-panel')).not.toBeNull();
+  });
+
+  it('closeGroup only removes panels in that group', () => {
+    const layer = document.createElement('div');
+    const host = createPanelHost(layer);
+    const router = createPanelRouter({
+      host,
+      registry: {
+        tech: { domId: 'tech-panel', group: 'main', open: stubPanel(layer, 'tech-panel') },
+        bestiary: { domId: 'bestiary-panel', group: 'transient', open: stubPanel(layer, 'bestiary-panel') },
+      },
+      context: {} as never,
+    });
+
+    router.open('tech');
+    router.open('bestiary');
+    router.closeGroup('transient');
+
+    expect(layer.querySelector('#tech-panel')).not.toBeNull();
+    expect(layer.querySelector('#bestiary-panel')).toBeNull();
+  });
+
   it('toggle closes an already-open panel instead of reopening it', () => {
     const layer = document.createElement('div');
     const host = createPanelHost(layer);


### PR DESCRIPTION
## Summary

Phase 5 of the [`main.ts` composition-root decomposition](https://github.com/a1flecke/conquestoria/blob/2ce97c70/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md) (index: #787). Replaces `togglePanel`'s 288-line `else if` chain, the module-scope `window.addEventListener('keydown', ...)` listener, and the `councilPanelOpen`/`pacingDebugOpen` module-scope flags with a `PanelRouter` dispatching through a 15-entry registry.

- `src/app/panel-host.ts` — `createPanelHost(layer): PanelHost`. Extends `UiInteractionState` (drop-in for `context-menu.ts` and existing tests), adds `layer` and `onInteractionUnblocked` (built and tested here; Phase 6's `CeremonyCoordinator` is the intended future consumer — not wired to the ceremony queues yet).
- `src/app/panel-router.ts` — `createPanelRouter(deps): PanelRouter`. `isOpen`/`close`/`closeGroup` are DOM-derived (`host.layer.querySelector('#' + domId)`), not tracked booleans, so they stay correct regardless of whether a panel's DOM was created through `open()` or one of the three parameterized helpers below.
- `src/app/panel-registry.ts` — `PanelId` (15-entry union), `PanelGroup` (`'main' | 'transient'`), `PanelContext`, `PanelDescriptor` types.
- `src/app/global-shortcuts.ts` — `installGlobalShortcuts(deps): () => void`. Escape-cancels-armed-journey and backtick-toggles-pacing-debug, installed from `init()` once the real `notifier` exists.
- `main.ts`: 5,187 → 5,246 lines (+59 net — the registry construction and doc comments explaining the design outweigh the else-if chain removed; `let` bindings 8 → 7, net -1 despite adding `router` because `councilPanelOpen`/`pacingDebugOpen` are gone).

## Key design decisions (verified against current code, not assumed from the plan)

- **`open()` only `closeGroup`s for `'main'`.** The plan doc's Step 4 says this explicitly ("`closeGroup(descriptor.group)` for `'main'` only"), and I initially implemented it wrong (closing for both groups) before catching it against the plan text and a live browser check — opening the Wonder Atlas must not silently close an open notification log, and now doesn't.
- **`city`, `wonder`, `territory-inspection` stay directly-callable, not routed.** `openCityPanelForCity(city)`, `openWonderPanelForCityId(cityId)`, `openTerritoryInspectionPanel(coord)` all take a required parameter the router's parameterless `open(panel)` can't carry — no current call site needs a parameterless open for any of them (verified by grep). Their registry entries exist so `closeGroup`/`isOpen`/`close` behave correctly against them (e.g. `closeGroup('main')` still removes `city-panel`, matching `togglePanel`'s old blanket removal); their `open` throws a descriptive error since it should never be invoked.
- **`onOpenCity` HUD button now targets `'city-overview'`, not `'city'`.** `togglePanel('city')` actually opened the all-cities overview dashboard (`openCityOverviewPanel`), not the single-city detail panel — the domId-aligned `PanelId` union needed `'city'` to mean `city-panel` (matching `openCityPanelForCity`), so the HUD wiring was renamed to the correct target. Net behavior is unchanged; only the internal id changed.
- **`notifier.toast` replaces `showNotification` for the Escape "Journey cancelled." toast**, since `installGlobalShortcuts` can only depend on the `Notifier` port. Confirmed byte-for-byte identical toast/SFX behavior (both call `notifier.toast` with the same default args) — the only loss is the notification-log entry, which I judged acceptable since this is transient feedback for the player's own keypress, not a game-consequence event.
- **`closeNetworkPanelsForHandoff` now calls `router.close('network')`** instead of `document.getElementById('network-panel')?.remove()` — same effect, scoped through the router. Left its sibling `closePirateWatersPanels`/`closePlanningPanels` calls untouched (they live in other files, out of this phase's modify-scope, and broadening them to a full `closeGroup` would change what gets closed at those call sites without a documented reason).

## Inline review (requested across gameplay/UX/architecture/testing/regressions)

Ran this myself, inline, per `CLAUDE.md`'s no-subagents policy — not delegated.

- **Gameplay balance, fun, new mechanics, player ages 7-43, difficulty modes, AI/computer players, SFX content, save schema:** all N/A by design — this is a pure internal UI-plumbing refactor with zero player-visible behavior change (verified live), matching the arc's explicit non-goals. AI never touches panel code; `src/ai/` and `src/systems/` are untouched.
- **SOLID/architecture:** verified against actual code, not just the plan's claims — `panel-router.ts`/`panel-host.ts` import only `@/app/panel-registry` types (DIP, no `RenderLoop`/`AudioContext`/`HTMLCanvasElement`), `PanelRouter`'s 5-method interface stays narrow (ISP), `PanelHost extends UiInteractionState` type-checks as a drop-in everywhere it's substituted (LSP), a new panel is one registry entry with no router changes (OCP), `satisfies PanelRegistry` gives compile-time completeness checking on the 15-entry union.
- **Hot-seat/solo regression risk:** panel routing is player-agnostic plumbing (`session.getState().currentPlayer` reads are unchanged inside each panel factory); `host`/`router` don't need per-player reset. Verified `closeNetworkPanelsForHandoff`'s narrower-than-"close everything" scope is pre-existing, deliberate design (network/pirate-waters carry live renderer-level state like `setSelectedPirateFactionId`, not just DOM) — not broadened or narrowed by this PR.
- **Testing gap found and fixed:** the router's core "transient panels never force-close each other" claim had no direct test (only "transient doesn't close main" was covered) — added `tests/app/panel-router.test.ts`'s "two transient panels coexist" and "closeGroup only removes panels in that group" cases after confirming the behavior live in the dev server.
- **Manual verification in the dev server (not just unit tests):** loaded a live Solo campaign and confirmed via direct DOM queries — Council/Tech mutual exclusion within the `'main'` group, Wonder Atlas + Council staying open simultaneously (`'transient'` vs `'main'`), notification-log real toggle (open → close on second click), and the backtick pacing-debug shortcut (open → close) dispatched on `window`, matching the original listener's target. Zero console errors from any interaction.

## Testing

- `tests/app/panel-host.test.ts` (2 tests), `tests/app/panel-router.test.ts` (5 tests), `tests/app/global-shortcuts.test.ts` (4 tests) — all new, TDD (written failing first).
- Full suite: `yarn test` — 451 files / 7,442 tests passing (3 pre-existing skips), `yarn build` clean.
- Manual smoke test in a live dev-server browser session (see above).

## Out of scope

Phase 6 (`CeremonyCoordinator` — wiring `onInteractionUnblocked` to the wonder-discovery/legendary-completion queue pumps), Phase 7 (presentation registrars), Phase 8 (`SelectionController`/`MapInteractionController`), Phase 9 (`TurnFlowController`), Phase 10 (final composition root, `onBeforeOpen` wired to `drawer.close()`), Phase 11 (boundary lock). No gameplay/balance/AI/RNG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)