### PR TITLE
Extract presentation event registrars from main.ts (#787 phase 7)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -280,7 +280,8 @@ import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/contr
 import type { PresentationContext } from '@/presentation/register-all';
 import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
 import { registerEraPresentation } from '@/presentation/register-era-presentation';
-import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, getRouteTechGoldBonus } from '@/systems/trade-system';
+import { registerTradePresentation } from '@/presentation/register-trade-presentation';
+import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { performMinorCivFestival, performMinorCivGift, performMinorCivReparations, setMinorCivWarState } from '@/systems/minor-civ-actions';
@@ -442,6 +443,8 @@ const presentationContext: PresentationContext = {
   get router() { return router; },
   ceremonies,
   selection,
+  requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
+  applyCombatVisual: result => renderLoop.applyCombatVisual(result),
 };
 
 // --- Resize ---
@@ -4438,9 +4441,7 @@ bus.on('combat:resolved', event => {
   });
 });
 
-bus.on('trade:route-delivered', ({ unitId }) => {
-  renderLoop.applyDeliveryVisual(unitId);
-});
+registerTradePresentation(bus, presentationContext);
 
 bus.on('combat:reward-earned', ({ reward }) => {
   routeCombatRewardEarned(session.getState(), reward, appendToCivLog);
@@ -4781,33 +4782,8 @@ bus.on('espionage:city-flipped', event => {
   routeCityFlipped(session.getState(), event, appendToCivLog);
 });
 
-bus.on('trade:route-created', ({ route }) => {
-  const ownerCity = session.getState().cities[route.fromCityId];
-  const toCity = session.getState().cities[route.toCityId];
-  if (!ownerCity) return;
-  const goldPerTurn = getEffectiveGoldPerTurn(route, getRouteTechGoldBonus(session.getState(), route));
-  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? route.toCityId} established (+${goldPerTurn} gold/turn)`, 'success');
-});
-
-bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {
-  const ownerCity = session.getState().cities[fromCityId];
-  const toCity = session.getState().cities[toCityId];
-  if (!ownerCity) return;
-  const reasonText: Record<string, string> = {
-    'unit-died': 'caravan destroyed',
-    'unit-disbanded': 'caravan disbanded',
-    'war-declared': 'war declared — caravan is free to redeploy',
-    'hostile-relations': 'hostile relations — caravan is free to redeploy',
-    'embargo': 'embargo enforced — caravan is free to redeploy',
-    'trips-exhausted': 'caravan retired after completing its service',
-    'unit-captured': 'caravan captured',
-  };
-  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? toCityId} ended: ${reasonText[reason] ?? reason}`, 'warning');
-  // Also tell the other end of the route, if it's a different human civ (#551).
-  if (toCity && toCity.owner !== ownerCity.owner && session.getState().civilizations[toCity.owner]?.isHuman) {
-    appendToCivLog(toCity.owner, `Trade route from ${ownerCity.name} ended: ${reasonText[reason] ?? reason}`, 'warning');
-  }
-});
+// trade:route-created and trade:route-ended also live in
+// registerTradePresentation, above (#787 phase 7).
 
 // --- Initialization ---
 async function init(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,7 +225,6 @@ import {
   type NotificationEntry,
 } from '@/core/notification-log';
 import {
-  routeCombatRewardEarned,
   TREATY_LABELS,
   routeStrategicWarning,
   type NotificationSink,
@@ -263,6 +262,7 @@ import { registerFactionCrisisPresentation } from '@/presentation/register-facti
 import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
 import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
 import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
+import { registerCombatPresentation } from '@/presentation/register-combat-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -274,7 +274,6 @@ import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import { runCompletedRound } from '@/core/completed-round-orchestrator';
 import { createCompletedRoundHandoffTransaction } from '@/core/completed-round-handoff';
 import { processImprovementTurns } from '@/systems/improvement-turn-system';
-import { handleCombatResolvedEvent } from '@/ui/combat-resolved-presentation';
 import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-system';
 import { createCityOverviewPanel } from '@/ui/city-overview-panel';
 import type { GameSession } from '@/app/ports';
@@ -430,6 +429,7 @@ const presentationContext: PresentationContext = {
   showEspionageCaptureChoice: (spyId, spyOwner) => showEspionageCaptureChoice(spyId, spyOwner),
   uiLayer,
   maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
+  isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
 };
 
 // --- Resize ---
@@ -4277,19 +4277,9 @@ bus.on('advisor:message', ({ advisor, message, icon }) => {
   showNotification(`${icon} ${message}`, 'info');
 });
 
-bus.on('combat:resolved', event => {
-  handleCombatResolvedEvent(session.getState(), event, {
-    isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
-    applyVisual: result => renderLoop.applyCombatVisual(result),
-    appendNotification: appendToCivLog,
-  });
-});
+registerCombatPresentation(bus, presentationContext);
 
 registerTradePresentation(bus, presentationContext);
-
-bus.on('combat:reward-earned', ({ reward }) => {
-  routeCombatRewardEarned(session.getState(), reward, appendToCivLog);
-});
 
 registerRaiderPresentation(bus, presentationContext);
 
@@ -4313,23 +4303,6 @@ registerReligionPresentation(bus, presentationContext);
 // diplomacy:opportunistic-war now lives in registerDiplomacyPresentation (#787 phase 7).
 
 registerEspionagePresentation(bus, presentationContext);
-
-bus.on('unit:obsolete', ({ civId, unitType }) => {
-  const name = UNIT_DEFINITIONS[unitType]?.name ?? unitType;
-  appendToCivLog(civId, `Your ${name} is now obsolete — upgrade it in your home city.`, 'info');
-});
-
-bus.on('unit:journey-blocked', ({ unitId, position }) => {
-  // #551: recipient is the unit's actual owner, not whoever currentPlayer
-  // happens to be at emit time -- the old showNotification call leaked this
-  // to the wrong hot-seat player. Skip entirely if the unit is gone rather
-  // than falling back to currentPlayer.
-  const unit = session.getState().units[unitId];
-  if (!unit) return;
-  const type = UNIT_DEFINITIONS[unit.type]?.name ?? unit.type;
-  const msg = `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`;
-  appendToCivLog(unit.owner, msg, 'warning');
-});
 
 // trade:route-created and trade:route-ended also live in
 // registerTradePresentation, above (#787 phase 7).

--- a/src/main.ts
+++ b/src/main.ts
@@ -247,10 +247,6 @@ import {
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
-  routeReligionFounded,
-  routeReligionCityConverted,
-  routeLoyaltyWarning,
-  routeCityDefected,
   routeSabotageReliefDiscovered,
   routeCityFlipped,
   type NotificationSink,
@@ -281,6 +277,7 @@ import type { PresentationContext } from '@/presentation/register-all';
 import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
 import { registerEraPresentation } from '@/presentation/register-era-presentation';
 import { registerTradePresentation } from '@/presentation/register-trade-presentation';
+import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4658,21 +4655,7 @@ bus.on('crisis:started', event => {
   routeWorldPressureCrisisStarted(session.getState(), event, appendToCivLog);
 });
 
-bus.on('religion:founded', event => {
-  routeReligionFounded(session.getState(), event, appendToCivLog);
-});
-
-bus.on('religion:city-converted', event => {
-  routeReligionCityConverted(session.getState(), event, appendToCivLog);
-});
-
-bus.on('religion:loyalty-warning', event => {
-  routeLoyaltyWarning(session.getState(), event, appendToCivLog);
-});
-
-bus.on('religion:city-defected', event => {
-  routeCityDefected(session.getState(), event, appendToCivLog);
-});
+registerReligionPresentation(bus, presentationContext);
 
 bus.on('crisis:spread', event => {
   routeCrisisSpread(session.getState(), event, appendToCivLog);

--- a/src/main.ts
+++ b/src/main.ts
@@ -249,20 +249,7 @@ import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer'
 import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
-import type { PresentationContext } from '@/presentation/register-all';
-import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
-import { registerEraPresentation } from '@/presentation/register-era-presentation';
-import { registerTradePresentation } from '@/presentation/register-trade-presentation';
-import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
-import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
-import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
-import { registerCityPresentation } from '@/presentation/register-city-presentation';
-import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
-import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
-import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
-import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
-import { registerCombatPresentation } from '@/presentation/register-combat-presentation';
-import { registerGeneralPresentation } from '@/presentation/register-general-presentation';
+import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4256,41 +4243,12 @@ function showEspionageCaptureChoice(spyId: string, spyOwner: string): void {
 }
 
 // --- Event listeners ---
-registerCityPresentation(bus, presentationContext);
-
-registerNetworkPresentation(bus, presentationContext);
-
-registerGeneralPresentation(bus, presentationContext);
-
-registerWonderPresentation(bus, presentationContext);
-
-// War, peace, treaties, first contact (#787 phase 7). Opportunistic-war
-// notifications also live in this registrar, further down the old bus.on
-// block below -- see registerDiplomacyPresentation.
-registerDiplomacyPresentation(bus, presentationContext);
-
-registerCombatPresentation(bus, presentationContext);
-
-registerTradePresentation(bus, presentationContext);
-
-registerRaiderPresentation(bus, presentationContext);
-
-registerBeastPresentation(bus, presentationContext);
+// All 72 module-scope bus.on(...) registrations that used to live inline here
+// now live in the thirteen domain registrars under src/presentation/,
+// composed into one install/dispose pair (#787 phase 7).
+registerAllPresentation(bus, presentationContext);
 
 registerMinorCivNotificationListeners(bus, () => session.getState(), { appendToCivLog });
-
-registerEraPresentation(bus, presentationContext);
-
-registerFactionCrisisPresentation(bus, presentationContext);
-
-registerReligionPresentation(bus, presentationContext);
-
-// diplomacy:opportunistic-war now lives in registerDiplomacyPresentation (#787 phase 7).
-
-registerEspionagePresentation(bus, presentationContext);
-
-// trade:route-created and trade:route-ended also live in
-// registerTradePresentation, above (#787 phase 7).
 
 // --- Initialization ---
 async function init(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,7 +226,6 @@ import {
 } from '@/core/notification-log';
 import {
   TREATY_LABELS,
-  routeStrategicWarning,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationCenter } from '@/ui/notification-center';
@@ -263,6 +262,7 @@ import { registerEspionagePresentation } from '@/presentation/register-espionage
 import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
 import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
 import { registerCombatPresentation } from '@/presentation/register-combat-presentation';
+import { registerGeneralPresentation } from '@/presentation/register-general-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -430,6 +430,9 @@ const presentationContext: PresentationContext = {
   uiLayer,
   maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
   isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
+  resetAdvisorMessage: id => advisorSystem.resetMessage(id),
+  checkAdvisors: () => advisorSystem.check(session.getState()),
+  showNotification: (message, type, target) => showNotification(message, type, target),
 };
 
 // --- Resize ---
@@ -4257,13 +4260,7 @@ registerCityPresentation(bus, presentationContext);
 
 registerNetworkPresentation(bus, presentationContext);
 
-bus.on('village:visited', ({ civId, outcome, message }) => {
-  if (outcome === 'gold') advisorSystem.resetMessage('treasurer_village_gold');
-  if (outcome === 'science') advisorSystem.resetMessage('scholar_village_science');
-  if (outcome === 'free_tech') advisorSystem.resetMessage('scholar_village_tech');
-  advisorSystem.check(session.getState());
-  appendToCivLog(civId, message, outcome === 'ambush' || outcome === 'illness' ? 'warning' : 'success');
-});
+registerGeneralPresentation(bus, presentationContext);
 
 registerWonderPresentation(bus, presentationContext);
 
@@ -4271,11 +4268,6 @@ registerWonderPresentation(bus, presentationContext);
 // notifications also live in this registrar, further down the old bus.on
 // block below -- see registerDiplomacyPresentation.
 registerDiplomacyPresentation(bus, presentationContext);
-
-// viewer-scoped by design: advisors run for the active player only (#551).
-bus.on('advisor:message', ({ advisor, message, icon }) => {
-  showNotification(`${icon} ${message}`, 'info');
-});
 
 registerCombatPresentation(bus, presentationContext);
 
@@ -4286,13 +4278,6 @@ registerRaiderPresentation(bus, presentationContext);
 registerBeastPresentation(bus, presentationContext);
 
 registerMinorCivNotificationListeners(bus, () => session.getState(), { appendToCivLog });
-
-bus.on('ai:strategic-warning', event => {
-  // #551: appendToCivLog (the delivery contract) already queues to
-  // pendingEvents for a non-active hot-seat recipient -- the old
-  // queueStrategicWarningPendingEvent call was a second, always-on queue.
-  routeStrategicWarning(event, appendToCivLog);
-});
 
 registerEraPresentation(bus, presentationContext);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,7 +142,6 @@ import {
   retargetNetworkPlan,
 } from '@/systems/network-plan-system';
 import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
-import { getNetworkWarningForViewer } from '@/systems/network-viewer-intel';
 import {
   getNextActiveHumanPlayerId,
   isActiveHumanRoundComplete,
@@ -278,6 +277,7 @@ import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy
 import { registerEraPresentation } from '@/presentation/register-era-presentation';
 import { registerTradePresentation } from '@/presentation/register-trade-presentation';
 import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
+import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4310,56 +4310,7 @@ bus.on('city:national-project-expired', ({ civId, cityId, buildingId }) => {
 
 bus.on('city:production-item-dropped', event => routeDroppedProductionItem(session.getState(), event, appendToCivLog));
 
-bus.on('city:cyber-drained', ({ cityName, drainerOwner, goldLost, blocked, victimCivId }) => {
-  const drainerName = session.getState().civilizations[drainerOwner]?.name ?? drainerOwner;
-  const victimName = session.getState().civilizations[victimCivId]?.name ?? victimCivId;
-  if (blocked) {
-    appendToCivLog(victimCivId, `Cyber Defense Center blocked an intrusion in ${cityName}.`, 'success');
-    appendToCivLog(drainerOwner, `Cyber attack on ${cityName} was blocked by ${victimName}'s Cyber Defense Center.`, 'warning');
-    return;
-  }
-  appendToCivLog(victimCivId, `Cyber attack: ${cityName} lost ${goldLost} gold (${drainerName} cyber unit).`, 'warning');
-  appendToCivLog(drainerOwner, `Cyber unit stole ${goldLost} gold from ${victimName}'s ${cityName}.`, 'success');
-});
-
-bus.on('network:exploit-warning', ({ planId, victimCivId, cityId }) => {
-  const warning = getNetworkWarningForViewer(session.getState(), victimCivId, planId);
-  const city = session.getState().cities[cityId];
-  if (!warning || !city) return;
-  const disclosure = warning.source?.unitId
-    ? ' The source has been identified.'
-    : warning.source?.position
-      ? ' The source position has been detected.'
-      : '';
-  appendToCivLog(
-    victimCivId,
-    `Network exploit warning: ${city.name} will be targeted at the end of this turn. A Cyber Defense Center or Harden reduces the effect.${disclosure}`,
-    'warning',
-    { kind: 'map', coord: city.position, label: city.name },
-  );
-  bus.emit('network:audio-cue', { cue: 'hostile-warning', viewerIds: [victimCivId] });
-});
-
-bus.on('network:exploit-resolved', ({ cityId, ownerCivId, goldTransferred, delayed }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  if (delayed) {
-    appendToCivLog(city.owner, `${city.name}'s Cyber Defense Center delayed a network exploit.`, 'success');
-    appendToCivLog(ownerCivId, `Your network exploit against ${city.name} was delayed by its Cyber Defense Center.`, 'warning');
-    return;
-  }
-  appendToCivLog(city.owner, `Network exploit: ${city.name} lost ${goldTransferred} gold.`, 'warning');
-  appendToCivLog(ownerCivId, `Network exploit transferred ${goldTransferred} gold from ${city.name}.`, 'success');
-  bus.emit('network:audio-cue', { cue: 'hostile-consequence', viewerIds: [city.owner, ownerCivId] });
-});
-
-bus.on('network:audio-cue', ({ cue, viewerIds }) => {
-  if (cue === 'constructive-resolution') {
-    appendToCivLog(viewerIds[0]!, 'Stable network plan milestone reached: three resolutions recorded.', 'success');
-  } else if (cue === 'recovery') {
-    appendToCivLog(viewerIds[0]!, 'Network recovery complete.', 'success');
-  }
-});
+registerNetworkPresentation(bus, presentationContext);
 
 bus.on('village:visited', ({ civId, outcome, message }) => {
   if (outcome === 'gold') advisorSystem.resetMessage('treasurer_village_gold');

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,13 +236,8 @@ import {
   routeEconomyTreasuryStrain,
   routeEraAdvanced,
   routeFactionTransition,
-  routeFirstContact,
   routeLegendaryWonder,
-  routePeaceMade,
-  routePeaceRequested,
   routeTerritoryTileFlipped,
-  routeWarDeclared,
-  routeTreatyProposed,
   TREATY_LABELS,
   routeStrategicWarning,
   routeCrisisStarted,
@@ -257,7 +252,6 @@ import {
   routeReligionCityConverted,
   routeLoyaltyWarning,
   routeCityDefected,
-  routeOpportunisticWar,
   routeSabotageReliefDiscovered,
   routeCityFlipped,
   type NotificationSink,
@@ -284,6 +278,8 @@ import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOut
 import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
 import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import type { PresentationContext } from '@/presentation/register-all';
+import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
 import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, getRouteTechGoldBonus } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -432,6 +428,21 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
     if (session.getState().cities[cityId]) openWonderPanelForCityId(cityId);
   },
 });
+
+/**
+ * Shared deps for the domain presentation registrars replacing 72
+ * module-scope `bus.on(...)` registrations (#787 phase 7). `notifier`/`router`
+ * resolve through getters -- the same deferred-but-eager pattern
+ * `panelContext` above already uses -- since both are only assigned once
+ * `init()` runs.
+ */
+const presentationContext: PresentationContext = {
+  session,
+  get notifier() { return notifier; },
+  get router() { return router; },
+  ceremonies,
+  selection,
+};
 
 // --- Resize ---
 window.addEventListener('resize', () => renderLoop.resizeCanvas());
@@ -4405,33 +4416,10 @@ bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId 
   );
 });
 
-bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
-  routeWarDeclared(session.getState(), attackerId, defenderId, appendToCivLog);
-});
-
-bus.on('diplomacy:treaty-proposed', event => {
-  routeTreatyProposed(session.getState(), event, appendToCivLog);
-});
-
-bus.on('civilization:first-contact', ({ civA, civB }) => {
-  // #551: routeFirstContact's sink is the delivery contract, which already
-  // queues to pendingEvents for a non-active hot-seat recipient -- the old
-  // unconditional queueFirstContactPendingEvents call was a second, always-on
-  // queue that leaked stale growth into solo saves (which never drain it).
-  routeFirstContact(session.getState(), civA, civB, appendToCivLog);
-});
-
-bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {
-  // #551: routePeaceRequested already delivers to toCivId via appendToCivLog
-  // (the delivery contract) -- the old extra showNotification here duplicated
-  // the message AND leaked it to whoever currentPlayer was at emit time
-  // instead of the actual recipient.
-  routePeaceRequested(session.getState(), fromCivId, toCivId, appendToCivLog);
-});
-
-bus.on('diplomacy:peace-made', ({ civA, civB }) => {
-  routePeaceMade(session.getState(), civA, civB, appendToCivLog);
-});
+// War, peace, treaties, first contact (#787 phase 7). Opportunistic-war
+// notifications also live in this registrar, further down the old bus.on
+// block below -- see registerDiplomacyPresentation.
+registerDiplomacyPresentation(bus, presentationContext);
 
 // viewer-scoped by design: advisors run for the active player only (#551).
 bus.on('advisor:message', ({ advisor, message, icon }) => {
@@ -4718,9 +4706,7 @@ bus.on('crisis:aid-sent', event => {
   routeCrisisAidSent(session.getState(), event, appendToCivLog);
 });
 
-bus.on('diplomacy:opportunistic-war', event => {
-  routeOpportunisticWar(session.getState(), event, appendToCivLog);
-});
+// diplomacy:opportunistic-war now lives in registerDiplomacyPresentation (#787 phase 7).
 
 bus.on('espionage:sabotage-relief-discovered', event => {
   routeSabotageReliefDiscovered(session.getState(), event, appendToCivLog);

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,8 +130,6 @@ import {
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import { visitVillage } from '@/systems/village-system';
-import { getWonderDefinition } from '@/systems/wonder-definitions';
-import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs, getEffectiveTechCost } from '@/systems/tech-system';
 import {
   assignNetworkPlan,
@@ -234,7 +232,6 @@ import {
   routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
   routeFactionTransition,
-  routeLegendaryWonder,
   routeTerritoryTileFlipped,
   TREATY_LABELS,
   routeStrategicWarning,
@@ -270,7 +267,6 @@ import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
 import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
 import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
-import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import type { PresentationContext } from '@/presentation/register-all';
 import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
@@ -278,6 +274,7 @@ import { registerEraPresentation } from '@/presentation/register-era-presentatio
 import { registerTradePresentation } from '@/presentation/register-trade-presentation';
 import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
 import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
+import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4320,52 +4317,7 @@ bus.on('village:visited', ({ civId, outcome, message }) => {
   appendToCivLog(civId, message, outcome === 'ambush' || outcome === 'illness' ? 'warning' : 'success');
 });
 
-bus.on('wonder:discovered', event => {
-  const wonderDef = getWonderDefinition(event.wonderId);
-  if (!wonderDef) return;
-  const message = event.isFirstDiscoverer
-    ? `Discovered ${wonderDef.name}! +${wonderDef.discoveryBonus.amount} ${wonderDef.discoveryBonus.type}`
-    : `Found ${wonderDef.name}!`;
-  appendToCivLog(event.civId, message, event.isFirstDiscoverer ? 'success' : 'info');
-
-  const revealItem = buildWonderDiscoveryRevealItem(session.getState(), session.getState().currentPlayer, event);
-  if (revealItem) {
-    ceremonies.enqueueWonderDiscovery(revealItem);
-  }
-});
-
-bus.on('wonder:legendary-ready', ({ civId, cityId, wonderId }) => {
-  routeLegendaryWonder(session.getState(), { type: 'wonder:legendary-ready', civId, cityId, wonderId }, appendToCivLog);
-});
-
-bus.on('wonder:legendary-availability', event => {
-  routeLegendaryWonder(session.getState(), { type: 'wonder:legendary-availability', ...event }, appendToCivLog);
-});
-
-bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId, turnCompleted }) => {
-  const event = { civId, cityId, wonderId, turnCompleted };
-  routeLegendaryWonder(session.getState(), { type: 'wonder:legendary-completed', ...event }, appendToCivLog);
-  const ceremonyItem = buildLegendaryWonderCompletionCeremonyItem(session.getState(), event);
-  if (ceremonyItem) {
-    ceremonies.enqueueLegendaryCompletion(ceremonyItem);
-  }
-});
-
-bus.on('wonder:legendary-lost', ({ civId, cityId, wonderId, goldRefund, transferableProduction }) => {
-  routeLegendaryWonder(
-    session.getState(),
-    { type: 'wonder:legendary-lost', civId, cityId, wonderId, goldRefund, transferableProduction },
-    appendToCivLog,
-  );
-});
-
-bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId }) => {
-  routeLegendaryWonder(
-    session.getState(),
-    { type: 'wonder:legendary-race-revealed', observerId, civId, cityId, wonderId },
-    appendToCivLog,
-  );
-});
+registerWonderPresentation(bus, presentationContext);
 
 // War, peace, treaties, first contact (#787 phase 7). Opportunistic-war
 // notifications also live in this registrar, further down the old bus.on

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ import { resolveCivilizationEra } from '@/systems/tech-definitions';
 import { resolveCombatEra } from '@/systems/era-resolution';
 import { preach } from '@/systems/religion-system';
 import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
-import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
+import { getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast, isCivUnitInBeastTerritory } from '@/systems/beast-system';
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
@@ -225,7 +225,6 @@ import {
   type NotificationEntry,
 } from '@/core/notification-log';
 import {
-  routeBarbarianSpawned,
   routeCombatRewardEarned,
   TREATY_LABELS,
   routeStrategicWarning,
@@ -263,6 +262,7 @@ import { registerCityPresentation } from '@/presentation/register-city-presentat
 import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
 import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
 import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
+import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4277,10 +4277,6 @@ bus.on('advisor:message', ({ advisor, message, icon }) => {
   showNotification(`${icon} ${message}`, 'info');
 });
 
-// Per-civ dedup: each civ sees a "raiders spotted!" entry only the first time
-// its visibility covers any raider from a given camp.
-const notifiedBarbarianCampsPerCiv = new Map<string, Set<string>>();
-
 bus.on('combat:resolved', event => {
   handleCombatResolvedEvent(session.getState(), event, {
     isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
@@ -4295,76 +4291,7 @@ bus.on('combat:reward-earned', ({ reward }) => {
   routeCombatRewardEarned(session.getState(), reward, appendToCivLog);
 });
 
-bus.on('barbarian:spawned', ({ campId, unitId }) => {
-  const unit = session.getState().units[unitId];
-  if (!unit) return;
-  routeBarbarianSpawned(
-    session.getState(),
-    unit.position,
-    campId,
-    notifiedBarbarianCampsPerCiv,
-    appendToCivLog,
-    (vis, pos) => isVisible(vis as Parameters<typeof isVisible>[0], pos),
-  );
-});
-
-bus.on('threat:barbarian-resurgence', ({ civId, isBanditLord, banditLordName }) => {
-  const message = isBanditLord
-    ? `${banditLordName ?? 'A bandit lord'} has united the raiders and threatens your lands!`
-    : 'Barbarian forces are resurgent on your lands!';
-  appendToCivLog(civId, message, 'warning');
-  SFX.barbarianResurgence?.();
-});
-
-bus.on('barbarian:city-attacked', ({ cityId, hpLost }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  if (!session.getState().civilizations[city.owner]?.isHuman) return;
-  appendToCivLog(city.owner, `Barbarians attack ${city.name}! (−${hpLost} HP)`, 'warning');
-});
-
-bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
-  if (!session.getState().civilizations[ownerId]?.isHuman) return;
-  const cityName = session.getState().cities[cityId]?.name ?? 'A city';
-  appendToCivLog(ownerId, `${cityName} was destroyed by barbarian raiders!`, 'warning');
-});
-
-// A walled, ungarrisoned city fighting back against a besieger (#522) -- covers BOTH
-// the barbarian (turn-manager.ts) and pirate (pirate-system.ts) counter-fire call
-// sites, since both emit this same shared event with their respective 'source' value.
-bus.on('city:counter-fire', ({ cityId, source, damage, attackerDied }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  if (!session.getState().civilizations[city.owner]?.isHuman) return;
-  const raiderLabel = source === 'barbarian' ? 'raider' : 'ship';
-  const message = attackerDied
-    ? `${city.name}'s defenses destroyed a ${source === 'barbarian' ? 'barbarian raider' : 'pirate ship'}!`
-    : `${city.name}'s walls fought back, damaging a ${raiderLabel} (−${damage} HP)!`;
-  appendToCivLog(city.owner, message, attackerDied ? 'success' : 'info');
-});
-
-// Pirate-faction naval siege (#522) mirror of the barbarian handler above.
-bus.on('pirate:city-destroyed', ({ cityId, ownerId }) => {
-  if (!session.getState().civilizations[ownerId]?.isHuman) return;
-  const cityName = session.getState().cities[cityId]?.name ?? 'A coastal city';
-  appendToCivLog(ownerId, `${cityName} was razed by pirates!`, 'warning');
-});
-
-// A sacked city survives the raid at 1 HP — phrased distinctly from outright
-// destruction so a recoverable loss is never mistaken for a permanent one. Both
-// barbarians (turn-manager.ts) and pirates (pirate-system.ts, #522) route through
-// this shared event with their respective 'source' value.
-bus.on('city:sacked', ({ cityId, source, goldLost }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  if (!session.getState().civilizations[city.owner]?.isHuman) return;
-  const raiders = source === 'barbarian' ? 'Barbarian raiders' : 'Pirates';
-  appendToCivLog(
-    city.owner,
-    `${raiders} have sacked ${city.name}! The city survives at 1 HP, but ${goldLost} gold was looted.`,
-    'warning',
-  );
-});
+registerRaiderPresentation(bus, presentationContext);
 
 registerBeastPresentation(bus, presentationContext);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,6 @@ import {
   routeCombatRewardEarned,
   routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
-  routeEraAdvanced,
   routeFactionTransition,
   routeLegendaryWonder,
   routeTerritoryTileFlipped,
@@ -280,6 +279,7 @@ import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import type { PresentationContext } from '@/presentation/register-all';
 import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
+import { registerEraPresentation } from '@/presentation/register-era-presentation';
 import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, getRouteTechGoldBonus } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4622,19 +4622,7 @@ function appendFactionNotice(civId: string, message: string, type: NotificationE
   appendToCivLog(civId, message, type);
 }
 
-bus.on('era:advanced', ({ era }) => {
-  const humanCivIds = Object.entries(session.getState().civilizations)
-    .filter(([, civ]) => civ.isHuman)
-    .map(([civId]) => civId);
-  routeEraAdvanced(era, humanCivIds, appendToCivLog);
-});
-
-bus.on('civilization:era-advanced', ({ civId, era }) => {
-  const civ = session.getState().civilizations[civId];
-  if (!civ?.isHuman) return;
-  appendToCivLog(civId, `${civ.name} has entered Era ${era}. Your technology now sets your civilization's era.`, 'success');
-  if (civId === session.getState().currentPlayer) SFX.notification();
-});
+registerEraPresentation(bus, presentationContext);
 
 bus.on('faction:unrest-started', event => {
   routeFactionTransition(session.getState(), { type: 'faction:unrest-started', ...event }, appendFactionNotice);

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,18 +229,8 @@ import {
 import {
   routeBarbarianSpawned,
   routeCombatRewardEarned,
-  routeEconomyTreasuryStrain,
-  routeFactionTransition,
   TREATY_LABELS,
   routeStrategicWarning,
-  routeCrisisStarted,
-  routeCrisisSpread,
-  routeCrisisEscalated,
-  routeCrisisResolved,
-  routeWorldPressureCrisisStarted,
-  routeWorldPressureCrisisResolved,
-  routeCrisisFoeHuntedByAlly,
-  routeCrisisAidSent,
   routeSabotageReliefDiscovered,
   routeCityFlipped,
   type NotificationSink,
@@ -274,6 +264,7 @@ import { registerReligionPresentation } from '@/presentation/register-religion-p
 import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
 import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
 import { registerCityPresentation } from '@/presentation/register-city-presentation';
+import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4467,83 +4458,16 @@ bus.on('ai:strategic-warning', event => {
   routeStrategicWarning(event, appendToCivLog);
 });
 
-function appendFactionNotice(civId: string, message: string, type: NotificationEntry['type']): void {
-  // #551: appendToCivLog (the delivery contract) already queues to
-  // pendingEvents for a non-active hot-seat recipient -- the old manual
-  // collectEvent call here was a second, always-on queue that duplicated the
-  // entry in that player's next turn-handoff summary.
-  appendToCivLog(civId, message, type);
-}
-
 registerEraPresentation(bus, presentationContext);
 
-bus.on('faction:unrest-started', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:unrest-started', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:revolt-started', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:revolt-started', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:unrest-resolved', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:unrest-resolved', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:concession-made', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:concession-made', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:breakaway-started', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:breakaway-started', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:breakaway-established', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:breakaway-established', ...event }, appendFactionNotice);
-});
-
-bus.on('faction:critical-status', event => {
-  routeFactionTransition(session.getState(), { type: 'faction:critical-status', ...event }, appendFactionNotice);
-});
-
-bus.on('crisis:started', event => {
-  routeCrisisStarted(session.getState(), event, appendToCivLog);
-  routeWorldPressureCrisisStarted(session.getState(), event, appendToCivLog);
-});
+registerFactionCrisisPresentation(bus, presentationContext);
 
 registerReligionPresentation(bus, presentationContext);
-
-bus.on('crisis:spread', event => {
-  routeCrisisSpread(session.getState(), event, appendToCivLog);
-});
-
-bus.on('crisis:escalated', event => {
-  routeCrisisEscalated(session.getState(), event, appendToCivLog);
-});
-
-bus.on('crisis:resolved', event => {
-  routeCrisisResolved(session.getState(), event, appendToCivLog);
-  routeWorldPressureCrisisResolved(session.getState(), event, appendToCivLog);
-});
-
-bus.on('crisis:foe-hunted-by-ally', event => {
-  routeCrisisFoeHuntedByAlly(session.getState(), event, appendToCivLog);
-});
-
-bus.on('crisis:aid-sent', event => {
-  routeCrisisAidSent(session.getState(), event, appendToCivLog);
-});
 
 // diplomacy:opportunistic-war now lives in registerDiplomacyPresentation (#787 phase 7).
 
 bus.on('espionage:sabotage-relief-discovered', event => {
   routeSabotageReliefDiscovered(session.getState(), event, appendToCivLog);
-});
-
-bus.on('economy:treasury-strain', event => {
-  // #551: routeEconomyTreasuryStrain already delivers to event.civId via the
-  // delivery contract; the old extra showNotification duplicated the message
-  // and leaked it to whoever currentPlayer was at emit time.
-  routeEconomyTreasuryStrain(session.getState(), event, appendToCivLog);
 });
 
 bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,12 +63,10 @@ import { preach } from '@/systems/religion-system';
 import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
-import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast, getBeastTrophyGoldPerTurn, isCivUnitInBeastTerritory } from '@/systems/beast-system';
+import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast, isCivUnitInBeastTerritory } from '@/systems/beast-system';
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS, getBeastDefinitionByUnitType } from '@/systems/beast-definitions';
 import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
-import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
-import { showBeastSlayCeremony } from '@/ui/beast-slay-ceremony';
 import { createBestiaryPanel } from '@/ui/bestiary-panel';
 import {
   autoSave,
@@ -264,6 +262,7 @@ import { registerWonderPresentation } from '@/presentation/register-wonder-prese
 import { registerCityPresentation } from '@/presentation/register-city-presentation';
 import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
 import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
+import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -429,6 +428,8 @@ const presentationContext: PresentationContext = {
   requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
   applyCombatVisual: result => renderLoop.applyCombatVisual(result),
   showEspionageCaptureChoice: (spyId, spyOwner) => showEspionageCaptureChoice(spyId, spyOwner),
+  uiLayer,
+  maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
 };
 
 // --- Resize ---
@@ -4365,89 +4366,7 @@ bus.on('city:sacked', ({ cityId, source, goldLost }) => {
   );
 });
 
-bus.on('beast:awakened', ({ beastId, position }) => {
-  const def = BEAST_DEFINITIONS[beastId];
-  for (const [civId, civ] of Object.entries(session.getState().civilizations)) {
-    if (!civ.visibility || getVisibility(civ.visibility, position) === 'unexplored') continue;
-    appendToCivLog(civId, def.awakeningFlavor, 'warning', { kind: 'map', coord: position, label: `${def.name} lair` });
-  }
-});
-
-bus.on('beast:slain', ({ beastId, lairId, slayerCivId, goldAwarded }) => {
-  const def = BEAST_DEFINITIONS[beastId];
-  const slayerName = session.getState().civilizations[slayerCivId]?.name ?? slayerCivId;
-  const isApex = def.tier >= 4;
-  const isChoiceTier = def.tier >= 2 && !isApex;
-  for (const civId of Object.keys(session.getState().civilizations)) {
-    const slayerMsg = isApex
-      ? `Your forces have slain the ${def.name}! The apex hoard is yours — gold, lore, trophy, and legend.`
-      : isChoiceTier
-        ? `Your forces have slain the ${def.name}! Choose your reward.`
-        : `Your forces have slain the ${def.name}! Hoard claimed: +${goldAwarded} gold.`;
-    const message = civId === slayerCivId ? slayerMsg : `${slayerName} has slain the ${def.name}!`;
-    appendToCivLog(civId, message, civId === slayerCivId ? 'success' : 'info');
-  }
-  if (slayerCivId === session.getState().currentPlayer) {
-    if (def.tier >= 3) {
-      let rewardLines: string[];
-      if (isApex) {
-        const trophyGold = getBeastTrophyGoldPerTurn(def.tier);
-        rewardLines = [
-          `+${goldAwarded} gold`,
-          'Ancient Lore claimed (+research)',
-          `Beast Trophy raised (+${trophyGold} gold/turn)`,
-          'Your hero is now Legendary',
-        ];
-      } else {
-        const preview = getHoardChoicePreview(session.getState(), lairId);
-        rewardLines = [
-          'Choose one reward:',
-          `Gold: +${preview.gold}`,
-          `Lore: +${preview.lore} research`,
-          `Trophy: +${preview.trophyGoldPerTurn} gold/turn`,
-        ];
-      }
-      showBeastSlayCeremony(uiLayer, {
-        beastName: def.name,
-        unitType: def.unitType,
-        slayerName,
-        rewardLines,
-        onContinue: () => { if (!isApex) maybeShowPendingHoardChoice(); },
-      });
-    }
-    // #551: the tier<3 case's toast used to be a separate showNotification
-    // call here, duplicating the delivery-contract message the appendToCivLog
-    // loop above already sent to slayerCivId. Removed; the loop's message
-    // ("Hoard claimed: +N gold" / "Choose your reward.") is the single
-    // delivery for this event now.
-  }
-});
-
-bus.on('beast:hoard-claimed', ({ beastId, civId, choice }) => {
-  const def = BEAST_DEFINITIONS[beastId];
-  let message: string;
-  if (choice === 'gold') message = `You took the Gold Hoard of the ${def.name}.`;
-  else if (choice === 'lore') message = `You claimed the Ancient Lore of the ${def.name}.`;
-  else message = `You raised a ${def.name} Trophy.`;
-  appendToCivLog(civId, message, 'success');
-});
-
-bus.on('beast:sighted', ({ beastId, civId }) => {
-  const def = BEAST_DEFINITIONS[beastId];
-  const beasts = session.getState().beasts;
-  const lair = beasts ? Object.values(beasts.lairs).find(l => l.beastId === beastId) : undefined;
-  const target = lair ? { kind: 'map' as const, coord: lair.position, label: def.name } : undefined;
-  appendToCivLog(civId, def.sightingFlavor, 'info', target);
-  if (civId === session.getState().currentPlayer) {
-    showBeastSightingBanner(uiLayer, {
-      name: def.name,
-      flavor: def.sightingFlavor,
-      unitType: def.unitType,
-      onContinue: () => {},
-      onOpenBestiary: () => openBestiary(),
-    });
-  }
-});
+registerBeastPresentation(bus, presentationContext);
 
 registerMinorCivNotificationListeners(bus, () => session.getState(), { appendToCivLog });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, findPath } from '@/systems/unit-system';
 import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owner-kind';
-import { BUILDINGS, getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
+import { getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
 import { civHasAirDefenseCoverage } from '@/systems/air-defense-system';
 import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
 import { usePropagandistAction } from '@/systems/propagandist-system';
@@ -229,10 +229,8 @@ import {
 import {
   routeBarbarianSpawned,
   routeCombatRewardEarned,
-  routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
   routeFactionTransition,
-  routeTerritoryTileFlipped,
   TREATY_LABELS,
   routeStrategicWarning,
   routeCrisisStarted,
@@ -275,6 +273,7 @@ import { registerTradePresentation } from '@/presentation/register-trade-present
 import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
 import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
 import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
+import { registerCityPresentation } from '@/presentation/register-city-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -4262,50 +4261,7 @@ function showEspionageCaptureChoice(spyId: string, spyOwner: string): void {
 }
 
 // --- Event listeners ---
-bus.on('tech:completed', ({ civId, techId }) => {
-  appendToCivLog(civId, `Research complete: ${techId}!`, 'success');
-  if (techId === 'fishing') {
-    appendToCivLog(civId, 'Fishing unlocked — build a Dock in your coastal cities to boost food and trade.', 'info');
-  }
-  if (civId === session.getState().currentPlayer) SFX.research();
-});
-
-bus.on('city:grew', ({ cityId, newPopulation }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  appendToCivLog(city.owner, `${city.name} grew to ${newPopulation} population!`, 'success');
-});
-
-bus.on('city:maturity-upgraded', ({ cityId, current }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  const label = `${current[0].toUpperCase()}${current.slice(1)}`;
-  appendToCivLog(city.owner, `${city.name} became a ${label}. New city slots unlocked.`, 'success');
-});
-
-bus.on('city:building-complete', ({ cityId, buildingId }) => {
-  const city = session.getState().cities[cityId];
-  if (!city) return;
-  const bldg = BUILDINGS[buildingId];
-  const buildingName = bldg?.name ?? buildingId;
-  appendToCivLog(city.owner, `${city.name}: ${buildingName} completed!`, 'success');
-  if (bldg?.nationalProject) {
-    SFX.nationalProjectBuilt();
-  }
-});
-
-bus.on('city:national-project-expired', ({ civId, cityId, buildingId }) => {
-  const city = session.getState().cities[cityId];
-  const bldg = BUILDINGS[buildingId];
-  if (!bldg || !city) return;
-  const msg = document.createTextNode(
-    `${city.name}: ${bldg.name} has expired — your civilization has grown beyond this era's institutions.`
-  );
-  appendToCivLog(civId, msg.textContent ?? '', 'warning');
-  SFX.nationalProjectExpired();
-});
-
-bus.on('city:production-item-dropped', event => routeDroppedProductionItem(session.getState(), event, appendToCivLog));
+registerCityPresentation(bus, presentationContext);
 
 registerNetworkPresentation(bus, presentationContext);
 
@@ -4345,10 +4301,6 @@ registerTradePresentation(bus, presentationContext);
 
 bus.on('combat:reward-earned', ({ reward }) => {
   routeCombatRewardEarned(session.getState(), reward, appendToCivLog);
-});
-
-bus.on('territory:tile-flipped', event => {
-  routeTerritoryTileFlipped(session.getState(), { type: 'territory:tile-flipped', ...event }, appendToCivLog);
 });
 
 bus.on('barbarian:spawned', ({ campId, unitId }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,8 +231,6 @@ import {
   routeCombatRewardEarned,
   TREATY_LABELS,
   routeStrategicWarning,
-  routeSabotageReliefDiscovered,
-  routeCityFlipped,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationCenter } from '@/ui/notification-center';
@@ -265,6 +263,7 @@ import { registerNetworkPresentation } from '@/presentation/register-network-pre
 import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
 import { registerCityPresentation } from '@/presentation/register-city-presentation';
 import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
+import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -429,6 +428,7 @@ const presentationContext: PresentationContext = {
   selection,
   requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
   applyCombatVisual: result => renderLoop.applyCombatVisual(result),
+  showEspionageCaptureChoice: (spyId, spyOwner) => showEspionageCaptureChoice(spyId, spyOwner),
 };
 
 // --- Resize ---
@@ -4466,53 +4466,7 @@ registerReligionPresentation(bus, presentationContext);
 
 // diplomacy:opportunistic-war now lives in registerDiplomacyPresentation (#787 phase 7).
 
-bus.on('espionage:sabotage-relief-discovered', event => {
-  routeSabotageReliefDiscovered(session.getState(), event, appendToCivLog);
-});
-
-bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {
-  const label = wasDisguised ? 'A disguised unit' : 'An enemy spy';
-  appendToCivLog(
-    detectingCivId,
-    `${label} from ${spyOwner} was spotted near (${position.q}, ${position.r}).`,
-    'warning',
-  );
-});
-
-bus.on('espionage:spy-caught-infiltrating', ({ capturingCivId, spyOwner, spyId, cityId }) => {
-  const spy = session.getState().espionage?.[spyOwner]?.spies[spyId];
-  const city = session.getState().cities[cityId];
-  const captor = session.getState().civilizations[capturingCivId]?.name ?? capturingCivId;
-  appendToCivLog(
-    spyOwner,
-    `${spy?.name ?? 'Your spy'} was caught by ${captor} trying to infiltrate ${city?.name ?? 'an enemy city'}!`,
-    'warning',
-  );
-  // Captor side: show verdict choice only when the human captor is currently active
-  if (capturingCivId === session.getState().currentPlayer) {
-    showEspionageCaptureChoice(spyId, spyOwner);
-  }
-});
-
-// Show verdict choice when human player captures a spy during a mission
-bus.on('espionage:spy-captured', ({ capturingCivId, spyOwner, spyId }) => {
-  if (capturingCivId === session.getState().currentPlayer) {
-    showEspionageCaptureChoice(spyId, spyOwner);
-  }
-  // Spy owner always gets a log entry, regardless of who is "current"
-  const spy = session.getState().espionage?.[spyOwner]?.spies[spyId];
-  const captorName = session.getState().civilizations[capturingCivId]?.name ?? capturingCivId;
-  appendToCivLog(spyOwner, `${spy?.name ?? 'Your spy'} was captured by ${captorName}!`, 'warning');
-});
-
-// Notify the spy's owner when they are executed by an AI or human captor
-bus.on('espionage:spy-executed', ({ executingCivId, spyOwner, spyName }) => {
-  appendToCivLog(
-    spyOwner,
-    `${spyName} was executed by ${session.getState().civilizations[executingCivId]?.name ?? 'an enemy'}.`,
-    'warning',
-  );
-});
+registerEspionagePresentation(bus, presentationContext);
 
 bus.on('unit:obsolete', ({ civId, unitType }) => {
   const name = UNIT_DEFINITIONS[unitType]?.name ?? unitType;
@@ -4529,19 +4483,6 @@ bus.on('unit:journey-blocked', ({ unitId, position }) => {
   const type = UNIT_DEFINITIONS[unit.type]?.name ?? unit.type;
   const msg = `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`;
   appendToCivLog(unit.owner, msg, 'warning');
-});
-
-bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
-  appendToCivLog(civId, `${spyName}'s network dissolved — ${unitType} era ended. No diplomatic penalty.`, 'info');
-});
-
-bus.on('espionage:spy-auto-exfiltrated', ({ civId, cityId }) => {
-  const city = session.getState().cities[cityId];
-  appendToCivLog(civId, `Your spy was auto-exfiltrated from ${city?.name ?? 'a city'} after it changed hands.`, 'info');
-});
-
-bus.on('espionage:city-flipped', event => {
-  routeCityFlipped(session.getState(), event, appendToCivLog);
 });
 
 // trade:route-created and trade:route-ended also live in

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -37,6 +37,20 @@ export interface PresentationContext {
    * later phase, not this one.
    */
   readonly showEspionageCaptureChoice: (spyId: string, spyOwner: string) => void;
+  /**
+   * The panel DOM layer, for `src/ui/*` ceremony/banner builders that take a
+   * container element directly (`showBeastSlayCeremony`,
+   * `showBeastSightingBanner`) -- not a concrete service like `RenderLoop`,
+   * the same class of dependency `PanelHost.layer` already exposes.
+   */
+  readonly uiLayer: HTMLElement;
+  /**
+   * Opens the queued beast-hoard-choice panel for the active viewer, if one
+   * is pending. Kept as a callback -- it mutates state via
+   * `session.setStateWithoutRefresh`, emits `beast:hoard-claimed`, and calls
+   * `updateHUD()`, none of which belong in a subscription-wiring registrar.
+   */
+  readonly maybeShowPendingHoardChoice: () => void;
 }
 
 /** Returns a disposer that removes every subscription the registrar added. */

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -51,6 +51,13 @@ export interface PresentationContext {
    * `updateHUD()`, none of which belong in a subscription-wiring registrar.
    */
   readonly maybeShowPendingHoardChoice: () => void;
+  /**
+   * Whether `RoundPresentationGate` is currently suppressing presentation
+   * (e.g. during a hot-seat handoff replay). A narrow callback rather than
+   * the gate instance itself, matching the same DIP boundary as the other
+   * concrete-service callbacks above.
+   */
+  readonly isPresentationSuppressed: () => boolean;
 }
 
 /** Returns a disposer that removes every subscription the registrar added. */

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -1,0 +1,25 @@
+/**
+ * Composes every domain presentation registrar into one install/dispose pair
+ * (#787 phase 7). Replaces 72 module-scope `bus.on(...)` registrations in
+ * `main.ts` that ran once at import and could never unregister -- a latent
+ * leak across a "new game from the pause menu" transition, since nothing
+ * ever called the old handlers' individual unsubscribers.
+ *
+ * Populated incrementally, one registrar per commit; `registerAllPresentation`
+ * itself is added once every domain registrar above it exists.
+ */
+import type { EventBus } from '@/core/event-bus';
+import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
+import type { PanelRouter } from '@/app/panel-router';
+import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+
+export interface PresentationContext {
+  readonly session: GameSession;
+  readonly notifier: Notifier;
+  readonly router: PanelRouter;
+  readonly ceremonies: CeremonyCoordinator;
+  readonly selection: SelectionStore;
+}
+
+/** Returns a disposer that removes every subscription the registrar added. */
+export type PresentationRegistrar = (bus: EventBus, ctx: PresentationContext) => () => void;

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -28,6 +28,15 @@ export interface PresentationContext {
    */
   readonly requestDeliveryVisual: (unitId: string) => void;
   readonly applyCombatVisual: (result: CombatResult) => void;
+  /**
+   * Opens the (multi-step, stateful) espionage capture verdict dialog. Kept
+   * as a callback into `main.ts` rather than moved here -- it mutates state
+   * directly via `session.setStateWithoutRefresh` and touches `renderLoop`,
+   * `bus.emit`, and `showNotification`, none of which belong in a
+   * subscription-wiring registrar. A candidate for its own extraction in a
+   * later phase, not this one.
+   */
+  readonly showEspionageCaptureChoice: (spyId: string, spyOwner: string) => void;
 }
 
 /** Returns a disposer that removes every subscription the registrar added. */

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -4,9 +4,6 @@
  * `main.ts` that ran once at import and could never unregister -- a latent
  * leak across a "new game from the pause menu" transition, since nothing
  * ever called the old handlers' individual unsubscribers.
- *
- * Populated incrementally, one registrar per commit; `registerAllPresentation`
- * itself is added once every domain registrar above it exists.
  */
 import type { EventBus } from '@/core/event-bus';
 import type { CombatResult } from '@/core/types';
@@ -14,6 +11,19 @@ import type { NotificationEntry } from '@/core/notification-log';
 import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
 import type { PanelRouter } from '@/app/panel-router';
 import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
+import { registerEraPresentation } from '@/presentation/register-era-presentation';
+import { registerTradePresentation } from '@/presentation/register-trade-presentation';
+import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
+import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
+import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
+import { registerCityPresentation } from '@/presentation/register-city-presentation';
+import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
+import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
+import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
+import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
+import { registerCombatPresentation } from '@/presentation/register-combat-presentation';
+import { registerGeneralPresentation } from '@/presentation/register-general-presentation';
 
 export interface PresentationContext {
   readonly session: GameSession;
@@ -79,3 +89,34 @@ export interface PresentationContext {
 
 /** Returns a disposer that removes every subscription the registrar added. */
 export type PresentationRegistrar = (bus: EventBus, ctx: PresentationContext) => () => void;
+
+const ALL_REGISTRARS: readonly PresentationRegistrar[] = [
+  registerDiplomacyPresentation,
+  registerEraPresentation,
+  registerTradePresentation,
+  registerReligionPresentation,
+  registerNetworkPresentation,
+  registerWonderPresentation,
+  registerCityPresentation,
+  registerFactionCrisisPresentation,
+  registerEspionagePresentation,
+  registerBeastPresentation,
+  registerRaiderPresentation,
+  registerCombatPresentation,
+  registerGeneralPresentation,
+];
+
+/**
+ * Installs all thirteen domain registrars and returns one disposer that
+ * removes every subscription all of them added. The guard against
+ * double-registration matters concretely: it is what stops AI move replay
+ * and the notification log from firing twice if this were ever installed
+ * more than once (e.g. a future "new game from the pause menu" transition
+ * that doesn't first dispose the previous installation).
+ */
+export const registerAllPresentation: PresentationRegistrar = (bus, ctx) => {
+  const disposers = ALL_REGISTRARS.map(register => register(bus, ctx));
+  return () => {
+    for (const dispose of disposers) dispose();
+  };
+};

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -10,6 +10,7 @@
  */
 import type { EventBus } from '@/core/event-bus';
 import type { CombatResult } from '@/core/types';
+import type { NotificationEntry } from '@/core/notification-log';
 import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
 import type { PanelRouter } from '@/app/panel-router';
 import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
@@ -58,6 +59,22 @@ export interface PresentationContext {
    * concrete-service callbacks above.
    */
   readonly isPresentationSuppressed: () => boolean;
+  /**
+   * `AdvisorSystem`'s two entry points as narrow callbacks rather than the
+   * class instance -- the same DIP boundary as every other concrete-service
+   * field above. `checkAdvisors` reads current state internally (via
+   * `session`), so it takes no arguments.
+   */
+  readonly resetAdvisorMessage: (id: string) => void;
+  readonly checkAdvisors: () => void;
+  /**
+   * The active-viewer's-own-input toast+log path (`main.ts`'s `showNotification`,
+   * a thin wrapper combining `notifier.toast` with a raw log append for the
+   * current player) -- distinct from `notifier.deliver`'s full hot-seat-aware
+   * delivery contract. Reserved for feedback about the active player's own
+   * action, per `.claude/rules/ui-panels.md`'s Notifications section.
+   */
+  readonly showNotification: (message: string, type?: NotificationEntry['type'], target?: NotificationEntry['target']) => void;
 }
 
 /** Returns a disposer that removes every subscription the registrar added. */

--- a/src/presentation/register-all.ts
+++ b/src/presentation/register-all.ts
@@ -9,6 +9,7 @@
  * itself is added once every domain registrar above it exists.
  */
 import type { EventBus } from '@/core/event-bus';
+import type { CombatResult } from '@/core/types';
 import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
 import type { PanelRouter } from '@/app/panel-router';
 import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
@@ -19,6 +20,14 @@ export interface PresentationContext {
   readonly router: PanelRouter;
   readonly ceremonies: CeremonyCoordinator;
   readonly selection: SelectionStore;
+  /**
+   * Narrow renderer-visual callbacks, not a `RenderLoop` import -- only
+   * `trade` (delivery) and `combat` (combat) registrars use these; every
+   * other registrar ignores them, the same way most registrars already
+   * ignore `ceremonies`/`selection`.
+   */
+  readonly requestDeliveryVisual: (unitId: string) => void;
+  readonly applyCombatVisual: (result: CombatResult) => void;
 }
 
 /** Returns a disposer that removes every subscription the registrar added. */

--- a/src/presentation/register-beast-presentation.ts
+++ b/src/presentation/register-beast-presentation.ts
@@ -1,0 +1,101 @@
+/**
+ * Legendary-beast awakening, slaying, hoard-choice, and sighting
+ * notifications (#787 phase 7). Moved verbatim from `main.ts`.
+ */
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { getBeastTrophyGoldPerTurn, getHoardChoicePreview } from '@/systems/beast-system';
+import { getVisibility } from '@/systems/fog-of-war';
+import { showBeastSlayCeremony } from '@/ui/beast-slay-ceremony';
+import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerBeastPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('beast:awakened', ({ beastId, position }) => {
+      const def = BEAST_DEFINITIONS[beastId];
+      for (const [civId, civ] of Object.entries(ctx.session.getState().civilizations)) {
+        if (!civ.visibility || getVisibility(civ.visibility, position) === 'unexplored') continue;
+        ctx.notifier.deliver(civId, def.awakeningFlavor, 'warning', { kind: 'map', coord: position, label: `${def.name} lair` });
+      }
+    }),
+    bus.on('beast:slain', ({ beastId, lairId, slayerCivId, goldAwarded }) => {
+      const state = ctx.session.getState();
+      const def = BEAST_DEFINITIONS[beastId];
+      const slayerName = state.civilizations[slayerCivId]?.name ?? slayerCivId;
+      const isApex = def.tier >= 4;
+      const isChoiceTier = def.tier >= 2 && !isApex;
+      for (const civId of Object.keys(state.civilizations)) {
+        const slayerMsg = isApex
+          ? `Your forces have slain the ${def.name}! The apex hoard is yours — gold, lore, trophy, and legend.`
+          : isChoiceTier
+            ? `Your forces have slain the ${def.name}! Choose your reward.`
+            : `Your forces have slain the ${def.name}! Hoard claimed: +${goldAwarded} gold.`;
+        const message = civId === slayerCivId ? slayerMsg : `${slayerName} has slain the ${def.name}!`;
+        ctx.notifier.deliver(civId, message, civId === slayerCivId ? 'success' : 'info');
+      }
+      if (slayerCivId === state.currentPlayer) {
+        if (def.tier >= 3) {
+          let rewardLines: string[];
+          if (isApex) {
+            const trophyGold = getBeastTrophyGoldPerTurn(def.tier);
+            rewardLines = [
+              `+${goldAwarded} gold`,
+              'Ancient Lore claimed (+research)',
+              `Beast Trophy raised (+${trophyGold} gold/turn)`,
+              'Your hero is now Legendary',
+            ];
+          } else {
+            const preview = getHoardChoicePreview(state, lairId);
+            rewardLines = [
+              'Choose one reward:',
+              `Gold: +${preview.gold}`,
+              `Lore: +${preview.lore} research`,
+              `Trophy: +${preview.trophyGoldPerTurn} gold/turn`,
+            ];
+          }
+          showBeastSlayCeremony(ctx.uiLayer, {
+            beastName: def.name,
+            unitType: def.unitType,
+            slayerName,
+            rewardLines,
+            onContinue: () => { if (!isApex) ctx.maybeShowPendingHoardChoice(); },
+          });
+        }
+        // #551: the tier<3 case's toast used to be a separate showNotification
+        // call here, duplicating the delivery-contract message the loop above
+        // already sent to slayerCivId. Removed; the loop's message ("Hoard
+        // claimed: +N gold" / "Choose your reward.") is the single delivery
+        // for this event now.
+      }
+    }),
+    bus.on('beast:hoard-claimed', ({ beastId, civId, choice }) => {
+      const def = BEAST_DEFINITIONS[beastId];
+      let message: string;
+      if (choice === 'gold') message = `You took the Gold Hoard of the ${def.name}.`;
+      else if (choice === 'lore') message = `You claimed the Ancient Lore of the ${def.name}.`;
+      else message = `You raised a ${def.name} Trophy.`;
+      ctx.notifier.deliver(civId, message, 'success');
+    }),
+    bus.on('beast:sighted', ({ beastId, civId }) => {
+      const state = ctx.session.getState();
+      const def = BEAST_DEFINITIONS[beastId];
+      const beasts = state.beasts;
+      const lair = beasts ? Object.values(beasts.lairs).find(l => l.beastId === beastId) : undefined;
+      const target = lair ? { kind: 'map' as const, coord: lair.position, label: def.name } : undefined;
+      ctx.notifier.deliver(civId, def.sightingFlavor, 'info', target);
+      if (civId === state.currentPlayer) {
+        showBeastSightingBanner(ctx.uiLayer, {
+          name: def.name,
+          flavor: def.sightingFlavor,
+          unitType: def.unitType,
+          onContinue: () => {},
+          onOpenBestiary: () => ctx.router.open('bestiary'),
+        });
+      }
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-city-presentation.ts
+++ b/src/presentation/register-city-presentation.ts
@@ -1,0 +1,61 @@
+/**
+ * Tech completion, city growth/maturity/building/national-project, dropped
+ * production, and territory-flip notifications (#787 phase 7). Moved
+ * verbatim from `main.ts`. `tech:completed` and `territory:tile-flipped`
+ * group here by theme (city/civ progress) despite their own namespaces.
+ */
+import { SFX } from '@/audio/sfx';
+import { BUILDINGS } from '@/systems/city-system';
+import { routeDroppedProductionItem, routeTerritoryTileFlipped } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerCityPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('tech:completed', ({ civId, techId }) => {
+      ctx.notifier.deliver(civId, `Research complete: ${techId}!`, 'success');
+      if (techId === 'fishing') {
+        ctx.notifier.deliver(civId, 'Fishing unlocked — build a Dock in your coastal cities to boost food and trade.', 'info');
+      }
+      if (civId === ctx.session.getState().currentPlayer) SFX.research();
+    }),
+    bus.on('city:grew', ({ cityId, newPopulation }) => {
+      const city = ctx.session.getState().cities[cityId];
+      if (!city) return;
+      ctx.notifier.deliver(city.owner, `${city.name} grew to ${newPopulation} population!`, 'success');
+    }),
+    bus.on('city:maturity-upgraded', ({ cityId, current }) => {
+      const city = ctx.session.getState().cities[cityId];
+      if (!city) return;
+      const label = `${current[0].toUpperCase()}${current.slice(1)}`;
+      ctx.notifier.deliver(city.owner, `${city.name} became a ${label}. New city slots unlocked.`, 'success');
+    }),
+    bus.on('city:building-complete', ({ cityId, buildingId }) => {
+      const city = ctx.session.getState().cities[cityId];
+      if (!city) return;
+      const bldg = BUILDINGS[buildingId];
+      const buildingName = bldg?.name ?? buildingId;
+      ctx.notifier.deliver(city.owner, `${city.name}: ${buildingName} completed!`, 'success');
+      if (bldg?.nationalProject) {
+        SFX.nationalProjectBuilt();
+      }
+    }),
+    bus.on('city:national-project-expired', ({ civId, cityId, buildingId }) => {
+      const city = ctx.session.getState().cities[cityId];
+      const bldg = BUILDINGS[buildingId];
+      if (!bldg || !city) return;
+      const msg = document.createTextNode(
+        `${city.name}: ${bldg.name} has expired — your civilization has grown beyond this era's institutions.`,
+      );
+      ctx.notifier.deliver(civId, msg.textContent ?? '', 'warning');
+      SFX.nationalProjectExpired();
+    }),
+    bus.on('city:production-item-dropped', event => routeDroppedProductionItem(ctx.session.getState(), event, ctx.notifier.deliver)),
+    bus.on('territory:tile-flipped', event => {
+      routeTerritoryTileFlipped(ctx.session.getState(), { type: 'territory:tile-flipped', ...event }, ctx.notifier.deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-combat-presentation.ts
+++ b/src/presentation/register-combat-presentation.ts
@@ -1,0 +1,42 @@
+/**
+ * Combat resolution, combat rewards, unit obsolescence, and blocked-journey
+ * notifications (#787 phase 7). Moved verbatim from `main.ts`.
+ */
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { handleCombatResolvedEvent } from '@/ui/combat-resolved-presentation';
+import { routeCombatRewardEarned } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerCombatPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('combat:resolved', event => {
+      handleCombatResolvedEvent(ctx.session.getState(), event, {
+        isPresentationSuppressed: () => ctx.isPresentationSuppressed(),
+        applyVisual: result => ctx.applyCombatVisual(result),
+        appendNotification: ctx.notifier.deliver,
+      });
+    }),
+    bus.on('combat:reward-earned', ({ reward }) => {
+      routeCombatRewardEarned(ctx.session.getState(), reward, ctx.notifier.deliver);
+    }),
+    bus.on('unit:obsolete', ({ civId, unitType }) => {
+      const name = UNIT_DEFINITIONS[unitType]?.name ?? unitType;
+      ctx.notifier.deliver(civId, `Your ${name} is now obsolete — upgrade it in your home city.`, 'info');
+    }),
+    bus.on('unit:journey-blocked', ({ unitId, position }) => {
+      // #551: recipient is the unit's actual owner, not whoever currentPlayer
+      // happens to be at emit time -- the old showNotification call leaked this
+      // to the wrong hot-seat player. Skip entirely if the unit is gone rather
+      // than falling back to currentPlayer.
+      const unit = ctx.session.getState().units[unitId];
+      if (!unit) return;
+      const type = UNIT_DEFINITIONS[unit.type]?.name ?? unit.type;
+      const msg = `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`;
+      ctx.notifier.deliver(unit.owner, msg, 'warning');
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-diplomacy-presentation.ts
+++ b/src/presentation/register-diplomacy-presentation.ts
@@ -1,0 +1,50 @@
+/**
+ * War, peace, treaties, first contact, and opportunistic-war reputation
+ * notifications (#787 phase 7). Moved verbatim from `main.ts`'s module-scope
+ * `bus.on(...)` block; the routing logic itself (`route*` functions) is
+ * untouched.
+ */
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import {
+  routeWarDeclared,
+  routeTreatyProposed,
+  routeFirstContact,
+  routePeaceRequested,
+  routePeaceMade,
+  routeOpportunisticWar,
+} from '@/ui/notification-routing';
+
+export const registerDiplomacyPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
+      routeWarDeclared(ctx.session.getState(), attackerId, defenderId, ctx.notifier.deliver);
+    }),
+    bus.on('diplomacy:treaty-proposed', event => {
+      routeTreatyProposed(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('civilization:first-contact', ({ civA, civB }) => {
+      // #551: routeFirstContact's sink is the delivery contract, which already
+      // queues to pendingEvents for a non-active hot-seat recipient -- the old
+      // unconditional queueFirstContactPendingEvents call was a second, always-on
+      // queue that leaked stale growth into solo saves (which never drain it).
+      routeFirstContact(ctx.session.getState(), civA, civB, ctx.notifier.deliver);
+    }),
+    bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {
+      // #551: routePeaceRequested already delivers to toCivId via appendToCivLog
+      // (the delivery contract) -- the old extra showNotification here duplicated
+      // the message AND leaked it to whoever currentPlayer was at emit time
+      // instead of the actual recipient.
+      routePeaceRequested(ctx.session.getState(), fromCivId, toCivId, ctx.notifier.deliver);
+    }),
+    bus.on('diplomacy:peace-made', ({ civA, civB }) => {
+      routePeaceMade(ctx.session.getState(), civA, civB, ctx.notifier.deliver);
+    }),
+    bus.on('diplomacy:opportunistic-war', event => {
+      routeOpportunisticWar(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-era-presentation.ts
+++ b/src/presentation/register-era-presentation.ts
@@ -1,0 +1,33 @@
+/**
+ * World-era and per-civ personal-era-advance notifications (#787 phase 7).
+ * Moved verbatim from `main.ts`; the routing logic itself (`routeEraAdvanced`)
+ * is untouched.
+ */
+import { SFX } from '@/audio/sfx';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import { routeEraAdvanced } from '@/ui/notification-routing';
+
+export const registerEraPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('era:advanced', ({ era }) => {
+      const humanCivIds = Object.entries(ctx.session.getState().civilizations)
+        .filter(([, civ]) => civ.isHuman)
+        .map(([civId]) => civId);
+      routeEraAdvanced(era, humanCivIds, ctx.notifier.deliver);
+    }),
+    bus.on('civilization:era-advanced', ({ civId, era }) => {
+      const civ = ctx.session.getState().civilizations[civId];
+      if (!civ?.isHuman) return;
+      ctx.notifier.deliver(
+        civId,
+        `${civ.name} has entered Era ${era}. Your technology now sets your civilization's era.`,
+        'success',
+      );
+      if (civId === ctx.session.getState().currentPlayer) SFX.notification();
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-espionage-presentation.ts
+++ b/src/presentation/register-espionage-presentation.ts
@@ -1,0 +1,72 @@
+/**
+ * Spy detection, capture, execution, expiry, and city-flip notifications
+ * (#787 phase 7). Moved verbatim from `main.ts`. The capture verdict dialog
+ * itself (`showEspionageCaptureChoice`) stays a `main.ts`-local function --
+ * see `PresentationContext`'s doc comment for why.
+ */
+import { routeCityFlipped, routeSabotageReliefDiscovered } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerEspionagePresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('espionage:sabotage-relief-discovered', event => {
+      routeSabotageReliefDiscovered(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {
+      const label = wasDisguised ? 'A disguised unit' : 'An enemy spy';
+      ctx.notifier.deliver(
+        detectingCivId,
+        `${label} from ${spyOwner} was spotted near (${position.q}, ${position.r}).`,
+        'warning',
+      );
+    }),
+    bus.on('espionage:spy-caught-infiltrating', ({ capturingCivId, spyOwner, spyId, cityId }) => {
+      const state = ctx.session.getState();
+      const spy = state.espionage?.[spyOwner]?.spies[spyId];
+      const city = state.cities[cityId];
+      const captor = state.civilizations[capturingCivId]?.name ?? capturingCivId;
+      ctx.notifier.deliver(
+        spyOwner,
+        `${spy?.name ?? 'Your spy'} was caught by ${captor} trying to infiltrate ${city?.name ?? 'an enemy city'}!`,
+        'warning',
+      );
+      // Captor side: show verdict choice only when the human captor is currently active
+      if (capturingCivId === state.currentPlayer) {
+        ctx.showEspionageCaptureChoice(spyId, spyOwner);
+      }
+    }),
+    // Show verdict choice when human player captures a spy during a mission
+    bus.on('espionage:spy-captured', ({ capturingCivId, spyOwner, spyId }) => {
+      const state = ctx.session.getState();
+      if (capturingCivId === state.currentPlayer) {
+        ctx.showEspionageCaptureChoice(spyId, spyOwner);
+      }
+      // Spy owner always gets a log entry, regardless of who is "current"
+      const spy = state.espionage?.[spyOwner]?.spies[spyId];
+      const captorName = state.civilizations[capturingCivId]?.name ?? capturingCivId;
+      ctx.notifier.deliver(spyOwner, `${spy?.name ?? 'Your spy'} was captured by ${captorName}!`, 'warning');
+    }),
+    // Notify the spy's owner when they are executed by an AI or human captor
+    bus.on('espionage:spy-executed', ({ executingCivId, spyOwner, spyName }) => {
+      ctx.notifier.deliver(
+        spyOwner,
+        `${spyName} was executed by ${ctx.session.getState().civilizations[executingCivId]?.name ?? 'an enemy'}.`,
+        'warning',
+      );
+    }),
+    bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
+      ctx.notifier.deliver(civId, `${spyName}'s network dissolved — ${unitType} era ended. No diplomatic penalty.`, 'info');
+    }),
+    bus.on('espionage:spy-auto-exfiltrated', ({ civId, cityId }) => {
+      const city = ctx.session.getState().cities[cityId];
+      ctx.notifier.deliver(civId, `Your spy was auto-exfiltrated from ${city?.name ?? 'a city'} after it changed hands.`, 'info');
+    }),
+    bus.on('espionage:city-flipped', event => {
+      routeCityFlipped(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-faction-crisis-presentation.ts
+++ b/src/presentation/register-faction-crisis-presentation.ts
@@ -16,13 +16,23 @@ import {
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
   routeEconomyTreasuryStrain,
+  type NotificationSink,
 } from '@/ui/notification-routing';
 
 export const registerFactionCrisisPresentation: PresentationRegistrar = (bus, ctx) => {
   // #551: routeFactionTransition already delivers via the delivery contract, which
   // queues to pendingEvents for a non-active hot-seat recipient -- no separate
   // collectEvent call needed here.
-  const deliver = ctx.notifier.deliver;
+  //
+  // Wrapped in a closure rather than hoisted as `const deliver = ctx.notifier.deliver`:
+  // `ctx.notifier` is a getter backed by a `let` in main.ts that's only assigned
+  // once `init()` runs, but this registrar is installed at module scope before
+  // `init()` ever executes. Capturing the property directly here dereferenced
+  // `ctx.notifier` (undefined at that point) immediately at registration time,
+  // crashing every load with "Cannot read properties of undefined (reading
+  // 'deliver')" -- caught by CI's web-smoke e2e run, not by the vitest suite,
+  // since `makePresentationContext` always supplies a real `notifier` up front.
+  const deliver: NotificationSink = (...args) => ctx.notifier.deliver(...args);
 
   const unsubscribers = [
     bus.on('faction:unrest-started', event => {

--- a/src/presentation/register-faction-crisis-presentation.ts
+++ b/src/presentation/register-faction-crisis-presentation.ts
@@ -1,0 +1,79 @@
+/**
+ * Faction unrest/revolt/breakaway, crisis lifecycle, and treasury-strain
+ * notifications (#787 phase 7). Moved verbatim from `main.ts`; the routing
+ * logic itself is untouched. `economy:treasury-strain` groups here by theme
+ * (empire-pressure notifications) despite its own namespace.
+ */
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import {
+  routeFactionTransition,
+  routeCrisisStarted,
+  routeCrisisSpread,
+  routeCrisisEscalated,
+  routeCrisisResolved,
+  routeWorldPressureCrisisStarted,
+  routeWorldPressureCrisisResolved,
+  routeCrisisFoeHuntedByAlly,
+  routeCrisisAidSent,
+  routeEconomyTreasuryStrain,
+} from '@/ui/notification-routing';
+
+export const registerFactionCrisisPresentation: PresentationRegistrar = (bus, ctx) => {
+  // #551: routeFactionTransition already delivers via the delivery contract, which
+  // queues to pendingEvents for a non-active hot-seat recipient -- no separate
+  // collectEvent call needed here.
+  const deliver = ctx.notifier.deliver;
+
+  const unsubscribers = [
+    bus.on('faction:unrest-started', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:unrest-started', ...event }, deliver);
+    }),
+    bus.on('faction:revolt-started', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:revolt-started', ...event }, deliver);
+    }),
+    bus.on('faction:unrest-resolved', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:unrest-resolved', ...event }, deliver);
+    }),
+    bus.on('faction:concession-made', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:concession-made', ...event }, deliver);
+    }),
+    bus.on('faction:breakaway-started', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:breakaway-started', ...event }, deliver);
+    }),
+    bus.on('faction:breakaway-established', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:breakaway-established', ...event }, deliver);
+    }),
+    bus.on('faction:critical-status', event => {
+      routeFactionTransition(ctx.session.getState(), { type: 'faction:critical-status', ...event }, deliver);
+    }),
+    bus.on('crisis:started', event => {
+      routeCrisisStarted(ctx.session.getState(), event, deliver);
+      routeWorldPressureCrisisStarted(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('crisis:spread', event => {
+      routeCrisisSpread(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('crisis:escalated', event => {
+      routeCrisisEscalated(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('crisis:resolved', event => {
+      routeCrisisResolved(ctx.session.getState(), event, deliver);
+      routeWorldPressureCrisisResolved(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('crisis:foe-hunted-by-ally', event => {
+      routeCrisisFoeHuntedByAlly(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('crisis:aid-sent', event => {
+      routeCrisisAidSent(ctx.session.getState(), event, deliver);
+    }),
+    bus.on('economy:treasury-strain', event => {
+      // #551: routeEconomyTreasuryStrain already delivers to event.civId via the
+      // delivery contract -- no extra showNotification needed here.
+      routeEconomyTreasuryStrain(ctx.session.getState(), event, deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-general-presentation.ts
+++ b/src/presentation/register-general-presentation.ts
@@ -1,0 +1,33 @@
+/**
+ * General-notification bucket for events that don't cleanly fit any of the
+ * other domain registrars (#787 phase 7): village-visit outcomes, advisor
+ * toasts, and AI strategic warnings. Moved verbatim from `main.ts`.
+ */
+import { routeStrategicWarning } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerGeneralPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('village:visited', ({ civId, outcome, message }) => {
+      if (outcome === 'gold') ctx.resetAdvisorMessage('treasurer_village_gold');
+      if (outcome === 'science') ctx.resetAdvisorMessage('scholar_village_science');
+      if (outcome === 'free_tech') ctx.resetAdvisorMessage('scholar_village_tech');
+      ctx.checkAdvisors();
+      ctx.notifier.deliver(civId, message, outcome === 'ambush' || outcome === 'illness' ? 'warning' : 'success');
+    }),
+    // viewer-scoped by design: advisors run for the active player only (#551).
+    bus.on('advisor:message', ({ advisor, message, icon }) => {
+      ctx.showNotification(`${icon} ${message}`, 'info');
+    }),
+    bus.on('ai:strategic-warning', event => {
+      // #551: notifier.deliver (the delivery contract) already queues to
+      // pendingEvents for a non-active hot-seat recipient -- no separate
+      // queueStrategicWarningPendingEvent call needed here.
+      routeStrategicWarning(event, ctx.notifier.deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-network-presentation.ts
+++ b/src/presentation/register-network-presentation.ts
@@ -1,0 +1,67 @@
+/**
+ * Cyber-drain and network-exploit notifications, plus the shared
+ * `network:audio-cue` handler both exploit events emit into (#787 phase 7).
+ * Moved verbatim from `main.ts`. `city:cyber-drained` groups here by theme
+ * (network/cyber attacks) despite its `city:` namespace prefix.
+ */
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import { getNetworkWarningForViewer } from '@/systems/network-viewer-intel';
+
+export const registerNetworkPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('city:cyber-drained', ({ cityName, drainerOwner, goldLost, blocked, victimCivId }) => {
+      const state = ctx.session.getState();
+      const drainerName = state.civilizations[drainerOwner]?.name ?? drainerOwner;
+      const victimName = state.civilizations[victimCivId]?.name ?? victimCivId;
+      if (blocked) {
+        ctx.notifier.deliver(victimCivId, `Cyber Defense Center blocked an intrusion in ${cityName}.`, 'success');
+        ctx.notifier.deliver(drainerOwner, `Cyber attack on ${cityName} was blocked by ${victimName}'s Cyber Defense Center.`, 'warning');
+        return;
+      }
+      ctx.notifier.deliver(victimCivId, `Cyber attack: ${cityName} lost ${goldLost} gold (${drainerName} cyber unit).`, 'warning');
+      ctx.notifier.deliver(drainerOwner, `Cyber unit stole ${goldLost} gold from ${victimName}'s ${cityName}.`, 'success');
+    }),
+    bus.on('network:exploit-warning', ({ planId, victimCivId, cityId }) => {
+      const state = ctx.session.getState();
+      const warning = getNetworkWarningForViewer(state, victimCivId, planId);
+      const city = state.cities[cityId];
+      if (!warning || !city) return;
+      const disclosure = warning.source?.unitId
+        ? ' The source has been identified.'
+        : warning.source?.position
+          ? ' The source position has been detected.'
+          : '';
+      ctx.notifier.deliver(
+        victimCivId,
+        `Network exploit warning: ${city.name} will be targeted at the end of this turn. A Cyber Defense Center or Harden reduces the effect.${disclosure}`,
+        'warning',
+        { kind: 'map', coord: city.position, label: city.name },
+      );
+      bus.emit('network:audio-cue', { cue: 'hostile-warning', viewerIds: [victimCivId] });
+    }),
+    bus.on('network:exploit-resolved', ({ cityId, ownerCivId, goldTransferred, delayed }) => {
+      const state = ctx.session.getState();
+      const city = state.cities[cityId];
+      if (!city) return;
+      if (delayed) {
+        ctx.notifier.deliver(city.owner, `${city.name}'s Cyber Defense Center delayed a network exploit.`, 'success');
+        ctx.notifier.deliver(ownerCivId, `Your network exploit against ${city.name} was delayed by its Cyber Defense Center.`, 'warning');
+        return;
+      }
+      ctx.notifier.deliver(city.owner, `Network exploit: ${city.name} lost ${goldTransferred} gold.`, 'warning');
+      ctx.notifier.deliver(ownerCivId, `Network exploit transferred ${goldTransferred} gold from ${city.name}.`, 'success');
+      bus.emit('network:audio-cue', { cue: 'hostile-consequence', viewerIds: [city.owner, ownerCivId] });
+    }),
+    bus.on('network:audio-cue', ({ cue, viewerIds }) => {
+      if (cue === 'constructive-resolution') {
+        ctx.notifier.deliver(viewerIds[0]!, 'Stable network plan milestone reached: three resolutions recorded.', 'success');
+      } else if (cue === 'recovery') {
+        ctx.notifier.deliver(viewerIds[0]!, 'Network recovery complete.', 'success');
+      }
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-raider-presentation.ts
+++ b/src/presentation/register-raider-presentation.ts
@@ -1,0 +1,90 @@
+/**
+ * Barbarian and pirate raider notifications (#787 phase 7). Moved verbatim
+ * from `main.ts`. Owns `notifiedBarbarianCampsPerCiv` -- per-civ dedup so a
+ * civ sees a "raiders spotted!" entry only the first time its visibility
+ * covers any raider from a given camp.
+ */
+import { SFX } from '@/audio/sfx';
+import { isVisible } from '@/systems/fog-of-war';
+import { routeBarbarianSpawned } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerRaiderPresentation: PresentationRegistrar = (bus, ctx) => {
+  const notifiedBarbarianCampsPerCiv = new Map<string, Set<string>>();
+
+  const unsubscribers = [
+    bus.on('barbarian:spawned', ({ campId, unitId }) => {
+      const unit = ctx.session.getState().units[unitId];
+      if (!unit) return;
+      routeBarbarianSpawned(
+        ctx.session.getState(),
+        unit.position,
+        campId,
+        notifiedBarbarianCampsPerCiv,
+        ctx.notifier.deliver,
+        (vis, pos) => isVisible(vis as Parameters<typeof isVisible>[0], pos),
+      );
+    }),
+    bus.on('threat:barbarian-resurgence', ({ civId, isBanditLord, banditLordName }) => {
+      const message = isBanditLord
+        ? `${banditLordName ?? 'A bandit lord'} has united the raiders and threatens your lands!`
+        : 'Barbarian forces are resurgent on your lands!';
+      ctx.notifier.deliver(civId, message, 'warning');
+      SFX.barbarianResurgence?.();
+    }),
+    bus.on('barbarian:city-attacked', ({ cityId, hpLost }) => {
+      const state = ctx.session.getState();
+      const city = state.cities[cityId];
+      if (!city) return;
+      if (!state.civilizations[city.owner]?.isHuman) return;
+      ctx.notifier.deliver(city.owner, `Barbarians attack ${city.name}! (−${hpLost} HP)`, 'warning');
+    }),
+    bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
+      const state = ctx.session.getState();
+      if (!state.civilizations[ownerId]?.isHuman) return;
+      const cityName = state.cities[cityId]?.name ?? 'A city';
+      ctx.notifier.deliver(ownerId, `${cityName} was destroyed by barbarian raiders!`, 'warning');
+    }),
+    // A walled, ungarrisoned city fighting back against a besieger (#522) -- covers BOTH
+    // the barbarian (turn-manager.ts) and pirate (pirate-system.ts) counter-fire call
+    // sites, since both emit this same shared event with their respective 'source' value.
+    bus.on('city:counter-fire', ({ cityId, source, damage, attackerDied }) => {
+      const state = ctx.session.getState();
+      const city = state.cities[cityId];
+      if (!city) return;
+      if (!state.civilizations[city.owner]?.isHuman) return;
+      const raiderLabel = source === 'barbarian' ? 'raider' : 'ship';
+      const message = attackerDied
+        ? `${city.name}'s defenses destroyed a ${source === 'barbarian' ? 'barbarian raider' : 'pirate ship'}!`
+        : `${city.name}'s walls fought back, damaging a ${raiderLabel} (−${damage} HP)!`;
+      ctx.notifier.deliver(city.owner, message, attackerDied ? 'success' : 'info');
+    }),
+    // Pirate-faction naval siege (#522) mirror of the barbarian handler above.
+    bus.on('pirate:city-destroyed', ({ cityId, ownerId }) => {
+      const state = ctx.session.getState();
+      if (!state.civilizations[ownerId]?.isHuman) return;
+      const cityName = state.cities[cityId]?.name ?? 'A coastal city';
+      ctx.notifier.deliver(ownerId, `${cityName} was razed by pirates!`, 'warning');
+    }),
+    // A sacked city survives the raid at 1 HP — phrased distinctly from outright
+    // destruction so a recoverable loss is never mistaken for a permanent one. Both
+    // barbarians (turn-manager.ts) and pirates (pirate-system.ts, #522) route through
+    // this shared event with their respective 'source' value.
+    bus.on('city:sacked', ({ cityId, source, goldLost }) => {
+      const state = ctx.session.getState();
+      const city = state.cities[cityId];
+      if (!city) return;
+      if (!state.civilizations[city.owner]?.isHuman) return;
+      const raiders = source === 'barbarian' ? 'Barbarian raiders' : 'Pirates';
+      ctx.notifier.deliver(
+        city.owner,
+        `${raiders} have sacked ${city.name}! The city survives at 1 HP, but ${goldLost} gold was looted.`,
+        'warning',
+      );
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-religion-presentation.ts
+++ b/src/presentation/register-religion-presentation.ts
@@ -1,0 +1,33 @@
+/**
+ * Religion founding, conversion, loyalty-pressure, and defection
+ * notifications (#787 phase 7). Moved verbatim from `main.ts`; the routing
+ * logic itself is untouched.
+ */
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import {
+  routeReligionFounded,
+  routeReligionCityConverted,
+  routeLoyaltyWarning,
+  routeCityDefected,
+} from '@/ui/notification-routing';
+
+export const registerReligionPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('religion:founded', event => {
+      routeReligionFounded(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('religion:city-converted', event => {
+      routeReligionCityConverted(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('religion:loyalty-warning', event => {
+      routeLoyaltyWarning(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('religion:city-defected', event => {
+      routeCityDefected(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-trade-presentation.ts
+++ b/src/presentation/register-trade-presentation.ts
@@ -1,0 +1,58 @@
+/**
+ * Trade-route delivery visual, creation, and ending notifications
+ * (#787 phase 7). Moved verbatim from `main.ts`.
+ */
+import type { PresentationRegistrar } from '@/presentation/register-all';
+import { getEffectiveGoldPerTurn, getRouteTechGoldBonus } from '@/systems/trade-system';
+
+export const registerTradePresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('trade:route-delivered', ({ unitId }) => {
+      ctx.requestDeliveryVisual(unitId);
+    }),
+    bus.on('trade:route-created', ({ route }) => {
+      const state = ctx.session.getState();
+      const ownerCity = state.cities[route.fromCityId];
+      const toCity = state.cities[route.toCityId];
+      if (!ownerCity) return;
+      const goldPerTurn = getEffectiveGoldPerTurn(route, getRouteTechGoldBonus(state, route));
+      ctx.notifier.deliver(
+        ownerCity.owner,
+        `Trade route to ${toCity?.name ?? route.toCityId} established (+${goldPerTurn} gold/turn)`,
+        'success',
+      );
+    }),
+    bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {
+      const state = ctx.session.getState();
+      const ownerCity = state.cities[fromCityId];
+      const toCity = state.cities[toCityId];
+      if (!ownerCity) return;
+      const reasonText: Record<string, string> = {
+        'unit-died': 'caravan destroyed',
+        'unit-disbanded': 'caravan disbanded',
+        'war-declared': 'war declared — caravan is free to redeploy',
+        'hostile-relations': 'hostile relations — caravan is free to redeploy',
+        embargo: 'embargo enforced — caravan is free to redeploy',
+        'trips-exhausted': 'caravan retired after completing its service',
+        'unit-captured': 'caravan captured',
+      };
+      ctx.notifier.deliver(
+        ownerCity.owner,
+        `Trade route to ${toCity?.name ?? toCityId} ended: ${reasonText[reason] ?? reason}`,
+        'warning',
+      );
+      // Also tell the other end of the route, if it's a different human civ (#551).
+      if (toCity && toCity.owner !== ownerCity.owner && state.civilizations[toCity.owner]?.isHuman) {
+        ctx.notifier.deliver(
+          toCity.owner,
+          `Trade route from ${ownerCity.name} ended: ${reasonText[reason] ?? reason}`,
+          'warning',
+        );
+      }
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/src/presentation/register-wonder-presentation.ts
+++ b/src/presentation/register-wonder-presentation.ts
@@ -1,0 +1,62 @@
+/**
+ * Natural-wonder discovery and legendary-wonder lifecycle notifications
+ * (#787 phase 7). Delegates ceremony playback to `CeremonyCoordinator`
+ * (#787 phase 6) instead of touching the move-settle defer flag directly.
+ */
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { routeLegendaryWonder } from '@/ui/notification-routing';
+import type { PresentationRegistrar } from '@/presentation/register-all';
+
+export const registerWonderPresentation: PresentationRegistrar = (bus, ctx) => {
+  const unsubscribers = [
+    bus.on('wonder:discovered', event => {
+      const wonderDef = getWonderDefinition(event.wonderId);
+      if (!wonderDef) return;
+      const message = event.isFirstDiscoverer
+        ? `Discovered ${wonderDef.name}! +${wonderDef.discoveryBonus.amount} ${wonderDef.discoveryBonus.type}`
+        : `Found ${wonderDef.name}!`;
+      ctx.notifier.deliver(event.civId, message, event.isFirstDiscoverer ? 'success' : 'info');
+
+      const state = ctx.session.getState();
+      const revealItem = buildWonderDiscoveryRevealItem(state, state.currentPlayer, event);
+      if (revealItem) {
+        ctx.ceremonies.enqueueWonderDiscovery(revealItem);
+      }
+    }),
+    bus.on('wonder:legendary-ready', ({ civId, cityId, wonderId }) => {
+      routeLegendaryWonder(ctx.session.getState(), { type: 'wonder:legendary-ready', civId, cityId, wonderId }, ctx.notifier.deliver);
+    }),
+    bus.on('wonder:legendary-availability', event => {
+      routeLegendaryWonder(ctx.session.getState(), { type: 'wonder:legendary-availability', ...event }, ctx.notifier.deliver);
+    }),
+    bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId, turnCompleted }) => {
+      const event = { civId, cityId, wonderId, turnCompleted };
+      const state = ctx.session.getState();
+      routeLegendaryWonder(state, { type: 'wonder:legendary-completed', ...event }, ctx.notifier.deliver);
+      const ceremonyItem = buildLegendaryWonderCompletionCeremonyItem(state, event);
+      if (ceremonyItem) {
+        ctx.ceremonies.enqueueLegendaryCompletion(ceremonyItem);
+      }
+    }),
+    bus.on('wonder:legendary-lost', ({ civId, cityId, wonderId, goldRefund, transferableProduction }) => {
+      routeLegendaryWonder(
+        ctx.session.getState(),
+        { type: 'wonder:legendary-lost', civId, cityId, wonderId, goldRefund, transferableProduction },
+        ctx.notifier.deliver,
+      );
+    }),
+    bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId }) => {
+      routeLegendaryWonder(
+        ctx.session.getState(),
+        { type: 'wonder:legendary-race-revealed', observerId, civId, cityId, wonderId },
+        ctx.notifier.deliver,
+      );
+    }),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+  };
+};

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -89,5 +89,6 @@ export function makePresentationContext(overrides: {
     // (from a jsdom-enabled test) if a registrar actually touches it.
     uiLayer: overrides.uiLayer ?? ({} as HTMLElement),
     maybeShowPendingHoardChoice: vi.fn(),
+    isPresentationSuppressed: () => false,
   };
 }

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -1,0 +1,83 @@
+import { vi } from 'vitest';
+import type { GameState } from '@/core/types';
+import type { SelectionStore } from '@/app/ports';
+import type { PresentationContext } from '@/presentation/register-all';
+import { NO_LAND_UNIT_WATER_RECOVERY } from '@/systems/unit-water-recovery';
+import type { NotificationSink } from '@/ui/notification-routing';
+
+function makeSelectionStoreDouble(): SelectionStore {
+  return {
+    snapshot: () => ({
+      selectedUnitId: null,
+      waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
+      movementRange: [],
+      attackRange: [],
+      pendingIntent: { kind: 'none' },
+    }),
+    getSelectedUnitId: () => null,
+    setSelectedUnitId: vi.fn(),
+    getWaterRecovery: () => NO_LAND_UNIT_WATER_RECOVERY,
+    setWaterRecovery: vi.fn(),
+    getMovementRange: () => [],
+    getAttackRange: () => [],
+    setRanges: vi.fn(),
+    getPirateSelection: () => ({ factionId: null, historyId: null }),
+    setPirateSelection: vi.fn(),
+    getPendingIntent: () => ({ kind: 'none' }),
+    setPendingIntent: vi.fn(),
+    shouldWarnOnMistap: () => false,
+    clear: vi.fn(),
+  };
+}
+
+/**
+ * A fake `PresentationContext` for the twelve-plus registrar test suites
+ * (#787 phase 7). `deliver` is exposed both standalone and inside `notifier`
+ * so a test can assert on it without reaching through `ctx.notifier.deliver`.
+ */
+export function makePresentationContext(overrides: {
+  state?: Partial<GameState>;
+  deliver?: ReturnType<typeof vi.fn<NotificationSink>>;
+} = {}): PresentationContext & { deliver: ReturnType<typeof vi.fn<NotificationSink>> } {
+  const deliver = overrides.deliver ?? vi.fn<NotificationSink>();
+  const state = {
+    turn: 1,
+    currentPlayer: 'player',
+    civilizations: {},
+    cities: {},
+    units: {},
+    ...overrides.state,
+  } as GameState;
+
+  return {
+    deliver,
+    session: {
+      getState: () => state,
+      commit: vi.fn(),
+      update: vi.fn(),
+      setStateWithoutRefresh: vi.fn(),
+      subscribe: () => () => {},
+    },
+    notifier: {
+      toast: vi.fn(),
+      deliver,
+      choice: vi.fn(),
+      withHappenedTurn: (_turn, fn) => fn(),
+    },
+    router: {
+      toggle: vi.fn(),
+      open: vi.fn(),
+      close: vi.fn(),
+      closeGroup: vi.fn(),
+      isOpen: () => false,
+    },
+    ceremonies: {
+      enqueueWonderDiscovery: vi.fn(),
+      enqueueLegendaryCompletion: vi.fn(),
+      beginDeferredAction: vi.fn(),
+      endAction: vi.fn(),
+      clearForHandoff: vi.fn(),
+    },
+    selection: makeSelectionStoreDouble(),
+  };
+}

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -81,5 +81,6 @@ export function makePresentationContext(overrides: {
     selection: makeSelectionStoreDouble(),
     requestDeliveryVisual: vi.fn(),
     applyCombatVisual: vi.fn(),
+    showEspionageCaptureChoice: vi.fn(),
   };
 }

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -79,5 +79,7 @@ export function makePresentationContext(overrides: {
       clearForHandoff: vi.fn(),
     },
     selection: makeSelectionStoreDouble(),
+    requestDeliveryVisual: vi.fn(),
+    applyCombatVisual: vi.fn(),
   };
 }

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -38,6 +38,7 @@ function makeSelectionStoreDouble(): SelectionStore {
 export function makePresentationContext(overrides: {
   state?: Partial<GameState>;
   deliver?: ReturnType<typeof vi.fn<NotificationSink>>;
+  uiLayer?: HTMLElement;
 } = {}): PresentationContext & { deliver: ReturnType<typeof vi.fn<NotificationSink>> } {
   const deliver = overrides.deliver ?? vi.fn<NotificationSink>();
   const state = {
@@ -82,5 +83,11 @@ export function makePresentationContext(overrides: {
     requestDeliveryVisual: vi.fn(),
     applyCombatVisual: vi.fn(),
     showEspionageCaptureChoice: vi.fn(),
+    // Not `document.createElement` -- most test files that use this helper
+    // don't declare `@vitest-environment jsdom`, and this must stay safe to
+    // call from a plain node environment. Pass a real element explicitly
+    // (from a jsdom-enabled test) if a registrar actually touches it.
+    uiLayer: overrides.uiLayer ?? ({} as HTMLElement),
+    maybeShowPendingHoardChoice: vi.fn(),
   };
 }

--- a/tests/helpers/presentation-context.ts
+++ b/tests/helpers/presentation-context.ts
@@ -90,5 +90,8 @@ export function makePresentationContext(overrides: {
     uiLayer: overrides.uiLayer ?? ({} as HTMLElement),
     maybeShowPendingHoardChoice: vi.fn(),
     isPresentationSuppressed: () => false,
+    resetAdvisorMessage: vi.fn(),
+    checkAdvisors: vi.fn(),
+    showNotification: vi.fn(),
   };
 }

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
 
 const PROJECT_ROOT = resolve(__dirname, '..');
 
@@ -255,59 +254,6 @@ describe('shared city assault wiring', () => {
       'const movement = executeAnimatedUnitMove(',
     );
     expect(minorCaptureFlow).toMatch(/if \(!movement\.ok\) return;/);
-  });
-});
-
-function makeSink() {
-  const calls: Array<{ civId: string; message: string; type: string }> = [];
-  const sink: NotificationSink = (civId, message, type) => calls.push({ civId, message, type });
-  return { sink, calls };
-}
-
-describe('era:advanced notification', () => {
-  it('plays one notification cue for the active human seat when that civilization reaches a personal era', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const handler = main.slice(
-      main.indexOf("bus.on('civilization:era-advanced'"),
-      main.indexOf("bus.on('faction:unrest-started'"),
-    );
-
-    expect(handler).toContain('if (civId === session.getState().currentPlayer) SFX.notification();');
-  });
-
-  it('era 2 delivers to every human civ, with an extra unrest-primer line per civ', () => {
-    const { sink, calls } = makeSink();
-
-    routeEraAdvanced(2, ['p1', 'p2'], sink);
-
-    // Each human civ gets both the era announcement and the era-2 unrest primer.
-    const p1Calls = calls.filter(c => c.civId === 'p1');
-    const p2Calls = calls.filter(c => c.civId === 'p2');
-    expect(p1Calls).toHaveLength(2);
-    expect(p2Calls).toHaveLength(2);
-    expect(p1Calls[0]!.message).toContain('Era 2');
-    expect(p1Calls[0]!.type).toBe('success');
-    expect(p1Calls[1]!.message).toContain('Era 2');
-    expect(p1Calls[1]!.message).toContain('unrest');
-    expect(p1Calls[1]!.type).toBe('info');
-  });
-
-  it('era 3 delivers only the announcement line to each human civ, no unrest primer', () => {
-    const { sink, calls } = makeSink();
-
-    routeEraAdvanced(3, ['p1'], sink);
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]!.civId).toBe('p1');
-    expect(calls[0]!.message).toContain('Era 3');
-  });
-
-  it('delivers to no one when there are no human civs', () => {
-    const { sink, calls } = makeSink();
-
-    routeEraAdvanced(2, [], sink);
-
-    expect(calls).toHaveLength(0);
   });
 });
 

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -139,10 +139,12 @@ describe('completed-round AI wiring', () => {
 
     expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus');
     expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus)');
-    // ai:strategic-warning's real consumer moved to registerGeneralPresentation
-    // (#787 phase 7) -- register-general-presentation.test.ts proves the
-    // registrar itself routes the event; this only proves main.ts installs it.
-    expect(main).toContain('registerGeneralPresentation(bus, presentationContext)');
+    // ai:strategic-warning's real consumer moved to registerGeneralPresentation,
+    // composed into registerAllPresentation (#787 phase 7) --
+    // register-general-presentation.test.ts and register-all.test.ts prove the
+    // registrar itself routes the event and is actually installed; this only
+    // proves main.ts installs the composed set.
+    expect(main).toContain('registerAllPresentation(bus, presentationContext)');
   });
 
   it('emits one warning cue only after the exact rendered handoff summary is acknowledged', () => {

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -60,7 +60,7 @@ describe('player combat wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const executeAttack = main.slice(
       main.indexOf('function executeAttack('),
-      main.indexOf("bus.on('combat:resolved'"),
+      main.indexOf('function restAction('),
     );
 
     expect(executeAttack).toContain(
@@ -72,7 +72,7 @@ describe('player combat wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const executeAttack = main.slice(
       main.indexOf('function executeAttack('),
-      main.indexOf("bus.on('combat:resolved'"),
+      main.indexOf('function restAction('),
     );
     const stateRefresh = executeAttack.indexOf('renderLoop.setGameState(session.getState());');
     const panelRefresh = executeAttack.indexOf('refreshSelectedUnitAfterCombat();');
@@ -139,7 +139,10 @@ describe('completed-round AI wiring', () => {
 
     expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus');
     expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus)');
-    expect(main).toContain("bus.on('ai:strategic-warning'");
+    // ai:strategic-warning's real consumer moved to registerGeneralPresentation
+    // (#787 phase 7) -- register-general-presentation.test.ts proves the
+    // registrar itself routes the event; this only proves main.ts installs it.
+    expect(main).toContain('registerGeneralPresentation(bus, presentationContext)');
   });
 
   it('emits one warning cue only after the exact rendered handoff summary is acknowledged', () => {

--- a/tests/presentation/register-all.test.ts
+++ b/tests/presentation/register-all.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerAllPresentation } from '@/presentation/register-all';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+describe('registerAllPresentation', () => {
+  it('installs every registrar exactly once and disposes them all together', () => {
+    // unit:obsolete's route is a single sink() call, unlike e.g.
+    // diplomacy:war-declared (which legitimately notifies both sides) --
+    // picked deliberately so a double-registration bug shows up as 2 calls,
+    // not as an already-expected 2.
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    const dispose = registerAllPresentation(bus, ctx);
+    bus.emit('unit:obsolete', { civId: 'p1', unitId: 'unit-1', unitType: 'warrior' as never });
+    expect(ctx.deliver).toHaveBeenCalledTimes(1);
+
+    dispose();
+    bus.emit('unit:obsolete', { civId: 'p1', unitId: 'unit-1', unitType: 'warrior' as never });
+    expect(ctx.deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires the last-added registrar too, not just the first (guards an off-by-one composition bug)', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerAllPresentation(bus, ctx);
+    bus.emit('village:visited', { civId: 'p1', position: { q: 0, r: 0 }, outcome: 'gold', message: 'Found gold!' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', 'Found gold!', 'success');
+  });
+
+  it('wires a registrar from the middle of the list too', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerAllPresentation(bus, ctx);
+    bus.emit('espionage:spy-executed', { executingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', spyName: 'Agent X' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('Agent X'), 'warning');
+  });
+
+  it('disposing stops every registrar, not just some', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+    const dispose = registerAllPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('village:visited', { civId: 'p1', position: { q: 0, r: 0 }, outcome: 'gold', message: 'Found gold!' });
+    bus.emit('espionage:spy-executed', { executingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', spyName: 'Agent X' });
+    bus.emit('trade:route-delivered', { unitId: 'unit-1', routeId: 'route-1', toCityId: 'city-1' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-beast-presentation.test.ts
+++ b/tests/presentation/register-beast-presentation.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerBeastPresentation } from '@/presentation/register-beast-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function civ(overrides: { visibility?: { tiles: Record<string, string> } } = {}) {
+  return { visibility: { tiles: {} }, ...overrides };
+}
+
+describe('beast presentation', () => {
+  it('notifies only civs whose visibility covers the awakening tile', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          rome: civ({ visibility: { tiles: { '0,0': 'visible' } } }),
+          carthage: civ({ visibility: { tiles: {} } }),
+        } as never,
+      },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:awakened', { lairId: 'lair-1', beastId: 'giant_boar', position: { q: 0, r: 0 } });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'warning', expect.anything());
+    expect(ctx.deliver).not.toHaveBeenCalledWith('carthage', expect.anything(), expect.anything(), expect.anything());
+  });
+
+  it('announces a low-tier slaying without showing the ceremony', () => {
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: {
+        currentPlayer: 'rome',
+        civilizations: { rome: civ(), carthage: civ() } as never,
+      },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:slain', { beastId: 'giant_boar', lairId: 'lair-1', slayerCivId: 'rome', slayerUnitId: 'unit-1', goldAwarded: 10 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Hoard claimed'), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('slain'), 'info');
+    expect(uiLayer.querySelector('#beast-slay-ceremony')).toBeNull();
+  });
+
+  it('shows the slay ceremony and a reward-choice preview for a tier-3 beast', () => {
+    // tier >= 3 is the ceremony gate; tier 2 ("choice tier") only changes the
+    // log message text ("Choose your reward") and does not show the overlay --
+    // an asymmetry in the original code, preserved verbatim here.
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: {
+        currentPlayer: 'rome',
+        civilizations: { rome: { techState: { completed: [] } } } as never,
+        beasts: { lairs: { 'lair-1': { beastId: 'sea_serpent', position: { q: 0, r: 0 } } } } as never,
+      },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:slain', { beastId: 'sea_serpent', lairId: 'lair-1', slayerCivId: 'rome', slayerUnitId: 'unit-1', goldAwarded: 20 });
+
+    expect(uiLayer.querySelector('#beast-slay-ceremony')).not.toBeNull();
+  });
+
+  it('does not show the ceremony to a non-slayer civ even for a high-tier beast', () => {
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: {
+        currentPlayer: 'carthage',
+        civilizations: { rome: civ(), carthage: civ() } as never,
+        beasts: { lairs: { 'lair-1': { beastId: 'ancient_dragon', position: { q: 0, r: 0 } } } } as never,
+      },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:slain', { beastId: 'ancient_dragon', lairId: 'lair-1', slayerCivId: 'rome', slayerUnitId: 'unit-1', goldAwarded: 50 });
+
+    expect(uiLayer.querySelector('#beast-slay-ceremony')).toBeNull();
+  });
+
+  it('announces a hoard-choice claim', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:hoard-claimed', { lairId: 'lair-1', beastId: 'giant_boar', civId: 'rome', choice: 'lore' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Ancient Lore'), 'success');
+  });
+
+  it('notifies a sighting and shows the banner only to the active viewer', () => {
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: { currentPlayer: 'rome' },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:sighted', { beastId: 'giant_boar', civId: 'rome' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'info', undefined);
+    expect(uiLayer.querySelector('#beast-sighting-banner')).not.toBeNull();
+  });
+
+  it('does not show the sighting banner for a non-active civ', () => {
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: { currentPlayer: 'egypt' },
+    });
+
+    registerBeastPresentation(bus, ctx);
+    bus.emit('beast:sighted', { beastId: 'giant_boar', civId: 'rome' });
+
+    expect(uiLayer.querySelector('#beast-sighting-banner')).toBeNull();
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const uiLayer = document.createElement('div');
+    const ctx = makePresentationContext({
+      uiLayer,
+      state: { currentPlayer: 'rome', civilizations: { rome: civ() } as never },
+    });
+    const dispose = registerBeastPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('beast:awakened', { lairId: 'lair-1', beastId: 'giant_boar', position: { q: 0, r: 0 } });
+    bus.emit('beast:slain', { beastId: 'giant_boar', lairId: 'lair-1', slayerCivId: 'rome', slayerUnitId: 'unit-1', goldAwarded: 10 });
+    bus.emit('beast:hoard-claimed', { lairId: 'lair-1', beastId: 'giant_boar', civId: 'rome', choice: 'lore' });
+    bus.emit('beast:sighted', { beastId: 'giant_boar', civId: 'rome' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+    expect(uiLayer.querySelector('#beast-slay-ceremony')).toBeNull();
+    expect(uiLayer.querySelector('#beast-sighting-banner')).toBeNull();
+  });
+});

--- a/tests/presentation/register-city-presentation.test.ts
+++ b/tests/presentation/register-city-presentation.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { SFX } from '@/audio/sfx';
+import { registerCityPresentation } from '@/presentation/register-city-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function city(overrides: { owner?: string; name?: string } = {}) {
+  return { owner: 'p1', name: 'Rome', ...overrides };
+}
+
+describe('city presentation', () => {
+  it('announces completed research, with a bonus fishing tip, gated to the active viewer for the SFX cue', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'p1' } });
+    const research = vi.spyOn(SFX, 'research').mockImplementation(() => {});
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('tech:completed', { civId: 'p1', techId: 'fishing' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Research complete'), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Dock'), 'info');
+    expect(research).toHaveBeenCalledTimes(1);
+
+    research.mockRestore();
+  });
+
+  it('does not play the research cue for a non-active civ', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'p2' } });
+    const research = vi.spyOn(SFX, 'research').mockImplementation(() => {});
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('tech:completed', { civId: 'p1', techId: 'bronze-working' });
+
+    expect(research).not.toHaveBeenCalled();
+    research.mockRestore();
+  });
+
+  it('announces city growth', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('city:grew', { cityId: 'city-a', newPopulation: 5 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('5'), 'success');
+  });
+
+  it('announces a maturity upgrade', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('city:maturity-upgraded', { cityId: 'city-a', previous: 'town', current: 'city' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('City'), 'success');
+  });
+
+  it('announces a completed building and plays the national-project SFX only for national projects', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+    const npBuilt = vi.spyOn(SFX, 'nationalProjectBuilt').mockImplementation(() => {});
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('city:building-complete', { cityId: 'city-a', buildingId: 'granary' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('completed'), 'success');
+    expect(npBuilt).not.toHaveBeenCalled();
+    npBuilt.mockRestore();
+  });
+
+  it('announces an expired national project and plays its SFX', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+    const npExpired = vi.spyOn(SFX, 'nationalProjectExpired').mockImplementation(() => {});
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('city:national-project-expired', { civId: 'p1', cityId: 'city-a', buildingId: 'grand_bazaar' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('expired'), 'warning');
+    expect(npExpired).toHaveBeenCalledTimes(1);
+    npExpired.mockRestore();
+  });
+
+  it('announces a dropped production item', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('city:production-item-dropped', { cityId: 'city-a', itemId: 'granary', itemKind: 'building', reason: 'obsoleted' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning');
+  });
+
+  it('announces a territory tile flipping ownership', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { civilizations: { p1: {}, p2: {} } as never },
+    });
+
+    registerCityPresentation(bus, ctx);
+    bus.emit('territory:tile-flipped', {
+      coord: { q: 0, r: 0 },
+      previousOwner: 'p2',
+      newOwner: 'p1',
+      improvement: 'farm',
+      constructionCancelled: false,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+    const dispose = registerCityPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('tech:completed', { civId: 'p1', techId: 'fishing' });
+    bus.emit('city:grew', { cityId: 'city-a', newPopulation: 5 });
+    bus.emit('city:maturity-upgraded', { cityId: 'city-a', previous: 'town', current: 'city' });
+    bus.emit('city:building-complete', { cityId: 'city-a', buildingId: 'granary' });
+    bus.emit('city:national-project-expired', { civId: 'p1', cityId: 'city-a', buildingId: 'grand_bazaar' });
+    bus.emit('city:production-item-dropped', { cityId: 'city-a', itemId: 'granary', itemKind: 'building', reason: 'obsoleted' });
+    bus.emit('territory:tile-flipped', { coord: { q: 0, r: 0 }, previousOwner: 'p2', newOwner: 'p1', improvement: 'farm', constructionCancelled: false });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-combat-presentation.test.ts
+++ b/tests/presentation/register-combat-presentation.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerCombatPresentation } from '@/presentation/register-combat-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function combatResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    attackerId: 'attacker-1',
+    defenderId: 'defender-1',
+    attackerDamage: 10,
+    defenderDamage: 20,
+    attackerSurvived: true,
+    defenderSurvived: false,
+    attackerStrength: 5,
+    defenderStrength: 3,
+    attackerPosition: { q: 0, r: 0 },
+    defenderPosition: { q: 1, r: 0 },
+    ...overrides,
+  };
+}
+
+describe('combat presentation', () => {
+  it('applies the combat visual only for a viewer who can see it and presentation is not suppressed', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'p1' } });
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('combat:resolved', {
+      result: combatResult() as never,
+      visibleToViewerIds: ['p1'],
+      attackerType: 'warrior' as never,
+      defenderType: 'warrior' as never,
+      attackerOwnerId: 'p1',
+      defenderOwnerId: 'p2',
+    });
+
+    expect(ctx.applyCombatVisual).toHaveBeenCalledTimes(1);
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('does not apply the combat visual for a viewer who cannot see it', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'p1' } });
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('combat:resolved', {
+      result: combatResult() as never,
+      visibleToViewerIds: ['p2'],
+      attackerType: 'warrior' as never,
+      defenderType: 'warrior' as never,
+      attackerOwnerId: 'p1',
+      defenderOwnerId: 'p2',
+    });
+
+    expect(ctx.applyCombatVisual).not.toHaveBeenCalled();
+  });
+
+  it('does not apply the combat visual while presentation is suppressed', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'p1' } });
+    Object.assign(ctx, { isPresentationSuppressed: () => true });
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('combat:resolved', {
+      result: combatResult() as never,
+      visibleToViewerIds: ['p1'],
+      attackerType: 'warrior' as never,
+      defenderType: 'warrior' as never,
+      attackerOwnerId: 'p1',
+      defenderOwnerId: 'p2',
+    });
+
+    expect(ctx.applyCombatVisual).not.toHaveBeenCalled();
+  });
+
+  it('announces a combat reward to its recipient', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('combat:reward-earned', { reward: { recipientCivId: 'p1', message: 'You gained veterancy!' } as never });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', 'You gained veterancy!', 'success');
+  });
+
+  it('notifies a civ their unit is now obsolete', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('unit:obsolete', { civId: 'p1', unitId: 'unit-1', unitType: 'warrior' as never });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('obsolete'), 'info');
+  });
+
+  it("notifies a unit's actual owner when its journey is blocked", () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { units: { 'unit-1': { owner: 'p1', type: 'warrior' } } as never },
+    });
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('unit:journey-blocked', { unitId: 'unit-1', position: { q: 2, r: 3 } });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('blocked'), 'warning');
+  });
+
+  it('does nothing for a journey-blocked event on a unit that no longer exists', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { units: {} as never } });
+
+    registerCombatPresentation(bus, ctx);
+    bus.emit('unit:journey-blocked', { unitId: 'gone', position: { q: 2, r: 3 } });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { currentPlayer: 'p1', units: { 'unit-1': { owner: 'p1', type: 'warrior' } } as never },
+    });
+    const dispose = registerCombatPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('combat:resolved', {
+      result: combatResult() as never,
+      visibleToViewerIds: ['p1'],
+      attackerType: 'warrior' as never,
+      defenderType: 'warrior' as never,
+      attackerOwnerId: 'p1',
+      defenderOwnerId: 'p2',
+    });
+    bus.emit('combat:reward-earned', { reward: { recipientCivId: 'p1', message: 'reward' } as never });
+    bus.emit('unit:obsolete', { civId: 'p1', unitId: 'unit-1', unitType: 'warrior' as never });
+    bus.emit('unit:journey-blocked', { unitId: 'unit-1', position: { q: 2, r: 3 } });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+    expect(ctx.applyCombatVisual).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-diplomacy-presentation.test.ts
+++ b/tests/presentation/register-diplomacy-presentation.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerDiplomacyPresentation } from '@/presentation/register-diplomacy-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+// Minimal civ shape matching the pattern already used in
+// tests/ui/notification-routing.test.ts for opportunistic-war's witness gate.
+function civ(overrides: { knownCivilizations?: string[] } = {}) {
+  return {
+    id: 'x',
+    name: 'Civ',
+    cities: [],
+    units: [],
+    diplomacy: { relationships: {} },
+    visibility: { tiles: {} },
+    knownCivilizations: [],
+    ...overrides,
+  };
+}
+
+describe('diplomacy presentation', () => {
+  it('announces a war declaration to the log', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player', opponentKind: 'major' });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('announces a treaty proposal', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:treaty-proposed', { fromCiv: 'ai-1', toCiv: 'player', treaty: 'trade_agreement' });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('announces first contact between two civs', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('civilization:first-contact', { civA: 'player', civB: 'ai-1' });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('announces a peace request', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:peace-requested', { fromCivId: 'ai-1', toCivId: 'player' });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('announces peace being made', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:peace-made', { civA: 'player', civB: 'ai-1' });
+
+    expect(ctx.deliver).toHaveBeenCalled();
+  });
+
+  it('announces an opportunistic war declaration to witnesses who have met both civs', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          rome: civ({ knownCivilizations: ['carthage', 'egypt'] }),
+          carthage: civ({ knownCivilizations: ['rome', 'egypt'] }),
+          egypt: civ({ knownCivilizations: ['rome', 'carthage'] }),
+        } as never,
+      },
+    });
+
+    registerDiplomacyPresentation(bus, ctx);
+    bus.emit('diplomacy:opportunistic-war', { actorId: 'rome', targetCivId: 'carthage', crisisId: 'crisis-1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('egypt', expect.any(String), expect.any(String));
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          rome: civ({ knownCivilizations: ['carthage', 'egypt'] }),
+          carthage: civ({ knownCivilizations: ['rome', 'egypt'] }),
+          egypt: civ({ knownCivilizations: ['rome', 'carthage'] }),
+        } as never,
+      },
+    });
+    const dispose = registerDiplomacyPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('diplomacy:war-declared', { attackerId: 'ai-1', defenderId: 'player', opponentKind: 'major' });
+    bus.emit('diplomacy:treaty-proposed', { fromCiv: 'ai-1', toCiv: 'player', treaty: 'trade_agreement' });
+    bus.emit('civilization:first-contact', { civA: 'player', civB: 'ai-1' });
+    bus.emit('diplomacy:peace-requested', { fromCivId: 'ai-1', toCivId: 'player' });
+    bus.emit('diplomacy:peace-made', { civA: 'player', civB: 'ai-1' });
+    bus.emit('diplomacy:opportunistic-war', { actorId: 'rome', targetCivId: 'carthage', crisisId: 'crisis-1' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-era-presentation.test.ts
+++ b/tests/presentation/register-era-presentation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { SFX } from '@/audio/sfx';
+import { registerEraPresentation } from '@/presentation/register-era-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function civ(overrides: { isHuman?: boolean; name?: string } = {}) {
+  return { isHuman: true, name: 'Civ', ...overrides };
+}
+
+describe('era presentation', () => {
+  it('delivers a world-era announcement to every human civ only', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          p1: civ({ name: 'Rome' }),
+          ai1: civ({ isHuman: false, name: 'Carthage' }),
+        } as never,
+      },
+    });
+
+    registerEraPresentation(bus, ctx);
+    bus.emit('era:advanced', { era: 3 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), expect.any(String));
+    expect(ctx.deliver).not.toHaveBeenCalledWith('ai1', expect.anything(), expect.anything());
+  });
+
+  it('announces a civ entering a new personal era, only for human civs', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          p1: civ({ name: 'Rome' }),
+          ai1: civ({ isHuman: false, name: 'Carthage' }),
+        } as never,
+      },
+    });
+
+    registerEraPresentation(bus, ctx);
+    bus.emit('civilization:era-advanced', { civId: 'ai1', previousEra: 2, era: 3 });
+    expect(ctx.deliver).not.toHaveBeenCalled();
+
+    bus.emit('civilization:era-advanced', { civId: 'p1', previousEra: 2, era: 3 });
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Era 3'), 'success');
+  });
+
+  it('plays the era-advanced notification cue only for the active viewer', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        currentPlayer: 'p1',
+        civilizations: { p1: civ({ name: 'Rome' }), p2: civ({ name: 'Egypt' }) } as never,
+      },
+    });
+    const notification = vi.spyOn(SFX, 'notification').mockImplementation(() => {});
+
+    registerEraPresentation(bus, ctx);
+    bus.emit('civilization:era-advanced', { civId: 'p2', previousEra: 2, era: 3 });
+    expect(notification).not.toHaveBeenCalled();
+
+    bus.emit('civilization:era-advanced', { civId: 'p1', previousEra: 2, era: 3 });
+    expect(notification).toHaveBeenCalledTimes(1);
+
+    notification.mockRestore();
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { civilizations: { p1: civ() } as never },
+    });
+    const dispose = registerEraPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('era:advanced', { era: 3 });
+    bus.emit('civilization:era-advanced', { civId: 'p1', previousEra: 2, era: 3 });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-espionage-presentation.test.ts
+++ b/tests/presentation/register-espionage-presentation.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerEspionagePresentation } from '@/presentation/register-espionage-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function spy(overrides: { name?: string; unitType?: string } = {}) {
+  return { name: 'Agent X', unitType: 'spy', ...overrides };
+}
+
+describe('espionage presentation', () => {
+  it('notifies the target civ (and witnesses) when a sabotage-relief attempt is discovered', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:sabotage-relief-discovered', { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning');
+  });
+
+  it('notifies the detecting civ of a spotted traveling spy', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-detected-traveling', {
+      detectingCivId: 'rome', spyOwner: 'carthage', spyUnitId: 'unit-1', position: { q: 1, r: 2 }, wasDisguised: false,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('enemy spy'), 'warning');
+  });
+
+  it('notifies the spy owner and shows the capture choice to the active human captor', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'rome' } });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', cityId: 'city-a' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('caught'), 'warning');
+    expect(ctx.showEspionageCaptureChoice).toHaveBeenCalledWith('spy-1', 'carthage');
+  });
+
+  it('does not show the capture choice when the captor is not the active viewer', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { currentPlayer: 'egypt' } });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', cityId: 'city-a' });
+
+    expect(ctx.showEspionageCaptureChoice).not.toHaveBeenCalled();
+  });
+
+  it('notifies the spy owner and shows the capture choice for an in-mission capture', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        currentPlayer: 'rome',
+        espionage: { carthage: { spies: { 'spy-1': spy() } } } as never,
+      },
+    });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-captured', { capturingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1' });
+
+    expect(ctx.showEspionageCaptureChoice).toHaveBeenCalledWith('spy-1', 'carthage');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('Agent X'), 'warning');
+  });
+
+  it('notifies the spy owner of an execution', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-executed', { executingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', spyName: 'Agent X' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('Agent X'), 'warning');
+  });
+
+  it('notifies a civ their spy expired with no diplomatic penalty', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-expired', { civId: 'rome', spyId: 'spy-1', spyName: 'Agent X', unitType: 'spy' as never });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Agent X'), 'info');
+  });
+
+  it('notifies a civ their spy was auto-exfiltrated', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': { name: 'Utica' } } as never } });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:spy-auto-exfiltrated', { civId: 'rome', spyId: 'spy-1', cityId: 'city-a' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Utica'), 'info');
+  });
+
+  it('notifies both civs when a city flips via propaganda', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': { name: 'Utica' } } as never } });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:city-flipped', { civId: 'rome', victimCivId: 'carthage', cityId: 'city-a' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { currentPlayer: 'rome', cities: { 'city-a': { name: 'Utica' } } as never },
+    });
+    const dispose = registerEspionagePresentation(bus, ctx);
+
+    dispose();
+    bus.emit('espionage:sabotage-relief-discovered', { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage' });
+    bus.emit('espionage:spy-detected-traveling', { detectingCivId: 'rome', spyOwner: 'carthage', spyUnitId: 'unit-1', position: { q: 1, r: 2 }, wasDisguised: false });
+    bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', cityId: 'city-a' });
+    bus.emit('espionage:spy-captured', { capturingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1' });
+    bus.emit('espionage:spy-executed', { executingCivId: 'rome', spyOwner: 'carthage', spyId: 'spy-1', spyName: 'Agent X' });
+    bus.emit('espionage:spy-expired', { civId: 'rome', spyId: 'spy-1', spyName: 'Agent X', unitType: 'spy' as never });
+    bus.emit('espionage:spy-auto-exfiltrated', { civId: 'rome', spyId: 'spy-1', cityId: 'city-a' });
+    bus.emit('espionage:city-flipped', { civId: 'rome', victimCivId: 'carthage', cityId: 'city-a' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+    expect(ctx.showEspionageCaptureChoice).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-faction-crisis-presentation.test.ts
+++ b/tests/presentation/register-faction-crisis-presentation.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function city(overrides: { name?: string; population?: number; position?: { q: number; r: number } } = {}) {
+  return { name: 'Rome', population: 4, position: { q: 0, r: 0 }, ...overrides };
+}
+
+describe('faction and crisis presentation', () => {
+  it('warns the owner when a city slips into unrest', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:unrest-started', { cityId: 'city-a', owner: 'p1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('unrest'), 'warning');
+  });
+
+  it('warns the owner when a city revolts', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:revolt-started', { cityId: 'city-a', owner: 'p1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('revolt'), 'warning');
+  });
+
+  it('announces a city stabilizing', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:unrest-resolved', { cityId: 'city-a', owner: 'p1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('stabilized'), 'success');
+  });
+
+  it('warns the old owner when a city breaks away', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:breakaway-started', { cityId: 'city-a', oldOwner: 'p1', breakawayId: 'breakaway-1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('broken away'), 'warning');
+  });
+
+  it('warns the origin owner when a breakaway state establishes', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:breakaway-established', { civId: 'breakaway-1', originOwnerId: 'p1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('established'), 'warning');
+  });
+
+  it('warns the owner of persistent critical status', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:critical-status', { cityId: 'city-a', owner: 'p1', status: 'unrest' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('unrest'), 'warning');
+  });
+
+  it('announces a concession grant', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({ state: { cities: { 'city-a': city() } as never } });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('faction:concession-made', { cityId: 'city-a', owner: 'p1', concessionType: 'charter' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('charter'), 'success');
+  });
+
+  it('announces a new crisis to the affected civ', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never },
+    });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:started', { crisisId: 'crisis-1', flavorId: 'plague', civId: 'p1', cityIds: ['city-a'] });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning', expect.anything(), undefined, undefined);
+  });
+
+  it('announces a crisis assaulting a city', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:escalated', { crisisId: 'crisis-1', stage: 'assaulting', civId: 'p1', foeName: 'The Reaper' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('The Reaper'), 'warning', undefined);
+  });
+
+  it('announces a crisis spreading to another city', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        activeCrises: { 'crisis-1': { flavorId: 'plague', targetCivId: 'p1', cityIds: ['city-a'] } } as never,
+        cities: { 'city-b': city({ name: 'Utica' }) } as never,
+      },
+    });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:spread', { crisisId: 'crisis-1', fromCityId: 'city-a', toCityId: 'city-b' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Utica'), 'warning', expect.anything());
+  });
+
+  it('announces a crisis resolving', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:resolved', { crisisId: 'crisis-1', flavorId: 'plague', civId: 'p1', outcome: 'contained' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('contained'), 'success', undefined, undefined, undefined);
+  });
+
+  it('tells a witnessing civ that an ally hunted a shared foe', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        civilizations: {
+          rome: { knownCivilizations: ['carthage', 'egypt'], diplomacy: { atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+          carthage: { knownCivilizations: ['rome', 'egypt'], diplomacy: { atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+          egypt: { knownCivilizations: ['rome', 'carthage'], diplomacy: { atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+        } as never,
+      },
+    });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:foe-hunted-by-ally', { crisisId: 'crisis-1', killerCivId: 'rome', targetCivId: 'carthage', foeName: 'The Reaper' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('egypt', expect.stringContaining('The Reaper'), expect.any(String));
+  });
+
+  it('announces aid sent between civs', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { civilizations: { rome: {}, carthage: {} } as never },
+    });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('crisis:aid-sent', { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage', goldCost: 50 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'success');
+  });
+
+  it('warns a civ of treasury strain', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { civilizations: { p1: {} } as never },
+    });
+
+    registerFactionCrisisPresentation(bus, ctx);
+    bus.emit('economy:treasury-strain', { civId: 'p1', level: 'high', netGoldPerTurn: -5, unpaidMaintenance: 0 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city() } as never,
+        civilizations: { p1: {}, rome: {}, carthage: {} } as never,
+      },
+    });
+    const dispose = registerFactionCrisisPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('faction:unrest-started', { cityId: 'city-a', owner: 'p1' });
+    bus.emit('faction:revolt-started', { cityId: 'city-a', owner: 'p1' });
+    bus.emit('faction:unrest-resolved', { cityId: 'city-a', owner: 'p1' });
+    bus.emit('faction:breakaway-started', { cityId: 'city-a', oldOwner: 'p1', breakawayId: 'breakaway-1' });
+    bus.emit('faction:breakaway-established', { civId: 'breakaway-1', originOwnerId: 'p1' });
+    bus.emit('faction:critical-status', { cityId: 'city-a', owner: 'p1', status: 'unrest' });
+    bus.emit('faction:concession-made', { cityId: 'city-a', owner: 'p1', concessionType: 'charter' });
+    bus.emit('crisis:started', { crisisId: 'crisis-1', flavorId: 'plague', civId: 'p1', cityIds: ['city-a'] });
+    bus.emit('crisis:escalated', { crisisId: 'crisis-1', stage: 'assaulting', civId: 'p1', foeName: 'The Reaper' });
+    bus.emit('crisis:spread', { crisisId: 'crisis-1', fromCityId: 'city-a', toCityId: 'city-a' });
+    bus.emit('crisis:resolved', { crisisId: 'crisis-1', flavorId: 'plague', civId: 'p1', outcome: 'contained' });
+    bus.emit('crisis:foe-hunted-by-ally', { crisisId: 'crisis-1', killerCivId: 'rome', targetCivId: 'carthage', foeName: 'The Reaper' });
+    bus.emit('crisis:aid-sent', { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage', goldCost: 50 });
+    bus.emit('economy:treasury-strain', { civId: 'p1', level: 'high', netGoldPerTurn: -5, unpaidMaintenance: 0 });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-faction-crisis-presentation.test.ts
+++ b/tests/presentation/register-faction-crisis-presentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import { registerFactionCrisisPresentation } from '@/presentation/register-faction-crisis-presentation';
+import type { PresentationContext } from '@/presentation/register-all';
 import { makePresentationContext } from '../helpers/presentation-context';
 
 function city(overrides: { name?: string; population?: number; position?: { q: number; r: number } } = {}) {
@@ -165,6 +166,34 @@ describe('faction and crisis presentation', () => {
     bus.emit('economy:treasury-strain', { civId: 'p1', level: 'high', netGoldPerTurn: -5, unpaidMaintenance: 0 });
 
     expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning');
+  });
+
+  it('does not read ctx.notifier at registration time (guards a #787 phase 7 boot crash)', () => {
+    // main.ts installs every registrar at module scope, before init() runs and
+    // assigns the real `notifier` -- ctx.notifier is a getter over a `let` that's
+    // undefined until then. A registrar that dereferences `ctx.notifier.deliver`
+    // eagerly (instead of only inside an event-handler closure, which only runs
+    // after init() has assigned it) crashes the entire app on load with
+    // "Cannot read properties of undefined (reading 'deliver')" -- this shipped
+    // and was caught by CI's web-smoke e2e run, not by this file's other tests,
+    // since makePresentationContext always hands back a real notifier up front.
+    const bus = new EventBus();
+    const base = makePresentationContext({ state: { civilizations: { p1: {} } as never } });
+    let notifierAssigned = false;
+    const ctx: PresentationContext = {
+      ...base,
+      get notifier() {
+        if (!notifierAssigned) throw new Error('ctx.notifier accessed before init() assigned it');
+        return base.notifier;
+      },
+    };
+
+    expect(() => registerFactionCrisisPresentation(bus, ctx)).not.toThrow();
+
+    notifierAssigned = true;
+    bus.emit('economy:treasury-strain', { civId: 'p1', level: 'high', netGoldPerTurn: -5, unpaidMaintenance: 0 });
+
+    expect(base.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning');
   });
 
   it('disposing removes every subscription this registrar added', () => {

--- a/tests/presentation/register-general-presentation.test.ts
+++ b/tests/presentation/register-general-presentation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerGeneralPresentation } from '@/presentation/register-general-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+describe('general presentation', () => {
+  it('resets the treasurer advisor message and re-checks advisors on a gold village outcome', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerGeneralPresentation(bus, ctx);
+    bus.emit('village:visited', { civId: 'p1', position: { q: 0, r: 0 }, outcome: 'gold', message: 'Found gold!' });
+
+    expect(ctx.resetAdvisorMessage).toHaveBeenCalledWith('treasurer_village_gold');
+    expect(ctx.checkAdvisors).toHaveBeenCalledTimes(1);
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', 'Found gold!', 'success');
+  });
+
+  it('delivers an ambush outcome as a warning', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerGeneralPresentation(bus, ctx);
+    bus.emit('village:visited', { civId: 'p1', position: { q: 0, r: 0 }, outcome: 'ambush', message: 'Ambushed!' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', 'Ambushed!', 'warning');
+  });
+
+  it('shows an advisor message as an immediate toast for the active viewer', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerGeneralPresentation(bus, ctx);
+    bus.emit('advisor:message', { advisor: 'builder', message: 'Build a Granary', icon: '🏗️' });
+
+    expect(ctx.showNotification).toHaveBeenCalledWith('🏗️ Build a Granary', 'info');
+  });
+
+  it('routes a strategic warning to its viewer', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerGeneralPresentation(bus, ctx);
+    bus.emit('ai:strategic-warning', {
+      viewerId: 'p1', actorId: 'ai-1', actorName: 'Carthage', warningKey: 'w1',
+      kind: 'recovery', evidence: 'visible', playAudio: false,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'success', undefined);
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+    const dispose = registerGeneralPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('village:visited', { civId: 'p1', position: { q: 0, r: 0 }, outcome: 'gold', message: 'Found gold!' });
+    bus.emit('advisor:message', { advisor: 'builder', message: 'Build a Granary', icon: '🏗️' });
+    bus.emit('ai:strategic-warning', {
+      viewerId: 'p1', actorId: 'ai-1', actorName: 'Carthage', warningKey: 'w1',
+      kind: 'recovery', evidence: 'visible', playAudio: false,
+    });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+    expect(ctx.showNotification).not.toHaveBeenCalled();
+    expect(ctx.checkAdvisors).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-network-presentation.test.ts
+++ b/tests/presentation/register-network-presentation.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerNetworkPresentation } from '@/presentation/register-network-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+describe('network presentation', () => {
+  it('notifies both sides of a blocked cyber-drain attempt', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerNetworkPresentation(bus, ctx);
+    bus.emit('city:cyber-drained', {
+      cityId: 'city-a',
+      cityName: 'Utica',
+      drainerOwner: 'ai-1',
+      drainerUnitId: 'unit-1',
+      goldLost: 0,
+      blocked: true,
+      victimCivId: 'p1',
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('blocked'), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('ai-1', expect.any(String), 'warning');
+  });
+
+  it('notifies both sides of a successful cyber-drain', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerNetworkPresentation(bus, ctx);
+    bus.emit('city:cyber-drained', {
+      cityId: 'city-a',
+      cityName: 'Utica',
+      drainerOwner: 'ai-1',
+      drainerUnitId: 'unit-1',
+      goldLost: 5,
+      blocked: false,
+      victimCivId: 'p1',
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('5 gold'), 'warning');
+    expect(ctx.deliver).toHaveBeenCalledWith('ai-1', expect.any(String), 'success');
+  });
+
+  it('warns the target civ of an impending exploit and emits the hostile-warning audio cue', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        autonomyByCiv: {
+          'ai-1': {
+            plans: { 'plan-1': { definitionId: 'exploit', target: { kind: 'city', cityId: 'city-a' } } },
+            detections: {},
+          },
+        } as never,
+        cities: { 'city-a': { name: 'Utica', position: { q: 0, r: 0 }, owner: 'p1' } } as never,
+      },
+    });
+
+    registerNetworkPresentation(bus, ctx);
+    bus.emit('network:exploit-warning', { planId: 'plan-1', victimCivId: 'p1', cityId: 'city-a' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith(
+      'p1',
+      expect.stringContaining('Utica'),
+      'warning',
+      expect.objectContaining({ kind: 'map' }),
+    );
+  });
+
+  it('notifies both sides when an exploit resolves and emits the hostile-consequence audio cue', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Utica', owner: 'p1' } } as never },
+    });
+
+    registerNetworkPresentation(bus, ctx);
+    bus.emit('network:exploit-resolved', { planId: 'plan-1', cityId: 'city-a', ownerCivId: 'ai-1', goldTransferred: 5, delayed: false });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('5 gold'), 'warning');
+    expect(ctx.deliver).toHaveBeenCalledWith('ai-1', expect.any(String), 'success');
+  });
+
+  it('announces a constructive-resolution and a recovery audio cue', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerNetworkPresentation(bus, ctx);
+    bus.emit('network:audio-cue', { cue: 'constructive-resolution', viewerIds: ['p1'] });
+    bus.emit('network:audio-cue', { cue: 'recovery', viewerIds: ['p1'] });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('milestone'), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('recovery'), 'success');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Utica', owner: 'p1' } } as never },
+    });
+    const dispose = registerNetworkPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('city:cyber-drained', { cityId: 'city-a', cityName: 'Utica', drainerOwner: 'ai-1', drainerUnitId: 'u1', goldLost: 1, blocked: false, victimCivId: 'p1' });
+    bus.emit('network:exploit-warning', { planId: 'plan-1', victimCivId: 'p1', cityId: 'city-a' });
+    bus.emit('network:exploit-resolved', { planId: 'plan-1', cityId: 'city-a', ownerCivId: 'ai-1', goldTransferred: 5, delayed: false });
+    bus.emit('network:audio-cue', { cue: 'recovery', viewerIds: ['p1'] });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-raider-presentation.test.ts
+++ b/tests/presentation/register-raider-presentation.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerRaiderPresentation } from '@/presentation/register-raider-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function city(overrides: { owner?: string; name?: string } = {}) {
+  return { owner: 'p1', name: 'Rome', ...overrides };
+}
+
+function humanCiv() {
+  return { isHuman: true };
+}
+
+describe('raider presentation', () => {
+  it('notifies a civ the first time it sees a raider from a given camp, and not again for the same camp', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        units: { 'unit-1': { position: { q: 0, r: 0 } } } as never,
+        civilizations: { p1: { visibility: { tiles: { '0,0': 'visible' } } } } as never,
+      },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('barbarian:spawned', { campId: 'camp-1', unitId: 'unit-1' });
+    bus.emit('barbarian:spawned', { campId: 'camp-1', unitId: 'unit-1' });
+
+    expect(ctx.deliver).toHaveBeenCalledTimes(1);
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('spotted'), 'warning', expect.anything());
+  });
+
+  it('warns a civ of ordinary barbarian resurgence', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('threat:barbarian-resurgence', { civId: 'p1', landmassId: 'l1', campId: 'camp-1', position: { q: 0, r: 0 }, isBanditLord: false });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('resurgent'), 'warning');
+  });
+
+  it('names the bandit lord when one has united the raiders', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('threat:barbarian-resurgence', {
+      civId: 'p1', landmassId: 'l1', campId: 'camp-1', position: { q: 0, r: 0 }, isBanditLord: true, banditLordName: 'Attila',
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Attila'), 'warning');
+  });
+
+  it('warns a human city owner of a barbarian attack', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('barbarian:city-attacked', { attackerUnitId: 'unit-1', cityId: 'city-a', hpLost: 10 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Rome'), 'warning');
+  });
+
+  it('does not notify a non-human city owner of a barbarian attack', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: { isHuman: false } } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('barbarian:city-attacked', { attackerUnitId: 'unit-1', cityId: 'city-a', hpLost: 10 });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+
+  it('warns a human civ their city was destroyed by barbarians', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('barbarian:city-destroyed', { attackerUnitId: 'unit-1', cityId: 'city-a', ownerId: 'p1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('destroyed'), 'warning');
+  });
+
+  it('warns a human civ their city was razed by pirates', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('pirate:city-destroyed', { cityId: 'city-a', ownerId: 'p1', factionId: 'faction-1' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('razed'), 'warning');
+  });
+
+  it('announces successful counter-fire against a barbarian raider', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('city:counter-fire', { cityId: 'city-a', attackerUnitId: 'unit-1', source: 'barbarian', damage: 5, attackerDied: true });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('raider'), 'success');
+  });
+
+  it('announces inconclusive counter-fire against a pirate ship', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('city:counter-fire', { cityId: 'city-a', attackerUnitId: 'unit-1', source: 'pirate', damage: 5, attackerDied: false });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('ship'), 'info');
+  });
+
+  it('announces a barbarian sacking, distinct from destruction', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never, civilizations: { p1: humanCiv() } as never },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('city:sacked', { cityId: 'city-a', source: 'barbarian', goldLost: 30 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('1 HP'), 'warning');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        units: { 'unit-1': { position: { q: 0, r: 0 } } } as never,
+        cities: { 'city-a': city() } as never,
+        civilizations: { p1: { ...humanCiv(), visibility: { tiles: { '0,0': 'visible' } } } } as never,
+      },
+    });
+    const dispose = registerRaiderPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('barbarian:spawned', { campId: 'camp-1', unitId: 'unit-1' });
+    bus.emit('threat:barbarian-resurgence', { civId: 'p1', landmassId: 'l1', campId: 'camp-1', position: { q: 0, r: 0 }, isBanditLord: false });
+    bus.emit('barbarian:city-attacked', { attackerUnitId: 'unit-1', cityId: 'city-a', hpLost: 10 });
+    bus.emit('barbarian:city-destroyed', { attackerUnitId: 'unit-1', cityId: 'city-a', ownerId: 'p1' });
+    bus.emit('pirate:city-destroyed', { cityId: 'city-a', ownerId: 'p1', factionId: 'faction-1' });
+    bus.emit('city:counter-fire', { cityId: 'city-a', attackerUnitId: 'unit-1', source: 'barbarian', damage: 5, attackerDied: true });
+    bus.emit('city:sacked', { cityId: 'city-a', source: 'barbarian', goldLost: 30 });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-religion-presentation.test.ts
+++ b/tests/presentation/register-religion-presentation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerReligionPresentation } from '@/presentation/register-religion-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function civ(overrides: { knownCivilizations?: string[] } = {}) {
+  return {
+    knownCivilizations: [],
+    diplomacy: { atWarWith: [], treaties: [] },
+    visibility: { tiles: {} },
+    cities: [],
+    units: [],
+    ...overrides,
+  };
+}
+
+function city(overrides: { owner?: string; name?: string } = {}) {
+  return { owner: 'p1', name: 'City', ...overrides };
+}
+
+describe('religion presentation', () => {
+  it('announces a religion founding to civs who have met the founder', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        map: { tiles: {} } as never,
+        cities: { 'city-a': city({ owner: 'rome', name: 'Rome' }) } as never,
+        civilizations: {
+          rome: civ({ knownCivilizations: [] }),
+          carthage: civ({ knownCivilizations: ['rome'] }),
+          egypt: civ({ knownCivilizations: [] }),
+        } as never,
+      },
+    });
+
+    registerReligionPresentation(bus, ctx);
+    bus.emit('religion:founded', { religionId: 'sun-cult', civId: 'rome', cityId: 'city-a', name: 'Sun Cult' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Sun Cult'), 'success', undefined, undefined, 'religion-founded');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'success', undefined, undefined, 'religion-founded');
+    expect(ctx.deliver).not.toHaveBeenCalledWith('egypt', expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+  });
+
+  it('announces a city converting to a religion, notifying the founder if different', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city({ owner: 'carthage', name: 'Utica' }) } as never,
+        civilizations: { carthage: civ(), rome: civ({ knownCivilizations: ['carthage'] }) } as never,
+        religions: { 'sun-cult': { name: 'Sun Cult', ownerCivId: 'rome' } } as never,
+      },
+    });
+
+    registerReligionPresentation(bus, ctx);
+    bus.emit('religion:city-converted', { cityId: 'city-a', toReligionId: 'sun-cult' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('Sun Cult'), 'info', undefined, undefined, 'city-converted');
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Utica'), 'success', undefined, undefined, 'city-converted');
+  });
+
+  it('warns the pressuring civ about a loyalty threshold', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city({ name: 'Utica' }) } as never },
+    });
+
+    registerReligionPresentation(bus, ctx);
+    bus.emit('religion:loyalty-warning', { cityId: 'city-a', pressuringCivId: 'rome', stage: 'final', turnsRemaining: 0 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Utica'), 'warning', undefined, undefined, 'loyalty-warning');
+  });
+
+  it('announces a city defecting between civs', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city({ name: 'Utica' }) } as never,
+        civilizations: { carthage: civ() } as never,
+      },
+    });
+
+    registerReligionPresentation(bus, ctx);
+    bus.emit('religion:city-defected', { cityId: 'city-a', fromCivId: 'carthage', toCivId: 'rome' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'success', undefined, undefined, 'city-defected');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning', undefined, undefined, 'city-defected');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city() } as never },
+    });
+    const dispose = registerReligionPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('religion:founded', { religionId: 'sun-cult', civId: 'rome', cityId: 'city-a', name: 'Sun Cult' });
+    bus.emit('religion:city-converted', { cityId: 'city-a', toReligionId: 'sun-cult' });
+    bus.emit('religion:loyalty-warning', { cityId: 'city-a', pressuringCivId: 'rome', stage: 'final', turnsRemaining: 0 });
+    bus.emit('religion:city-defected', { cityId: 'city-a', fromCivId: 'carthage', toCivId: 'rome' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-trade-presentation.test.ts
+++ b/tests/presentation/register-trade-presentation.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerTradePresentation } from '@/presentation/register-trade-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+function city(overrides: { owner?: string; name?: string } = {}) {
+  return { owner: 'p1', name: 'City', position: { q: 0, r: 0 }, ...overrides };
+}
+
+const emptyMap = { width: 10, wrapsHorizontally: false, tiles: {} };
+
+describe('trade presentation', () => {
+  it('applies the delivery visual for a delivered caravan', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerTradePresentation(bus, ctx);
+    bus.emit('trade:route-delivered', { unitId: 'caravan-1', routeId: 'route-1', toCityId: 'city-1' });
+
+    expect(ctx.requestDeliveryVisual).toHaveBeenCalledWith('caravan-1');
+  });
+
+  it('announces a new trade route to the owning civ', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        map: emptyMap as never,
+        cities: { 'city-a': city({ owner: 'p1' }), 'city-b': city({ owner: 'p2', name: 'Carthage' }) } as never,
+      },
+    });
+
+    registerTradePresentation(bus, ctx);
+    bus.emit('trade:route-created', {
+      route: { fromCityId: 'city-a', toCityId: 'city-b', goldPerTrip: 10, turnsPerTrip: 2 } as never,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Carthage'), 'success');
+  });
+
+  it('announces a route ending to the owning civ', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city({ owner: 'p1' }), 'city-b': city({ owner: 'p2', name: 'Carthage' }) } as never,
+      },
+    });
+
+    registerTradePresentation(bus, ctx);
+    bus.emit('trade:route-ended', { routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-b', reason: 'unit-died' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('destroyed'), 'warning');
+  });
+
+  it('also tells the other end of the route when it belongs to a different human civ', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city({ owner: 'p1', name: 'Rome' }), 'city-b': city({ owner: 'p2', name: 'Carthage' }) } as never,
+        civilizations: { p1: { isHuman: true }, p2: { isHuman: true } } as never,
+      },
+    });
+
+    registerTradePresentation(bus, ctx);
+    bus.emit('trade:route-ended', { routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-b', reason: 'embargo' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.any(String), 'warning');
+    expect(ctx.deliver).toHaveBeenCalledWith('p2', expect.stringContaining('Rome'), 'warning');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': city({ owner: 'p1' }) } as never },
+    });
+    const dispose = registerTradePresentation(bus, ctx);
+
+    dispose();
+    bus.emit('trade:route-delivered', { unitId: 'caravan-1', routeId: 'route-1', toCityId: 'city-1' });
+    bus.emit('trade:route-created', { route: { fromCityId: 'city-a', toCityId: 'city-a', goldPerTurn: 1 } as never });
+    bus.emit('trade:route-ended', { routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-a', reason: 'unit-died' });
+
+    expect(ctx.requestDeliveryVisual).not.toHaveBeenCalled();
+    expect(ctx.deliver).not.toHaveBeenCalled();
+  });
+});

