### PR TITLE
refactor(app): CeremonyCoordinator owns ceremony queues + defer flag (#787 phase 6)

### DIFF
--- a/src/app/controllers/ceremony-coordinator.ts
+++ b/src/app/controllers/ceremony-coordinator.ts
@@ -1,0 +1,94 @@
+/**
+ * Owns `wonderDiscoveryQueue`, `legendaryCompletionQueue`, and the
+ * move-settle defer flag that used to live in `main.ts` module scope
+ * (#787 phase 6).
+ *
+ * Exists because of a `setBlockingOverlay` side effect: unblocking the UI is
+ * what pumps both ceremony queues (`main.ts:407-413` pre-phase-6). Porting
+ * `PanelHost` verbatim without this coordinator would mean any ceremony
+ * queued while a panel was open never plays. `PanelHost.onInteractionUnblocked`
+ * (#787 phase 5) is the hook this coordinator subscribes to instead, so
+ * `PanelHost` stays ignorant of what a wonder ceremony is.
+ */
+import type { PanelHost } from '@/app/panel-host';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { createWonderDiscoveryRevealQueue, type WonderDiscoveryRevealQueueOptions } from '@/ui/wonder-discovery-queue';
+import {
+  createLegendaryWonderCompletionQueue,
+  type LegendaryWonderCompletionQueueOptions,
+} from '@/ui/legendary-wonder-completion-queue';
+
+export interface CeremonyCoordinator {
+  /** Queue a natural-wonder reveal. Plays when nothing is blocking and no move is settling. */
+  enqueueWonderDiscovery(item: WonderDiscoveryRevealItem): void;
+  /** Queue a legendary-wonder completion ceremony. Never deferred by an animated move. */
+  enqueueLegendaryCompletion(item: LegendaryWonderCompletionCeremonyItem): void;
+  /** Call around an animated move: reveals queued before `endAction` wait for it. */
+  beginDeferredAction(): void;
+  endAction(): void;
+}
+
+export interface CeremonyCoordinatorDeps {
+  readonly host: PanelHost;
+  readonly container: HTMLElement;
+  readonly reducedMotion: () => boolean;
+  readonly requestMapHighlight: (item: WonderDiscoveryRevealItem, reducedMotion: boolean) => void;
+  readonly playDiscoveryAudio: (wonderId: string) => void;
+  readonly openAtlas: (wonderId: string) => void;
+  readonly openCity: (cityId: string) => void;
+  readonly openJournal: (cityId: string, wonderId: string) => void;
+  /** Test-only ceremony-presentation overrides; production omits both and gets the real DOM ceremony. */
+  readonly presentWonderDiscovery?: WonderDiscoveryRevealQueueOptions['present'];
+  readonly presentLegendaryCompletion?: LegendaryWonderCompletionQueueOptions['present'];
+}
+
+export function createCeremonyCoordinator(deps: CeremonyCoordinatorDeps): CeremonyCoordinator {
+  let deferUntilMoveSettles = false;
+
+  const wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
+    container: deps.container,
+    isInteractionBlocked: () => deps.host.isInteractionBlocked(),
+    requestMapHighlight: deps.requestMapHighlight,
+    openAtlas: deps.openAtlas,
+    onRevealStarted: item => deps.playDiscoveryAudio(item.wonderId),
+    reducedMotion: deps.reducedMotion,
+    present: deps.presentWonderDiscovery,
+    setBlockingOverlay: id => deps.host.setBlockingOverlay(id),
+  });
+
+  const legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
+    container: deps.container,
+    isInteractionBlocked: () => deps.host.isInteractionBlocked(),
+    reducedMotion: deps.reducedMotion,
+    openCity: deps.openCity,
+    openJournal: deps.openJournal,
+    present: deps.presentLegendaryCompletion,
+    setBlockingOverlay: id => deps.host.setBlockingOverlay(id),
+  });
+
+  deps.host.onInteractionUnblocked(() => {
+    wonderDiscoveryQueue.pump();
+    legendaryCompletionQueue.pump();
+  });
+
+  return {
+    enqueueWonderDiscovery(item) {
+      wonderDiscoveryQueue.enqueue(item);
+      if (!deferUntilMoveSettles) {
+        wonderDiscoveryQueue.notifyActionSettled();
+      }
+    },
+    enqueueLegendaryCompletion(item) {
+      legendaryCompletionQueue.enqueue(item);
+      legendaryCompletionQueue.notifyActionSettled();
+    },
+    beginDeferredAction() {
+      deferUntilMoveSettles = true;
+    },
+    endAction() {
+      deferUntilMoveSettles = false;
+      wonderDiscoveryQueue.notifyActionSettled();
+    },
+  };
+}

