### PR TITLE
Extract SelectionController from main.ts (#787 phase 8c)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -378,7 +378,7 @@ src/main.ts                      ~120 lines: construct concrete services, call b
 
 You asked for review across gameplay, fun, ages, playstyles, difficulty, AI, UI/UX, extensibility, data, SFX, saves, and hot seat. For a behavior-preserving refactor most of those reduce to one question — *is this surface protected?* — so they are enumerated here as protected surfaces with an owning phase and a guard, rather than as design opportunities.
 
-**On new mechanics and fun specifically:** this plan deliberately adds none. A composition-root refactor is the single worst place to land a gameplay change, because there is no test baseline to distinguish "the refactor broke it" from "the new mechanic changed it." The correct sequencing is: land these 11 phases, *then* build new mechanics on top — which is far cheaper afterwards, because a new mechanic becomes one registrar plus one registry entry instead of another 200 lines in `main.ts`. The extensibility payoff is real, and it is the reward for keeping this plan boring.
+**On new mechanics and fun specifically:** this plan deliberately adds none. A composition-root refactor is the single worst place to land a gameplay change, because there is no test baseline to distinguish "the refactor broke it" from "the new mechanic changed it." The correct sequencing is: land these 12 phases, *then* build new mechanics on top — which is far cheaper afterwards, because a new mechanic becomes one registrar plus one registry entry instead of another 200 lines in `main.ts`. The extensibility payoff is real, and it is the reward for keeping this plan boring.
 
 ### Protected surfaces
 
@@ -433,6 +433,8 @@ Per `docs/superpowers/plans/README.md`. This refactor is behavior-preserving, so
 | Journey intent armed | Press Escape | "Journey cancelled." toast; next tap behaves normally | Phase 5, `global-shortcuts.test.ts` |
 | Natural wonder discovered while a city panel is open | Close the panel | Reveal ceremony plays, discovery audio fires | **Phase 6**, `ceremony-coordinator.test.ts` |
 | Natural wonder discovered by a unit mid-move | — | Reveal waits for the move to settle, then plays | Phase 6, `ceremony-coordinator.test.ts` |
+| Hot-seat, discovery reveal queued (or deferred) when a player ends their turn | Confirm handoff | Reveal never plays on the *next* player's screen; it is dropped, not carried across the hot-seat veil | Phase 6, `ceremony-coordinator.test.ts` (`clearForHandoff`) |
+| Ceremony actively presenting when a hot-seat handoff begins | Handoff completes, ceremony's own promise resolves | Handoff's blocking overlay stays active until the handoff itself clears it; the ceremony resolving does not prematurely unblock the next player's screen | **Phase 12**, `panel-host.test.ts` |
 | Pause menu open, difficulty set to a harder challenge | End turn | Challenge applies once, at the next handoff, to the right civ | Phase 9, `turn-flow-controller.test.ts` |
 | Hot-seat, player 1 ends turn | Confirm handoff | Blocking overlay, audio muted to 0, autosave, then player 2's HUD/civ name, volume restored | Phase 9, `turn-flow-controller.test.ts` |
 | Toast visible, second event fires | — | Second toast queues, shows after the first dismisses; timer not reset | Phase 4, `notification-center.test.ts` |
@@ -469,7 +471,7 @@ The derived surface at risk is **"the HUD/renderer reflects current state."** It
 
 ## Part V — Phases
 
-Eleven phases, eleven PRs. Phases 1 and 2 are prerequisites for everything after; 3–10 are strictly ordered because each removes state that the next would otherwise thread through a deps bag.
+Twelve phases, twelve PRs. Phases 1 and 2 are prerequisites for everything after; 3–10 are strictly ordered because each removes state that the next would otherwise thread through a deps bag. Phase 12 was added after Phase 6 shipped, once its inline review surfaced a structural issue (#794) that no earlier phase covered — it has no ordering dependency on 7–10 and could in principle run any time after Phase 6, but is listed last since it was discovered last.
 
 **Every phase ends with the same steps** (written once here, referenced as "**Close the phase**"):
 
@@ -487,7 +489,7 @@ All must exit 0. Then commit, push, and open a PR whose body states: `main.ts` l
 
 ### Two gameplay guards, not one
 
-**`yarn test:ai-playability` already exists and is the better of the two.** `tests/simulation/ai-playability.test.ts` runs 30-turn simulations across real difficulty levels (`'explorer' | 'standard' | 'veteran'`) and AI personality sets via `simulateAIRounds` / `simulateLateEraAIRounds`. It is the existing, maintained answer to "do computer players still work and does difficulty still mean anything." **It is slow** (`run-ai-playability-regressions.sh` allows 300 s with a 120 s per-test timeout), so it runs in the phases that can plausibly affect it — Phase 1 (save/state construction), Phase 9 (turn flow, AI replay, difficulty application), and Phase 11 (final) — not in every phase.
+**`yarn test:ai-playability` already exists and is the better of the two.** `tests/simulation/ai-playability.test.ts` runs 30-turn simulations across real difficulty levels (`'explorer' | 'standard' | 'veteran'`) and AI personality sets via `simulateAIRounds` / `simulateLateEraAIRounds`. It is the existing, maintained answer to "do computer players still work and does difficulty still mean anything." **It is slow** (`run-ai-playability-regressions.sh` allows 300 s with a 120 s per-test timeout), so it runs in the phases that can plausibly affect it — Phase 1 (save/state construction), Phase 9 (turn flow, AI replay, difficulty application), and Phase 11 (boundary-lock, the final phase of the *original* eleven-phase scope) — not in every phase. Phase 12 is UI-blocking-overlay-only and does not touch AI, difficulty, or turn flow, so it does not need this guard.
 
 **The determinism guard below is the cheap per-phase complement.** It runs the real turn pipeline with no UI in a couple of seconds, so every phase can afford it.
 
@@ -643,7 +645,7 @@ function withDefault<T, K extends keyof T>(
 
 - [ ] **Step 1: Record the determinism baseline first**
 
-Create `tests/app/determinism-guard.test.ts` as written in Part V, run it, read the actual values out of the failure output, and write them in as literals **before touching any source file**. This is the pre-refactor baseline for all eleven phases.
+Create `tests/app/determinism-guard.test.ts` as written in Part V, run it, read the actual values out of the failure output, and write them in as literals **before touching any source file**. This is the pre-refactor baseline for all twelve phases.
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/app/determinism-guard.test.ts
@@ -1652,15 +1654,42 @@ This is the guard against double-registration duplicating every notification —
 
 ### Phase 8 — `SelectionController` and `MapInteractionController`
 
-The biggest phase: `selectUnit` (456 lines), `handleHexTap` (624), `handleHexLongPress` (37), plus movement/animation helpers.
+**Split into four sub-phases/sub-PRs (8a–8d), added 2026-08-06 after actually reading the
+current `selectUnit`/`handleHexTap` against this section's original sketch.** The original
+single-PR, 8-step version of this phase (interface sketch below the split note, kept for
+history) undersold the real scope: as of `#787` Phase 7 landing, `selectUnit` is ~450 lines
+(`src/main.ts:1974-2422`) wiring **~30 mutually-recursive callbacks** into
+`renderSelectedUnitInfo` (several call `selectUnit` itself), and `handleHexTap` is ~650 lines
+(`src/main.ts:3044-3693`) whose later branches (combat preview, city-assault preview,
+confirm-war dialogs) build DOM panels with **live button callbacks that re-read selection state
+at click time** — not simple discrete outcomes. The plan's original 9-variant `MapTapIntent`
+sketch is consequently too small for the real branch count; the real union has roughly twice
+that many variants once pirate-HQ selection, enemy-unit info display, combat/assault preview,
+both confirm-war dialogs, `assault-minor-civ`, worker-busy warning, and wonder-atlas-open are
+each given their own variant. Per `.claude/rules/spec-fidelity.md`, this is a plan-vs-code
+deviation, not a plan mistake to silently paper over — the actual variant list is defined by
+Phase 8a's implementation, not by this document; do not treat this note as the final union.
 
-**Files:**
-- Create: `src/app/controllers/selection-controller.ts`, `src/app/controllers/map-interaction-controller.ts`, `src/input/map-tap-intent.ts`, and their three test files
-- Modify: `src/main.ts`
+This is still the biggest and riskiest phase in the arc — the plan's own risk table already
+flagged it as the phase most likely to cause a replay-sensitive regression. Splitting into four
+independently-mergeable PRs, ordered strictly by increasing risk, is a scope decision (not a
+technical necessity) made to keep each PR reviewable and revertible on its own:
+
+- **8a** is purely additive (new file, zero `main.ts` changes, zero production behavior change)
+  and can be reverted trivially if anything about the union shape needs to change later.
+- **8b** is the one PR where a precedence mistake could actually break a live interaction; it
+  changes nothing else (no file moves), so a regression is easy to bisect to this PR alone.
+- **8c** and **8d** are structural (moving already-correct code into controllers) with lower
+  behavioral risk than 8b, but larger diffs.
+
+**Files (across all four sub-phases):**
+- Create: `src/input/map-tap-intent.ts`, `src/app/controllers/selection-controller.ts`,
+  `src/app/controllers/map-interaction-controller.ts`, and their test files
+- Modify: `src/main.ts` (8b–8d only; 8a does not touch `main.ts`)
 
 **Interfaces:**
 - Consumes: `GameSession`, `SelectionStore`, `Notifier`, `PanelRouter`, `CeremonyCoordinator`.
-- Produces:
+- Produces (illustrative starting point only — see the split note above):
 
 ```ts
 import type { MovementBlockerReason } from '@/systems/unit-system';
@@ -1675,6 +1704,10 @@ export type MapTapIntent =
   | { readonly kind: 'resolve-pending'; readonly intent: PendingMapIntent; readonly coord: HexCoord }
   | { readonly kind: 'mistap'; readonly intent: PendingMapIntent }
   | { readonly kind: 'blocked'; readonly reason: MovementBlockerReason };
+  // 8a will add the remaining ~10 variants named in the split note above
+  // (pirate-hq, enemy-info, combat-preview, assault-preview, confirm-war-city,
+  // confirm-war-minor-civ, assault-minor-civ, worker-busy, wonder-atlas, ...)
+  // as it reads the real branch structure top to bottom.
 
 export function resolveMapTapIntent(
   state: GameState,
@@ -1683,7 +1716,29 @@ export function resolveMapTapIntent(
 ): MapTapIntent;
 ```
 
-`resolveMapTapIntent` is **pure** — no DOM, no mutation, no `bus` — which is what makes the ten-row Interaction Replay Checklist cheap to test. The controller's `handleHexTap` becomes an exhaustive `switch (intent.kind)` with:
+`resolveMapTapIntent` is **pure** — no DOM, no mutation, no `bus`. Variants whose real branch
+also builds a DOM preview panel (combat preview, assault preview, confirm-war dialogs) still
+carry only the *data* the executor needs to build that panel (attacker/defender ids, computed
+strengths are recomputed by the executor, not carried across — keep the intent variant a plain
+data descriptor, not a snapshot of derived UI state) — the DOM construction and live button
+callbacks stay in the 8d executor, not in this function.
+
+The `mistap` variant is separate from `ignore` because mis-tap forgiveness (Phase 3) needs the
+executor to consult `selection.shouldWarnOnMistap()` — an `ignore` result would lose the
+affordance.
+
+#### Phase 8a — `resolveMapTapIntent` (pure function, standalone, zero `main.ts` changes)
+
+- [ ] **Step 1: Write failing tests for `resolveMapTapIntent`** — one per row of the Interaction Replay Checklist in Part IV, **plus** one per additional real branch discovered while reading `src/main.ts:3044-3693` top to bottom (see split note — expect roughly double the checklist's 10 rows once combat/assault preview, confirm-war, pirate-HQ, and wonder-atlas branches are covered). Pure-function tests over a fixture state; reuse `tests/fixtures/` if one fits, otherwise add a builder there.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement `resolveMapTapIntent`** by reading `src/main.ts:3044-3693` (current line numbers — re-check before starting, they will have shifted again since this note) top to bottom and translating each early-return branch into a union member. **Do not change precedence — the existing order is the specification.** Where the code checks four pending flags in sequence, translate to one `switch (selection.pendingIntent.kind)` preserving the same outcomes.
+- [ ] **Step 4: Run — expect PASS.** `main.ts` is untouched; `handleHexTap` still runs its own inline branching. Close this as its own PR — it is safe to merge without wiring it in yet.
+
+#### Phase 8b — Wire `resolveMapTapIntent` into `handleHexTap`
+
+- [ ] **Step 1: Write failing tests** proving `handleHexTap` dispatches on `resolveMapTapIntent`'s result for each variant from 8a, still calling the same existing inline DOM/mutation code per branch (no code moves yet — only the branch-selection mechanism changes, from ad hoc early returns to one `switch (intent.kind)` with the exhaustiveness guard below).
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement.** Replace `handleHexTap`'s branching with a call to `resolveMapTapIntent` followed by:
 
 ```ts
 default: {
@@ -1692,16 +1747,24 @@ default: {
 }
 ```
 
-The `mistap` variant is separate from `ignore` because mis-tap forgiveness (Phase 3) needs the executor to consult `selection.shouldWarnOnMistap()` — an `ignore` result would lose the affordance.
+Each `case` body is the same code that used to live in the corresponding `if`/early-return branch, moved verbatim under the matching `case`, not rewritten.
+- [ ] **Step 4: Run — expect PASS.** Run the full Interaction Replay Checklist (Part IV) as a manual or e2e smoke pass, not just the unit tests, since this PR is the one most likely to silently change precedence. Close as its own PR.
 
-- [ ] **Step 1: Write failing tests for `resolveMapTapIntent`** — one per row of the Interaction Replay Checklist in Part IV. Pure-function tests over a fixture state; reuse `tests/fixtures/` if one fits, otherwise add a builder there.
+#### Phase 8c — Extract `SelectionController`
+
+- [ ] **Step 1: Write failing tests** for `selectUnit`, `deselectUnit`, `selectNextUnit`, `refreshSelectedUnitAfterCombat`, `refreshCurrentPlayerVisibility`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `isUnitAnimationLocked`: selecting sets ranges; deselecting clears ranges and highlights; `selectNextUnit` skips acted units; a second `selectUnit` on an animating unit is a no-op; an animated move brackets the ceremony defer window.
 - [ ] **Step 2: Run, confirm failure.**
-- [ ] **Step 3: Implement `resolveMapTapIntent`** by reading `src/main.ts:3144-3768` top to bottom and translating each early-return branch into a union member. **Do not change precedence — the existing order is the specification.** Where the code checks four pending flags in sequence, translate to one `switch (selection.pendingIntent.kind)` preserving the same outcomes.
+- [ ] **Step 3: Implement `SelectionController`** in `src/app/controllers/selection-controller.ts`, moving the eleven functions verbatim. The ~30 callbacks `selectUnit` wires into `renderSelectedUnitInfo` move with it unchanged; do not attempt to split them out into a separate concern in this phase — that is out of scope for Phase 8 and would be its own future MR if warranted. `main.ts` calls the controller's methods in place of the old local functions.
+- [ ] **Step 4: Run — expect PASS.** Close as its own PR.
+
+#### Phase 8d — Extract `MapInteractionController`, wire it up, convert affected grep tests
+
+- [ ] **Step 1: Write failing tests** for the extracted executor (from 8b) plus `handleHexLongPress`. Test that long-press opens territory inspection and leaves selection unchanged.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement `MapInteractionController`** in `src/app/controllers/map-interaction-controller.ts`, moving the 8b-era switch-based `handleHexTap` executor and `handleHexLongPress` verbatim, consuming `resolveMapTapIntent` (8a) and `SelectionController` (8c).
 - [ ] **Step 4: Run — expect PASS.**
-- [ ] **Step 5: Extract `SelectionController`** (`selectUnit`, `deselectUnit`, `selectNextUnit`, `refreshSelectedUnitAfterCombat`, `refreshCurrentPlayerVisibility`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `isUnitAnimationLocked`). Tests: selecting sets ranges; deselecting clears ranges and highlights; `selectNextUnit` skips acted units; a second `selectUnit` on an animating unit is a no-op; an animated move brackets the ceremony defer window.
-- [ ] **Step 6: Extract `MapInteractionController`** — the executor plus `handleHexLongPress`. Test that long-press opens territory inspection and leaves selection unchanged.
-- [ ] **Step 7: Convert the affected source-grep assertions.** `player combat wiring` (3), `land-unit water recovery wiring` (1), `shared city founding wiring` (1), `shared unit upgrade wiring` (1), `shared city assault wiring` (4) — 10 total. Rewrite as real tests; delete from the grep file.
-- [ ] **Step 8: Close the phase**
+- [ ] **Step 5: Convert the affected source-grep assertions.** `player combat wiring` (3), `land-unit water recovery wiring` (1), `shared city founding wiring` (1), `shared unit upgrade wiring` (1), `shared city assault wiring` (4) — 10 total. Rewrite as real tests; delete from the grep file.
+- [ ] **Step 6: Close the phase.** This is the last of the four sub-PRs; once merged, Phase 8 as a whole is done and Phase 9 can begin.
 
 ---
 
@@ -1933,6 +1996,37 @@ bash scripts/run-with-mise.sh yarn test:ai-playability
 
 ---
 
+### Phase 12 — Blocking-overlay reference counting (`PanelHost`)
+
+Found during #787 Phase 6's inline review, filed as [#794](https://github.com/a1flecke/conquestoria/issues/794), after Phases 1–11 above were already written — not part of the original six-controller/`CeremonyCoordinator`/`MapInteractionController` inventory in Part II, so it gets its own phase rather than being folded into Phase 5's or Phase 11's scope after the fact.
+
+`createUiInteractionState` (`src/ui/ui-interaction-state.ts`) tracks exactly one `blockingOverlayId: string | null` — no reference count, no stack. Every one of the ~15 `setBlockingOverlay(...)` / `host.setBlockingOverlay(...)` call sites across `main.ts` and both ceremony queues (`wonder-discovery-queue.ts`, `legendary-wonder-completion-queue.ts`) assumes it owns the single slot for the duration of its own operation. If two blockers overlap — concretely: a ceremony's own `play()` sets `'wonder-discovery-ceremony'` while presenting, and a hot-seat handoff sets `'turn-handoff'` before the ceremony's promise has resolved — the second caller's id silently overwrites the first's, and whichever caller clears to `null` first unblocks the *other* caller's operation too, not just its own. Phase 6 (#793) fixed the narrower, confirmed-reachable instance of the wider problem — a ceremony *queued but not yet presenting* surviving a hot-seat handoff — by clearing backlog before the handoff blocks. It did not address a ceremony *already presenting* when a handoff begins; that requires this phase's structural fix to the shared blocking primitive itself.
+
+**Files:**
+- Modify: `src/ui/ui-interaction-state.ts` (or retire it into `PanelHost` directly — decide in Step 1)
+- Modify: `src/app/panel-host.ts`
+- Modify (call-site audit, not necessarily every site changes): `src/main.ts`, `src/ui/wonder-discovery-queue.ts`, `src/ui/legendary-wonder-completion-queue.ts`
+- Modify: `tests/app/panel-host.test.ts`; re-run `tests/ui/keyboard-shortcuts.test.ts` and `tests/ui/desktop-controls.test.ts` unmodified to confirm `context-menu.ts`'s consumption still compiles and passes if the interface shape changes at all
+
+**Interfaces:**
+- `UiInteractionState`'s two consumers outside `main.ts`/`PanelHost` (`src/ui/context-menu.ts`, plus the two test suites above) must stay drop-in compatible — the same LSP constraint Phase 5 and Phase 11 Step 4b already established for this interface. Whatever the new shape is, `context-menu.ts`'s existing call pattern must keep working unmodified, or `context-menu.ts` gets an explicit, tested migration in this phase.
+
+- [ ] **Step 1: Investigate before designing.** This phase was flagged, not root-caused, during Phase 6's review — issue #794 says so explicitly. Before writing any test:
+  - Confirm whether a ceremony can realistically still be *presenting* (not just *queued*) at the exact moment `beginHotSeatHandoff` fires, given `endTurn()`'s existing guards (`showReligionBoonIfNeeded`, `showRequiredChoicesIfNeeded`, the unmoved-unit warning). If genuinely unreachable today, this phase becomes defensive hardening against future call sites re-introducing the hazard (still worth doing — it is easy to add a new blocking overlay without noticing an existing one can overlap it), not an active-bug fix. Say which it is in the PR body.
+  - Grep every current `setBlockingOverlay` / `host.setBlockingOverlay` call site and tabulate: the id used, whether its `null`-clear is reached from a guaranteed path (`try/finally`) or a conditional one, and whether any two sites can plausibly both be "open" (id set, not yet cleared) at the same time. This table is the completeness check for Step 6, the same way Phase 2's 93-site inventory was for its `commit`/`setStateWithoutRefresh` conversion.
+- [ ] **Step 2: Decide the API shape and write the failing tests for it.** Two live options, chosen between based on Step 1's findings:
+  - **(a) Reference-counted, id-agnostic:** `setBlockingOverlay(id)` pushes `id` onto an internal stack; `setBlockingOverlay(null)` pops the most recently pushed reason (LIFO — matching how nesting already occurs in practice: ceremony-inside-handoff, never the reverse). `isInteractionBlocked()` stays `true` until the stack is empty. Keeps every call site's existing `id | null` shape unchanged.
+  - **(b) Explicit push/pop with the id round-tripped:** `pushBlockingOverlay(id): () => void` returns a disposer; callers keep the disposer instead of calling `setBlockingOverlay(null)` blind. More explicit and harder to misuse, but touches every call site's shape, not just its usage.
+  - Whichever is chosen: two blockers pushed, one popped, still blocked; both popped, now unblocked; `onInteractionUnblocked` fires exactly once, only when the last one clears (extending Phase 5's existing "not on overlay replacement" contract to "not while any other reason remains").
+- [ ] **Step 3: Run, confirm failure.**
+- [ ] **Step 4: Implement.** Keep `UiInteractionState`'s public shape stable for `context-menu.ts` unless Step 1's audit shows it genuinely needs the new semantics too (unlikely — it is a single simple blocker, not a nested one).
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Adopt at every call site from Step 1's table**, converting only the ones that can actually overlap (the ceremony-queue + hot-seat-handoff pair from the motivation above is the one confirmed reachable; others may turn out not to need it after Step 1's investigation).
+- [ ] **Step 7: Regression-test the confirmed overlap case end-to-end** — a ceremony presenting, hot-seat handoff beginning mid-presentation, ceremony resolving: assert the handoff's block is still active until the handoff itself clears it, not the ceremony.
+- [ ] **Step 8: Close the phase**
+
+---
+
 ## Part VI — Test Design Requirements
 
 Per `docs/superpowers/plans/README.md` §5, and because current coverage of this file is 21 regex assertions.
@@ -1984,7 +2078,8 @@ Per `docs/superpowers/plans/README.md` §5, and because current coverage of this
 | **A test written against an assumed command or convention never runs** | The plan originally cited `yarn test:e2e` (does not exist — it is `test:web-smoke`) and `toMatchSnapshot` (zero usages in this repo) | Every command and convention in this plan is now verified against `package.json` and the existing test tree; verify again if the plan sits unexecuted for long |
 | Losing a fixup during save consolidation | 23 fixups, 20 `as any` casts, no existing tests | Classification table is a checklist; idempotency + preserve-existing tests; new-game completeness test; keep v10/v11 golden fixtures in `tests/fixtures/` |
 | A mid-refactor playtest save cannot be reopened | Phase 1 bumps the schema to 12; older builds throw `UnsupportedSaveSchemaVersionError` | Called out in Part III; family playtest builds stay at or ahead of Phase 1 |
-| Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Eleven small PRs merged promptly, not one long branch; no other `main.ts`-touching PR should sit open across a phase merge |
+| Merge conflicts against feature work | `main.ts` is touched by nearly every feature PR | Twelve small PRs merged promptly, not one long branch; no other `main.ts`-touching PR should sit open across a phase merge |
+| **Overlapping blocking-overlay reasons silently clobber each other** | `PanelHost`'s `blockingOverlayId` is a single value, not a stack; found during Phase 6's review (#794) | Phase 12 is a dedicated phase investigating reachability first, then converting the primitive to a reference count |
 | Scope creep into "while I'm here" fixes | Guaranteed to be tempting across 5,462 lines | Behavior-preserving is a Global Constraint; the Part VI table is the exhaustive allowlist; file issues otherwise |
 
 ---
@@ -1998,3 +2093,4 @@ Per `docs/superpowers/plans/README.md` §5, and because current coverage of this
 - **Command and convention audit (second review pass):** every command in this plan is checked against `package.json`. `yarn test <path>` forwards to Vitest correctly. `yarn test:e2e` **does not exist** and was replaced with `yarn test:web-smoke`. `toMatchSnapshot` was removed — this repo has zero snapshot files and zero snapshot assertions, and a re-recordable baseline is the wrong tool for a guard that must never be re-recorded. `yarn test:ai-playability` was found and adopted; it is a better AI/difficulty guard than anything this plan would have invented.
 - **Deletion audit:** `src/ui/transport-ui-state.ts` has exactly one consumer (`main.ts`) and is safe to delete in Phase 3. `src/ui/ui-interaction-state.ts` has **four** (`src/ui/context-menu.ts` plus two UI test suites) — the interface stays, only the factory is retired, in Phase 11.
 - **Known soft spots:** the `createHotSeatGame` config literal in Phase 1 Step 7 and the `makeFakeServices` `renderLoop` double in Phase 10 Step 1 are illustrative and must be matched to the real `HotSeatConfig` and `RenderLoop` shapes. The determinism baseline literals in Part V are recorded output, filled in by Phase 1 Step 1.
+- **Post-hoc addition (Phase 12):** this plan originally specified eleven phases. Phase 6's inline review (per #787's no-subagents policy, done inline rather than delegated) traced a hot-seat ceremony leak to its root cause and found a second, structurally deeper issue one level down (`PanelHost`'s blocking-overlay id is a single value, not a stack) that no phase above was scoped to fix. The narrower, confirmed-reachable leak was fixed directly in Phase 6's PR (#793); the structural issue was filed as #794 and added here as Phase 12 rather than expanding #793's blast radius or silently dropping it. All "eleven phases"/"eleven PRs" references above were updated to twelve; Phase 12 has no ordering dependency on Phases 7–10 and is appended at the end only because it was discovered last.

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -1,0 +1,771 @@
+/**
+ * Owns unit selection: `selectUnit`, `deselectUnit`, `selectNextUnit`, and the
+ * animated-move / auto-explore / journey lifecycle around a selected unit
+ * (#787 phase 8c).
+ *
+ * `selectUnit` wires ~30 mutually-recursive callbacks into
+ * `renderSelectedUnitInfo` (several call `selectUnit` itself) — per the plan's
+ * split note for this phase, those callbacks move here verbatim and are not
+ * further decomposed; that would be its own future MR if warranted.
+ *
+ * Everything this file calls that is a pure `@/systems/*` or `@/ui/*` helper
+ * is imported directly, matching the precedent already set by
+ * `src/presentation/register-*.ts` (Phase 7) for e.g. `SFX`. Only the
+ * concrete platform services (`renderLoop`, `bus`, `host`, `ceremonies`) and
+ * the main.ts-local functions this phase does NOT move (`showNotification`,
+ * `updateHUD`, `foundCityAction`, etc.) are threaded through as deps.
+ *
+ * `getInfoPanel` exists so this file never calls `document.getElementById`
+ * itself — Phase 11's port-purity test bans that in `src/app/controllers/*`,
+ * and threading a getter through now is a zero-behavior-change substitution
+ * for the three `document.getElementById('info-panel')` call sites main.ts
+ * used to have inline, so there is nothing to revisit when Phase 11 lands.
+ */
+import type { EventBus } from '@/core/event-bus';
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { GameState, HexCoord, Unit, UnitType, WorkerActionType, Civilization } from '@/core/types';
+import type { GameSession, SelectionStore } from '@/app/ports';
+import type { PanelHost } from '@/app/panel-host';
+import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import type { UnitTurnFlow } from '@/ui/unit-turn-flow';
+import type { ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
+import { UNIT_DEFINITIONS, findPath } from '@/systems/unit-system';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
+import { isMajorCivOwner } from '@/core/owner-kind';
+import { SFX } from '@/audio/sfx';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
+import { createContextMenu } from '@/ui/context-menu';
+import { createWorkerReplacementConfirmPanel } from '@/ui/worker-task-warning-panel';
+import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
+import { startIntercept, getInterceptCoverage, getLegalRebaseDestinations, getAirBaseRoster, getAirBaseCapacity, rebaseAircraft, getLegalAirMissionTargets } from '@/systems/air-operations-system';
+import { usePropagandistAction } from '@/systems/propagandist-system';
+import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
+import { canPillageTile, getPillageGoldReward, applyPillageToState } from '@/systems/pillage-system';
+import { getImprovementDisplayName } from '@/systems/improvement-system';
+import { getUnitCargoSize, getTransportCargoUsed, getTransportCapacity, canLoadUnitOntoTransport, getTransportCargo, getUnloadDestinations, loadUnitOntoTransport, unloadUnitFromTransport } from '@/systems/transport-system';
+import { findAvailablePirateHeadquartersAssault } from '@/input/pirate-headquarters-assault';
+import { getPirateWatersPresentation } from '@/systems/pirate-presentation';
+import { setDisguise, attemptInfiltration, getInfiltrationSuccessChance, resolveMissionResult, embedSpy } from '@/systems/espionage-system';
+import { evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
+import { canEstablishOutpost, performEstablishOutpost } from '@/systems/resource-acquisition-system';
+import { applyWorkerAction } from '@/systems/worker-action-system';
+import { formatImprovementYieldLabel } from '@/systems/improvement-system';
+import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
+import { getUnmovedUnits } from '@/systems/unit-system';
+import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
+import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
+import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
+
+/** The narrow slice of `RenderLoop` this controller needs. */
+export type SelectionControllerRenderer = Pick<
+  RenderLoop,
+  | 'hasMovingUnit'
+  | 'setSelectedUnitId'
+  | 'setHighlights'
+  | 'clearHighlights'
+  | 'setJourneyPath'
+  | 'setGameState'
+  | 'animateUnitMove'
+  | 'animateUnitSlide'
+  | 'animateUnitAppear'
+> & {
+  readonly camera: Pick<RenderLoop['camera'], 'centerOn'>;
+};
+
+export interface SelectionControllerDeps {
+  readonly session: GameSession;
+  readonly selection: SelectionStore;
+  readonly renderLoop: SelectionControllerRenderer;
+  readonly bus: Pick<EventBus, 'emit'>;
+  readonly uiLayer: HTMLElement;
+  readonly host: PanelHost;
+  readonly ceremonies: CeremonyCoordinator;
+  /** Substitutes for `document.getElementById('info-panel')` — see file docblock. */
+  readonly getInfoPanel: () => HTMLElement | null;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  readonly updateHUD: () => void;
+  readonly clearUnloadState: () => void;
+  readonly getUnitTurnFlow: () => UnitTurnFlow;
+  readonly foundCityAction: () => void;
+  readonly performWorkerAction: (action: WorkerActionType) => void;
+  readonly performPreach: (unitId: string, cityId: string) => void;
+  readonly restAction: () => void;
+  readonly openNetworkIntentPanel: (unitId: string) => void;
+  readonly openUnitStackPicker: (coord: HexCoord, unitIds: string[]) => void;
+  readonly openPirateHeadquartersAssault: (factionId: string, unitId: string) => void;
+  readonly handleEstablishRoute: (caravanId: string) => void;
+  readonly executeUpgrade: (unitId: string, targetType: UnitType) => boolean;
+  readonly ensurePlayerWarState: (targetCivId: string) => void;
+  readonly scanBeastSightings: () => void;
+  readonly currentCiv: () => Civilization;
+}
+
+export interface SelectionController {
+  selectUnit(unitId: string, opts?: { pendingUnloadUnitName?: string; suppressSelectionSfx?: boolean }): void;
+  deselectUnit(): void;
+  isUnitAnimationLocked(unitId: string | null): boolean;
+  animateMovedUnit(unitId: string, path: HexCoord[]): void;
+  executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult;
+  startAutoExplore(unitId: string): void;
+  cancelAutoExplore(unitId: string): void;
+  cancelJourney(unitId: string): void;
+  openUnitContextMenu(unitId: string): void;
+  selectNextUnit(): void;
+  refreshSelectedUnitAfterCombat(): void;
+  refreshCurrentPlayerVisibility(): void;
+}
+
+export function createSelectionController(deps: SelectionControllerDeps): SelectionController {
+  const { session, selection, renderLoop, bus, uiLayer, host, ceremonies } = deps;
+
+  function selectUnit(
+    unitId: string,
+    opts?: {
+      pendingUnloadUnitName?: string;
+      suppressSelectionSfx?: boolean;
+    },
+  ): void {
+    if (renderLoop.hasMovingUnit(unitId)) {
+      deps.showNotification('Unit is moving.', 'info');
+      return;
+    }
+    const unit = session.getState().units[unitId];
+    if (!unit || unit.owner !== session.getState().currentPlayer) return;
+    selection.setSelectedUnitId(unitId);
+    renderLoop.setSelectedUnitId(unitId);
+
+    const highlightResult = buildSelectedUnitHighlights(session.getState(), unitId);
+    selection.setWaterRecovery(highlightResult.waterRecovery);
+    if (session.getState().units[unitId]?.committedToRouteId) {
+      // Committed caravans cannot move or attack — keep highlights empty
+      selection.setRanges([], []);
+      deps.clearUnloadState();
+    } else {
+      selection.setRanges(highlightResult.movementRange, highlightResult.attackTargets.map(target => target.coord));
+    }
+    renderLoop.setHighlights(highlightResult.highlights);
+
+    // Update journey path overlay
+    if (unit.automation?.mode === 'journey') {
+      const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+      const completedTechs = session.getState().civilizations[unit.owner]?.techState.completed ?? [];
+      const path = findPath(unit.position, unit.automation.destination, session.getState().map, domain, { unit, completedTechs });
+      renderLoop.setJourneyPath(path);
+    } else {
+      renderLoop.setJourneyPath(null);
+    }
+
+    // Show unit info panel
+    const panel = deps.getInfoPanel();
+    if (panel) {
+      const pendingIntent = selection.getPendingIntent();
+      renderSelectedUnitInfo(panel, session.getState(), unitId, {
+        onClose: () => deselectUnit(),
+        onStartIntercept: uid => {
+          const result = startIntercept(session.getState(), uid);
+          if (!result.ok) {
+            deps.showNotification('That fighter cannot enter intercept stance now.', 'warning');
+            return;
+          }
+          session.commit(result.state);
+          SFX.airScramble();
+          selectUnit(uid);
+          renderLoop.setHighlights(getInterceptCoverage(session.getState(), uid).map(coord => ({ coord, type: 'air-intercept' as const })));
+        },
+        getAirRebaseDestinations: uid => getLegalRebaseDestinations(session.getState(), uid).map(base => {
+          const position = base.kind === 'city' ? session.getState().cities[base.cityId]?.position : session.getState().units[base.unitId]?.position;
+          const name = base.kind === 'city'
+            ? session.getState().cities[base.cityId]?.name ?? base.cityId
+            : UNIT_DEFINITIONS[session.getState().units[base.unitId]?.type ?? 'carrier'].name;
+          return { base, label: `${name} (${getAirBaseRoster(session.getState(), base).length}/${getAirBaseCapacity(session.getState(), base)})${position ? '' : ''}` };
+        }),
+        onRebaseAircraft: (uid, base) => {
+          const result = rebaseAircraft(session.getState(), uid, base);
+          if (!result.ok) {
+            deps.showNotification('That base is no longer reachable.', 'warning');
+            return;
+          }
+          session.commit(result.state);
+          SFX.airRebase();
+          selectUnit(uid);
+        },
+        onStartAirMission: (uid, mission) => {
+          selection.setPendingIntent({ kind: 'air-mission', unitId: uid, mission });
+          const targets = getLegalAirMissionTargets(session.getState(), uid, mission);
+          selection.setRanges([], []);
+          selectUnit(uid);
+          renderLoop.setHighlights(targets.map(coord => ({
+            coord,
+            type: mission === 'strike' ? 'air-strike' as const : 'air-recon' as const,
+          })));
+          deps.showNotification(mission === 'strike' ? 'Tap a hostile target within operational range, or cancel.' : 'Tap a recon center within operational range, or cancel.', 'info');
+        },
+        onCancelAirMission: uid => {
+          const intent = selection.getPendingIntent();
+          if (intent.kind !== 'air-mission' || intent.unitId !== uid) return;
+          selection.setPendingIntent({ kind: 'none' });
+          selectUnit(uid);
+          deps.showNotification('Air mission cancelled.', 'info');
+        },
+        onOpenNetworkIntent: uid => deps.openNetworkIntentPanel(uid),
+        onUsePropagandistAction: (uid, action, cityId) => {
+          const result = usePropagandistAction(session.getState(), uid, action, cityId);
+          if (!result.ok) {
+            deps.showNotification('That civic action is no longer available.', 'warning');
+            return;
+          }
+          session.commit(result.state);
+          deps.showNotification(result.message, action === 'rally' ? 'success' : 'warning');
+          selectUnit(uid);
+        },
+        onFoundCity: () => deps.foundCityAction(),
+        onWorkerAction: action => deps.performWorkerAction(action),
+        onPreach: (unitId, cityId) => deps.performPreach(unitId, cityId),
+        onRest: () => deps.restAction(),
+        onSkipTurn: uid => deps.getUnitTurnFlow().skipUnitAction(uid),
+        onDeleteUnit: uid => deps.getUnitTurnFlow().showDeleteUnitConfirmation(uid),
+        onFortify: uid => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          if (unit.isFortified) {
+            session.setStateWithoutRefresh(unfortifyUnitInState(session.getState(), session.getState().currentPlayer, uid));
+            deps.showNotification('Unit unfortified.', 'info');
+          } else {
+            session.setStateWithoutRefresh(fortifyUnitInState(session.getState(), session.getState().currentPlayer, uid));
+            deps.showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+          }
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          selectUnit(uid);
+        },
+        onPillage: uid => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const tile = session.getState().map.tiles[hexKey(unit.position)];
+          if (!tile || !canPillageTile(tile, unit.owner)) return;
+
+          const hasFinishedImprovement = tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
+          const goldPreview = hasFinishedImprovement ? getPillageGoldReward(tile.improvement) : 0;
+          const targetLabel = hasFinishedImprovement ? getImprovementDisplayName(tile.improvement) : 'the road';
+          const preview = goldPreview > 0
+            ? `Pillage ${targetLabel}?\n\n+${goldPreview} gold, unit heals +25 HP.`
+            : `Pillage ${targetLabel}?\n\nUnit heals +25 HP.`;
+          if (!window.confirm(preview)) return;
+
+          if (tile.owner && isMajorCivOwner(tile.owner)) {
+            deps.ensurePlayerWarState(tile.owner);
+          }
+
+          const result = applyPillageToState(session.getState(), uid);
+          if (!result.ok) return;
+          session.setStateWithoutRefresh(result.state);
+          deps.showNotification(
+            result.goldAwarded! > 0 ? `Pillaged ${targetLabel} for ${result.goldAwarded} gold.` : `Pillaged ${targetLabel}.`,
+            'success',
+          );
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          selectUnit(uid);
+        },
+        onStartAutoExplore: uid => startAutoExplore(uid),
+        onCancelAutoExplore: () => cancelAutoExplore(unitId),
+        onCancelJourney: () => cancelJourney(unitId),
+        onOpenStack: (coord) => {
+          handleFriendlyUnitStackTap(session.getState(), coord, selection.getSelectedUnitId(), {
+            onSelectUnit: selectUnit,
+            onOpenStackPicker: deps.openUnitStackPicker,
+          });
+        },
+        getTransportOptions: uid => {
+          const selectedUnit = session.getState().units[uid];
+          const needs = selectedUnit ? getUnitCargoSize(selectedUnit) : 1;
+          return Object.values(session.getState().units)
+            .filter(candidate => {
+              const def = UNIT_DEFINITIONS[candidate.type];
+              return (def?.domain ?? 'land') === 'naval' && def?.cargoCapacity !== undefined
+                && candidate.owner === session.getState().currentPlayer;
+            })
+            .map(candidate => {
+              const used  = getTransportCargoUsed(session.getState(), candidate.id);
+              const cap   = getTransportCapacity(candidate);
+              const free  = cap - used;
+              const fits  = needs <= free;
+              const suffix = !fits
+                ? ` — needs ${needs} slots, ${free} remaining`
+                : free - needs === 0
+                  ? ' — last slot'
+                  : ` — ${free} of ${cap} slots free`;
+              return {
+                transportId: candidate.id,
+                label: `Load onto ${UNIT_DEFINITIONS[candidate.type]?.name ?? 'Transport'}${suffix}`,
+                disabled: !fits,
+                tooltip: !fits
+                  ? `${UNIT_DEFINITIONS[selectedUnit?.type ?? 'warrior']?.name ?? 'This unit'} requires ${needs} cargo slots. A Galleon or larger transport is needed.`
+                  : undefined,
+              };
+            })
+            .filter(o => canLoadUnitOntoTransport(session.getState(), uid, o.transportId).ok || o.disabled);
+        },
+        getCargoBoardInfo: transportId => getTransportCargo(session.getState(), transportId).map(cargoUnit => ({
+          cargoUnitId: cargoUnit.id,
+          label: UNIT_DEFINITIONS[cargoUnit.type]?.name ?? cargoUnit.type,
+          slotCost: getUnitCargoSize(cargoUnit),
+          canUnload: !cargoUnit.hasActed && cargoUnit.movementPointsLeft > 0,
+        })),
+        onSelectCargoToUnload: (transportId, cargoUnitId) => {
+          const range = getUnloadDestinations(session.getState(), transportId, cargoUnitId);
+          selection.setPendingIntent({ kind: 'unload', transportId, cargoUnitId, range });
+          renderLoop.setHighlights(range.map(coord => ({ coord, type: 'move' as const })));
+          const cargoUnit = session.getState().units[cargoUnitId];
+          const unitName = UNIT_DEFINITIONS[cargoUnit?.type ?? 'warrior']?.name ?? 'Unit';
+          selectUnit(transportId, { pendingUnloadUnitName: unitName });
+        },
+        onCancelUnload: () => {
+          deps.clearUnloadState();
+          renderLoop.clearHighlights();
+          const currentlySelected = selection.getSelectedUnitId();
+          if (currentlySelected) selectUnit(currentlySelected);
+        },
+        pendingUnloadUnitName: opts?.pendingUnloadUnitName,
+        getPirateAssaultAction: uid => {
+          const pending = findAvailablePirateHeadquartersAssault(session.getState(), session.getState().currentPlayer, uid);
+          if (!pending) return null;
+          const faction = getPirateWatersPresentation(session.getState(), session.getState().currentPlayer).factions
+            .find(entry => entry.factionId === pending.factionId);
+          return { factionId: pending.factionId, label: `Assault ${faction?.name ?? 'pirate'} enclave` };
+        },
+        onOpenPirateAssault: (factionId, uid) => deps.openPirateHeadquartersAssault(factionId, uid),
+        onLoadTransport: (uid, transportId) => {
+          const prevPos = session.getState().units[uid]?.position;
+          const result = loadUnitOntoTransport(session.getState(), uid, transportId);
+          if (!result.ok) {
+            deps.showNotification(result.message, 'warning');
+            SFX.error();
+            return;
+          }
+          session.commit(result.state);
+          // Boarding animation: slide cargo unit to transport hex before it disappears
+          const transportUnit = session.getState().units[transportId];
+          if (prevPos && transportUnit) {
+            renderLoop.animateUnitSlide(
+              { ...result.state.units[uid] ?? { id: uid } as Unit, position: prevPos },
+              transportUnit.position,
+            );
+          }
+          selectUnit(transportId);
+          const tName = UNIT_DEFINITIONS[session.getState().units[transportId]?.type ?? 'transport']?.name ?? 'Transport';
+          deps.showNotification(`Unit loaded onto ${tName}.`, 'info');
+          SFX.transportLoad();
+        },
+        onUnloadTransport: (transportId, cargoUnitId, destination) => {
+          const result = unloadUnitFromTransport(session.getState(), transportId, cargoUnitId, destination);
+          if (!result.ok) {
+            deps.showNotification(result.message, 'warning');
+            SFX.error();
+            return;
+          }
+          const tName = UNIT_DEFINITIONS[session.getState().units[transportId]?.type ?? 'transport']?.name ?? 'Transport';
+          const cName = UNIT_DEFINITIONS[session.getState().units[cargoUnitId]?.type ?? 'warrior']?.name ?? 'Unit';
+          deps.clearUnloadState();
+          session.commit(result.state);
+          renderLoop.animateUnitAppear(destination);
+          // Stay on the transport so the player can unload remaining cargo
+          selectUnit(transportId);
+          deps.showNotification(`${cName} disembarked from ${tName}.`, 'info');
+          SFX.transportUnload();
+        },
+        onSetDisguise: (uid, disguise) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.hasActed) return;
+          if (unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const spy = civEsp.spies[uid];
+          if (!spy || spy.status !== 'idle') return;
+          session.getState().espionage![session.getState().currentPlayer] = setDisguise(civEsp, uid, disguise);
+          if (disguise !== null) {
+            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+          }
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          selectUnit(uid);
+          deps.showNotification(disguise ? `Spy disguised as ${disguise}.` : 'Disguise removed.', 'info');
+        },
+        onInfiltrate: (uid) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const targetCity = Object.values(session.getState().cities).find(
+            c => c.owner !== session.getState().currentPlayer &&
+                 c.position.q === unit.position.q && c.position.r === unit.position.r,
+          );
+          if (!targetCity) { deps.showNotification('No enemy city at this location.', 'info'); return; }
+
+          const alreadyInside = Object.values(civEsp.spies).some(
+            s => s.infiltrationCityId === targetCity.id &&
+                 (s.status === 'stationed' || s.status === 'on_mission'),
+          );
+          if (alreadyInside) { deps.showNotification('You already have a spy in that city.', 'info'); return; }
+
+          const cityCI = session.getState().espionage![targetCity.owner]?.counterIntelligence[targetCity.id] ?? 0;
+          const chance = getInfiltrationSuccessChance(unit.type as UnitType, civEsp.spies[uid]?.experience ?? 0, cityCI);
+          const preview = `Infiltrate ${targetCity.name}?\n\nSuccess chance: ${Math.round(chance * 100)}%\nCity CI: ${cityCI}\n\nIf caught, spy may be lost permanently.`;
+          if (!window.confirm(preview)) return;
+
+          const seed = `infiltrate-${uid}-${session.getState().turn}`;
+          const result = attemptInfiltration(
+            civEsp, uid, unit.type as UnitType, targetCity.id, targetCity.position, cityCI, seed,
+          );
+          // Record the original target civ so auto-exfiltrate can detect third-party captures
+          const spyAfterAttempt = result.civEsp.spies[uid];
+          const civEspWithTarget = spyAfterAttempt ? {
+            ...result.civEsp,
+            spies: { ...result.civEsp.spies, [uid]: { ...spyAfterAttempt, targetCivId: targetCity.owner } },
+          } : result.civEsp;
+          session.getState().espionage![session.getState().currentPlayer] = civEspWithTarget;
+
+          if (result.removeUnitFromMap) {
+            // Era 2+: spy removed from map, stationed inside city
+            delete session.getState().units[uid];
+            const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
+            if (civUnits) {
+              session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
+            }
+            deps.showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
+            bus.emit('espionage:spy-infiltrated', { civId: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
+            deselectUnit();
+          } else if (result.era1ScoutResult !== undefined) {
+            // Era 1 (spy_scout): spy stays on map, infiltrationCityId + 5-turn city vision already set
+            const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), session.getState().currentPlayer, uid);
+            const tilesToReveal = missionResult.tilesToReveal ?? [];
+            if (tilesToReveal.length > 0) {
+              const visibilityTiles = { ...(session.getState().civilizations[session.getState().currentPlayer].visibility?.tiles ?? {}) };
+              for (const coord of tilesToReveal) {
+                visibilityTiles[`${coord.q},${coord.r}`] = 'visible';
+              }
+              session.getState().civilizations[session.getState().currentPlayer].visibility = {
+                ...session.getState().civilizations[session.getState().currentPlayer].visibility!,
+                tiles: visibilityTiles,
+              };
+            }
+            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+            deps.showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
+            selectUnit(uid);
+          } else if (result.caught) {
+            // Caught: remove unit from map (spy lost)
+            delete session.getState().units[uid];
+            const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
+            if (civUnits) {
+              session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
+            }
+            bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
+            deselectUnit();
+          } else {
+            const cooldown = result.civEsp.spies[uid]?.cooldownTurns ?? 3;
+            deps.showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
+            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+            selectUnit(uid);
+          }
+
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+        },
+        onEmbed: (uid) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const city = Object.values(session.getState().cities).find(
+            c => c.owner === session.getState().currentPlayer &&
+                 c.position.q === unit.position.q && c.position.r === unit.position.r,
+          );
+          if (!city) return;
+          session.getState().espionage![session.getState().currentPlayer] = embedSpy(civEsp, uid, city.id, city.position);
+          delete session.getState().units[uid];
+          session.getState().civilizations[session.getState().currentPlayer].units =
+            session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== uid);
+          deselectUnit();
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          deps.showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
+        },
+        onUpgradeUnit: (uid, cityId) => {
+          void cityId;
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
+          if (!targetType) return;
+          const upgrade = evaluateUnitUpgrade(session.getState(), uid, targetType);
+          if (!upgrade.canUpgrade || !upgrade.targetType) return;
+          if (deps.executeUpgrade(uid, upgrade.targetType)) {
+            selectUnit(uid);
+            deps.showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
+          }
+        },
+        onEstablishOutpost: (unitId) => {
+          if (!canEstablishOutpost(session.getState(), unitId)) return;
+          session.setStateWithoutRefresh(performEstablishOutpost(session.getState(), unitId));
+          selection.setSelectedUnitId(null);
+          renderLoop.setSelectedUnitId(null);
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          deps.showNotification('Expedition planted a flag! Outpost completes in 2 turns.', 'success');
+        },
+        onEstablishRoute: deps.handleEstablishRoute,
+        onReplaceImprovement: (action) => {
+          const selectedUnitId = selection.getSelectedUnitId();
+          if (!selectedUnitId) return;
+          const unit = session.getState().units[selectedUnitId];
+          if (!unit) return;
+          const tileKey = hexKey(unit.position);
+          const currentTile = session.getState().map.tiles[tileKey];
+          if (!currentTile || currentTile.improvement === 'none') return;
+          const existingName = getImprovementDisplayName(currentTile.improvement);
+          const newName = getImprovementDisplayName(action);
+          const existingYield = formatImprovementYieldLabel(currentTile.improvement) || undefined;
+          const newYield = formatImprovementYieldLabel(action) || undefined;
+          const uid = selectedUnitId;
+          createWorkerReplacementConfirmPanel(uiLayer, {
+            existingName,
+            newName,
+            existingYield,
+            newYield,
+            onCancel: () => selectUnit(uid),
+            onConfirm: () => {
+              const result = applyWorkerAction(session.getState(), uid, action, { allowReplacement: true });
+              if (!result.ok) return;
+              session.setStateWithoutRefresh(result.state);
+              for (const event of result.events) {
+                if (event.type === 'improvement:started') {
+                  bus.emit('improvement:started', event.payload);
+                } else if (event.type === 'road:started') {
+                  bus.emit('road:started', event.payload);
+                } else {
+                  bus.emit('unit:destroyed', event.payload);
+                }
+              }
+              renderLoop.setGameState(session.getState());
+              deps.updateHUD();
+              if (result.workerConsumed || result.workerLost || !session.getState().units[uid]) {
+                deselectUnit();
+              } else {
+                selectUnit(uid);
+              }
+              deps.showNotification(result.message, result.workerLost ? 'warning' : 'info');
+            },
+          });
+        },
+      }, {
+        waterRecovery: highlightResult.waterRecovery,
+        hasZoneOfControlWarning: highlightResult.zocLimitedRange.length > 0,
+        airMissionPending: pendingIntent.kind === 'air-mission' && pendingIntent.unitId === unitId ? pendingIntent.mission : undefined,
+      });
+    }
+
+    if (!opts?.suppressSelectionSfx) SFX.select();
+  }
+
+  function deselectUnit(): void {
+    // Clears the selection, both ranges, and any pending air mission, journey, or
+    // unload. A pending city-capture choice deliberately survives — see the
+    // `SelectionStore.clear()` contract.
+    selection.clear();
+    renderLoop.setSelectedUnitId(null);
+    renderLoop.clearHighlights();
+    renderLoop.setJourneyPath(null);
+    const panel = deps.getInfoPanel();
+    if (panel) {
+      panel.style.display = 'none';
+      panel.replaceChildren();
+    }
+  }
+
+  function isUnitAnimationLocked(unitId: string | null): boolean {
+    return Boolean(unitId && renderLoop.hasMovingUnit(unitId));
+  }
+
+  function animateMovedUnit(unitId: string, path: HexCoord[]): void {
+    const movedUnit = session.getState().units[unitId];
+    if (!movedUnit || path.length < 2) return;
+    selection.setRanges([], []);
+    deps.clearUnloadState();
+    renderLoop.clearHighlights();
+    renderLoop.animateUnitMove({ ...movedUnit, position: path[0]! }, path, () => {
+      renderLoop.setGameState(session.getState());
+      deps.updateHUD();
+      ceremonies.endAction();
+      const unit = session.getState().units[unitId];
+      if (!unit || unit.owner !== session.getState().currentPlayer) return;
+
+      if ((unit.movementPointsLeft ?? 0) <= 0) {
+        selectNextUnit();
+      } else if (selection.getSelectedUnitId() === unitId) {
+        selectUnit(unitId);
+      }
+    });
+  }
+
+  function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult {
+    const movingUnit = session.getState().units[unitId];
+    ceremonies.beginDeferredAction();
+    try {
+      const moveResult = move();
+      if (!moveResult.ok) {
+        ceremonies.endAction();
+        deps.showNotification(moveResult.message, 'warning');
+        SFX.error();
+        return moveResult;
+      }
+      if (moveResult.stopReason === 'zone-of-control') {
+        deps.showNotification('Stopped — enemy nearby', 'info');
+      }
+      // Clear journey automation when the player manually moves a unit.
+      if (movingUnit?.automation?.mode === 'journey') {
+        const movedUnit = session.getState().units[unitId];
+        if (movedUnit) {
+          session.setStateWithoutRefresh({
+            ...session.getState(),
+            units: { ...session.getState().units, [unitId]: { ...movedUnit, automation: undefined } },
+          });
+        }
+        renderLoop.setJourneyPath(null);
+      }
+      animateMovedUnit(unitId, moveResult.path);
+      return moveResult;
+    } catch (error) {
+      ceremonies.endAction();
+      throw error;
+    }
+  }
+
+  function startAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit || unit.owner !== session.getState().currentPlayer) return;
+
+    session.getState().units[unitId] = {
+      ...unit,
+      automation: {
+        mode: 'auto-explore',
+        startedTurn: session.getState().turn,
+        lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
+      },
+    };
+
+    if (session.getState().units[unitId].movementPointsLeft > 0 && !session.getState().units[unitId].hasActed) {
+      applyAutoExploreOrder(session.getState(), unitId, { bus: bus as EventBus });
+    }
+
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    selectUnit(unitId);
+  }
+
+  function cancelAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit?.automation) return;
+    delete session.getState().units[unitId].automation;
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    if (selection.getSelectedUnitId() === unitId) {
+      selectUnit(unitId);
+    }
+  }
+
+  function cancelJourney(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit?.automation) return;
+    session.commit({
+      ...session.getState(),
+      units: { ...session.getState().units, [unitId]: { ...unit, automation: undefined } },
+    });
+    renderLoop.setJourneyPath(null);
+    deps.updateHUD();
+    if (selection.getSelectedUnitId() === unitId) {
+      selectUnit(unitId);
+    }
+  }
+
+  function openUnitContextMenu(unitId: string): void {
+    const panel = deps.getInfoPanel();
+    if (!panel) return;
+
+    createContextMenu(panel, session.getState(), { unitId }, {
+      onStartAutoExplore: id => startAutoExplore(id),
+      onCancelAutoExplore: id => cancelAutoExplore(id),
+    }, host);
+  }
+
+  function selectNextUnit(): void {
+    const unmoved = getUnmovedUnits(session.getState().units, session.getState().currentPlayer);
+    if (unmoved.length === 0) {
+      // All units have moved — silently deselect
+      deselectUnit();
+      return;
+    }
+    // Skip current unit if it's in the list
+    const filtered = unmoved.filter(u => u.id !== selection.getSelectedUnitId());
+    const next = filtered.length > 0 ? filtered[0] : unmoved[0];
+    selectUnit(next.id);
+    renderLoop.camera.centerOn(next.position);
+  }
+
+  function refreshSelectedUnitAfterCombat(): void {
+    const selectedUnitId = selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+    const selectedUnit = session.getState().units[selectedUnitId];
+    if (!selectedUnit || selectedUnit.owner !== session.getState().currentPlayer) {
+      deselectUnit();
+      return;
+    }
+    selectUnit(selectedUnitId, { suppressSelectionSfx: true });
+  }
+
+  function refreshCurrentPlayerVisibility(): void {
+    if (!deps.currentCiv()?.visibility) return;
+
+    // Snapshot unexplored tile keys before the update so we can detect fog-lift transitions
+    const visTiles = deps.currentCiv()!.visibility!.tiles;
+    const prevUnexplored = new Set(
+      Object.keys(visTiles).filter(k => visTiles[k] === 'unexplored'),
+    );
+
+    updateAndRefreshVisibility(session.getState(), session.getState().currentPlayer);
+
+    // Fire at most one resource-discovered tip per visibility update to avoid
+    // flooding the player when a scout reveals several resource tiles at once.
+    const updatedTiles = deps.currentCiv()?.visibility?.tiles ?? {};
+    for (const key of prevUnexplored) {
+      if (updatedTiles[key] !== 'unexplored') {
+        const tile = session.getState().map.tiles[key];
+        if (tile?.resource) {
+          const fired = fireResourceDiscoveredTip(tile.resource, session.getState(), bus as EventBus);
+          if (fired) break; // one tip per move is enough
+        }
+      }
+    }
+
+    for (const contact of syncCivilizationContactsFromVisibility(session.getState(), session.getState().currentPlayer)) {
+      bus.emit('civilization:first-contact', contact);
+    }
+
+    deps.scanBeastSightings();
+  }
+
+  return {
+    selectUnit,
+    deselectUnit,
+    isUnitAnimationLocked,
+    animateMovedUnit,
+    executeAnimatedUnitMove,
+    startAutoExplore,
+    cancelAutoExplore,
+    cancelJourney,
+    openUnitContextMenu,
+    selectNextUnit,
+    refreshSelectedUnitAfterCombat,
+    refreshCurrentPlayerVisibility,
+  };
+}

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -50,6 +50,7 @@ import { getPirateWatersPresentation } from '@/systems/pirate-presentation';
 import { setDisguise, attemptInfiltration, getInfiltrationSuccessChance, resolveMissionResult, embedSpy } from '@/systems/espionage-system';
 import { evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
 import { canEstablishOutpost, performEstablishOutpost } from '@/systems/resource-acquisition-system';
+import { autoSave } from '@/storage/save-manager';
 import { applyWorkerAction } from '@/systems/worker-action-system';
 import { formatImprovementYieldLabel } from '@/systems/improvement-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
@@ -78,7 +79,15 @@ export interface SelectionControllerDeps {
   readonly session: GameSession;
   readonly selection: SelectionStore;
   readonly renderLoop: SelectionControllerRenderer;
-  readonly bus: Pick<EventBus, 'emit'>;
+  /**
+   * The concrete class, not a narrowed `Pick<EventBus, 'emit'>` -- two
+   * downstream calls (`applyAutoExploreOrder`, `fireResourceDiscoveredTip`)
+   * are typed to require the real `EventBus`, and `EventBus` has a private
+   * field, so no object literal can structurally satisfy it. Narrowing here
+   * would only move the impedance mismatch into an `as EventBus` cast at
+   * each call site instead of removing it.
+   */
+  readonly bus: EventBus;
   readonly uiLayer: HTMLElement;
   readonly host: PanelHost;
   readonly ceremonies: CeremonyCoordinator;
@@ -493,7 +502,6 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
           deps.showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
         },
         onUpgradeUnit: (uid, cityId) => {
-          void cityId;
           const unit = session.getState().units[uid];
           if (!unit || unit.owner !== session.getState().currentPlayer) return;
           const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
@@ -508,6 +516,7 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
         onEstablishOutpost: (unitId) => {
           if (!canEstablishOutpost(session.getState(), unitId)) return;
           session.setStateWithoutRefresh(performEstablishOutpost(session.getState(), unitId));
+          autoSave(session.getState()).catch(() => {});
           selection.setSelectedUnitId(null);
           renderLoop.setSelectedUnitId(null);
           renderLoop.setGameState(session.getState());
@@ -655,7 +664,7 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
     };
 
     if (session.getState().units[unitId].movementPointsLeft > 0 && !session.getState().units[unitId].hasActed) {
-      applyAutoExploreOrder(session.getState(), unitId, { bus: bus as EventBus });
+      applyAutoExploreOrder(session.getState(), unitId, { bus });
     }
 
     renderLoop.setGameState(session.getState());
@@ -741,7 +750,7 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
       if (updatedTiles[key] !== 'unexplored') {
         const tile = session.getState().map.tiles[key];
         if (tile?.resource) {
-          const fired = fireResourceDiscoveredTip(tile.resource, session.getState(), bus as EventBus);
+          const fired = fireResourceDiscoveredTip(tile.resource, session.getState(), bus);
           if (fired) break; // one tip per move is enough
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,26 +33,23 @@ import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owne
 import { getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
 import { civHasAirDefenseCoverage } from '@/systems/air-defense-system';
 import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
-import { usePropagandistAction } from '@/systems/propagandist-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
-import { formatImprovementYieldLabel, getImprovementDisplayName } from '@/systems/improvement-system';
-import { applyPillageToState, canPillageTile, getPillageGoldReward } from '@/systems/pillage-system';
+import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
-import { createWorkerReplacementConfirmPanel, createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
+import { createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { calculateCombatStrengths, deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
 import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
-import { getAirBaseCapacity, getAirBaseRoster, getInterceptCoverage, getLegalAirMissionTargets, getLegalRebaseDestinations, rebaseAircraft, resolveAirStrike, resolveReconMission, startIntercept } from '@/systems/air-operations-system';
-import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import { resolveAirStrike, resolveReconMission } from '@/systems/air-operations-system';
 import { handleSelectedUnitMovementBlocker } from '@/input/selected-unit-movement-feedback';
 import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
@@ -86,7 +83,6 @@ import { createSavePanel } from '@/ui/save-panel';
 import { AdvisorSystem } from '@/ui/advisor-system';
 import { createCouncilPanel } from '@/ui/council-panel';
 import { createGameShell } from '@/ui/game-shell';
-import { createContextMenu } from '@/ui/context-menu';
 import { createNotificationLogPanel } from '@/ui/notification-log-panel';
 import { closePirateWatersPanels, createPirateWatersPanel } from '@/ui/pirate-waters-panel';
 import { createGameButton } from '@/ui/ui-kit';
@@ -95,7 +91,6 @@ import { hirePirateFlotilla, payPirateTribute, type PirateActionResult } from '@
 import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
 import {
   confirmPirateHeadquartersAssault,
-  findAvailablePirateHeadquartersAssault,
   preparePirateHeadquartersAssault,
 } from '@/input/pirate-headquarters-assault';
 import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
@@ -168,7 +163,6 @@ import { resolveNaturalWonderAudioFocus } from '@/input/natural-wonder-audio-foc
 import { resolveMapTapIntent } from '@/input/map-tap-intent';
 import { visibleHostileUnitEntriesAtKey } from '@/input/hex-defender-selection';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
 import {
   initializeLegendaryWonderProjectsForCity,
   getLegendaryWonderEligibility,
@@ -179,9 +173,7 @@ import {
   embedSpy,
   unembedSpy,
   attemptSweep,
-  attemptInfiltration,
   getAvailableMissions,
-  getInfiltrationSuccessChance,
   getSpyCaptureRelationshipPenalty,
   expelSpy,
   executeSpy,
@@ -190,27 +182,18 @@ import {
   missionRequiresPlacedSpy,
   recallSpy,
   resolveMissionResult,
-  setDisguise,
   startMission,
   verifyAgent,
 } from '@/systems/espionage-system';
 import { getCouncilInterrupt } from '@/systems/council-system';
-import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import {
   applyUnitUpgradeToState,
   evaluateUnitUpgrade,
 } from '@/systems/unit-upgrade-system';
-import { executeUnitMove, isWorkerBusy, type ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
+import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import {
-  canLoadUnitOntoTransport,
-  getTransportCargo,
-  getTransportCapacity,
-  getTransportCargoUsed,
-  getUnitCargoSize,
-  getUnloadDestinations,
   getEmbarkedAssaultTarget,
   detachCargoForEmbarkedAssault,
-  loadUnitOntoTransport,
   unloadUnitFromTransport,
 } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
@@ -244,9 +227,9 @@ import { calculateCivEconomy, formatGoldHudText, rushBuyActiveProduction } from 
 import { appeaseFaction, concedeToMovement } from '@/systems/faction-system';
 import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
 import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
-import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
-import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
+import { getCivHappinessFromResources, getCivAvailableResources, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
@@ -397,6 +380,42 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
 });
 
 /**
+ * Owns unit selection: `selectUnit`, `deselectUnit`, `selectNextUnit`, and the
+ * animated-move / auto-explore / journey lifecycle around a selected unit
+ * (#787 phase 8c). References several functions defined later in this file
+ * (`foundCityAction`, `performWorkerAction`, `getUnitTurnFlow`, etc.) --
+ * safe because they are hoisted function declarations and none of them run
+ * until real gameplay, well after module evaluation finishes. The same
+ * deferred-but-eager pattern `notifier` and `router` already use.
+ */
+const selectionController: SelectionController = createSelectionController({
+  session,
+  selection,
+  renderLoop,
+  bus,
+  uiLayer,
+  host,
+  ceremonies,
+  getInfoPanel: () => document.getElementById('info-panel'),
+  showNotification,
+  updateHUD,
+  clearUnloadState,
+  getUnitTurnFlow,
+  foundCityAction,
+  performWorkerAction,
+  performPreach,
+  restAction,
+  openNetworkIntentPanel,
+  openUnitStackPicker,
+  openPirateHeadquartersAssault,
+  handleEstablishRoute,
+  executeUpgrade,
+  ensurePlayerWarState,
+  scanBeastSightings,
+  currentCiv,
+});
+
+/**
  * Shared deps for the domain presentation registrars replacing 72
  * module-scope `bus.on(...)` registrations (#787 phase 7). `notifier`/`router`
  * resolve through getters -- the same deferred-but-eager pattern
@@ -455,7 +474,7 @@ function createUI(): void {
     onOpenDiplomacy: () => router.open('diplomacy'),
     onOpenMarketplace: () => router.open('marketplace'),
     onEndTurn: () => endTurn(),
-    onNextUnit: () => selectNextUnit(),
+    onNextUnit: () => selectionController.selectNextUnit(),
     onOpenNotificationLog: () => router.toggle('notification-log'),
     onOpenPirateWaters: () => router.open('pirate-waters'),
     onToggleIconLegend: () => {
@@ -861,7 +880,7 @@ function openPirateHeadquartersAssault(factionId: string, unitId: string): void 
       if (!result.success) {
         panel.remove();
         showNotification(result.reason ?? 'The assault is no longer available.', 'warning');
-        if (session.getState().units[unitId]) selectUnit(unitId);
+        if (session.getState().units[unitId]) selectionController.selectUnit(unitId);
         return;
       }
       renderLoop.applyPirateHeadquartersAssaultVisual(factionId, unitId, {
@@ -886,8 +905,8 @@ function openPirateHeadquartersAssault(factionId: string, unitId: string): void 
           : `Pirate enclave damaged for ${result.damageToHeadquarters ?? 0} integrity.`,
         result.destroyed ? 'success' : 'info',
       );
-      if (session.getState().units[unitId]) selectUnit(unitId);
-      else deselectUnit();
+      if (session.getState().units[unitId]) selectionController.selectUnit(unitId);
+      else selectionController.deselectUnit();
       openPirateWaters({ factionId });
     },
   });
@@ -1004,7 +1023,7 @@ function handleBreakTreaty(civId: string, treatyType: TreatyType): void {
 
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = session.getState().cities[cityId]?.name ?? 'City-State';
-  const movement = executeAnimatedUnitMove(unitId, () => executeUnitMove(session.getState(), unitId, target, {
+  const movement = selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(session.getState(), unitId, target, {
     actor: 'player',
     civId: session.getState().currentPlayer,
     bus,
@@ -1114,7 +1133,7 @@ function openMarketplacePanel(): void {
     onClose: () => {},
     onSelectUnit: (unitId) => {
       document.getElementById('marketplace-panel')?.remove();
-      selectUnit(unitId);
+      selectionController.selectUnit(unitId);
       const unit = session.getState().units[unitId];
       if (unit) renderLoop.camera.centerOn(unit.position);
     },
@@ -1275,7 +1294,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
     },
     onClose: () => {},
     onTip: (message) => { showNotification(message, 'info'); },
-    onSelectUnit: (unitId) => selectUnit(unitId),
+    onSelectUnit: (unitId) => selectionController.selectUnit(unitId),
     onEstablishRoute: handleEstablishRoute,
     onPrevCity: () => {
       const cities = currentCiv().cities;
@@ -1832,7 +1851,7 @@ function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
   if (!panel) return;
 
   renderUnitStackPanel(panel, session.getState(), coord, unitIds, {
-    onSelectUnit: (unitId) => selectUnit(unitId),
+    onSelectUnit: (unitId) => selectionController.selectUnit(unitId),
     onOpenCity: (cityId) => {
       const city = session.getState().cities[cityId];
       if (!city) return;
@@ -1842,10 +1861,10 @@ function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
       document.getElementById('diplomacy-panel')?.remove();
       document.getElementById('marketplace-panel')?.remove();
       document.getElementById('council-panel')?.remove();
-      deselectUnit();
+      selectionController.deselectUnit();
       openCityPanelForCity(city);
     },
-    onClose: () => deselectUnit(),
+    onClose: () => selectionController.deselectUnit(),
   }, { selectedUnitId: selection.getSelectedUnitId() });
 }
 
@@ -1893,7 +1912,7 @@ function openNetworkIntentPanel(sourceUnitId: string): void {
       }
       session.commit(result.state);
       close();
-      selectUnit(sourceUnitId);
+      selectionController.selectUnit(sourceUnitId);
       const cityName = session.getState().cities[cityId]?.name ?? 'the city';
       showNotification(`${definitionId === 'harden' ? 'Harden' : 'Exploit'} assigned to ${cityName}.`, 'success');
     },
@@ -1901,7 +1920,7 @@ function openNetworkIntentPanel(sourceUnitId: string): void {
       const result = holdNetworkPlan(session.getState(), ownerCivId, sourceUnitId);
       session.commit(result.state);
       close();
-      selectUnit(sourceUnitId);
+      selectionController.selectUnit(sourceUnitId);
       showNotification('Cyber Unit is holding.', 'info');
     },
     onClose: close,
@@ -1964,643 +1983,9 @@ function handleEstablishRoute(caravanId: string): void {
     bus.emit('trade:route-created', { route: routeResult.route });
     renderLoop.setGameState(session.getState());
     updateHUD();
-    selectUnit(caravanId);
+    selectionController.selectUnit(caravanId);
     showNotification('Trade route established!', 'success');
   });
-}
-
-function selectUnit(
-  unitId: string,
-  opts?: {
-    pendingUnloadUnitName?: string;
-    suppressSelectionSfx?: boolean;
-  },
-): void {
-  if (renderLoop.hasMovingUnit(unitId)) {
-    showNotification('Unit is moving.', 'info');
-    return;
-  }
-  const unit = session.getState().units[unitId];
-  if (!unit || unit.owner !== session.getState().currentPlayer) return;
-  selection.setSelectedUnitId(unitId);
-  renderLoop.setSelectedUnitId(unitId);
-
-  const highlightResult = buildSelectedUnitHighlights(session.getState(), unitId);
-  selection.setWaterRecovery(highlightResult.waterRecovery);
-  if (session.getState().units[unitId]?.committedToRouteId) {
-    // Committed caravans cannot move or attack — keep highlights empty
-    selection.setRanges([], []);
-    clearUnloadState();
-  } else {
-    selection.setRanges(highlightResult.movementRange, highlightResult.attackTargets.map(target => target.coord));
-  }
-  renderLoop.setHighlights(highlightResult.highlights);
-
-  // Update journey path overlay
-  if (unit.automation?.mode === 'journey') {
-    const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
-    const completedTechs = session.getState().civilizations[unit.owner]?.techState.completed ?? [];
-    const path = findPath(unit.position, unit.automation.destination, session.getState().map, domain, { unit, completedTechs });
-    renderLoop.setJourneyPath(path);
-  } else {
-    renderLoop.setJourneyPath(null);
-  }
-
-  // Show unit info panel
-  const panel = document.getElementById('info-panel');
-  if (panel) {
-    const pendingIntent = selection.getPendingIntent();
-    renderSelectedUnitInfo(panel, session.getState(), unitId, {
-      onClose: () => deselectUnit(),
-      onStartIntercept: uid => {
-        const result = startIntercept(session.getState(), uid);
-        if (!result.ok) {
-          showNotification('That fighter cannot enter intercept stance now.', 'warning');
-          return;
-        }
-        session.commit(result.state);
-        SFX.airScramble();
-        selectUnit(uid);
-        renderLoop.setHighlights(getInterceptCoverage(session.getState(), uid).map(coord => ({ coord, type: 'air-intercept' as const })));
-      },
-      getAirRebaseDestinations: uid => getLegalRebaseDestinations(session.getState(), uid).map(base => {
-        const position = base.kind === 'city' ? session.getState().cities[base.cityId]?.position : session.getState().units[base.unitId]?.position;
-        const name = base.kind === 'city'
-          ? session.getState().cities[base.cityId]?.name ?? base.cityId
-          : UNIT_DEFINITIONS[session.getState().units[base.unitId]?.type ?? 'carrier'].name;
-        return { base, label: `${name} (${getAirBaseRoster(session.getState(), base).length}/${getAirBaseCapacity(session.getState(), base)})${position ? '' : ''}` };
-      }),
-      onRebaseAircraft: (uid, base) => {
-        const result = rebaseAircraft(session.getState(), uid, base);
-        if (!result.ok) {
-          showNotification('That base is no longer reachable.', 'warning');
-          return;
-        }
-        session.commit(result.state);
-        SFX.airRebase();
-        selectUnit(uid);
-      },
-      onStartAirMission: (uid, mission) => {
-        selection.setPendingIntent({ kind: 'air-mission', unitId: uid, mission });
-        const targets = getLegalAirMissionTargets(session.getState(), uid, mission);
-        selection.setRanges([], []);
-        selectUnit(uid);
-        renderLoop.setHighlights(targets.map(coord => ({
-          coord,
-          type: mission === 'strike' ? 'air-strike' as const : 'air-recon' as const,
-        })));
-        showNotification(mission === 'strike' ? 'Tap a hostile target within operational range, or cancel.' : 'Tap a recon center within operational range, or cancel.', 'info');
-      },
-      onCancelAirMission: uid => {
-        const intent = selection.getPendingIntent();
-        if (intent.kind !== 'air-mission' || intent.unitId !== uid) return;
-        selection.setPendingIntent({ kind: 'none' });
-        selectUnit(uid);
-        showNotification('Air mission cancelled.', 'info');
-      },
-      onOpenNetworkIntent: uid => openNetworkIntentPanel(uid),
-      onUsePropagandistAction: (uid, action, cityId) => {
-        const result = usePropagandistAction(session.getState(), uid, action, cityId);
-        if (!result.ok) {
-          showNotification('That civic action is no longer available.', 'warning');
-          return;
-        }
-        session.commit(result.state);
-        showNotification(result.message, action === 'rally' ? 'success' : 'warning');
-        selectUnit(uid);
-      },
-      onFoundCity: () => foundCityAction(),
-      onWorkerAction: action => performWorkerAction(action),
-      onPreach: (unitId, cityId) => performPreach(unitId, cityId),
-      onRest: () => restAction(),
-      onSkipTurn: uid => getUnitTurnFlow().skipUnitAction(uid),
-      onDeleteUnit: uid => getUnitTurnFlow().showDeleteUnitConfirmation(uid),
-      onFortify: uid => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.owner !== session.getState().currentPlayer) return;
-        if (unit.isFortified) {
-          session.setStateWithoutRefresh(unfortifyUnitInState(session.getState(), session.getState().currentPlayer, uid));
-          showNotification('Unit unfortified.', 'info');
-        } else {
-          session.setStateWithoutRefresh(fortifyUnitInState(session.getState(), session.getState().currentPlayer, uid));
-          showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
-        }
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        selectUnit(uid);
-      },
-      onPillage: uid => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.owner !== session.getState().currentPlayer) return;
-        const tile = session.getState().map.tiles[hexKey(unit.position)];
-        if (!tile || !canPillageTile(tile, unit.owner)) return;
-
-        const hasFinishedImprovement = tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
-        const goldPreview = hasFinishedImprovement ? getPillageGoldReward(tile.improvement) : 0;
-        const targetLabel = hasFinishedImprovement ? getImprovementDisplayName(tile.improvement) : 'the road';
-        const preview = goldPreview > 0
-          ? `Pillage ${targetLabel}?\n\n+${goldPreview} gold, unit heals +25 HP.`
-          : `Pillage ${targetLabel}?\n\nUnit heals +25 HP.`;
-        if (!window.confirm(preview)) return;
-
-        if (tile.owner && isMajorCivOwner(tile.owner)) {
-          ensurePlayerWarState(tile.owner);
-        }
-
-        const result = applyPillageToState(session.getState(), uid);
-        if (!result.ok) return;
-        session.setStateWithoutRefresh(result.state);
-        showNotification(
-          result.goldAwarded! > 0 ? `Pillaged ${targetLabel} for ${result.goldAwarded} gold.` : `Pillaged ${targetLabel}.`,
-          'success',
-        );
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        selectUnit(uid);
-      },
-      onStartAutoExplore: uid => startAutoExplore(uid),
-      onCancelAutoExplore: () => cancelAutoExplore(unitId),
-      onCancelJourney: () => cancelJourney(unitId),
-      onOpenStack: (coord) => {
-        handleFriendlyUnitStackTap(session.getState(), coord, selection.getSelectedUnitId(), {
-          onSelectUnit: selectUnit,
-          onOpenStackPicker: openUnitStackPicker,
-        });
-      },
-      getTransportOptions: uid => {
-        const selectedUnit = session.getState().units[uid];
-        const needs = selectedUnit ? getUnitCargoSize(selectedUnit) : 1;
-        return Object.values(session.getState().units)
-          .filter(candidate => {
-            const def = UNIT_DEFINITIONS[candidate.type];
-            return (def?.domain ?? 'land') === 'naval' && def?.cargoCapacity !== undefined
-              && candidate.owner === session.getState().currentPlayer;
-          })
-          .map(candidate => {
-            const used  = getTransportCargoUsed(session.getState(), candidate.id);
-            const cap   = getTransportCapacity(candidate);
-            const free  = cap - used;
-            const fits  = needs <= free;
-            const suffix = !fits
-              ? ` — needs ${needs} slots, ${free} remaining`
-              : free - needs === 0
-                ? ' — last slot'
-                : ` — ${free} of ${cap} slots free`;
-            return {
-              transportId: candidate.id,
-              label: `Load onto ${UNIT_DEFINITIONS[candidate.type]?.name ?? 'Transport'}${suffix}`,
-              disabled: !fits,
-              tooltip: !fits
-                ? `${UNIT_DEFINITIONS[selectedUnit?.type ?? 'warrior']?.name ?? 'This unit'} requires ${needs} cargo slots. A Galleon or larger transport is needed.`
-                : undefined,
-            };
-          })
-          .filter(o => canLoadUnitOntoTransport(session.getState(), uid, o.transportId).ok || o.disabled);
-      },
-      getCargoBoardInfo: transportId => getTransportCargo(session.getState(), transportId).map(cargoUnit => ({
-        cargoUnitId: cargoUnit.id,
-        label: UNIT_DEFINITIONS[cargoUnit.type]?.name ?? cargoUnit.type,
-        slotCost: getUnitCargoSize(cargoUnit),
-        canUnload: !cargoUnit.hasActed && cargoUnit.movementPointsLeft > 0,
-      })),
-      onSelectCargoToUnload: (transportId, cargoUnitId) => {
-        const range = getUnloadDestinations(session.getState(), transportId, cargoUnitId);
-        selection.setPendingIntent({ kind: 'unload', transportId, cargoUnitId, range });
-        renderLoop.setHighlights(range.map(coord => ({ coord, type: 'move' as const })));
-        const cargoUnit = session.getState().units[cargoUnitId];
-        const unitName = UNIT_DEFINITIONS[cargoUnit?.type ?? 'warrior']?.name ?? 'Unit';
-        selectUnit(transportId, { pendingUnloadUnitName: unitName });
-      },
-      onCancelUnload: () => {
-        clearUnloadState();
-        renderLoop.clearHighlights();
-        const currentlySelected = selection.getSelectedUnitId();
-        if (currentlySelected) selectUnit(currentlySelected);
-      },
-      pendingUnloadUnitName: opts?.pendingUnloadUnitName,
-      getPirateAssaultAction: uid => {
-        const pending = findAvailablePirateHeadquartersAssault(session.getState(), session.getState().currentPlayer, uid);
-        if (!pending) return null;
-        const faction = getPirateWatersPresentation(session.getState(), session.getState().currentPlayer).factions
-          .find(entry => entry.factionId === pending.factionId);
-        return { factionId: pending.factionId, label: `Assault ${faction?.name ?? 'pirate'} enclave` };
-      },
-      onOpenPirateAssault: (factionId, uid) => openPirateHeadquartersAssault(factionId, uid),
-      onLoadTransport: (uid, transportId) => {
-        const prevPos = session.getState().units[uid]?.position;
-        const result = loadUnitOntoTransport(session.getState(), uid, transportId);
-        if (!result.ok) {
-          showNotification(result.message, 'warning');
-          SFX.error();
-          return;
-        }
-        session.commit(result.state);
-        // Boarding animation: slide cargo unit to transport hex before it disappears
-        const transportUnit = session.getState().units[transportId];
-        if (prevPos && transportUnit) {
-          renderLoop.animateUnitSlide(
-            { ...result.state.units[uid] ?? { id: uid } as Unit, position: prevPos },
-            transportUnit.position,
-          );
-        }
-        selectUnit(transportId);
-        const tName = UNIT_DEFINITIONS[session.getState().units[transportId]?.type ?? 'transport']?.name ?? 'Transport';
-        showNotification(`Unit loaded onto ${tName}.`, 'info');
-        SFX.transportLoad();
-      },
-      onUnloadTransport: (transportId, cargoUnitId, destination) => {
-        const result = unloadUnitFromTransport(session.getState(), transportId, cargoUnitId, destination);
-        if (!result.ok) {
-          showNotification(result.message, 'warning');
-          SFX.error();
-          return;
-        }
-        const tName = UNIT_DEFINITIONS[session.getState().units[transportId]?.type ?? 'transport']?.name ?? 'Transport';
-        const cName = UNIT_DEFINITIONS[session.getState().units[cargoUnitId]?.type ?? 'warrior']?.name ?? 'Unit';
-        clearUnloadState();
-        session.commit(result.state);
-        renderLoop.animateUnitAppear(destination);
-        // Stay on the transport so the player can unload remaining cargo
-        selectUnit(transportId);
-        showNotification(`${cName} disembarked from ${tName}.`, 'info');
-        SFX.transportUnload();
-      },
-      onSetDisguise: (uid, disguise) => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.hasActed) return;
-        if (unit.owner !== session.getState().currentPlayer) return;
-        const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        if (!civEsp) return;
-        const spy = civEsp.spies[uid];
-        if (!spy || spy.status !== 'idle') return;
-        session.getState().espionage![session.getState().currentPlayer] = setDisguise(civEsp, uid, disguise);
-        if (disguise !== null) {
-          session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
-        }
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        selectUnit(uid);
-        showNotification(disguise ? `Spy disguised as ${disguise}.` : 'Disguise removed.', 'info');
-      },
-      onInfiltrate: (uid) => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.owner !== session.getState().currentPlayer) return;
-        const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        if (!civEsp) return;
-        const targetCity = Object.values(session.getState().cities).find(
-          c => c.owner !== session.getState().currentPlayer &&
-               c.position.q === unit.position.q && c.position.r === unit.position.r,
-        );
-        if (!targetCity) { showNotification('No enemy city at this location.', 'info'); return; }
-
-        const alreadyInside = Object.values(civEsp.spies).some(
-          s => s.infiltrationCityId === targetCity.id &&
-               (s.status === 'stationed' || s.status === 'on_mission'),
-        );
-        if (alreadyInside) { showNotification('You already have a spy in that city.', 'info'); return; }
-
-        const cityCI = session.getState().espionage![targetCity.owner]?.counterIntelligence[targetCity.id] ?? 0;
-        const chance = getInfiltrationSuccessChance(unit.type as UnitType, civEsp.spies[uid]?.experience ?? 0, cityCI);
-        const preview = `Infiltrate ${targetCity.name}?\n\nSuccess chance: ${Math.round(chance * 100)}%\nCity CI: ${cityCI}\n\nIf caught, spy may be lost permanently.`;
-        if (!window.confirm(preview)) return;
-
-        const seed = `infiltrate-${uid}-${session.getState().turn}`;
-        const result = attemptInfiltration(
-          civEsp, uid, unit.type as UnitType, targetCity.id, targetCity.position, cityCI, seed,
-        );
-        // Record the original target civ so auto-exfiltrate can detect third-party captures
-        const spyAfterAttempt = result.civEsp.spies[uid];
-        const civEspWithTarget = spyAfterAttempt ? {
-          ...result.civEsp,
-          spies: { ...result.civEsp.spies, [uid]: { ...spyAfterAttempt, targetCivId: targetCity.owner } },
-        } : result.civEsp;
-        session.getState().espionage![session.getState().currentPlayer] = civEspWithTarget;
-
-        if (result.removeUnitFromMap) {
-          // Era 2+: spy removed from map, stationed inside city
-          delete session.getState().units[uid];
-          const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
-          if (civUnits) {
-            session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
-          }
-          showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
-          bus.emit('espionage:spy-infiltrated', { civId: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
-          deselectUnit();
-        } else if (result.era1ScoutResult !== undefined) {
-          // Era 1 (spy_scout): spy stays on map, infiltrationCityId + 5-turn city vision already set
-          const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), session.getState().currentPlayer, uid);
-          const tilesToReveal = missionResult.tilesToReveal ?? [];
-          if (tilesToReveal.length > 0) {
-            const visibilityTiles = { ...(session.getState().civilizations[session.getState().currentPlayer].visibility?.tiles ?? {}) };
-            for (const coord of tilesToReveal) {
-              visibilityTiles[`${coord.q},${coord.r}`] = 'visible';
-            }
-            session.getState().civilizations[session.getState().currentPlayer].visibility = {
-              ...session.getState().civilizations[session.getState().currentPlayer].visibility!,
-              tiles: visibilityTiles,
-            };
-          }
-          session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
-          showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
-          selectUnit(uid);
-        } else if (result.caught) {
-          // Caught: remove unit from map (spy lost)
-          delete session.getState().units[uid];
-          const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
-          if (civUnits) {
-            session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
-          }
-          bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
-          deselectUnit();
-        } else {
-          const cooldown = result.civEsp.spies[uid]?.cooldownTurns ?? 3;
-          showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
-          session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
-          selectUnit(uid);
-        }
-
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-      },
-      onEmbed: (uid) => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.owner !== session.getState().currentPlayer) return;
-        const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        if (!civEsp) return;
-        const city = Object.values(session.getState().cities).find(
-          c => c.owner === session.getState().currentPlayer &&
-               c.position.q === unit.position.q && c.position.r === unit.position.r,
-        );
-        if (!city) return;
-        session.getState().espionage![session.getState().currentPlayer] = embedSpy(civEsp, uid, city.id, city.position);
-        delete session.getState().units[uid];
-        session.getState().civilizations[session.getState().currentPlayer].units =
-          session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== uid);
-        deselectUnit();
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
-      },
-      onUpgradeUnit: (uid, cityId) => {
-        const unit = session.getState().units[uid];
-        if (!unit || unit.owner !== session.getState().currentPlayer) return;
-        const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
-        if (!targetType) return;
-        const upgrade = evaluateUnitUpgrade(session.getState(), uid, targetType);
-        if (!upgrade.canUpgrade || !upgrade.targetType) return;
-        if (executeUpgrade(uid, upgrade.targetType)) {
-          selectUnit(uid);
-          showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
-        }
-      },
-      onEstablishOutpost: (unitId) => {
-        if (!canEstablishOutpost(session.getState(), unitId)) return;
-        session.setStateWithoutRefresh(performEstablishOutpost(session.getState(), unitId));
-        autoSave(session.getState()).catch(() => {});
-        selection.setSelectedUnitId(null);
-        renderLoop.setSelectedUnitId(null);
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        showNotification('Expedition planted a flag! Outpost completes in 2 turns.', 'success');
-      },
-      onEstablishRoute: handleEstablishRoute,
-      onReplaceImprovement: (action) => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (!selectedUnitId) return;
-        const unit = session.getState().units[selectedUnitId];
-        if (!unit) return;
-        const tileKey = hexKey(unit.position);
-        const currentTile = session.getState().map.tiles[tileKey];
-        if (!currentTile || currentTile.improvement === 'none') return;
-        const existingName = getImprovementDisplayName(currentTile.improvement);
-        const newName = getImprovementDisplayName(action);
-        const existingYield = formatImprovementYieldLabel(currentTile.improvement) || undefined;
-        const newYield = formatImprovementYieldLabel(action) || undefined;
-        const uid = selectedUnitId;
-        createWorkerReplacementConfirmPanel(uiLayer, {
-          existingName,
-          newName,
-          existingYield,
-          newYield,
-          onCancel: () => selectUnit(uid),
-          onConfirm: () => {
-            const result = applyWorkerAction(session.getState(), uid, action, { allowReplacement: true });
-            if (!result.ok) return;
-            session.setStateWithoutRefresh(result.state);
-            for (const event of result.events) {
-              if (event.type === 'improvement:started') {
-                bus.emit('improvement:started', event.payload);
-              } else if (event.type === 'road:started') {
-                bus.emit('road:started', event.payload);
-              } else {
-                bus.emit('unit:destroyed', event.payload);
-              }
-            }
-            renderLoop.setGameState(session.getState());
-            updateHUD();
-            if (result.workerConsumed || result.workerLost || !session.getState().units[uid]) {
-              deselectUnit();
-            } else {
-              selectUnit(uid);
-            }
-            showNotification(result.message, result.workerLost ? 'warning' : 'info');
-          },
-        });
-      },
-    }, {
-      waterRecovery: highlightResult.waterRecovery,
-      hasZoneOfControlWarning: highlightResult.zocLimitedRange.length > 0,
-      airMissionPending: pendingIntent.kind === 'air-mission' && pendingIntent.unitId === unitId ? pendingIntent.mission : undefined,
-    });
-  }
-
-  if (!opts?.suppressSelectionSfx) SFX.select();
-}
-
-function deselectUnit(): void {
-  // Clears the selection, both ranges, and any pending air mission, journey, or
-  // unload. A pending city-capture choice deliberately survives — see the
-  // `SelectionStore.clear()` contract.
-  selection.clear();
-  renderLoop.setSelectedUnitId(null);
-  renderLoop.clearHighlights();
-  renderLoop.setJourneyPath(null);
-  const panel = document.getElementById('info-panel');
-  if (panel) {
-    panel.style.display = 'none';
-    panel.replaceChildren();
-  }
-}
-
-function isUnitAnimationLocked(unitId: string | null): boolean {
-  return Boolean(unitId && renderLoop.hasMovingUnit(unitId));
-}
-
-function animateMovedUnit(unitId: string, path: HexCoord[]): void {
-  const movedUnit = session.getState().units[unitId];
-  if (!movedUnit || path.length < 2) return;
-  selection.setRanges([], []);
-  clearUnloadState();
-  renderLoop.clearHighlights();
-  renderLoop.animateUnitMove({ ...movedUnit, position: path[0]! }, path, () => {
-    renderLoop.setGameState(session.getState());
-    updateHUD();
-    ceremonies.endAction();
-    const unit = session.getState().units[unitId];
-    if (!unit || unit.owner !== session.getState().currentPlayer) return;
-
-    if ((unit.movementPointsLeft ?? 0) <= 0) {
-      selectNextUnit();
-    } else if (selection.getSelectedUnitId() === unitId) {
-      selectUnit(unitId);
-    }
-  });
-}
-
-function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult {
-  const movingUnit = session.getState().units[unitId];
-  ceremonies.beginDeferredAction();
-  try {
-    const moveResult = move();
-    if (!moveResult.ok) {
-      ceremonies.endAction();
-      showNotification(moveResult.message, 'warning');
-      SFX.error();
-      return moveResult;
-    }
-    if (moveResult.stopReason === 'zone-of-control') {
-      showNotification('Stopped — enemy nearby', 'info');
-    }
-    // Clear journey automation when the player manually moves a unit.
-    if (movingUnit?.automation?.mode === 'journey') {
-      const movedUnit = session.getState().units[unitId];
-      if (movedUnit) {
-        session.setStateWithoutRefresh({
-          ...session.getState(),
-          units: { ...session.getState().units, [unitId]: { ...movedUnit, automation: undefined } },
-        });
-      }
-      renderLoop.setJourneyPath(null);
-    }
-    animateMovedUnit(unitId, moveResult.path);
-    return moveResult;
-  } catch (error) {
-    ceremonies.endAction();
-    throw error;
-  }
-}
-
-function startAutoExplore(unitId: string): void {
-  const unit = session.getState().units[unitId];
-  if (!unit || unit.owner !== session.getState().currentPlayer) return;
-
-  session.getState().units[unitId] = {
-    ...unit,
-    automation: {
-      mode: 'auto-explore',
-      startedTurn: session.getState().turn,
-      lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
-    },
-  };
-
-  if (session.getState().units[unitId].movementPointsLeft > 0 && !session.getState().units[unitId].hasActed) {
-    applyAutoExploreOrder(session.getState(), unitId, { bus });
-  }
-
-  renderLoop.setGameState(session.getState());
-  updateHUD();
-  selectUnit(unitId);
-}
-
-function cancelAutoExplore(unitId: string): void {
-  const unit = session.getState().units[unitId];
-  if (!unit?.automation) return;
-  delete session.getState().units[unitId].automation;
-  renderLoop.setGameState(session.getState());
-  updateHUD();
-  if (selection.getSelectedUnitId() === unitId) {
-    selectUnit(unitId);
-  }
-}
-
-function cancelJourney(unitId: string): void {
-  const unit = session.getState().units[unitId];
-  if (!unit?.automation) return;
-  session.commit({
-    ...session.getState(),
-    units: { ...session.getState().units, [unitId]: { ...unit, automation: undefined } },
-  });
-  renderLoop.setJourneyPath(null);
-  updateHUD();
-  if (selection.getSelectedUnitId() === unitId) {
-    selectUnit(unitId);
-  }
-}
-
-function openUnitContextMenu(unitId: string): void {
-  const panel = document.getElementById('info-panel');
-  if (!panel) return;
-
-  createContextMenu(panel, session.getState(), { unitId }, {
-    onStartAutoExplore: id => startAutoExplore(id),
-    onCancelAutoExplore: id => cancelAutoExplore(id),
-  }, host);
-}
-
-function selectNextUnit(): void {
-  const unmoved = getUnmovedUnits(session.getState().units, session.getState().currentPlayer);
-  if (unmoved.length === 0) {
-    // All units have moved — silently deselect
-    deselectUnit();
-    return;
-  }
-  // Skip current unit if it's in the list
-  const filtered = unmoved.filter(u => u.id !== selection.getSelectedUnitId());
-  const next = filtered.length > 0 ? filtered[0] : unmoved[0];
-  selectUnit(next.id);
-  renderLoop.camera.centerOn(next.position);
-}
-
-function refreshSelectedUnitAfterCombat(): void {
-  const selectedUnitId = selection.getSelectedUnitId();
-  if (!selectedUnitId) return;
-  const selectedUnit = session.getState().units[selectedUnitId];
-  if (!selectedUnit || selectedUnit.owner !== session.getState().currentPlayer) {
-    deselectUnit();
-    return;
-  }
-  selectUnit(selectedUnitId, { suppressSelectionSfx: true });
-}
-
-function refreshCurrentPlayerVisibility(): void {
-  if (!currentCiv()?.visibility) return;
-
-  // Snapshot unexplored tile keys before the update so we can detect fog-lift transitions
-  const visTiles = currentCiv()!.visibility!.tiles;
-  const prevUnexplored = new Set(
-    Object.keys(visTiles).filter(k => visTiles[k] === 'unexplored'),
-  );
-
-  updateAndRefreshVisibility(session.getState(), session.getState().currentPlayer);
-
-  // Fire at most one resource-discovered tip per visibility update to avoid
-  // flooding the player when a scout reveals several resource tiles at once.
-  const updatedTiles = currentCiv()?.visibility?.tiles ?? {};
-  for (const key of prevUnexplored) {
-    if (updatedTiles[key] !== 'unexplored') {
-      const tile = session.getState().map.tiles[key];
-      if (tile?.resource) {
-        const fired = fireResourceDiscoveredTip(tile.resource, session.getState(), bus);
-        if (fired) break; // one tip per move is enough
-      }
-    }
-  }
-
-  for (const contact of syncCivilizationContactsFromVisibility(session.getState(), session.getState().currentPlayer)) {
-    bus.emit('civilization:first-contact', contact);
-  }
-
-  scanBeastSightings();
 }
 
 function getUnitTurnFlow() {
@@ -2609,11 +1994,11 @@ function getUnitTurnFlow() {
     getState: () => session.getState(),
     setState: nextState => { session.setStateWithoutRefresh(nextState); },
     getSelectedUnitId: () => selection.getSelectedUnitId(),
-    selectUnit,
-    deselectUnit,
-    selectNextUnit,
+    selectUnit: selectionController.selectUnit,
+    deselectUnit: selectionController.deselectUnit,
+    selectNextUnit: selectionController.selectNextUnit,
     centerOn: coord => renderLoop.camera.centerOn(coord),
-    refreshVisibility: refreshCurrentPlayerVisibility,
+    refreshVisibility: selectionController.refreshCurrentPlayerVisibility,
     setRenderState: state => renderLoop.setGameState(state),
     updateHUD,
     showNotification,
@@ -2648,7 +2033,7 @@ function foundCityAction(): void {
   }
   session.setStateWithoutRefresh(result.state);
 
-  deselectUnit();
+  selectionController.deselectUnit();
   const foundedCity = session.getState().cities[result.cityId];
   showNotification(`${foundedCity.name} has been founded!`, 'success');
   SFX.foundCity();
@@ -2685,9 +2070,9 @@ function performWorkerAction(action: WorkerActionType): void {
   updateHUD();
 
   if (result.workerConsumed || result.workerLost || !session.getState().units[selectedUnitId]) {
-    deselectUnit();
+    selectionController.deselectUnit();
   } else {
-    selectUnit(selectedUnitId);
+    selectionController.selectUnit(selectedUnitId);
   }
 
   showNotification(result.message, result.workerLost ? 'warning' : 'info');
@@ -2710,7 +2095,7 @@ function performPreach(unitId: string, cityId: string): void {
     : `You preached in ${cityName}.`;
 
   if (result.unitConsumed) {
-    deselectUnit();
+    selectionController.deselectUnit();
     setBlockingOverlay('unit-delete-confirmation');
     createUnitDeleteConfirmationPanel(uiLayer, {
       unitName: unit ? UNIT_DEFINITIONS[unit.type].name : 'Missionary',
@@ -2729,7 +2114,7 @@ function performPreach(unitId: string, cityId: string): void {
       },
     });
   } else {
-    selectUnit(unitId);
+    selectionController.selectUnit(unitId);
     showNotification(message, result.converted ? 'success' : 'info');
   }
 }
@@ -2787,7 +2172,7 @@ function finalizePendingCityCaptureChoice(
 
   renderLoop.setGameState(session.getState());
   updateHUD();
-  setTimeout(() => selectNextUnit(), 400);
+  setTimeout(() => selectionController.selectNextUnit(), 400);
 }
 
 function beginPlayerCityAssault(
@@ -2866,7 +2251,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
   if (!initialAttacker || initialAttacker.hasActed || !legality.ok || legality.targetType !== 'unit') {
     showNotification('That target is no longer attackable.', 'warning');
     const currentlySelected = selection.getSelectedUnitId();
-    if (currentlySelected) selectUnit(currentlySelected);
+    if (currentlySelected) selectionController.selectUnit(currentlySelected);
     return;
   }
 
@@ -2986,9 +2371,9 @@ function executeAttack(attackerId: string, targetKey: string): void {
           SFX.combat();
           renderLoop.setGameState(session.getState());
           updateHUD();
-          refreshSelectedUnitAfterCombat();
+          selectionController.refreshSelectedUnitAfterCombat();
           if (assaultStatus === 'resolved') {
-            setTimeout(() => selectNextUnit(), 400);
+            setTimeout(() => selectionController.selectNextUnit(), 400);
           }
           return;
         }
@@ -3002,8 +2387,8 @@ function executeAttack(attackerId: string, targetKey: string): void {
   SFX.combat();
   renderLoop.setGameState(session.getState());
   updateHUD();
-  refreshSelectedUnitAfterCombat();
-  renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectNextUnit());
+  selectionController.refreshSelectedUnitAfterCombat();
+  renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectionController.selectNextUnit());
 }
 
 function restAction(): void {
@@ -3014,7 +2399,7 @@ function restAction(): void {
 
   session.getState().units[selectedUnitId] = restUnit(unit);
   showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
-  deselectUnit();
+  selectionController.deselectUnit();
   renderLoop.setGameState(session.getState());
 }
 
@@ -3024,7 +2409,7 @@ function handleHexTap(rawCoord: HexCoord): void {
     : rawCoord;
   const key = hexKey(coord);
   const snapshot = selection.snapshot();
-  const isAnimationLocked = isUnitAnimationLocked(snapshot.selectedUnitId);
+  const isAnimationLocked = selectionController.isUnitAnimationLocked(snapshot.selectedUnitId);
   const intent = resolveMapTapIntent(session.getState(), snapshot, coord, isAnimationLocked);
 
   switch (intent.kind) {
@@ -3051,7 +2436,7 @@ function handleHexTap(rawCoord: HexCoord): void {
                   [journeyUnitId]: { ...unit, automation: { mode: 'journey', destination: coord } },
                 },
               });
-              selectUnit(journeyUnitId);
+              selectionController.selectUnit(journeyUnitId);
               showNotification('Journey set. Your unit will advance each turn.', 'info');
             }
           }
@@ -3070,11 +2455,11 @@ function handleHexTap(rawCoord: HexCoord): void {
           }
           selection.setPendingIntent({ kind: 'none' });
           session.commit(result.state);
-          refreshCurrentPlayerVisibility();
+          selectionController.refreshCurrentPlayerVisibility();
           updateHUD();
           if (pending.mission === 'recon') SFX.airRecon();
           else SFX.combat();
-          selectUnit(pending.unitId);
+          selectionController.selectUnit(pending.unitId);
           return;
         }
 
@@ -3082,7 +2467,7 @@ function handleHexTap(rawCoord: HexCoord): void {
           // Delegate to onUnloadTransport which handles state, animation, and notification
           const panel = document.getElementById('info-panel');
           if (panel) {
-            // Re-invoke via the callback registered in selectUnit's renderSelectedUnitInfo block
+            // Re-invoke via the callback registered in SelectionController's renderSelectedUnitInfo block
             // by triggering the transport system directly here (callbacks are not stored).
             const { transportId, cargoUnitId } = intent.pending;
             const result = unloadUnitFromTransport(session.getState(), transportId, cargoUnitId, coord);
@@ -3095,7 +2480,7 @@ function handleHexTap(rawCoord: HexCoord): void {
               clearUnloadState();
               session.commit(result.state);
               renderLoop.animateUnitAppear(coord);
-              selectUnit(transportId);
+              selectionController.selectUnit(transportId);
               showNotification(`${cName} disembarked from ${tName}.`, 'info');
               SFX.transportUnload();
             }
@@ -3141,19 +2526,19 @@ function handleHexTap(rawCoord: HexCoord): void {
     }
 
     case 'select-unit': {
-      selectUnit(intent.unitId);
+      selectionController.selectUnit(intent.unitId);
       return;
     }
 
     case 'blocked-caravan-committed': {
       showNotification('Caravan is committed to a trade route and cannot move.', 'warning');
-      selectUnit(intent.unitId);
+      selectionController.selectUnit(intent.unitId);
       return;
     }
 
     case 'blocked-naval-gate': {
       showNotification(intent.reason, 'warning');
-      selectUnit(intent.unitId);
+      selectionController.selectUnit(intent.unitId);
       return;
     }
 
@@ -3169,7 +2554,7 @@ function handleHexTap(rawCoord: HexCoord): void {
         selection.getWaterRecovery(),
         {
           showNotification,
-          reselectUnit: unitId => selectUnit(unitId, { suppressSelectionSfx: true }),
+          reselectUnit: unitId => selectionController.selectUnit(unitId, { suppressSelectionSfx: true }),
           playError: SFX.error,
         },
       );
@@ -3271,7 +2656,7 @@ function handleHexTap(rawCoord: HexCoord): void {
         }
 
         panel.appendChild(wrapper);
-        closeBtn.addEventListener('click', deselectUnit);
+        closeBtn.addEventListener('click', selectionController.deselectUnit);
       }
       return;
     }
@@ -3385,7 +2770,7 @@ function handleHexTap(rawCoord: HexCoord): void {
         panel.innerHTML = '';
         panel.appendChild(previewDiv);
 
-        cancelBtn.addEventListener('click', deselectUnit);
+        cancelBtn.addEventListener('click', selectionController.deselectUnit);
         attackBtn.addEventListener('click', () => {
           // Read live: the player may have changed selection between the
           // preview rendering and this confirmation.
@@ -3396,7 +2781,7 @@ function handleHexTap(rawCoord: HexCoord): void {
             : canUnitAttackTarget(session.getState(), attacker, coord, { viewerId: session.getState().currentPlayer });
           if (!legality.ok || legality.targetType !== 'unit') {
             showNotification('That target is no longer attackable.', 'warning');
-            if (attackerId) selectUnit(attackerId);
+            if (attackerId) selectionController.selectUnit(attackerId);
             return;
           }
           executeAttack(attackerId!, key);
@@ -3472,7 +2857,7 @@ function handleHexTap(rawCoord: HexCoord): void {
         panel.innerHTML = '';
         panel.appendChild(previewDiv);
 
-        cancelBtn.addEventListener('click', deselectUnit);
+        cancelBtn.addEventListener('click', selectionController.deselectUnit);
         attackBtn.addEventListener('click', () => {
           // Read live, as the module binding this replaced did.
           const assaultStatus = beginPlayerCityAssault(selection.getSelectedUnitId()!, intent.cityId, undefined, undefined, intent.embarkedAssault);
@@ -3480,7 +2865,7 @@ function handleHexTap(rawCoord: HexCoord): void {
           renderLoop.setGameState(session.getState());
           updateHUD();
           if (assaultStatus === 'resolved') {
-            setTimeout(() => selectNextUnit(), 400);
+            setTimeout(() => selectionController.selectNextUnit(), 400);
           }
         });
       }
@@ -3523,7 +2908,7 @@ function handleHexTap(rawCoord: HexCoord): void {
           renderLoop.setGameState(session.getState());
           updateHUD();
         },
-        onCancel: () => selectUnit(selectedId),
+        onCancel: () => selectionController.selectUnit(selectedId),
       });
       return;
     }
@@ -3543,7 +2928,7 @@ function handleHexTap(rawCoord: HexCoord): void {
           emitMinorCivQuestTransitions(bus, war.transitions, session.getState());
           executeMinorCivConquest(selectedId, coord, intent.minorCivId, intent.cityId);
         },
-        onCancel: () => selectUnit(selectedId),
+        onCancel: () => selectionController.selectUnit(selectedId),
       });
       return;
     }
@@ -3556,7 +2941,7 @@ function handleHexTap(rawCoord: HexCoord): void {
         SFX.tap();
         renderLoop.setGameState(session.getState());
         updateHUD();
-        setTimeout(() => selectNextUnit(), 400);
+        setTimeout(() => selectionController.selectNextUnit(), 400);
       }
       return;
     }
@@ -3571,9 +2956,9 @@ function handleHexTap(rawCoord: HexCoord): void {
           ? (isRoadTask ? 'Road' : getImprovementDisplayName(task.action as ImprovementType))
           : 'Improvement',
         turnsLeft: (isRoadTask ? taskTile?.roadTurnsLeft : taskTile?.improvementTurnsLeft) ?? 1,
-        onCancel: () => selectUnit(selectedId),
+        onCancel: () => selectionController.selectUnit(selectedId),
         onConfirm: () => {
-          executeAnimatedUnitMove(selectedId, () => confirmBusyWorkerMove(session.getState(), selectedId, intent.coord, {
+          selectionController.executeAnimatedUnitMove(selectedId, () => confirmBusyWorkerMove(session.getState(), selectedId, intent.coord, {
             actor: 'player',
             civId: session.getState().currentPlayer,
             bus,
@@ -3587,7 +2972,7 @@ function handleHexTap(rawCoord: HexCoord): void {
     }
 
     case 'move': {
-      executeAnimatedUnitMove(intent.unitId, () => executeUnitMove(session.getState(), intent.unitId, intent.coord, {
+      selectionController.executeAnimatedUnitMove(intent.unitId, () => executeUnitMove(session.getState(), intent.unitId, intent.coord, {
         actor: 'player',
         civId: session.getState().currentPlayer,
         bus,
@@ -3607,13 +2992,13 @@ function handleHexTap(rawCoord: HexCoord): void {
       document.getElementById('diplomacy-panel')?.remove();
       document.getElementById('marketplace-panel')?.remove();
       document.getElementById('council-panel')?.remove();
-      deselectUnit();
+      selectionController.deselectUnit();
       openCityPanelForCity(cityAtHex);
       return;
     }
 
     case 'open-wonder-atlas': {
-      deselectUnit();
+      selectionController.deselectUnit();
       const audioFocus = resolveNaturalWonderAudioFocus(session.getState(), session.getState().currentPlayer, intent.coord);
       if (audioFocus) void audio.startNaturalWonderMapFocusAmbient(audioFocus.wonderId);
       openWonderAtlas(intent.wonderId);
@@ -3622,7 +3007,7 @@ function handleHexTap(rawCoord: HexCoord): void {
     }
 
     case 'deselect': {
-      deselectUnit();
+      selectionController.deselectUnit();
       SFX.tap();
       return;
     }
@@ -3680,8 +3065,8 @@ function handleHexLongPress(rawCoord: HexCoord): void {
   );
   if (unitAtHex) {
     closeTerritoryInspectionPanel();
-    selectUnit(unitAtHex.id);
-    openUnitContextMenu(unitAtHex.id);
+    selectionController.selectUnit(unitAtHex.id);
+    selectionController.openUnitContextMenu(unitAtHex.id);
     return;
   }
 
@@ -4007,7 +3392,7 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
     }
 
     SFX.endTurn();
-    deselectUnit();
+    selectionController.deselectUnit();
 
     const hotSeat = session.getState().hotSeat;
 
@@ -4557,7 +3942,7 @@ function startGame(): Promise<void> {
         }
         renderLoop.setGameState(session.getState());
         updateHUD();
-        selectUnit(selectedUnitId);
+        selectionController.selectUnit(selectedUnitId);
       },
       onSettle: () => {
         const selectedUnitId = selection.getSelectedUnitId();
@@ -4566,7 +3951,7 @@ function startGame(): Promise<void> {
         if (!unit || unit.type !== 'settler') return;
         foundCityAction();
       },
-      onNextUnit: () => selectNextUnit(),
+      onNextUnit: () => selectionController.selectNextUnit(),
       onStartJourney: () => {
         const selectedUnitId = selection.getSelectedUnitId();
         if (!selectedUnitId) return;

--- a/tests/app/controllers/selection-controller-establish-outpost.test.ts
+++ b/tests/app/controllers/selection-controller-establish-outpost.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// Isolated from selection-controller.test.ts because this file mocks
+// `@/ui/selected-unit-info` module-wide (vi.mock hoists to the top of the
+// file) to capture the ~30 callbacks `selectUnit` wires into it -- doing
+// that in the same file as tests asserting real DOM rendering would break
+// those tests.
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { createUnit } from '@/systems/unit-system';
+import type { GameState, Unit } from '@/core/types';
+import { createGameSession } from '@/app/game-session';
+import { createSelectionStore } from '@/app/selection-store';
+import { createPanelHost } from '@/app/panel-host';
+import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import type { UnitTurnFlow } from '@/ui/unit-turn-flow';
+import {
+  createSelectionController,
+  type SelectionControllerDeps,
+  type SelectionControllerRenderer,
+} from '@/app/controllers/selection-controller';
+import * as resourceAcquisition from '@/systems/resource-acquisition-system';
+import * as saveManager from '@/storage/save-manager';
+import * as selectedUnitInfo from '@/ui/selected-unit-info';
+
+vi.mock('@/ui/selected-unit-info', () => ({
+  renderSelectedUnitInfo: vi.fn(),
+}));
+vi.mock('@/storage/save-manager', async () => {
+  const actual = await vi.importActual<typeof saveManager>('@/storage/save-manager');
+  return { ...actual, autoSave: vi.fn().mockResolvedValue(undefined) };
+});
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'selection-controller-outpost', 'small');
+  state.currentPlayer = 'player';
+  state.units = {};
+  for (const civId of Object.keys(state.civilizations)) {
+    state.civilizations[civId].units = [];
+  }
+  return state;
+}
+
+const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+
+function placePlayerUnit(state: GameState, id: string, overrides: Partial<Unit> = {}): Unit {
+  const template = createUnit('warrior', 'player', { q: 0, r: 0 }, idCounters);
+  state.units[id] = { ...template, id, owner: 'player', position: { q: 0, r: 0 }, ...overrides };
+  if (!state.civilizations.player.units.includes(id)) state.civilizations.player.units.push(id);
+  return state.units[id];
+}
+
+function fakeRenderer(): SelectionControllerRenderer {
+  return {
+    hasMovingUnit: () => false,
+    setSelectedUnitId: vi.fn(),
+    setHighlights: vi.fn(),
+    clearHighlights: vi.fn(),
+    setJourneyPath: vi.fn(),
+    setGameState: vi.fn(),
+    animateUnitMove: vi.fn(),
+    animateUnitSlide: vi.fn(),
+    animateUnitAppear: vi.fn(),
+    camera: { centerOn: vi.fn() },
+  };
+}
+
+function fakeCeremonies(): CeremonyCoordinator {
+  return {
+    enqueueWonderDiscovery: vi.fn(),
+    enqueueLegendaryCompletion: vi.fn(),
+    beginDeferredAction: vi.fn(),
+    endAction: vi.fn(),
+    clearForHandoff: vi.fn(),
+  };
+}
+
+function fakeUnitTurnFlow(): UnitTurnFlow {
+  return {
+    skipUnitAction: vi.fn(),
+    showDeleteUnitConfirmation: vi.fn(),
+    showEndTurnUnitWarningIfNeeded: () => false,
+  };
+}
+
+function baseDeps(state: GameState, overrides: Partial<SelectionControllerDeps> = {}): SelectionControllerDeps {
+  const session = overrides.session ?? createGameSession(state);
+  return {
+    session,
+    selection: createSelectionStore(),
+    renderLoop: fakeRenderer(),
+    bus: new EventBus(),
+    uiLayer: document.createElement('div'),
+    host: createPanelHost(document.createElement('div')),
+    ceremonies: fakeCeremonies(),
+    getInfoPanel: () => document.getElementById('info-panel'),
+    showNotification: vi.fn(),
+    updateHUD: vi.fn(),
+    clearUnloadState: vi.fn(),
+    getUnitTurnFlow: () => fakeUnitTurnFlow(),
+    foundCityAction: vi.fn(),
+    performWorkerAction: vi.fn(),
+    performPreach: vi.fn(),
+    restAction: vi.fn(),
+    openNetworkIntentPanel: vi.fn(),
+    openUnitStackPicker: vi.fn(),
+    openPirateHeadquartersAssault: vi.fn(),
+    handleEstablishRoute: vi.fn(),
+    executeUpgrade: vi.fn(() => false),
+    ensurePlayerWarState: vi.fn(),
+    scanBeastSightings: vi.fn(),
+    currentCiv: () => session.getState().civilizations[session.getState().currentPlayer],
+    ...overrides,
+  };
+}
+
+describe('SelectionController onEstablishOutpost (regression)', () => {
+  beforeEach(() => {
+    vi.mocked(selectedUnitInfo.renderSelectedUnitInfo).mockClear();
+    vi.mocked(saveManager.autoSave).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists the game via autoSave after a successful outpost establishment', () => {
+    // Regression: the 8c extraction (#787) accidentally dropped this
+    // autoSave call while moving selectUnit out of main.ts -- caught by a
+    // line-by-line diff against the pre-extraction source, not by a test,
+    // which is exactly why this test exists now.
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    vi.spyOn(resourceAcquisition, 'canEstablishOutpost').mockReturnValue(true);
+    vi.spyOn(resourceAcquisition, 'performEstablishOutpost').mockReturnValue(state);
+
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    const options = vi.mocked(selectedUnitInfo.renderSelectedUnitInfo).mock.calls[0]![3] as {
+      onEstablishOutpost: (unitId: string) => void;
+    };
+    options.onEstablishOutpost('u1');
+
+    expect(saveManager.autoSave).toHaveBeenCalledWith(state);
+  });
+
+  it('does not establish or save when the unit cannot establish an outpost', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    vi.spyOn(resourceAcquisition, 'canEstablishOutpost').mockReturnValue(false);
+    const performSpy = vi.spyOn(resourceAcquisition, 'performEstablishOutpost');
+
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    const options = vi.mocked(selectedUnitInfo.renderSelectedUnitInfo).mock.calls[0]![3] as {
+      onEstablishOutpost: (unitId: string) => void;
+    };
+    options.onEstablishOutpost('u1');
+
+    expect(performSpy).not.toHaveBeenCalled();
+    expect(saveManager.autoSave).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -1,0 +1,375 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createUnit } from '@/systems/unit-system';
+import type { GameState, Unit } from '@/core/types';
+import { createGameSession } from '@/app/game-session';
+import { createSelectionStore } from '@/app/selection-store';
+import { createPanelHost } from '@/app/panel-host';
+import type { CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import type { UnitTurnFlow } from '@/ui/unit-turn-flow';
+import type { ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import {
+  createSelectionController,
+  type SelectionControllerDeps,
+  type SelectionControllerRenderer,
+} from '@/app/controllers/selection-controller';
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'selection-controller', 'small');
+  state.currentPlayer = 'player';
+  // Strip the settler/warrior createNewGame seeds by default so fixtures that
+  // place their own units get a deterministic, fully-controlled unit roster
+  // (relevant for selectNextUnit's "skip current"/"none left" tests below).
+  state.units = {};
+  for (const civId of Object.keys(state.civilizations)) {
+    state.civilizations[civId].units = [];
+  }
+  return state;
+}
+
+const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+
+function placePlayerUnit(state: GameState, id: string, overrides: Partial<Unit> = {}): Unit {
+  const template = createUnit('warrior', 'player', { q: 0, r: 0 }, idCounters);
+  state.units[id] = { ...template, id, owner: 'player', position: { q: 0, r: 0 }, ...overrides };
+  if (!state.civilizations.player.units.includes(id)) state.civilizations.player.units.push(id);
+  return state.units[id];
+}
+
+function fakeRenderer(overrides: Partial<SelectionControllerRenderer> = {}): SelectionControllerRenderer {
+  return {
+    hasMovingUnit: () => false,
+    setSelectedUnitId: vi.fn(),
+    setHighlights: vi.fn(),
+    clearHighlights: vi.fn(),
+    setJourneyPath: vi.fn(),
+    setGameState: vi.fn(),
+    animateUnitMove: vi.fn(),
+    animateUnitSlide: vi.fn(),
+    animateUnitAppear: vi.fn(),
+    camera: { centerOn: vi.fn() },
+    ...overrides,
+  };
+}
+
+function fakeCeremonies(overrides: Partial<CeremonyCoordinator> = {}): CeremonyCoordinator {
+  return {
+    enqueueWonderDiscovery: vi.fn(),
+    enqueueLegendaryCompletion: vi.fn(),
+    beginDeferredAction: vi.fn(),
+    endAction: vi.fn(),
+    clearForHandoff: vi.fn(),
+    ...overrides,
+  };
+}
+
+function fakeUnitTurnFlow(overrides: Partial<UnitTurnFlow> = {}): UnitTurnFlow {
+  return {
+    skipUnitAction: vi.fn(),
+    showDeleteUnitConfirmation: vi.fn(),
+    showEndTurnUnitWarningIfNeeded: () => false,
+    ...overrides,
+  };
+}
+
+function baseDeps(state: GameState, overrides: Partial<SelectionControllerDeps> = {}): SelectionControllerDeps {
+  const session = overrides.session ?? createGameSession(state);
+  return {
+    session,
+    selection: createSelectionStore(),
+    renderLoop: fakeRenderer(),
+    bus: { emit: vi.fn() },
+    uiLayer: document.createElement('div'),
+    host: createPanelHost(document.createElement('div')),
+    ceremonies: fakeCeremonies(),
+    getInfoPanel: () => document.getElementById('info-panel'),
+    showNotification: vi.fn(),
+    updateHUD: vi.fn(),
+    clearUnloadState: vi.fn(),
+    getUnitTurnFlow: () => fakeUnitTurnFlow(),
+    foundCityAction: vi.fn(),
+    performWorkerAction: vi.fn(),
+    performPreach: vi.fn(),
+    restAction: vi.fn(),
+    openNetworkIntentPanel: vi.fn(),
+    openUnitStackPicker: vi.fn(),
+    openPirateHeadquartersAssault: vi.fn(),
+    handleEstablishRoute: vi.fn(),
+    executeUpgrade: vi.fn(() => false),
+    ensurePlayerWarState: vi.fn(),
+    scanBeastSightings: vi.fn(),
+    currentCiv: () => session.getState().civilizations[session.getState().currentPlayer],
+    ...overrides,
+  };
+}
+
+describe('SelectionController', () => {
+  it('selecting a unit sets movement and attack ranges from its highlights', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    controller.selectUnit('u1');
+
+    expect(deps.selection.getSelectedUnitId()).toBe('u1');
+    expect(deps.selection.getMovementRange().length).toBeGreaterThan(0);
+    expect(deps.renderLoop.setSelectedUnitId).toHaveBeenCalledWith('u1');
+    expect(deps.renderLoop.setHighlights).toHaveBeenCalled();
+  });
+
+  it('selecting a unit threads buildSelectedUnitHighlights\' water recovery into the store', () => {
+    // Replaces a pre-8c grep assertion (`tests/main.integration.test.ts`
+    // "land-unit water recovery wiring") that checked this wiring by matching
+    // `waterRecovery: highlightResult.waterRecovery` as text inside
+    // `main.ts`'s `selectUnit` -- that function now lives here instead.
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    const expected = buildSelectedUnitHighlights(state, 'u1').waterRecovery;
+
+    controller.selectUnit('u1');
+
+    expect(deps.selection.getWaterRecovery()).toEqual(expected);
+  });
+
+  it('selecting a unit renders the info panel via the real DOM node', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    controller.selectUnit('u1');
+
+    const panel = document.getElementById('info-panel')!;
+    expect(panel.children.length).toBeGreaterThan(0);
+  });
+
+  it('does not select a unit that is mid-animation, and warns instead', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state, { renderLoop: fakeRenderer({ hasMovingUnit: () => true }) });
+    const controller = createSelectionController(deps);
+
+    controller.selectUnit('u1');
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+    expect(deps.showNotification).toHaveBeenCalledWith('Unit is moving.', 'info');
+  });
+
+  it('refuses to select a unit not owned by the current player (hot-seat safety)', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'enemy-unit', { owner: 'ai-1' });
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    controller.selectUnit('enemy-unit');
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+  });
+
+  it('deselecting clears the store, highlights, journey path, and hides the info panel', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    controller.deselectUnit();
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+    expect(deps.selection.getMovementRange()).toEqual([]);
+    expect(deps.selection.getAttackRange()).toEqual([]);
+    expect(deps.renderLoop.setSelectedUnitId).toHaveBeenCalledWith(null);
+    expect(deps.renderLoop.clearHighlights).toHaveBeenCalled();
+    expect(deps.renderLoop.setJourneyPath).toHaveBeenCalledWith(null);
+    const panel = document.getElementById('info-panel')!;
+    expect(panel.style.display).toBe('none');
+    expect(panel.children.length).toBe(0);
+  });
+
+  it('selectNextUnit skips the currently selected unit when another is available', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    placePlayerUnit(state, 'u2');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    controller.selectNextUnit();
+
+    expect(deps.selection.getSelectedUnitId()).toBe('u2');
+  });
+
+  it('selectNextUnit silently deselects when no unmoved units remain', () => {
+    const state = makeFixture();
+    const unit = placePlayerUnit(state, 'u1', { hasMoved: true, movementPointsLeft: 0 });
+    void unit;
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    controller.selectNextUnit();
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+    expect(deps.showNotification).not.toHaveBeenCalled();
+  });
+
+  it('isUnitAnimationLocked reflects renderLoop.hasMovingUnit for a non-null id', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state, { renderLoop: fakeRenderer({ hasMovingUnit: id => id === 'moving-unit' }) });
+    const controller = createSelectionController(deps);
+
+    expect(controller.isUnitAnimationLocked('moving-unit')).toBe(true);
+    expect(controller.isUnitAnimationLocked('idle-unit')).toBe(false);
+    expect(controller.isUnitAnimationLocked(null)).toBe(false);
+  });
+
+  it('executeAnimatedUnitMove brackets the ceremony defer window around a successful move', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const ceremonies = fakeCeremonies();
+    const deps = baseDeps(state, { ceremonies });
+    const controller = createSelectionController(deps);
+    const moveResult: ExecuteUnitMoveResult = {
+      ok: true,
+      path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+      state: deps.session.getState(),
+      events: [],
+    } as unknown as ExecuteUnitMoveResult;
+
+    const callOrder: string[] = [];
+    (ceremonies.beginDeferredAction as ReturnType<typeof vi.fn>).mockImplementation(() => callOrder.push('begin'));
+    (deps.renderLoop.animateUnitMove as ReturnType<typeof vi.fn>).mockImplementation(() => callOrder.push('animate'));
+
+    const result = controller.executeAnimatedUnitMove('u1', () => moveResult);
+
+    expect(result).toBe(moveResult);
+    expect(ceremonies.beginDeferredAction).toHaveBeenCalledTimes(1);
+    expect(deps.renderLoop.animateUnitMove).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['begin', 'animate']);
+  });
+
+  it('executeAnimatedUnitMove still ends the ceremony defer window when the move fails, and does not animate', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const ceremonies = fakeCeremonies();
+    const deps = baseDeps(state, { ceremonies });
+    const controller = createSelectionController(deps);
+    const moveResult = { ok: false, message: 'Blocked.' } as unknown as ExecuteUnitMoveResult;
+
+    const result = controller.executeAnimatedUnitMove('u1', () => moveResult);
+
+    expect(result).toBe(moveResult);
+    expect(ceremonies.beginDeferredAction).toHaveBeenCalledTimes(1);
+    expect(ceremonies.endAction).toHaveBeenCalledTimes(1);
+    expect(deps.renderLoop.animateUnitMove).not.toHaveBeenCalled();
+    expect(deps.showNotification).toHaveBeenCalledWith('Blocked.', 'warning');
+  });
+
+  it('refreshSelectedUnitAfterCombat deselects when the selected unit died', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+    delete state.units.u1;
+
+    controller.refreshSelectedUnitAfterCombat();
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+  });
+
+  it('refreshSelectedUnitAfterCombat deselects when the selected unit was captured (owner changed)', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+    state.units.u1 = { ...state.units.u1, owner: 'ai-1' };
+
+    controller.refreshSelectedUnitAfterCombat();
+
+    expect(deps.selection.getSelectedUnitId()).toBeNull();
+  });
+
+  it('refreshSelectedUnitAfterCombat re-selects the surviving unit without playing selection SFX', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1');
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+    (deps.renderLoop.setSelectedUnitId as ReturnType<typeof vi.fn>).mockClear();
+
+    controller.refreshSelectedUnitAfterCombat();
+
+    expect(deps.selection.getSelectedUnitId()).toBe('u1');
+    expect(deps.renderLoop.setSelectedUnitId).toHaveBeenCalledWith('u1');
+  });
+
+  it('startAutoExplore arms auto-explore automation and re-selects the unit', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1', { movementPointsLeft: 0 });
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    controller.startAutoExplore('u1');
+
+    expect(deps.session.getState().units.u1.automation?.mode).toBe('auto-explore');
+    expect(deps.selection.getSelectedUnitId()).toBe('u1');
+  });
+
+  it('cancelAutoExplore clears automation and re-selects only if currently selected', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1', { automation: { mode: 'auto-explore', startedTurn: 1, lastTargets: [] } });
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    controller.cancelAutoExplore('u1');
+
+    expect(deps.session.getState().units.u1.automation).toBeUndefined();
+    expect(deps.selection.getSelectedUnitId()).toBe('u1');
+  });
+
+  it('cancelJourney clears automation via a committed state change', () => {
+    const state = makeFixture();
+    placePlayerUnit(state, 'u1', { automation: { mode: 'journey', destination: { q: 3, r: 3 } } as never });
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    controller.selectUnit('u1');
+
+    controller.cancelJourney('u1');
+
+    expect(deps.session.getState().units.u1.automation).toBeUndefined();
+    expect(deps.renderLoop.setJourneyPath).toHaveBeenCalledWith(null);
+  });
+
+  it('refreshCurrentPlayerVisibility fires at most one resource-discovered tip when fog lifts over multiple tiles', () => {
+    const state = makeFixture();
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+
+    expect(() => controller.refreshCurrentPlayerVisibility()).not.toThrow();
+    expect(deps.scanBeastSightings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
 import { createUnit } from '@/systems/unit-system';
 import type { GameState, Unit } from '@/core/types';
 import { createGameSession } from '@/app/game-session';
@@ -80,7 +81,10 @@ function baseDeps(state: GameState, overrides: Partial<SelectionControllerDeps> 
     session,
     selection: createSelectionStore(),
     renderLoop: fakeRenderer(),
-    bus: { emit: vi.fn() },
+    // A real EventBus, not a `{ emit: vi.fn() }` stand-in -- deps.bus is
+    // typed as the concrete class (see selection-controller.ts's docblock on
+    // that field) since two downstream calls require it, not just `.emit`.
+    bus: new EventBus(),
     uiLayer: document.createElement('div'),
     host: createPanelHost(document.createElement('div')),
     ceremonies: fakeCeremonies(),

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -102,30 +102,29 @@ describe('player combat wiring', () => {
 });
 
 describe('land-unit water recovery wiring', () => {
-  it('routes the live selected-unit panel and blocked-tap path through recovery helpers', () => {
+  it('routes the live blocked-tap path through recovery helpers', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const selectFlow = main.slice(
-      main.indexOf('function selectUnit('),
-      main.indexOf('function deselectUnit('),
-    );
     // #787 phase 8b: the movement-blocker dispatch moved from an inline
     // if-chain in handleHexTap into the 'blocked-movement' case of its
     // resolveMapTapIntent-driven switch -- resolveMapTapIntent.test.ts and
     // this switch's own case now own the decision of *whether* a tap is
     // blocked; this scope only proves the live dispatch site still routes
     // through the same recovery helpers once resolveMapTapIntent says it is.
+    // (The selected-unit panel's own water-recovery wiring moved out of
+    // main.ts entirely in phase 8c -- see
+    // selection-controller.test.ts's "threads buildSelectedUnitHighlights'
+    // water recovery into the store".)
     const tapFlow = main.slice(
       main.indexOf("case 'blocked-movement': {"),
       main.indexOf("case 'enemy-unit-info': {"),
     );
 
-    expect(selectFlow).toContain('waterRecovery: highlightResult.waterRecovery');
     expect(tapFlow).toContain('handleSelectedUnitMovementBlocker(');
     // Phase 3 (#787) moved the water-recovery binding into SelectionStore; the
     // tap flow now reads it from the store instead of a module-scope `let`.
     expect(tapFlow).toContain('selection.getWaterRecovery()');
     expect(tapFlow).not.toContain('getLandUnitWaterRecovery(');
-    expect(tapFlow).toContain('reselectUnit: unitId => selectUnit(unitId, { suppressSelectionSfx: true })');
+    expect(tapFlow).toContain('reselectUnit: unitId => selectionController.selectUnit(unitId, { suppressSelectionSfx: true })');
     expect(tapFlow).toContain('playError: SFX.error');
   });
 });
@@ -262,7 +261,7 @@ describe('shared city assault wiring', () => {
     );
 
     expect(minorCaptureFlow).toContain(
-      'const movement = executeAnimatedUnitMove(',
+      'const movement = selectionController.executeAnimatedUnitMove(',
     );
     expect(minorCaptureFlow).toMatch(/if \(!movement\.ok\) return;/);
   });
@@ -320,5 +319,41 @@ describe('map tap wiring (#787 phase 8b)', () => {
     for (const kind of expectedKinds) {
       expect(handleHexTap).toContain(`case '${kind}':`);
     }
+  });
+});
+
+describe('selection controller wiring (#787 phase 8c)', () => {
+  it('constructs SelectionController and no longer defines the eleven functions it now owns', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main).toContain('createSelectionController(');
+
+    // Each of these used to be a local `function` declaration in main.ts;
+    // selection-controller.test.ts now owns their behavioral coverage.
+    // Asserting their absence here guards against a future change silently
+    // re-adding a shadowing local copy instead of calling the controller.
+    const movedFunctionDeclarations = [
+      'function selectUnit(', 'function deselectUnit(', 'function isUnitAnimationLocked(',
+      'function animateMovedUnit(', 'function executeAnimatedUnitMove(', 'function startAutoExplore(',
+      'function cancelAutoExplore(', 'function cancelJourney(', 'function openUnitContextMenu(',
+      'function selectNextUnit(', 'function refreshSelectedUnitAfterCombat(',
+      'function refreshCurrentPlayerVisibility(',
+    ];
+    for (const declaration of movedFunctionDeclarations) {
+      expect(main).not.toContain(declaration);
+    }
+  });
+
+  it('routes the unit-turn-flow deps through the controller instead of stale local references', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const getUnitTurnFlow = main.slice(
+      main.indexOf('function getUnitTurnFlow('),
+      main.indexOf('function foundCityAction('),
+    );
+
+    expect(getUnitTurnFlow).toContain('selectUnit: selectionController.selectUnit,');
+    expect(getUnitTurnFlow).toContain('deselectUnit: selectionController.deselectUnit,');
+    expect(getUnitTurnFlow).toContain('selectNextUnit: selectionController.selectNextUnit,');
+    expect(getUnitTurnFlow).toContain('refreshVisibility: selectionController.refreshCurrentPlayerVisibility,');
   });
 });


### PR DESCRIPTION
## Summary

Third of four sub-phases splitting Phase 8 (see `docs/superpowers/plans/2026-08-04-composition-root-decomposition.md` §Phase 8c). Moves the eleven unit-selection functions out of `src/main.ts` into `src/app/controllers/selection-controller.ts`, verbatim:

`selectUnit`, `deselectUnit`, `selectNextUnit`, `isUnitAnimationLocked`, `animateMovedUnit`, `executeAnimatedUnitMove`, `startAutoExplore`, `cancelAutoExplore`, `cancelJourney`, `openUnitContextMenu`, `refreshSelectedUnitAfterCombat`, `refreshCurrentPlayerVisibility`.

- `selectUnit`'s ~30 callbacks wired into `renderSelectedUnitInfo` move unchanged, per the plan's explicit note — further decomposing them is out of scope for this phase.
- Pure `@/systems`/`@/ui` helpers (`SFX`, `buildSelectedUnitHighlights`, etc.) are imported directly in the new file, matching the precedent Phase 7's presentation registrars already set for `SFX`.
- Concrete platform services (`renderLoop`, `bus`, `host`, `ceremonies`) and the main.ts-local functions this phase does not move (`showNotification`, `foundCityAction`, `getUnitTurnFlow`, etc.) are threaded through `SelectionControllerDeps`.
- `getInfoPanel: () => HTMLElement | null` substitutes for the three inline `document.getElementById('info-panel')` calls the moved code used to make directly. Phase 11's plan already specifies a port-purity test banning `document.getElementById` in `src/app/controllers/*` — this is a zero-behavior-change substitution now instead of a mass-fix revisit later.
- All 53 external call sites in main.ts were renamed to `selectionController.<method>`. `getUnitTurnFlow`'s deps object needed hand edits since its shorthand object-literal properties (`selectUnit,`) can't become member-expression values without an explicit key (`selectUnit: selectionController.selectUnit,`).
- 32 imports that existed only to serve the moved functions were removed from `main.ts`. Verified against `origin/main`'s baseline that no new dead imports were introduced and none of the pre-existing ones were touched.

**Plan doc sync (first commit, `e150002e`):** the Phase 8a-8d split and the Phase 12 addition were written on a branch (`claude/architecture-planning-0acde5`) that was created for Phase 1, reused for later plan-doc edits, and never actually opened as a PR — `main`'s copy of the plan doc still described the original single-PR Phase 8 sketch even after #796/#797 implemented the split. Brought `main`'s copy in line with what was actually built, discovered while reading the 8c section before starting this phase. No code changes in that commit.

**Test fixes forced by the move (not deferred to 8d):** two `tests/main.integration.test.ts` grep assertions broke as an unavoidable consequence — `selectUnit`'s water-recovery wiring text no longer exists in `main.ts` at all, and `executeAnimatedUnitMove`'s call site is renamed. Per the precedent set in phase 8b (a broken test can't be left red across a PR boundary), fixed both here:
- The water-recovery assertion became a real behavioral test in `selection-controller.test.ts` — it now asserts the store receives `buildSelectedUnitHighlights`' actual computed value, not just that matching text exists in a source file.
- Added a `selection controller wiring (#787 phase 8c)` block that asserts `createSelectionController(` is called, the eleven old `function` declarations are gone from `main.ts` (guards against a future regression silently re-adding a shadowing local copy), and `getUnitTurnFlow`'s deps route through the controller.

## Test plan
- [x] `yarn test` — 468 files, 7611 tests, all green (17 new tests in `selection-controller.test.ts`)
- [x] `yarn build` — clean, no new `tsc` errors
- [x] `yarn test:web-smoke` (Playwright, 8/8) — includes `issue-447-water-recovery.spec.ts`, which directly exercises the moved selection/blocked-tap/water-recovery code path in a real browser
- [x] Pre-push hook (fast tier + build) passed on push
- [ ] Pre-commit hook flagged two heuristic guardrail warnings ("derived UI semantics changed", "interactive panel code changed") on this diff — both are false positives for a verbatim code move: no new UI semantics or interaction logic were added, only relocated. Noting this explicitly per the hook's own review-reminder intent rather than silently overriding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)