### PR TITLE
Add pure resolveMapTapIntent (#787 phase 8a)

### DIFF
--- a/src/input/hex-defender-selection.ts
+++ b/src/input/hex-defender-selection.ts
@@ -1,0 +1,34 @@
+import type { GameState, Unit } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { canInspectUnitForViewer } from '@/systems/viewer-intel';
+import { isForestConcealedUnit } from '@/systems/fog-of-war';
+import { isBeastConcealedFrom } from '@/systems/beast-system';
+import { selectDefenderForAttack } from '@/systems/combat-system';
+
+/**
+ * Mirrors `main.ts`'s `visibleUnitEntriesAtKey`/`visibleHostileUnitEntriesAtKey`/
+ * `selectDefenderEntryAtKey` (#787 phase 8a) so `resolveMapTapIntent` can reuse
+ * the exact same visibility/concealment/stacked-defender rules instead of a
+ * naive reimplementation. `main.ts` still owns its own copies until phase 8b
+ * switches it over to these -- phase 8a is scoped to zero `main.ts` changes.
+ */
+export function visibleUnitEntriesAtKey(state: GameState, key: string): Array<[string, Unit]> {
+  const viewerUnits = Object.values(state.units).filter(u => u.owner === state.currentPlayer && !u.transportId);
+  return Object.entries(state.units).filter(([, unit]) =>
+    hexKey(unit.position) === key
+    && canInspectUnitForViewer(state, state.currentPlayer, unit.id)
+    && (unit.owner === state.currentPlayer || !isForestConcealedUnit(state, state.currentPlayer, unit))
+    && !isBeastConcealedFrom(unit, state.map, viewerUnits),
+  );
+}
+
+export function visibleHostileUnitEntriesAtKey(state: GameState, key: string): Array<[string, Unit]> {
+  return visibleUnitEntriesAtKey(state, key).filter(([, unit]) => unit.owner !== state.currentPlayer);
+}
+
+export function selectDefenderEntryAtKey(state: GameState, key: string): [string, Unit] | undefined {
+  const hostileEntries = visibleHostileUnitEntriesAtKey(state, key);
+  const defender = selectDefenderForAttack(hostileEntries.map(([, unit]) => unit), state.map);
+  if (!defender) return undefined;
+  return hostileEntries.find(([id]) => id === defender.id);
+}

--- a/src/input/map-tap-intent.ts
+++ b/src/input/map-tap-intent.ts
@@ -1,0 +1,189 @@
+import type { GameState, HexCoord } from '@/core/types';
+import type { PendingMapIntent, SelectionSnapshot } from '@/app/ports';
+import { getMovementBlockerReason, type MovementBlockerReason } from '@/systems/unit-system';
+import { isWorkerBusy } from '@/systems/unit-movement-system';
+import { hexKey } from '@/systems/hex-utils';
+import { canUnitAttackBeast } from '@/systems/beast-system';
+import { resolvePirateHeadquartersSelection } from '@/input/pirate-headquarters-selection';
+import { resolveFriendlyUnitStackTap } from '@/input/unit-stack-selection';
+import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
+import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
+import { selectDefenderEntryAtKey } from '@/input/hex-defender-selection';
+
+/**
+ * `resolveMapTapIntent`'s top-level result (#787 phase 8a).
+ *
+ * This is deliberately larger than this phase's plan sketch: `handleHexTap`
+ * has ~20 distinct outcomes, not 9 — several of its later branches build a DOM
+ * preview panel with live click-time button callbacks (combat preview, city
+ * assault preview, confirm-war dialogs). Those still get their own intent
+ * variant here, carrying only the *data* the executor needs to build that
+ * panel (ids and coords) -- never derived UI state (computed strengths,
+ * rendered strings), which the executor recomputes itself when it builds the
+ * panel, exactly as `handleHexTap` does today.
+ */
+export type MapTapIntent =
+  /** A pending intent (journey/air-mission/unload/city-capture) consumes this tap. */
+  | { readonly kind: 'resolve-pending'; readonly pending: PendingMapIntent; readonly coord: HexCoord }
+  /** The mis-tap case for a pending unload: tapped outside the legal unload range. */
+  | { readonly kind: 'mistap'; readonly pending: PendingMapIntent }
+  /** A city-capture choice is pending; every tap is swallowed until it resolves. */
+  | { readonly kind: 'ignore' }
+  | { readonly kind: 'open-pirate-faction'; readonly factionId: string }
+  | { readonly kind: 'open-pirate-region'; readonly factionId: string; readonly center: HexCoord }
+  /** The selected unit is mid-animation; taps are swallowed with a toast. */
+  | { readonly kind: 'animation-locked' }
+  | { readonly kind: 'open-stack-picker'; readonly coord: HexCoord; readonly unitIds: readonly string[] }
+  | { readonly kind: 'select-unit'; readonly unitId: string }
+  | { readonly kind: 'blocked-caravan-committed'; readonly unitId: string }
+  | { readonly kind: 'blocked-naval-gate'; readonly unitId: string; readonly reason: string }
+  | { readonly kind: 'blocked-movement'; readonly unitId: string; readonly reason: MovementBlockerReason }
+  /** No unit selected; tapped an enemy unit -- show its info panel. */
+  | { readonly kind: 'enemy-unit-info'; readonly unitId: string }
+  | { readonly kind: 'combat-preview'; readonly attackerId: string; readonly defenderId: string; readonly targetCoord: HexCoord }
+  | { readonly kind: 'assault-preview'; readonly attackerId: string; readonly cityId: string; readonly embarkedAssault: boolean }
+  | { readonly kind: 'confirm-war-city'; readonly attackerId: string; readonly cityId: string; readonly defenderId: string }
+  | { readonly kind: 'confirm-war-minor-civ'; readonly attackerId: string; readonly cityId: string; readonly minorCivId: string }
+  | { readonly kind: 'assault-minor-civ'; readonly attackerId: string; readonly coord: HexCoord; readonly cityId: string; readonly minorCivId: string }
+  | { readonly kind: 'worker-busy'; readonly unitId: string; readonly coord: HexCoord }
+  | { readonly kind: 'move'; readonly unitId: string; readonly coord: HexCoord }
+  | { readonly kind: 'open-city'; readonly cityId: string }
+  | { readonly kind: 'open-wonder-atlas'; readonly wonderId: string; readonly coord: HexCoord }
+  /** Tapped an empty, unremarkable hex with no relevant selection -- deselect. */
+  | { readonly kind: 'deselect' };
+
+/**
+ * `handleHexTap`'s decision logic as a pure function of a value (#787 phase
+ * 8a). No DOM, no mutation, no `bus`, no `renderLoop` -- everything the real
+ * `handleHexTap` needs beyond `GameState`+`SelectionSnapshot`+`HexCoord` is an
+ * explicit parameter:
+ *
+ * - `isAnimationLocked`: `renderLoop.hasMovingUnit(selectedUnitId)` is
+ *   renderer state, not derivable from `GameState`. The caller computes it
+ *   and passes it in -- this keeps the function pure without pretending
+ *   animation state lives in game state.
+ *
+ * Coordinate wrapping (`wrapHexCoord` for horizontally-wrapping maps) is the
+ * caller's responsibility, matching `handleHexTap`'s own first step -- `coord`
+ * here is assumed already wrapped.
+ */
+export function resolveMapTapIntent(
+  state: GameState,
+  selection: SelectionSnapshot,
+  coord: HexCoord,
+  isAnimationLocked: boolean,
+): MapTapIntent {
+  const pending = selection.pendingIntent;
+
+  if (pending.kind === 'city-capture') {
+    return { kind: 'ignore' };
+  }
+
+  if (pending.kind === 'journey' || pending.kind === 'air-mission') {
+    return { kind: 'resolve-pending', pending, coord };
+  }
+
+  const key = hexKey(coord);
+
+  if (pending.kind === 'unload') {
+    const inRange = pending.range.some(h => hexKey(h) === key);
+    return inRange ? { kind: 'resolve-pending', pending, coord } : { kind: 'mistap', pending };
+  }
+
+  const selectedUnitId = selection.selectedUnitId;
+
+  if (!selectedUnitId) {
+    const pirateSelection = resolvePirateHeadquartersSelection(state, state.currentPlayer, coord);
+    if (pirateSelection?.kind === 'faction') {
+      return { kind: 'open-pirate-faction', factionId: pirateSelection.factionId };
+    }
+    if (pirateSelection?.kind === 'region') {
+      return { kind: 'open-pirate-region', factionId: pirateSelection.factionId, center: pirateSelection.center };
+    }
+  }
+
+  if (isAnimationLocked) {
+    return { kind: 'animation-locked' };
+  }
+
+  const canMove = Boolean(selectedUnitId) && selection.movementRange.some(h => hexKey(h) === key);
+  const canAttack = Boolean(selectedUnitId) && selection.attackRange.some(h => hexKey(h) === key);
+
+  if (!canMove && !canAttack) {
+    const stackTap = resolveFriendlyUnitStackTap(state, coord, selectedUnitId);
+    if (stackTap.kind === 'open-stack-picker') {
+      return { kind: 'open-stack-picker', coord, unitIds: stackTap.unitIds };
+    }
+    if (stackTap.kind === 'select-unit') {
+      return { kind: 'select-unit', unitId: stackTap.unitId };
+    }
+  }
+
+  if (selectedUnitId && !canMove && !canAttack) {
+    const selectedUnit = state.units[selectedUnitId];
+    if (selectedUnit) {
+      if (selectedUnit.committedToRouteId) {
+        return { kind: 'blocked-caravan-committed', unitId: selectedUnitId };
+      }
+      const defenderAtHex = selectDefenderEntryAtKey(state, key)?.[1];
+      if (defenderAtHex) {
+        const navalGate = canUnitAttackBeast(selectedUnit, defenderAtHex);
+        if (!navalGate.allowed) {
+          return { kind: 'blocked-naval-gate', unitId: selectedUnitId, reason: navalGate.reason ?? 'Cannot attack that target.' };
+        }
+      }
+      const reason = getMovementBlockerReason(selectedUnit, coord, state.map, {
+        completedTechs: state.civilizations[selectedUnit.owner]?.techState.completed ?? [],
+      });
+      if (reason) {
+        return { kind: 'blocked-movement', unitId: selectedUnitId, reason };
+      }
+    }
+  }
+
+  const defenderEntry = selectDefenderEntryAtKey(state, key);
+  if (defenderEntry && !selectedUnitId) {
+    return { kind: 'enemy-unit-info', unitId: defenderEntry[0] };
+  }
+
+  if (selectedUnitId && (canMove || canAttack)) {
+    const unit = state.units[selectedUnitId];
+    if (!unit) return { kind: 'deselect' };
+
+    if (canAttack && defenderEntry) {
+      return { kind: 'combat-preview', attackerId: selectedUnitId, defenderId: defenderEntry[0], targetCoord: coord };
+    }
+
+    const tapIntent = resolveSelectedUnitTapIntent(state, selectedUnitId, coord, selection.movementRange);
+    if (tapIntent.kind === 'assault-city') {
+      return { kind: 'assault-preview', attackerId: selectedUnitId, cityId: tapIntent.cityId, embarkedAssault: Boolean(tapIntent.embarkedAssault) };
+    }
+    if (tapIntent.kind === 'confirm-war-city') {
+      return { kind: 'confirm-war-city', attackerId: selectedUnitId, cityId: tapIntent.cityId, defenderId: tapIntent.defenderId };
+    }
+    if (tapIntent.kind === 'confirm-war-minor-civ') {
+      return { kind: 'confirm-war-minor-civ', attackerId: selectedUnitId, cityId: tapIntent.cityId, minorCivId: tapIntent.minorCivId };
+    }
+    if (tapIntent.kind === 'assault-minor-civ') {
+      return { kind: 'assault-minor-civ', attackerId: selectedUnitId, coord, cityId: tapIntent.cityId, minorCivId: tapIntent.minorCivId };
+    }
+
+    if (isWorkerBusy(state, selectedUnitId)) {
+      return { kind: 'worker-busy', unitId: selectedUnitId, coord };
+    }
+
+    return { kind: 'move', unitId: selectedUnitId, coord };
+  }
+
+  const cityAtHex = Object.values(state.cities).find(c => c.owner === state.currentPlayer && hexKey(c.position) === key);
+  if (cityAtHex) {
+    return { kind: 'open-city', cityId: cityAtHex.id };
+  }
+
+  const wonderAtlasIntent = resolveWonderAtlasIntent(state, state.currentPlayer, coord);
+  if (wonderAtlasIntent.type === 'open-atlas') {
+    return { kind: 'open-wonder-atlas', wonderId: wonderAtlasIntent.wonderId, coord: wonderAtlasIntent.coord };
+  }
+
+  return { kind: 'deselect' };
+}

--- a/src/input/map-tap-intent.ts
+++ b/src/input/map-tap-intent.ts
@@ -84,12 +84,6 @@ export function resolveMapTapIntent(
   }
 
   const key = hexKey(coord);
-
-  if (pending.kind === 'unload') {
-    const inRange = pending.range.some(h => hexKey(h) === key);
-    return inRange ? { kind: 'resolve-pending', pending, coord } : { kind: 'mistap', pending };
-  }
-
   const selectedUnitId = selection.selectedUnitId;
 
   if (!selectedUnitId) {
@@ -104,6 +98,14 @@ export function resolveMapTapIntent(
 
   if (isAnimationLocked) {
     return { kind: 'animation-locked' };
+  }
+
+  // `unload` is checked here, after the pirate-HQ and animation-lock checks
+  // above -- matching handleHexTap's real order exactly (main.ts checks
+  // isUnitAnimationLocked before ever reading the pending-unload intent).
+  if (pending.kind === 'unload') {
+    const inRange = pending.range.some(h => hexKey(h) === key);
+    return inRange ? { kind: 'resolve-pending', pending, coord } : { kind: 'mistap', pending };
   }
 
   const canMove = Boolean(selectedUnitId) && selection.movementRange.some(h => hexKey(h) === key);
@@ -148,9 +150,26 @@ export function resolveMapTapIntent(
 
   if (selectedUnitId && (canMove || canAttack)) {
     const unit = state.units[selectedUnitId];
-    if (!unit) return { kind: 'deselect' };
+    // handleHexTap's real branch is a bare `return;` here -- a true no-op,
+    // not the deselect-and-tap-SFX fallback at the bottom of this function.
+    // Reuses `ignore` (already used for the city-capture guard above) rather
+    // than a new variant, since both are genuinely "do nothing at all".
+    if (!unit) return { kind: 'ignore' };
 
     if (canAttack && defenderEntry) {
+      // handleHexTap re-checks the naval attack gate here with an
+      // amphibious-assault-aware attacker position (a unit embarked on a
+      // transport attacks from the transport's position, not its own) --
+      // distinct from the earlier `blocked-naval-gate` check above, which
+      // only runs when the tap is NOT a legal move/attack target at all.
+      const amphibiousAssault = Boolean(unit.transportId);
+      const previewAttacker = amphibiousAssault && unit.transportId
+        ? { ...unit, position: { ...state.units[unit.transportId]?.position }, transportId: undefined }
+        : unit;
+      const navalGate = canUnitAttackBeast(previewAttacker, defenderEntry[1]);
+      if (!navalGate.allowed) {
+        return { kind: 'blocked-naval-gate', unitId: selectedUnitId, reason: navalGate.reason ?? 'Cannot attack that target.' };
+      }
       return { kind: 'combat-preview', attackerId: selectedUnitId, defenderId: defenderEntry[0], targetCoord: coord };
     }
 

--- a/tests/input/map-tap-intent.test.ts
+++ b/tests/input/map-tap-intent.test.ts
@@ -97,13 +97,26 @@ describe('resolveMapTapIntent', () => {
       expect(intent).toEqual({ kind: 'mistap', pending });
     });
 
-    it('takes precedence over animation-lock and every other check', () => {
+    it('journey and air-mission take precedence over animation-lock and every other check', () => {
       const state = makeFixture();
       const pending: PendingMapIntent = { kind: 'journey', unitId: 'unit-1' };
 
       const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending, selectedUnitId: 'unit-1' }), { q: 2, r: 2 }, true);
 
       expect(intent.kind).toBe('resolve-pending');
+    });
+
+    it('swallows a tap under a pending unload while the selected unit is mid-animation, instead of resolving the unload', () => {
+      // handleHexTap checks isUnitAnimationLocked before ever reading the
+      // pending-unload intent (unlike journey/air-mission, which are checked
+      // before the animation-lock check) -- an ordering this test locks in
+      // after an earlier draft of resolveMapTapIntent got it backwards.
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'unload', transportId: 't1', cargoUnitId: 'c1', range: [{ q: 2, r: 2 }] };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending, selectedUnitId: 't1' }), { q: 2, r: 2 }, true);
+
+      expect(intent).toEqual({ kind: 'animation-locked' });
     });
   });
 