--- a/src/app/controllers/ceremony-coordinator.ts
+++ b/src/app/controllers/ceremony-coordinator.ts
@@ -27,11 +27,19 @@ export interface CeremonyCoordinator {
   /** Call around an animated move: reveals queued before `endAction` wait for it. */
   beginDeferredAction(): void;
   endAction(): void;
+  /**
+   * Drops every ceremony queued but not yet presenting, and cancels any
+   * in-progress move-settle defer. Call before a hot-seat handoff -- without
+   * this, a discovery deferred (or blocked by another overlay) at the moment
+   * a player ends their turn survives the handoff and plays after
+   * `releaseHandoffToViewer` unblocks the UI, on the *next* player's screen.
+   * A ceremony already presenting is left alone; this only clears backlog.
+   */
+  clearForHandoff(): void;
 }
 
 export interface CeremonyCoordinatorDeps {
   readonly host: PanelHost;
-  readonly container: HTMLElement;
   readonly reducedMotion: () => boolean;
   readonly requestMapHighlight: (item: WonderDiscoveryRevealItem, reducedMotion: boolean) => void;
   readonly playDiscoveryAudio: (wonderId: string) => void;
@@ -47,7 +55,7 @@ export function createCeremonyCoordinator(deps: CeremonyCoordinatorDeps): Ceremo
   let deferUntilMoveSettles = false;
 
   const wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
-    container: deps.container,
+    container: deps.host.layer,
     isInteractionBlocked: () => deps.host.isInteractionBlocked(),
     requestMapHighlight: deps.requestMapHighlight,
     openAtlas: deps.openAtlas,
@@ -58,7 +66,7 @@ export function createCeremonyCoordinator(deps: CeremonyCoordinatorDeps): Ceremo
   });
 
   const legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
-    container: deps.container,
+    container: deps.host.layer,
     isInteractionBlocked: () => deps.host.isInteractionBlocked(),
     reducedMotion: deps.reducedMotion,
     openCity: deps.openCity,
@@ -89,6 +97,11 @@ export function createCeremonyCoordinator(deps: CeremonyCoordinatorDeps): Ceremo
     endAction() {
       deferUntilMoveSettles = false;
       wonderDiscoveryQueue.notifyActionSettled();
+    },
+    clearForHandoff() {
+      deferUntilMoveSettles = false;
+      wonderDiscoveryQueue.clear();
+      legendaryCompletionQueue.clear();
     },
   };
 }

--- a/src/app/panel-host.ts
+++ b/src/app/panel-host.ts
@@ -9,11 +9,11 @@
  * from the arc's Architecture section. `createUiInteractionState`'s factory
  * itself is retired in Phase 11, once nothing constructs it directly.
  *
- * `onInteractionUnblocked` is new: `setBlockingOverlay` in `main.ts` today
- * directly pumps the wonder-discovery and legendary-completion ceremony
- * queues whenever the overlay clears. Phase 6's `CeremonyCoordinator` is the
- * intended consumer of this hook; Phase 5 only builds and tests the
- * capability, it does not rewire the ceremony queues to it yet.
+ * `onInteractionUnblocked` replaced a `setBlockingOverlay` side effect that
+ * used to directly pump the wonder-discovery and legendary-completion
+ * ceremony queues whenever the overlay cleared. `CeremonyCoordinator`
+ * (`src/app/controllers/ceremony-coordinator.ts`, #787 phase 6) is now the
+ * sole subscriber.
  */
 import { createUiInteractionState, type UiInteractionState } from '@/ui/ui-interaction-state';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -282,9 +282,8 @@ import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
 import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
 import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
-import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
 import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
-import { createLegendaryWonderCompletionQueue } from '@/ui/legendary-wonder-completion-queue';
+import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, getRouteTechGoldBonus } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -323,7 +322,6 @@ const session: GameSession = createGameSession(undefined as unknown as GameState
 const selection = createSelectionStore();
 let drawer: TreasuryDrawer;
 let inputInitialized = false;
-let deferWonderDiscoveryRevealUntilMoveSettles = false;
 /** Owns persisted A/V settings + master volume, moved out of module scope (#787 phase 4). */
 const userSettingsStore = createUserSettingsStore({ load: loadSettings });
 /**
@@ -401,15 +399,8 @@ airDefenseOverlayButton.addEventListener('click', () => {
   airDefenseOverlayButton.setAttribute('aria-pressed', String(enabled));
   airDefenseOverlayButton.textContent = enabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
 });
-let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
-let legendaryCompletionQueue: ReturnType<typeof createLegendaryWonderCompletionQueue> | null = null;
-
 function setBlockingOverlay(id: string | null): void {
   host.setBlockingOverlay(id);
-  if (id === null) {
-    wonderDiscoveryQueue?.pump();
-    legendaryCompletionQueue?.pump();
-  }
 }
 
 function prefersReducedMotion(): boolean {
@@ -417,24 +408,23 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
+/**
+ * Owns the wonder-discovery and legendary-completion ceremony queues plus
+ * the move-settle defer flag, replacing three module-scope bindings
+ * (#787 phase 6). Subscribes to `host.onInteractionUnblocked` for the pump
+ * that used to live inside `setBlockingOverlay` above.
+ */
+const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
+  host,
   container: uiLayer,
-  isInteractionBlocked: () => host.isInteractionBlocked(),
+  reducedMotion: prefersReducedMotion,
   requestMapHighlight: (item, reducedMotion) => {
     renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
   },
-  openAtlas: wonderId => openWonderAtlas(wonderId),
-  onRevealStarted: item => {
-    void audio.playNaturalWonderDiscovery(item.wonderId);
+  playDiscoveryAudio: wonderId => {
+    void audio.playNaturalWonderDiscovery(wonderId);
   },
-  reducedMotion: prefersReducedMotion,
-  setBlockingOverlay,
-});
-
-legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
-  container: uiLayer,
-  isInteractionBlocked: () => host.isInteractionBlocked(),
-  reducedMotion: prefersReducedMotion,
+  openAtlas: wonderId => openWonderAtlas(wonderId),
   openCity: cityId => {
     const city = session.getState().cities[cityId];
     if (city) openCityPanelForCity(city);
@@ -442,7 +432,6 @@ legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
   openJournal: cityId => {
     if (session.getState().cities[cityId]) openWonderPanelForCityId(cityId);
   },
-  setBlockingOverlay,
 });
 
 // --- Resize ---