--- a/tests/presentation/register-wonder-presentation.test.ts
+++ b/tests/presentation/register-wonder-presentation.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { registerWonderPresentation } from '@/presentation/register-wonder-presentation';
+import { makePresentationContext } from '../helpers/presentation-context';
+
+describe('wonder presentation', () => {
+  it('logs a first discovery and enqueues the ceremony reveal', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        currentPlayer: 'player',
+        wonderDiscoverers: { great_volcano: ['player'] } as never,
+        civilizations: { player: { isHuman: true } } as never,
+      },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:discovered', {
+      civId: 'player',
+      wonderId: 'great_volcano',
+      position: { q: 0, r: 0 },
+      isFirstDiscoverer: true,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('player', expect.stringContaining('Discovered'), 'success');
+    expect(ctx.ceremonies.enqueueWonderDiscovery).toHaveBeenCalledWith(
+      expect.objectContaining({ wonderId: 'great_volcano', civId: 'player' }),
+    );
+  });
+
+  it('logs a later discovery without re-enqueuing the ceremony for a non-viewer', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { currentPlayer: 'other', wonderDiscoverers: {} as never },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:discovered', {
+      civId: 'player',
+      wonderId: 'great_volcano',
+      position: { q: 0, r: 0 },
+      isFirstDiscoverer: false,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('player', expect.stringContaining('Found'), 'info');
+    expect(ctx.ceremonies.enqueueWonderDiscovery).not.toHaveBeenCalled();
+  });
+
+  it('notifies the builder a legendary wonder is ready to start', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Rome' } } as never },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:legendary-ready', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('Rome'), 'info');
+  });
+
+  it('notifies the recipient of a legendary availability change', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:legendary-availability', { recipientCivId: 'rome', wonderId: 'oracle-of-delphi', status: 'buildable', cityActions: [] });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('ready to build'), 'info', undefined, []);
+  });
+
+  it('notifies the builder of a legendary completion and enqueues the ceremony', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        currentPlayer: 'rome',
+        cities: { 'city-a': { name: 'Rome', owner: 'rome' } } as never,
+        civilizations: { rome: {} } as never,
+      },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:legendary-completed', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi', turnCompleted: 42 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('completed'), 'success');
+    expect(ctx.ceremonies.enqueueLegendaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ civId: 'rome', wonderId: 'oracle-of-delphi', turnCompleted: 42 }),
+    );
+  });
+
+  it('notifies the civ a legendary wonder was lost', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Rome' } } as never },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:legendary-lost', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi', goldRefund: 20, transferableProduction: 5 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('abandoned'), 'warning');
+  });
+
+  it('notifies the observer of a revealed legendary wonder race', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Rome' } } as never },
+    });
+
+    registerWonderPresentation(bus, ctx);
+    bus.emit('wonder:legendary-race-revealed', { observerId: 'egypt', civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi' });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('egypt', expect.stringContaining('Spy report'), 'info');
+  });
+
+  it('disposing removes every subscription this registrar added', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Rome' } } as never },
+    });
+    const dispose = registerWonderPresentation(bus, ctx);
+
+    dispose();
+    bus.emit('wonder:discovered', { civId: 'player', wonderId: 'great_volcano', position: { q: 0, r: 0 }, isFirstDiscoverer: true });
+    bus.emit('wonder:legendary-ready', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi' });
+    bus.emit('wonder:legendary-availability', { recipientCivId: 'rome', wonderId: 'oracle-of-delphi', status: 'buildable', cityActions: [] });
+    bus.emit('wonder:legendary-completed', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi', turnCompleted: 42 });
+    bus.emit('wonder:legendary-lost', { civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi', goldRefund: 20, transferableProduction: 5 });
+    bus.emit('wonder:legendary-race-revealed', { observerId: 'egypt', civId: 'rome', cityId: 'city-a', wonderId: 'oracle-of-delphi' });
+
+    expect(ctx.deliver).not.toHaveBeenCalled();
+    expect(ctx.ceremonies.enqueueWonderDiscovery).not.toHaveBeenCalled();
+    expect(ctx.ceremonies.enqueueLegendaryCompletion).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -9,6 +9,7 @@ import {
   routeCombatResolved,
   routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
+  routeEraAdvanced,
   routeLegendaryWonder,
   routeFactionTransition,
   routeFirstContact,
@@ -1050,5 +1051,42 @@ describe('espionage:city-flipped routing (#524 MR2a review fix)', () => {
     const { sink, calls } = makeSink();
     routeCityFlipped(flipState(), { civId: 'rome', victimCivId: 'unknown-civ', cityId: 'city-1' }, sink);
     expect(calls.every(c => typeof c.message === 'string' && c.message.length > 0)).toBe(true);
+  });
+});
+
+describe('era:advanced routing', () => {
+  it('era 2 delivers to every human civ, with an extra unrest-primer line per civ', () => {
+    const { sink, calls } = makeSink();
+
+    routeEraAdvanced(2, ['p1', 'p2'], sink);
+
+    // Each human civ gets both the era announcement and the era-2 unrest primer.
+    const p1Calls = calls.filter(c => c.civId === 'p1');
+    const p2Calls = calls.filter(c => c.civId === 'p2');
+    expect(p1Calls).toHaveLength(2);
+    expect(p2Calls).toHaveLength(2);
+    expect(p1Calls[0]!.message).toContain('Era 2');
+    expect(p1Calls[0]!.type).toBe('success');
+    expect(p1Calls[1]!.message).toContain('Era 2');
+    expect(p1Calls[1]!.message).toContain('unrest');
+    expect(p1Calls[1]!.type).toBe('info');
+  });
+
+  it('era 3 delivers only the announcement line to each human civ, no unrest primer', () => {
+    const { sink, calls } = makeSink();
+
+    routeEraAdvanced(3, ['p1'], sink);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.civId).toBe('p1');
+    expect(calls[0]!.message).toContain('Era 3');
+  });
+
+  it('delivers to no one when there are no human civs', () => {
+    const { sink, calls } = makeSink();
+
+    routeEraAdvanced(2, [], sink);
+
+    expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Extracts all 72 module-scope `bus.on(...)` event registrations out of `main.ts` into 13 domain-specific presentation registrar modules under `src/presentation/`, composed by a single `registerAllPresentation(bus, ctx)` call. Continues the composition-root decomposition arc (#787) after Phase 6 (#793, CeremonyCoordinator).

**Registrars extracted** (event count each):
1. `register-diplomacy-presentation.ts` (6)
2. `register-era-presentation.ts` (2)
3. `register-trade-presentation.ts` (3)
4. `register-religion-presentation.ts` (4)
5. `register-network-presentation.ts` (4)
6. `register-wonder-presentation.ts` (6, delegates to `CeremonyCoordinator`)
7. `register-city-presentation.ts` (7)
8. `register-faction-crisis-presentation.ts` (14, largest)
9. `register-espionage-presentation.ts` (8)
10. `register-beast-presentation.ts` (4)
11. `register-raider-presentation.ts` (7)
12. `register-combat-presentation.ts` (4)
13. `register-general-presentation.ts` (3 — catch-all for events with no clean domain home)

Each registrar has the shape `(bus: EventBus, ctx: PresentationContext) => () => void`: subscribes on install, returns a disposer that removes every subscription it added. `main.ts` no longer has any module-scope `bus.on(...)` calls (`grep -n "^bus\.on(" src/main.ts` returns empty).

## Key design decisions

- **Plan said ~12 registrars; this PR has 13.** The extra bucket (`general`) holds three events (`village:visited`, `advisor:message`, `ai:strategic-warning`) that don't cleanly fit any named domain rather than being force-fit into one — noted here per `.claude/rules/spec-fidelity.md`'s guidance to flag plan/code divergence rather than silently comply or silently "fix" the plan.
- **Combat registrar does not take `SelectionStore`**, despite the plan listing it as a dependency — `handleCombatResolvedEvent`'s current implementation doesn't touch selection. Verified directly against the function rather than trusting the plan text.
- **DIP discipline extended from Phase 6**: registrars never import a concrete main.ts-owned service (`RenderLoop`, `RoundPresentationGate`, `AdvisorSystem`). Each dependency crosses the `PresentationContext` boundary as a narrow single-purpose callback (`requestDeliveryVisual`, `applyCombatVisual`, `isPresentationSuppressed`, `resetAdvisorMessage`, `checkAdvisors`, `showNotification`, `maybeShowPendingHoardChoice`, `showEspionageCaptureChoice`, `uiLayer`).
- **`showEspionageCaptureChoice` and `maybeShowPendingHoardChoice` were kept as `main.ts` callbacks, not moved.** Both mutate state directly (`session.setStateWithoutRefresh`), touch `renderLoop`, and emit further events — extracting them is a larger, separate change than "wire up an event listener." Documented in `PresentationContext`'s doc comments as deliberate, not deferred-by-oversight.
- **`registerAllPresentation` composes all 13 into one install/dispose pair.** This is a real behavior improvement, not just organization: the old code could never unregister any of its 72 listeners (nothing ever called an unsubscriber), a latent leak across any future "new game from the pause menu" transition. Now the whole set can be disposed and re-installed atomically.

## Testing

- Every registrar was written test-first (TDD): failing test confirmed RED for the right reason, then implemented to GREEN.
- `tests/helpers/presentation-context.ts` adds a `makePresentationContext(overrides)` factory producing a fully-mocked `PresentationContext`.
- `tests/presentation/register-all.test.ts` covers install-once/dispose-together (including a first-registrar and a last-registrar check, guarding an off-by-one composition bug) and a middle-of-the-list registrar, so a broken composition wiring can't hide behind "only the first one is tested."
- Converted 3 stale grep-based (`readFileSync` + string match) assertions in `tests/main.integration.test.ts` that were bound to code this refactor moved: an `era:advanced` SFX-cue check (replaced with real `routeEraAdvanced` behavioral tests, relocated to `tests/ui/notification-routing.test.ts`), and two slice-boundary markers that had silently degraded to slicing near end-of-file once their target string moved (repointed at a stable anchor already used elsewhere in the same file).
- Full suite: 466 test files, 7562 tests passing, 3 skipped. `yarn build` clean. Both re-confirmed at push time via the pre-push gate.

## Out of scope

- The 145-line `showEspionageCaptureChoice` capture-verdict dialog and `maybeShowPendingHoardChoice` remain in `main.ts` (see design decisions above) — candidates for a later phase.
- An unrelated pre-existing dead-import audit turned up 8 names in `main.ts` that look unused by a naive grep (`moveUnit`, `getMovementCost`, `visitVillage`, `clearStaleSoloPendingEvents`, `refreshKnownCivilizations`, `getMinorCivNotification`, `reconstructLastSeenFromMap`, `createMarketplaceState`). Spot-checked all 8 against `origin/main`: identical single-occurrence (import-line-only) count on both sides, confirming all predate this PR. Left untouched as out-of-scope tech debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)