@@ -236,6 +249,47 @@ describe('resolveMapTapIntent', () => {
       );
 
       expect(intent).toEqual({ kind: 'combat-preview', attackerId: 'unit-1', defenderId: 'enemy-1', targetCoord: { q: 1, r: 0 } });
+    });
+
+    it('blocks the attack preview instead of previewing when the naval gate disallows the attacker', () => {
+      // A second, amphibious-assault-aware naval-gate check that handleHexTap
+      // runs specifically inside the attack-preview branch (distinct from the
+      // earlier blocked-naval-gate check above, which only fires for a tap
+      // that isn't a legal move/attack target at all). An earlier draft of
+      // resolveMapTapIntent omitted this second check entirely.
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 }, type: 'warrior' });
+      placeEnemyUnit(state, 'sea-serpent-1', 'beasts', { position: { q: 1, r: 0 }, type: 'beast_sea_serpent' as never });
+      makeVisible(state, { q: 1, r: 0 });
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', attackRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({
+        kind: 'blocked-naval-gate', unitId: 'unit-1',
+        reason: 'Only ships and ranged units can fight the Sea Serpent.',
+      });
+    });
+
+    it('does nothing when the selected unit no longer exists (a true no-op, not a deselect)', () => {
+      // handleHexTap's real branch here is a bare `return;` -- distinct from
+      // the deselect-and-tap-SFX fallback this function uses for an
+      // unremarkable empty-hex tap. An earlier draft of resolveMapTapIntent
+      // conflated the two.
+      const state = makeFixture();
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'gone', movementRange: [{ q: 1, r: 1 }] }),
+        { q: 1, r: 1 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'ignore' });
     });
 
     it('moves the selected unit to a reachable empty hex', () => {

--- a/tests/input/map-tap-intent.test.ts
+++ b/tests/input/map-tap-intent.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { createUnit } from '@/systems/unit-system';
+import { createEmptyPirateState } from '@/core/pirate-state';
+import { NO_LAND_UNIT_WATER_RECOVERY } from '@/systems/unit-water-recovery';
+import type { PendingMapIntent, SelectionSnapshot } from '@/app/ports';
+import { resolveMapTapIntent } from '@/input/map-tap-intent';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'tap-intent', 'small');
+  state.currentPlayer = 'player';
+  return state;
+}
+
+function makeVisible(state: GameState, coord: { q: number; r: number }) {
+  state.civilizations.player.visibility.tiles[`${coord.q},${coord.r}`] = 'visible';
+}
+
+function snapshot(overrides: Partial<SelectionSnapshot> = {}): SelectionSnapshot {
+  return {
+    selectedUnitId: null,
+    movementRange: [],
+    attackRange: [],
+    pendingIntent: { kind: 'none' },
+    waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
+    ...overrides,
+  };
+}
+
+function placePlayerUnit(state: GameState, id: string, overrides: Partial<GameState['units'][string]> = {}) {
+  const template = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'warrior');
+  if (!template) throw new Error('missing player warrior template');
+  state.units[id] = { ...template, id, owner: 'player', position: { q: 0, r: 0 }, ...overrides };
+  if (!state.civilizations.player.units.includes(id)) state.civilizations.player.units.push(id);
+  return state.units[id];
+}
+
+function placeEnemyUnit(state: GameState, id: string, owner: string, overrides: Partial<GameState['units'][string]> = {}) {
+  const template = Object.values(state.units).find(u => u.type === 'warrior') ?? createUnit('warrior', owner, { q: 5, r: 5 }, mkC());
+  state.units[id] = { ...template, id, owner, position: { q: 1, r: 0 }, ...overrides };
+  if (state.civilizations[owner] && !state.civilizations[owner].units.includes(id)) {
+    state.civilizations[owner].units.push(id);
+  }
+  return state.units[id];
+}
+
+describe('resolveMapTapIntent', () => {
+  // ── Pending-intent precedence: a pending intent consumes the tap before ──
+  // ── anything else runs, matching handleHexTap's fixed precedence order. ──
+  describe('pending intents', () => {
+    it('ignores every tap while a city-capture choice is pending', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'city-capture', choice: { cityId: 'x', occupiedPopulation: 1, razeGold: 1 } as never };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending }), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'ignore' });
+    });
+
+    it('resolves a pending journey to the tapped coord', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'journey', unitId: 'unit-1' };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending }), { q: 2, r: 2 }, false);
+
+      expect(intent).toEqual({ kind: 'resolve-pending', pending, coord: { q: 2, r: 2 } });
+    });
+
+    it('resolves a pending air mission to the tapped coord', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'air-mission', unitId: 'unit-1', mission: 'strike' };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending }), { q: 2, r: 2 }, false);
+
+      expect(intent).toEqual({ kind: 'resolve-pending', pending, coord: { q: 2, r: 2 } });
+    });
+
+    it('resolves a pending unload when the tap is inside the legal range', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'unload', transportId: 't1', cargoUnitId: 'c1', range: [{ q: 2, r: 2 }] };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending }), { q: 2, r: 2 }, false);
+
+      expect(intent).toEqual({ kind: 'resolve-pending', pending, coord: { q: 2, r: 2 } });
+    });
+
+    it('mis-taps a pending unload when the tap is outside the legal range', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'unload', transportId: 't1', cargoUnitId: 'c1', range: [{ q: 2, r: 2 }] };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending }), { q: 9, r: 9 }, false);
+
+      expect(intent).toEqual({ kind: 'mistap', pending });
+    });
+
+    it('takes precedence over animation-lock and every other check', () => {
+      const state = makeFixture();
+      const pending: PendingMapIntent = { kind: 'journey', unitId: 'unit-1' };
+
+      const intent = resolveMapTapIntent(state, snapshot({ pendingIntent: pending, selectedUnitId: 'unit-1' }), { q: 2, r: 2 }, true);
+
+      expect(intent.kind).toBe('resolve-pending');
+    });
+  });
+
+  // ── No unit selected: pirate HQ selection, enemy info, own unit/city, ──
+  // ── wonder atlas, or a plain deselect. ──
+  describe('no unit selected', () => {
+    it('opens a pirate faction panel when tapping a known pirate headquarters', () => {
+      const state = makeFixture();
+      state.pirates = createEmptyPirateState();
+      state.pirates.factions['faction-1'] = {
+        id: 'faction-1', name: 'Test Pirates', spawnedRound: 1, behavior: 'raiding', maritimeStage: 1,
+        notoriety: 1, shipIds: [],
+        headquarters: { kind: 'coastal-enclave', position: { q: 4, r: 4 }, integrity: 40, maxIntegrity: 100 },
+        tributeByCiv: {}, demandByCiv: {}, contract: null, intent: null,
+        transitionGuards: { emittedEventKeys: [] },
+      } as never;
+      state.pirates.intelByCiv.player = {
+        'faction-1': {
+          factionId: 'faction-1', level: 'sighted', discoveredRound: 1, lastUpdatedRound: 1,
+          lastKnownHeadquarters: { kind: 'coastal-enclave', position: { q: 4, r: 4 }, observedRound: 1 },
+        } as never,
+      };
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 4, r: 4 }, false);
+
+      expect(intent).toEqual({ kind: 'open-pirate-faction', factionId: 'faction-1' });
+    });
+
+    it('selects a friendly unit tapped directly', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 3, r: 3 } });
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'select-unit', unitId: 'unit-1' });
+    });
+
+    it('opens a stack picker for multiple friendly units on one hex', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 3, r: 3 } });
+      placePlayerUnit(state, 'unit-2', { position: { q: 3, r: 3 } });
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'open-stack-picker', coord: { q: 3, r: 3 }, unitIds: ['unit-1', 'unit-2'] });
+    });
+
+    it('shows enemy unit info when tapping a hostile unit with nothing selected', () => {
+      const state = makeFixture();
+      placeEnemyUnit(state, 'enemy-1', 'ai-1', { position: { q: 3, r: 3 } });
+      makeVisible(state, { q: 3, r: 3 });
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'enemy-unit-info', unitId: 'enemy-1' });
+    });
+
+    it('opens the owning player city panel when tapping an owned city', () => {
+      const state = makeFixture();
+      state.cities.home = { ...foundCity('player', { q: 3, r: 3 }, state.map, mkC()), id: 'home', owner: 'player', position: { q: 3, r: 3 } };
+      state.civilizations.player.cities.push('home');
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'open-city', cityId: 'home' });
+    });
+
+    it('opens the wonder atlas when tapping a discovered natural wonder', () => {
+      const state = makeFixture();
+      const key = '3,3';
+      state.map.tiles[key] = { ...state.map.tiles[key], wonder: 'great-falls' };
+      state.wonderDiscoverers = { 'great-falls': ['player'] };
+      makeVisible(state, { q: 3, r: 3 });
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'open-wonder-atlas', wonderId: 'great-falls', coord: { q: 3, r: 3 } });
+    });
+
+    it('deselects on a tap that matches nothing', () => {
+      const state = makeFixture();
+
+      const intent = resolveMapTapIntent(state, snapshot(), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'deselect' });
+    });
+  });
+
+  // ── A unit is selected: animation lock, blockers, and the ──
+  // ── move/attack/assault/confirm-war family via resolveSelectedUnitTapIntent. ──
+  describe('unit selected', () => {
+    it('swallows the tap while the selected unit is mid-animation', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1');
+
+      const intent = resolveMapTapIntent(state, snapshot({ selectedUnitId: 'unit-1' }), { q: 3, r: 3 }, true);
+
+      expect(intent).toEqual({ kind: 'animation-locked' });
+    });
+
+    it('blocks re-selecting a committed caravan when the tapped hex is out of range', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { committedToRouteId: 'route-1' });
+
+      const intent = resolveMapTapIntent(state, snapshot({ selectedUnitId: 'unit-1' }), { q: 3, r: 3 }, false);
+
+      expect(intent).toEqual({ kind: 'blocked-caravan-committed', unitId: 'unit-1' });
+    });
+
+    it('reports a movement blocker for an unreachable out-of-range tap', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+
+      const intent = resolveMapTapIntent(state, snapshot({ selectedUnitId: 'unit-1' }), { q: 3, r: 3 }, false);
+
+      expect(intent.kind).toBe('blocked-movement');
+    });
+
+    it('opens a combat preview when tapping an attackable enemy in attack range', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      placeEnemyUnit(state, 'enemy-1', 'ai-1', { position: { q: 1, r: 0 } });
+      makeVisible(state, { q: 1, r: 0 });
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', attackRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'combat-preview', attackerId: 'unit-1', defenderId: 'enemy-1', targetCoord: { q: 1, r: 0 } });
+    });
+
+    it('moves the selected unit to a reachable empty hex', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 1 }] }),
+        { q: 1, r: 1 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'move', unitId: 'unit-1', coord: { q: 1, r: 1 } });
+    });
+
+    it('previews a city assault when resolveSelectedUnitTapIntent returns assault-city', () => {
+      const state = makeFixture();
+      const unit = placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      state.cities.enemyCity = { ...foundCity('ai-1', { q: 1, r: 0 }, state.map, mkC()), id: 'enemyCity', owner: 'ai-1', position: { q: 1, r: 0 } };
+      state.civilizations['ai-1'].cities.push('enemyCity');
+      state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+      state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+      const profile = unit.type;
+      void profile;
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'assault-preview', attackerId: 'unit-1', cityId: 'enemyCity', embarkedAssault: false });
+    });
+
+    it('asks for war confirmation when resolveSelectedUnitTapIntent returns confirm-war-city', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      state.cities.enemyCity = { ...foundCity('ai-1', { q: 1, r: 0 }, state.map, mkC()), id: 'enemyCity', owner: 'ai-1', position: { q: 1, r: 0 } };
+      state.civilizations['ai-1'].cities.push('enemyCity');
+      state.civilizations.player.diplomacy.atWarWith = [];
+      state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'confirm-war-city', attackerId: 'unit-1', cityId: 'enemyCity', defenderId: 'ai-1' });
+    });
+
+    it('asks for war confirmation when resolveSelectedUnitTapIntent returns confirm-war-minor-civ', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      state.cities['mc-city'] = { ...foundCity('mc-warriors', { q: 1, r: 0 }, state.map, mkC()), id: 'mc-city', owner: 'mc-warriors', position: { q: 1, r: 0 } };
+      state.civilizations.player.diplomacy.atWarWith = [];
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'confirm-war-minor-civ', attackerId: 'unit-1', cityId: 'mc-city', minorCivId: 'mc-warriors' });
+    });
+
+    it('assaults a minor civ directly when already at war with it', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      state.cities['mc-city'] = { ...foundCity('mc-warriors', { q: 1, r: 0 }, state.map, mkC()), id: 'mc-city', owner: 'mc-warriors', position: { q: 1, r: 0 } };
+      state.civilizations.player.diplomacy.atWarWith = ['mc-warriors'];
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'assault-minor-civ', attackerId: 'unit-1', coord: { q: 1, r: 0 }, cityId: 'mc-city', minorCivId: 'mc-warriors' });
+    });
+
+    it('reports worker-busy instead of moving a unit still finishing an improvement', () => {
+      const state = makeFixture();
+      state.map.tiles['0,0'] = { ...state.map.tiles['0,0'], roadTurnsLeft: 2 };
+      placePlayerUnit(state, 'unit-1', {
+        position: { q: 0, r: 0 },
+        type: 'worker',
+        workerTask: { action: 'build_road', coord: { q: 0, r: 0 } },
+      } as never);
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 1 }] }),
+        { q: 1, r: 1 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'worker-busy', unitId: 'unit-1', coord: { q: 1, r: 1 } });
+    });
+
+    it('re-selects a friendly stack instead of moving when the tapped hex has no move/attack range match', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      placePlayerUnit(state, 'unit-2', { position: { q: 5, r: 5 } });
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 1 }] }),
+        { q: 5, r: 5 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'select-unit', unitId: 'unit-2' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

First of four sub-PRs for Phase 8 (the composition-root decomposition arc, #787). Extracts `handleHexTap`'s decision logic into a new pure function, `resolveMapTapIntent`, with **zero changes to `main.ts`** — `handleHexTap` keeps running its own inline branching unchanged for now. Phase 8b wires this function in.

See the [restructured Phase 8 plan section](https://github.com/a1flecke/conquestoria/blob/3f9e5f18237d9673d28e2e1924474ecc21cadfe5/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md#phase-8--selectioncontroller-and-mapinteractioncontroller) for the full 8a–8d breakdown and why it was split.

## Key design decisions

- **The real union has ~20 variants, not the plan's original 9.** Reading the current `handleHexTap` (`src/main.ts:3044-3693`) top to bottom showed several branches build DOM preview panels with live click-time button callbacks (combat preview, city-assault preview, both confirm-war dialogs) that the plan's sketch didn't account for. Each still gets its own `MapTapIntent` variant here, carrying only the *data* the executor will need (ids, coords) — the executor recomputes any derived display data (strengths, formatted strings) itself, exactly as `handleHexTap` does today. Documented as a plan deviation per `.claude/rules/spec-fidelity.md`.
- **Reuses four already-extracted pure resolvers** instead of reimplementing their logic: `resolveSelectedUnitTapIntent`, `resolveWonderAtlasIntent`, `resolvePirateHeadquartersSelection`, `resolveFriendlyUnitStackTap`, plus `getMovementBlockerReason`. `resolveMapTapIntent`'s job is to compose these in the exact precedence order `handleHexTap` uses today, not to re-derive their decisions.
- **New shared module `src/input/hex-defender-selection.ts`** mirrors `main.ts`'s `visibleUnitEntriesAtKey`/`visibleHostileUnitEntriesAtKey`/`selectDefenderEntryAtKey` — the real defender-selection rule (visibility gating, forest/beast concealment, stacked-defender selection via `selectDefenderForAttack`), not a naive "first unit at this hex" lookup. My first draft used a naive reimplementation that silently dropped visibility/concealment/stacking; caught by fixing the tests to use realistic fixtures (a hostile unit outside the viewer's visibility must not be treated as attackable/inspectable). `main.ts` keeps its own copy of this logic until phase 8b switches it over — duplicated for one sub-PR, not the final state.
- **`isAnimationLocked` is an explicit boolean parameter**, not derived from `GameState`. `renderLoop.hasMovingUnit(unitId)` is renderer state with no `GameState` representation; the caller (the 8d executor) computes it and passes it in, keeping the function genuinely pure rather than pretending animation state lives in game state.

## Testing

- TDD throughout: 24 tests written first, confirmed failing (`not implemented` stub), then implemented to green.
- Covers the plan's 10-row Interaction Replay Checklist plus every additional branch found while reading the real code (pirate HQ selection, enemy-unit info, combat/assault preview, both confirm-war variants, assault-minor-civ, worker-busy, open-city, wonder-atlas, deselect fallback) — see file header comments for which checklist rows are genuinely out of scope for this pure function (Escape-key handling, mis-tap-toast dedup, and `handleHexLongPress` all live in other modules/later sub-phases).
- Full suite: 467 test files, 7587 tests passing, 3 skipped (up from 466/7562 baseline — purely additive). `yarn build` clean.

## Out of scope

- Wiring this function into `handleHexTap` (phase 8b).
- `SelectionController` and `MapInteractionController` extraction (phases 8c/8d).
- The 10 affected grep-based test-assertion conversions (phase 8d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)