@@ -2470,8 +2459,7 @@ function animateMovedUnit(unitId: string, path: HexCoord[]): void {
   renderLoop.animateUnitMove({ ...movedUnit, position: path[0]! }, path, () => {
     renderLoop.setGameState(session.getState());
     updateHUD();
-    deferWonderDiscoveryRevealUntilMoveSettles = false;
-    wonderDiscoveryQueue?.notifyActionSettled();
+    ceremonies.endAction();
     const unit = session.getState().units[unitId];
     if (!unit || unit.owner !== session.getState().currentPlayer) return;
 
@@ -2485,11 +2473,11 @@ function animateMovedUnit(unitId: string, path: HexCoord[]): void {
 
 function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult {
   const movingUnit = session.getState().units[unitId];
-  deferWonderDiscoveryRevealUntilMoveSettles = true;
+  ceremonies.beginDeferredAction();
   try {
     const moveResult = move();
     if (!moveResult.ok) {
-      deferWonderDiscoveryRevealUntilMoveSettles = false;
+      ceremonies.endAction();
       showNotification(moveResult.message, 'warning');
       SFX.error();
       return moveResult;
@@ -2511,7 +2499,7 @@ function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResu
     animateMovedUnit(unitId, moveResult.path);
     return moveResult;
   } catch (error) {
-    deferWonderDiscoveryRevealUntilMoveSettles = false;
+    ceremonies.endAction();
     throw error;
   }
 }
@@ -4377,10 +4365,7 @@ bus.on('wonder:discovered', event => {
 
   const revealItem = buildWonderDiscoveryRevealItem(session.getState(), session.getState().currentPlayer, event);
   if (revealItem) {
-    wonderDiscoveryQueue?.enqueue(revealItem);
-    if (!deferWonderDiscoveryRevealUntilMoveSettles) {
-      wonderDiscoveryQueue?.notifyActionSettled();
-    }
+    ceremonies.enqueueWonderDiscovery(revealItem);
   }
 });
 
@@ -4397,8 +4382,7 @@ bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId, turnCompleted }
   routeLegendaryWonder(session.getState(), { type: 'wonder:legendary-completed', ...event }, appendToCivLog);
   const ceremonyItem = buildLegendaryWonderCompletionCeremonyItem(session.getState(), event);
   if (ceremonyItem) {
-    legendaryCompletionQueue?.enqueue(ceremonyItem);
-    legendaryCompletionQueue?.notifyActionSettled();
+    ceremonies.enqueueLegendaryCompletion(ceremonyItem);
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,7 +416,6 @@ function prefersReducedMotion(): boolean {
  */
 const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
   host,
-  container: uiLayer,
   reducedMotion: prefersReducedMotion,
   requestMapHighlight: (item, reducedMotion) => {
     renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
@@ -3878,6 +3877,10 @@ async function beginHotSeatHandoff(
   const nextPlayer = hotSeat.players.find(player => player.slotId === resolvedNextSlotId);
   closePirateWatersPanels(uiLayer);
   closeNetworkPanelsForHandoff();
+  // A discovery ceremony queued (or deferred by an in-flight move animation) at the
+  // instant a player ends their turn must not survive to play on the next player's
+  // screen once releaseHandoffToViewer's setBlockingOverlay(null) pumps the queues.
+  ceremonies.clearForHandoff();
   renderLoop.setSelectedPirateFactionId(null);
   audio.stopPirateAmbience('player-changed');
   audio.setMasterVolume(0);

--- a/src/ui/legendary-wonder-completion-queue.ts
+++ b/src/ui/legendary-wonder-completion-queue.ts
@@ -19,7 +19,12 @@ export interface LegendaryWonderCompletionQueue {
   notifyActionSettled(): void;
   pump(): void;
   pendingCount(): number;
-  /** Drops every completion not already presenting. Does not interrupt one in progress. */
+  /**
+   * Drops every completion not already presenting. Does not interrupt one in
+   * progress, and does not un-dedupe anything that already played -- only
+   * the dropped items' own keys are freed, so a completion shown before this
+   * call can never silently replay after it.
+   */
   clear(): void;
 }
 
@@ -95,8 +100,10 @@ export function createLegendaryWonderCompletionQueue(
       return pending.length;
     },
     clear() {
+      for (const dropped of pending) {
+        seen.delete(keyFor(dropped));
+      }
       pending.length = 0;
-      seen.clear();
       actionSettled = false;
     },
   };

--- a/src/ui/legendary-wonder-completion-queue.ts
+++ b/src/ui/legendary-wonder-completion-queue.ts
@@ -19,6 +19,8 @@ export interface LegendaryWonderCompletionQueue {
   notifyActionSettled(): void;
   pump(): void;
   pendingCount(): number;
+  /** Drops every completion not already presenting. Does not interrupt one in progress. */
+  clear(): void;
 }
 
 function keyFor(item: LegendaryWonderCompletionCeremonyItem): string {
@@ -91,6 +93,11 @@ export function createLegendaryWonderCompletionQueue(
     pump,
     pendingCount() {
       return pending.length;
+    },
+    clear() {
+      pending.length = 0;
+      seen.clear();
+      actionSettled = false;
     },
   };
 }

--- a/src/ui/wonder-discovery-queue.ts
+++ b/src/ui/wonder-discovery-queue.ts
@@ -17,6 +17,8 @@ export interface WonderDiscoveryRevealQueue {
   notifyActionSettled(): void;
   pump(): void;
   pendingCount(): number;
+  /** Drops every reveal not already presenting. Does not interrupt one in progress. */
+  clear(): void;
 }
 
 function keyFor(item: WonderDiscoveryRevealItem): string {
@@ -86,6 +88,11 @@ export function createWonderDiscoveryRevealQueue(options: WonderDiscoveryRevealQ
     pump,
     pendingCount() {
       return pending.length;
+    },
+    clear() {
+      pending.length = 0;
+      seen.clear();
+      actionSettled = false;
     },
   };
 }

--- a/src/ui/wonder-discovery-queue.ts
+++ b/src/ui/wonder-discovery-queue.ts
@@ -17,7 +17,12 @@ export interface WonderDiscoveryRevealQueue {
   notifyActionSettled(): void;
   pump(): void;
   pendingCount(): number;
-  /** Drops every reveal not already presenting. Does not interrupt one in progress. */
+  /**
+   * Drops every reveal not already presenting. Does not interrupt one in
+   * progress, and does not un-dedupe anything that already played -- only
+   * the dropped items' own keys are freed, so a wonder shown before this
+   * call can never silently replay after it.
+   */
   clear(): void;
 }
 
@@ -90,8 +95,10 @@ export function createWonderDiscoveryRevealQueue(options: WonderDiscoveryRevealQ
       return pending.length;
     },
     clear() {
+      for (const dropped of pending) {
+        seen.delete(keyFor(dropped));
+      }
       pending.length = 0;
-      seen.clear();
       actionSettled = false;
     },
   };

--- a/tests/app/controllers/ceremony-coordinator.test.ts
+++ b/tests/app/controllers/ceremony-coordinator.test.ts
@@ -43,7 +43,6 @@ function legendaryItem(overrides: Partial<LegendaryWonderCompletionCeremonyItem>
 function baseDeps(overrides: Partial<CeremonyCoordinatorDeps> = {}): CeremonyCoordinatorDeps {
   return {
     host: createPanelHost(document.createElement('div')),
-    container: document.body,
     reducedMotion: () => false,
     requestMapHighlight: vi.fn(),
     playDiscoveryAudio: vi.fn(),
@@ -149,5 +148,54 @@ describe('ceremony coordinator', () => {
     await Promise.resolve();
 
     expect(openCity).toHaveBeenCalledWith('city-river');
+  });
+
+  it('clearForHandoff drops a reveal queued but not yet shown, so it never plays after the host later unblocks', () => {
+    // Reproduces a hot-seat leak: a discovery deferred by an in-flight move
+    // animation (or blocked by any overlay) must not survive a handoff and
+    // play on the next player's screen. See beginHotSeatHandoff in main.ts.
+    const host = createPanelHost(document.createElement('div'));
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({ host, playDiscoveryAudio }));
+
+    host.setBlockingOverlay('city-panel');
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    coordinator.clearForHandoff();
+
+    host.setBlockingOverlay(null);
+
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+  });
+
+  it('clearForHandoff cancels an in-progress move-settle defer', () => {
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({ playDiscoveryAudio }));
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    coordinator.clearForHandoff();
+
+    // A later, unrelated discovery must play normally -- clearForHandoff
+    // must not leave the coordinator permanently stuck mid-defer.
+    coordinator.enqueueWonderDiscovery(wonderItem({ wonderId: 'crystal_caverns' }));
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+    expect(playDiscoveryAudio).toHaveBeenCalledWith('crystal_caverns');
+  });
+
+  it('clearForHandoff drops a queued legendary completion too', () => {
+    const presentLegendaryCompletion = vi.fn(
+      (): Promise<LegendaryWonderCompletionCeremonyAction> => new Promise(() => {}),
+    );
+    const host = createPanelHost(document.createElement('div'));
+    const coordinator = createCeremonyCoordinator(baseDeps({ host, presentLegendaryCompletion }));
+
+    host.setBlockingOverlay('city-panel');
+    coordinator.enqueueLegendaryCompletion(legendaryItem());
+    coordinator.clearForHandoff();
+
+    host.setBlockingOverlay(null);
+
+    expect(presentLegendaryCompletion).not.toHaveBeenCalled();
   });
 });

--- a/tests/app/controllers/ceremony-coordinator.test.ts
+++ b/tests/app/controllers/ceremony-coordinator.test.ts
@@ -198,4 +198,26 @@ describe('ceremony coordinator', () => {
 
     expect(presentLegendaryCompletion).not.toHaveBeenCalled();
   });
+
+  it('clearForHandoff does not let an already-played reveal replay on a later re-encounter', async () => {
+    // wonder:discovered re-fires whenever fog-of-war re-reveals an
+    // already-discovered wonder tile, not just on first discovery. A
+    // hot-seat handoff must not reset that dedupe for ceremonies the player
+    // already saw -- only for backlog it never got to show them.
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({
+      playDiscoveryAudio,
+      presentWonderDiscovery: () => Promise.resolve('continue'),
+    }));
+
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+
+    coordinator.clearForHandoff();
+    coordinator.enqueueWonderDiscovery(wonderItem());
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/app/controllers/ceremony-coordinator.test.ts
+++ b/tests/app/controllers/ceremony-coordinator.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import type { LegendaryWonderCompletionCeremonyAction } from '@/ui/legendary-wonder-completion-ceremony';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { createPanelHost } from '@/app/panel-host';
+import { createCeremonyCoordinator, type CeremonyCoordinatorDeps } from '@/app/controllers/ceremony-coordinator';
+
+function wonderItem(overrides: Partial<WonderDiscoveryRevealItem> = {}): WonderDiscoveryRevealItem {
+  return {
+    title: 'Natural Wonder Discovered',
+    wonderId: 'great_volcano',
+    civId: 'player',
+    coord: { q: 2, r: 0 },
+    name: 'Great Volcano',
+    revealLine: 'A discovery line.',
+    effectSummary: 'Yields +1 Science',
+    rewardSummary: '+30 Science discovery reward',
+    visual: getWonderVisualDefinition('great_volcano'),
+    motionAssetId: null,
+    ...overrides,
+  };
+}
+
+function legendaryItem(overrides: Partial<LegendaryWonderCompletionCeremonyItem> = {}): LegendaryWonderCompletionCeremonyItem {
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: 'player',
+    cityId: 'city-river',
+    wonderId: 'oracle-of-delphi',
+    turnCompleted: 42,
+    name: 'Oracle of Delphi',
+    cityName: 'city-river',
+    achievementLine: 'city-river has completed a work that will shape its legacy.',
+    rewardSummary: '+60 research immediately',
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition('oracle-of-delphi'),
+    ...overrides,
+  };
+}
+
+function baseDeps(overrides: Partial<CeremonyCoordinatorDeps> = {}): CeremonyCoordinatorDeps {
+  return {
+    host: createPanelHost(document.createElement('div')),
+    container: document.body,
+    reducedMotion: () => false,
+    requestMapHighlight: vi.fn(),
+    playDiscoveryAudio: vi.fn(),
+    openAtlas: vi.fn(),
+    openCity: vi.fn(),
+    openJournal: vi.fn(),
+    // Never-resolving by default so tests only observe the synchronous
+    // portion of ceremony playback unless they explicitly await resolution.
+    presentWonderDiscovery: () => new Promise(() => {}),
+    presentLegendaryCompletion: () => new Promise(() => {}),
+    ...overrides,
+  };
+}
+
+describe('ceremony coordinator', () => {
+  it('plays a ceremony queued while the UI was blocked, once the overlay clears', () => {
+    const host = createPanelHost(document.createElement('div'));
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({ host, playDiscoveryAudio }));
+
+    host.setBlockingOverlay('city-panel');
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+
+    host.setBlockingOverlay(null);
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers a reveal queued during an animated move until the move settles', () => {
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({ playDiscoveryAudio }));
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+
+    coordinator.endAction();
+
+    expect(playDiscoveryAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not play a reveal queued mid-move before the move settles, even if nothing blocks the UI', () => {
+    const playDiscoveryAudio = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({ playDiscoveryAudio }));
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueWonderDiscovery(wonderItem());
+
+    expect(playDiscoveryAudio).not.toHaveBeenCalled();
+  });
+
+  it('passes reduced-motion through to the queue when the media query matches', async () => {
+    const requestMapHighlight = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({
+      reducedMotion: () => true,
+      requestMapHighlight,
+      presentWonderDiscovery: () => Promise.resolve('continue'),
+    }));
+
+    coordinator.enqueueWonderDiscovery(wonderItem());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(requestMapHighlight).toHaveBeenCalledWith(expect.objectContaining({ wonderId: 'great_volcano' }), true);
+  });
+
+  it('a legendary completion plays immediately — it is never deferred by a move', () => {
+    const presentLegendaryCompletion = vi.fn(
+      (): Promise<LegendaryWonderCompletionCeremonyAction> => new Promise(() => {}),
+    );
+    const coordinator = createCeremonyCoordinator(baseDeps({ presentLegendaryCompletion }));
+
+    coordinator.beginDeferredAction();
+    coordinator.enqueueLegendaryCompletion(legendaryItem());
+
+    expect(presentLegendaryCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes an open-atlas ceremony resolution to the openAtlas callback', async () => {
+    const openAtlas = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({
+      openAtlas,
+      presentWonderDiscovery: () => Promise.resolve('open-atlas'),
+    }));
+
+    coordinator.enqueueWonderDiscovery(wonderItem({ wonderId: 'crystal_caverns' }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(openAtlas).toHaveBeenCalledWith('crystal_caverns');
+  });
+
+  it('routes an open-city ceremony resolution to the openCity callback', async () => {
+    const openCity = vi.fn();
+    const coordinator = createCeremonyCoordinator(baseDeps({
+      openCity,
+      presentLegendaryCompletion: () => Promise.resolve('open-city'),
+    }));
+
+    coordinator.enqueueLegendaryCompletion(legendaryItem({ cityId: 'city-river' }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(openCity).toHaveBeenCalledWith('city-river');
+  });
+});

--- a/tests/ui/legendary-wonder-completion-queue.test.ts
+++ b/tests/ui/legendary-wonder-completion-queue.test.ts
@@ -111,4 +111,28 @@ describe('legendary-wonder-completion-queue', () => {
     expect(queue.pendingCount()).toBe(0);
     expect(present).toHaveBeenCalledTimes(1);
   });
+
+  it('clear() drops pending completions so they never surface after a later unblock', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    let blocked = true;
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => blocked,
+      reducedMotion: () => false,
+      openCity: vi.fn(),
+      openJournal: vi.fn(),
+      present,
+    });
+
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+    expect(present).not.toHaveBeenCalled();
+
+    queue.clear();
+    blocked = false;
+    queue.pump();
+
+    expect(present).not.toHaveBeenCalled();
+    expect(queue.pendingCount()).toBe(0);
+  });
 });

--- a/tests/ui/legendary-wonder-completion-queue.test.ts
+++ b/tests/ui/legendary-wonder-completion-queue.test.ts
@@ -135,4 +135,28 @@ describe('legendary-wonder-completion-queue', () => {
     expect(present).not.toHaveBeenCalled();
     expect(queue.pendingCount()).toBe(0);
   });
+
+  it('clear() does not un-dedupe a completion that already finished playing before the clear', async () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      reducedMotion: () => false,
+      openCity: vi.fn(),
+      openJournal: vi.fn(),
+      present,
+    });
+
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.clear();
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+
+    expect(present).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/ui/wonder-discovery-queue.test.ts
+++ b/tests/ui/wonder-discovery-queue.test.ts
@@ -165,6 +165,49 @@ describe('wonder-discovery-queue', () => {
     expect(overlays).toEqual(['wonder-discovery-ceremony', null]);
   });
 
+  it('clear() drops pending reveals so they never surface after a later unblock', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    let blocked = true;
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => blocked,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    expect(present).not.toHaveBeenCalled();
+
+    queue.clear();
+    blocked = false;
+    queue.pump();
+
+    expect(present).not.toHaveBeenCalled();
+    expect(queue.pendingCount()).toBe(0);
+  });
+
+  it('clear() lets a same wonder be re-queued instead of being treated as a dedupe of the dropped item', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.clear();
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
   it('notifies when a reveal starts so audio can play in sync with the ceremony', () => {
     const onRevealStarted = vi.fn();
     const queue = createWonderDiscoveryRevealQueue({

--- a/tests/ui/wonder-discovery-queue.test.ts
+++ b/tests/ui/wonder-discovery-queue.test.ts
@@ -208,6 +208,35 @@ describe('wonder-discovery-queue', () => {
     expect(present).toHaveBeenCalledTimes(1);
   });
 
+  it('clear() does not un-dedupe a reveal that already finished playing before the clear', async () => {
+    // wonder:discovered re-fires every time fog-of-war re-reveals an
+    // already-discovered wonder tile (see unit-movement-system.ts), not just
+    // on first discovery -- `seen` is what stops the ceremony replaying every
+    // time a unit patrols past it. `clear()` must only free the dedupe key
+    // for items it actually drops, never one that already played.
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.clear();
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
   it('notifies when a reveal starts so audio can play in sync with the ceremony', () => {
     const onRevealStarted = vi.fn();
     const queue = createWonderDiscoveryRevealQueue({


### PR DESCRIPTION
## Summary

Phase 6 of the [`main.ts` composition-root decomposition](https://github.com/a1flecke/conquestoria/blob/2ce97c70/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md) (index: #787). Follows on from Phase 5 (#792).

Exists because of a `setBlockingOverlay` side effect (documented in Phase 5's `panel-host.ts`): unblocking the UI is what pumps the natural-wonder-discovery and legendary-wonder-completion ceremony queues — the game's biggest payoff moments, audio sting included. Without a dedicated owner, `deferWonderDiscoveryRevealUntilMoveSettles` would be written by Phase 8's future `SelectionController` and read by Phase 7's future presentation registrar — a shared mutable flag straddling two future phases.

- `src/app/controllers/ceremony-coordinator.ts` — `createCeremonyCoordinator(deps): CeremonyCoordinator`. Wraps the two existing queue factories (`createWonderDiscoveryRevealQueue`, `createLegendaryWonderCompletionQueue`, both untouched aside from a new `clear()` method — see review section), subscribes once to `host.onInteractionUnblocked` for the pump that used to live inline in `setBlockingOverlay`, and owns the move-settle defer flag behind `beginDeferredAction()`/`endAction()`.
- `main.ts`: 5,246 → 5,233 lines; module-scope `let` bindings 7 → 4 (retires `deferWonderDiscoveryRevealUntilMoveSettles`, `wonderDiscoveryQueue`, `legendaryCompletionQueue`).
- `setBlockingOverlay` in `main.ts` is now a thin one-line forward to `host.setBlockingOverlay` — kept as a wrapper (not deleted) since ~13 call sites still use it; full retirement is Phase 11 scope.

## Key design decisions

- **All three `deferWonderDiscoveryRevealUntilMoveSettles`-clearing sites in `executeAnimatedUnitMove`/`animateMovedUnit` (success path, `!moveResult.ok` path, and the `catch` path) now call `ceremonies.endAction()`.** The original code only called `notifyActionSettled()` on the success path, not the two failure paths. Traced this carefully: `move()` is synchronous and a failed/thrown move commits no state, so nothing could have been enqueued in the brief `beginDeferredAction()`→failure window either way — the extra `notifyActionSettled()` call on those paths is an observable no-op today. Matches the plan's explicit instruction that `beginDeferredAction`/`endAction` are "the only writers of the defer flag," rather than inventing a third `cancelDeferredAction` that skips the settle call.
- **Legendary completions are never deferred** — `enqueueLegendaryCompletion` always calls `notifyActionSettled()` immediately, matching the pre-existing (and intentionally preserved, per the plan) asymmetry with wonder discoveries.
- **`presentWonderDiscovery`/`presentLegendaryCompletion` are new optional deps**, forwarded straight to the two queues' existing `present` override. Both are `undefined` in production (real ceremony UI, unchanged); tests use them to control ceremony resolution deterministically, the same pattern the pre-existing `wonder-discovery-queue.test.ts`/`legendary-wonder-completion-queue.test.ts` already use.
- Updated `panel-host.ts`'s doc comment, which said "Phase 6 ... does not rewire the ceremony queues to it yet" — now stale since this PR does exactly that.

## Inline review (gameplay/fun/mechanics/ages 7-43/playstyles/difficulty/AI/UI/UX/architecture/extensibility/data/SFX/saves/testing/solo+hot-seat regressions/SRP/SOLID/TypeScript)

Ran this myself, inline, per `CLAUDE.md`'s no-subagents policy — not delegated, across two passes (a requested second pass found a real bug the first missed — see below).

- **Fixed — hot-seat ceremony leak.** Traced the full lifecycle of `deferWonderDiscoveryRevealUntilMoveSettles` against `beginHotSeatHandoff`/`releaseHandoffToViewer` and found a genuine, reachable bug (pre-existing, not introduced by this PR — the old inline `setBlockingOverlay` pump had byte-for-byte the same defect): `endTurn()` has no check for an in-flight move animation or a pending ceremony before calling `beginHotSeatHandoff`. If a player discovers a natural wonder via an animated move and clicks End Turn before the animation settles, the reveal item sits queued (`buildWonderDiscoveryRevealItem` already correctly gates on `event.civId === activeViewerId` and `civ.isHuman`, so it's only ever queued for the actual discovering human). `beginHotSeatHandoff` blocks the UI (`'turn-handoff'`) and switches `currentPlayer` to the next player; `releaseHandoffToViewer` then calls `setBlockingOverlay(null)`, which — via `onInteractionUnblocked` — pumps both ceremony queues and plays the previous player's discovery (reveal text, reward summary, and audio sting) **on the next player's screen**. This is exactly the class of leak `closeNetworkPanelsForHandoff`'s existing comment warns about ("these player-owned surfaces may contain strategic targets; never carry them across a hot-seat veil") — ceremonies just weren't included in that cleanup. Fixed by adding `clear()` to both queues and `CeremonyCoordinator.clearForHandoff()`, called from `beginHotSeatHandoff` alongside the existing panel cleanup. TDD, 6 new tests (2 queue-level, 1 legendary-queue-level, 3 coordinator-level) covering: pending items dropped and never surface after a later unblock; a dropped item's dedupe key doesn't block a genuinely later occurrence; an in-progress defer is cancelled (not left permanently stuck) so a later unrelated discovery still plays normally; both queues are covered.
- **Flagged, not fixed — `PanelHost`'s blocking-overlay id is a single value, not a stack.** While tracing the leak above I found `createUiInteractionState` (`src/ui/ui-interaction-state.ts`) stores exactly one `blockingOverlayId: string | null`, no reference-count or stack. A ceremony's own `play()` calls `setBlockingOverlay('wonder-discovery-ceremony')` / `setBlockingOverlay(null)` around its presentation — if a ceremony is actively presenting at the moment `beginHotSeatHandoff` calls `setBlockingOverlay('turn-handoff')`, the id is silently overwritten, and when the ceremony's own promise later resolves and calls `setBlockingOverlay(null)` in its `finally`, that can prematurely clear the turn-handoff block mid-handoff. This is 100% pre-existing (predates this entire 11-phase arc — `ui-interaction-state.ts` is unchanged since before Phase 5), not something Phase 6 introduced or worsened, and a real fix (a blocking-reason stack/counter on `PanelHost`) is a materially bigger, riskier change spanning a shared port with its own consumers (`context-menu.ts`, `keyboard-shortcuts.test.ts`, `desktop-controls.test.ts`) — out of proportion to a ceremony-ownership refactor and explicitly against this arc's "no gameplay/behavior changes outside each phase's stated scope" discipline. Filed as #794 rather than expanding this PR.
- **Simplified — redundant `container` dep.** `CeremonyCoordinatorDeps.container` was always `host.layer` at the one real call site (`host: createPanelHost(uiLayer)` then `createCeremonyCoordinator({ host, container: uiLayer, ... })`) — two names for one value, with no guard against them drifting apart. Removed; the coordinator now reads `deps.host.layer` internally.
- **Fixed (second pass) — `clear()`'s `seen.clear()` was too broad and could let an already-watched ceremony replay.** Traced `wonder:discovered`'s emission site (`unit-movement-system.ts:236`) and found it fires unconditionally every time fog-of-war *re-reveals* an already-discovered wonder tile — not only on first discovery — with `isFirstDiscoverer` just a display-text flag, not a re-fire gate. `buildWonderDiscoveryRevealItem` doesn't filter repeats either (`state.wonderDiscoverers[...].includes(civId)` stays `true` forever once set), so the queue's own `seen` set of `civId:wonderId` keys is the *only* thing stopping a ceremony from replaying every time a unit patrols back past an already-discovered wonder. My first-pass `clear()` did `seen.clear()` wholesale — meaning any hot-seat handoff would also erase the dedupe state for ceremonies the player had *already watched* days/turns earlier, letting them silently replay the next time fog re-revealed that tile. Fixed to delete only the dropped (never-shown) items' own keys, leaving already-played ones permanently deduped. Same fix applied to the legendary-completion queue for symmetry (its `turnCompleted`-qualified key makes the scenario far less reachable there, but the two queues should behave identically for the same operation). 3 new tests (2 queue-level, 1 coordinator-level), confirmed red against the old implementation before fixing.
- **Everything else checked and found non-issues, with reasoning (not just "N/A"):** gameplay balance/fun/new mechanics/difficulty modes/player ages 7-43/play styles — no behavior a player can observe changed (verified via the diff being a pure ownership move, confirmed by the full suite staying green at identical assertion counts outside the two new test files). AI/computer players — untouched; `buildWonderDiscoveryRevealItem`'s `civ.isHuman` gate (pre-existing) already keeps AI civs out of the ceremony system entirely, so this refactor can't newly expose them to it. Data/save schema — ceremony items are built from state at event time and never persisted; nothing in `game-state.ts` or the migration pipeline touches this. SFX — `playDiscoveryAudio`/the embedded legendary-ceremony audio are forwarded unchanged; the hot-seat fix above additionally stops the discovery audio sting from misfiring on the wrong player's screen. SRP/SOLID — `CeremonyCoordinator` has one axis of change (ceremony sequencing); no concrete `RenderLoop`/`AudioContext`/`HTMLElement`-beyond-`layer` types leak into its deps (DIP); `beginDeferredAction`/`endAction`/`clearForHandoff` stay small and intention-revealing rather than one generic `setFlag` (ISP). Considered whether the two near-identical queues justify a shared generic `CeremonyQueue<T>` abstraction — declined: they already diverge in shape (`onRevealStarted` vs. none, `openAtlas` vs. `openCity`/`openJournal`), and forcing a shared generic now would be speculative generality for exactly two known implementers, against `CLAUDE.md`'s "don't design for hypothetical future requirements." TypeScript — no `any`, no non-null assertions, `readonly` deps, `present` override types extracted via `Options['present']` rather than duplicated.

## Testing

- `tests/app/controllers/ceremony-coordinator.test.ts` (11 tests, TDD — written failing first): queued-while-blocked plays on unblock; deferred-during-move waits for `endAction`; a second assertion that nothing plays mid-defer even when unblocked; reduced-motion passthrough to `requestMapHighlight`; legendary completion never deferred; `open-atlas` and `open-city` ceremony-resolution routing; the 3 `clearForHandoff` tests from the first review pass; plus the second-pass test proving `clearForHandoff` doesn't un-dedupe an already-played reveal.
- `tests/ui/wonder-discovery-queue.test.ts` / `tests/ui/legendary-wonder-completion-queue.test.ts`: 3 `clear()` tests from the first review pass, plus 2 more from the second pass proving already-played items stay deduped across a `clear()`.
- Full suite: `yarn test` — 452 files / 7,458 tests passing (3 pre-existing skips), `yarn build` clean.
- Manual verification in a live dev-server browser session: loaded a solo campaign save, confirmed the composition root boots cleanly through `createCeremonyCoordinator`'s construction with zero console errors, HUD/panel/unit-selection/research-selection all functional. Could not click-drive an actual hex-tap move in this sandboxed preview (the game canvas reports `height: 0` in this specific headless harness — a pre-existing preview-environment limitation unrelated to this diff, since nothing here touches canvas sizing/resize code) — the animated-move code path (`executeAnimatedUnitMove`/`animateMovedUnit`) is otherwise only covered by this PR's static typecheck and the fact that `main.ts` has zero unit-test coverage today (the whole reason this arc exists). Flagging this gap explicitly rather than overclaiming coverage.
- Pre-commit guardrail hook flagged this diff (both commits) for "queue-related UI" and "interactive panel" changes — false positives from matching the words "queue"/"panel" in the code. This is an internal ceremony-playback sequencer with no player-facing reorder/remove/ETA UI, and no new panel DOM/text was introduced.

## Out of scope

Phase 7 (presentation registrars), Phase 8 (`SelectionController`/`MapInteractionController`), Phase 9 (`TurnFlowController`), Phase 10 (final composition root), Phase 11 (boundary lock, including full `setBlockingOverlay` retirement, and possibly the `PanelHost` blocking-overlay stacking issue flagged above). No gameplay/balance/AI/RNG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

