### PR TITLE
refactor(app): Phase 10 — HudController/CampaignEntryController/GameSessionController + bootstrap() (#787)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
+++ b/docs/superpowers/plans/2026-08-04-composition-root-decomposition.md
@@ -1921,7 +1921,44 @@ bash scripts/run-with-mise.sh yarn test:web-smoke
 
 ---
 
+### Phase 10b — `PanelActionsController`, `DiplomacyActionsController`, and finishing the composition root
+
+Found during Phase 10 planning (2026-08-07), before any Phase 10 code was written. Phase 10's own "Moves" list and its "`main.ts`'s final form" code sample are inconsistent: the Moves list accounts for roughly 1,000–1,250 of `main.ts`'s (then-)2,814 lines, but Phase 11's boundary test (`expect(main.split('\n').length).toBeLessThan(150)`) requires all of it gone. Grepping every phase 1–13 section in this document for the ~47 functions below returns zero hits — they were never assigned a destination. This phase is that assignment. It must land **after Phase 10** (needs `GameSessionController`/`bootstrap.ts` to exist as a home for the final wiring) and **before Phase 11** (whose boundary test cannot pass without it).
+
+**Do not trust the line-count estimates below without re-measuring** — `main.ts`'s line numbers will have shifted after Phase 10 lands. Re-run the inventory grep (Step 1) before starting.
+
+**Files:**
+- Create: `src/app/controllers/panel-actions-controller.ts`, `src/app/controllers/diplomacy-actions-controller.ts`, plus test files
+- Modify: `src/app/controllers/player-action-controller.ts` (Phase 13 — see "Fold into Phase 13" below; if Phase 13 has not yet been implemented when this phase starts, add these functions to Phase 13's own Moves list instead of creating a second controller)
+- Modify: `src/main.ts`, `src/app/bootstrap.ts`
+
+**Inventory (as measured against `main.ts` post-Phase-9, pre-Phase-10, commit `a019bb42`):**
+
+*Panel openers → `PanelActionsController`* (~900 lines): `openPacingDebugPanel`, `openBestiary`, `openWonderAtlas`, `openPirateWaters`, `openPirateHeadquartersAssault`, `openNotificationLog`, `openDiplomacyPanel`, `openMarketplacePanel`, `openWonderPanelForCityId`, `openCityOverviewPanel`, `openCityPanelForCity` (the largest single function here at ~141 lines), `openCouncilPanel`, `openTechPanel`, `openEspionagePanel` (the largest at ~279 lines), `openUnitStackPicker`, `openNetworkIntentPanel`, `openNetworkPanel`.
+
+*Diplomacy/minor-civ/crisis handlers → `DiplomacyActionsController`* (~166 lines): `handleDiplomaticAction`, `handleAcceptPeaceRequest`, `handleRejectPeaceRequest`, `handleAcceptTreatyProposal`, `handleDeclineTreatyProposal`, `handleBreakTreaty`, `handleGiftGold`, `handleSponsorFestival`, `handleMinorCivReparations`, `handleSendAid`, `handleMinorCivWarPeace`, `handleAppeaseFaction`, `handleConcedeToMovement`, `handleEstablishRoute`.
+
+*Fold into Phase 13's `PlayerActionController`* (~274 lines) — these are player-unit-action functions, the same domain Phase 13 already covers (`executeAttack`, `foundCityAction`, `executeUpgrade`, `beginPlayerCityAssault`, `executeMinorCivConquest`); adding a third controller for the same domain would violate this arc's own SRP goal: `getUnitTurnFlow`, `performWorkerAction`, `performPreach`, `ensurePlayerWarState`, `restAction`, `showEspionageCaptureChoice`. If Phase 13 already shipped by the time this phase starts, this is an addendum to `PlayerActionController` (its own small PR), not a rewrite.
+
+*Cross-cutting helpers — destination is an implementation-time decision, investigate first* (~108 lines): `currentCiv`, `currentCivDef`, `clearUnloadState`, `setBlockingOverlay` (likely deletable — it is already a one-line wrapper around `host.setBlockingOverlay`, ported to `PanelHost` in Phase 5; audit whether any call site still needs the bare function or can call `host.setBlockingOverlay` directly), `prefersReducedMotion`, `showNotification`, `appendToCivLog`, `focusNotificationTarget`, `focusPirateTarget`, `applyPirateActionResult`, `scanBeastSightings`, `maybeShowPendingHoardChoice`. These are already passed as deps into every existing controller (`ceremonies`, `selectionController`, `turnFlow`, `mapInteraction`), so moving them risks constructor-ordering circularity. The pragmatic default is folding them into `GameSessionController` (Phase 10) since it is already the "foundational glue" controller and is constructed first — but confirm no earlier-constructed controller needs one of these at its own construction time before committing to that. `setBlockingOverlay`, `showNotification`+`appendToCivLog`+`focusNotificationTarget` in particular may be better resolved by having callers depend on `PanelHost`/`Notifier` directly instead of a bare-function wrapper — do not port the wrapper forward reflexively just because it exists today.
+
+**Finishing the composition root:** Once the above have real controller homes, `host`, `panelContext`, `ceremonies`, `selectionController`, `turnFlow`, `mapInteraction`, `presentationContext`, `panelRegistry`, and `router` construction (currently module-scope in `main.ts`, ~254 lines, never assigned a phase because each was constructed inline at extraction time in phases 5/6/8c/8d/9 with no follow-up relocation step) can finally move into `bootstrap.ts`. This is the step that actually makes `bootstrap()` the composition root Phase 10's code sample described, and the step that gets `main.ts` into Phase 11's `<150` line range for the first time. `panelRegistry`'s ~15 entries can only move once every function they reference (all of the panel openers above) already lives outside `main.ts` — that dependency is why this must be the last step of this phase, not the first.
+
+- [ ] **Step 1: Re-run the inventory.** Re-grep `main.ts` for every function named above (and any the earlier grep missed) with current line numbers; confirm none have been renamed or removed since this section was written, and decide the cross-cutting-helpers question above before writing any test.
+- [ ] **Step 2: Write failing tests, then extract `PanelActionsController`.** Given its size (~900 lines, comparable to Phase 8's total pre-split scope), expect to split this into sub-phases (10b-a, 10b-b, ...) grouped by panel domain the same way Phase 8 split into 8a–8d once the real work starts — do not force it into one PR if the diff review would be unreviewable.
+- [ ] **Step 3: Write failing tests, then extract `DiplomacyActionsController`.**
+- [ ] **Step 4: Extend (or write, if Phase 13 hasn't shipped yet) `PlayerActionController`** with the unit-action group.
+- [ ] **Step 5: Resolve the cross-cutting helpers** per Step 1's decision.
+- [ ] **Step 6: Move `host`/`ceremonies`/`selectionController`/`turnFlow`/`mapInteraction`/`presentationContext`/`panelRegistry`/`router` construction into `bootstrap.ts`.** This is the step with the most forward-reference/circularity risk in the whole arc (`panelContext` and `router` are already mutually circular via getters; `PanelActionsController` will need the same lazy-getter pattern for `router` that `turnFlow`/`selectionController` already use). Budget real time for this step specifically.
+- [ ] **Step 7: Re-run Phase 11's boundary-test draft** (`main.ts` line count, zero `bus.on`/`let`/`window.addEventListener`) as a sanity check before calling this phase done, even though writing the actual enforced test is Phase 11's job.
+- [ ] **Step 8: Run the full verification suite** (`yarn build`, `yarn test`, `yarn test:web-smoke` — this phase touches panel routing and campaign-adjacent wiring).
+- [ ] **Step 9: Close the phase.**
+
+---
+
 ### Phase 11 — Ratchet down and lock the boundary
+
+**Depends on Phase 10b.** The `<150` line boundary test below is unreachable until Phase 10b moves the ~47 functions/~1,700 lines it names (panel openers, diplomacy handlers, cross-cutting helpers, and the final `host`/`ceremonies`/`router`/etc. construction) out of `main.ts`. Confirm Phase 10b is closed before starting Step 2.
 
 **Files:**
 - Create: `tests/app/architecture-boundaries.test.ts`

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,0 +1,48 @@
+/**
+ * Sequences the three module-scope statements that used to run
+ * unconditionally as an import side effect at the bottom of `main.ts`
+ * (#787 phase 10): register the 72-registration presentation layer,
+ * register minor-civ notification listeners, then initialize the game
+ * session.
+ *
+ * **Deviation from this arc's plan doc, documented per
+ * `.claude/rules/spec-fidelity.md`:** the plan's Phase 10 sketch describes
+ * `bootstrap()` as the full composition root -- constructing `session`,
+ * `selection`, `host`, `ceremonies`, `router`, `panelRegistry`, and every
+ * sibling controller itself, reducing `main.ts` to about 15 lines. That is
+ * not what this file does. `panelRegistry`'s ~15 entries (and therefore
+ * `router`, and therefore everything that depends on `router`) reference
+ * roughly 35 panel-opener and handler functions that Phase 10's own "Moves"
+ * list never assigned anywhere -- see the newly-added Phase 10b in the plan
+ * doc, filed when that gap was discovered during this phase's planning.
+ * Moving `panelRegistry`/`router`/`host`/`ceremonies`/etc. construction into
+ * this file before those ~35 functions have a real home would require
+ * threading all of them through as deps unchanged, which is churn without
+ * payoff. `main.ts` keeps constructing all of that today, exactly as it did
+ * before this phase, and hands `bootstrap()` only the pieces this phase's
+ * three new controllers (`GameSessionController`, `HudController`,
+ * `CampaignEntryController`) actually need. Phase 10b is the phase that
+ * finishes the composition-root move this file's name promises.
+ */
+import type { EventBus } from '@/core/event-bus';
+import type { GameState } from '@/core/types';
+import type { NotificationSink } from '@/ui/notification-routing';
+import type { GameSessionController } from '@/app/controllers/game-session-controller';
+import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
+import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
+
+export interface AppServices {
+  readonly bus: EventBus;
+  readonly presentationContext: PresentationContext;
+  readonly getState: () => GameState;
+  readonly appendToCivLog: NotificationSink;
+  readonly gameSession: Pick<GameSessionController, 'init'>;
+}
+
+export async function bootstrap(services: AppServices): Promise<void> {
+  registerAllPresentation(services.bus, services.presentationContext);
+  registerMinorCivNotificationListeners(services.bus, services.getState, {
+    appendToCivLog: services.appendToCivLog,
+  });
+  await services.gameSession.init();
+}

--- a/src/app/controllers/campaign-entry-controller.ts
+++ b/src/app/controllers/campaign-entry-controller.ts
@@ -1,0 +1,279 @@
+/**
+ * Owns campaign entry: the start/save panel, new-game mode selection, and
+ * `enterCampaign`'s hot-seat-handoff-aware game-start ritual (#787 phase 10).
+ *
+ * `startGame` (GameSessionController) and this controller are mutually
+ * referential -- `showGameModeSelection`'s solo path calls `startGame()`
+ * directly, and `GameSessionController.init()` calls this controller's
+ * `showStartSavePanel()`. The composition root breaks the cycle with the
+ * same deferred-but-eager `let` + wrapper-closure pattern `main.ts` already
+ * used for `router`/`notifier` before this phase: `startGame` is passed in
+ * as a thunk that resolves to the real controller once both exist.
+ *
+ * Everything this file calls that is a pure `@/systems/*`, `@/core/*`,
+ * `@/storage/*`, or `@/ui/*` helper is imported directly, matching the
+ * precedent set by `TurnFlowController`/`SelectionController`. Only
+ * concrete platform services and the main.ts-local functions this phase
+ * does NOT move (`showNotification`) are threaded through as deps.
+ */
+import type { EventBus } from '@/core/event-bus';
+import type { AudioSystem } from '@/audio/audio-system';
+import type { GameState } from '@/core/types';
+import type { GameSession } from '@/app/ports';
+import type { PanelHost } from '@/app/panel-host';
+import type { UserSettingsStore } from '@/app/user-settings-store';
+import type { TurnFlowController } from '@/app/controllers/turn-flow-controller';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { createNewGame, createHotSeatGame } from '@/core/game-state';
+import {
+  autoSave,
+  loadMostRecentAutoSaveEntry,
+  loadSaveEntry,
+  rewriteLoadedSaveEntry,
+} from '@/storage/save-manager';
+import { applyPersistedUserSettings } from '@/storage/settings-merge';
+import { createSavePanel } from '@/ui/save-panel';
+import { showGameModeSelect } from '@/ui/game-mode-select';
+import { showCampaignSetup } from '@/ui/campaign-setup';
+import { showHotSeatSetup } from '@/ui/hotseat-setup';
+import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
+import { beginCampaignEntry } from '@/ui/campaign-entry-flow';
+import { acknowledgeTurnHandoffSummary, showTurnHandoff } from '@/ui/turn-handoff';
+
+export interface CampaignEntryController {
+  enterCampaign(state: GameState, message: string, persistBeforeReady?: boolean): Promise<void> | null;
+  enterCampaignForE2E(state: GameState): Promise<void>;
+  showStartSavePanel(): Promise<void>;
+  showGameModeSelection(): void;
+}
+
+export interface CampaignEntryControllerDeps {
+  readonly session: GameSession;
+  readonly uiLayer: HTMLDivElement;
+  readonly audio: Pick<AudioSystem, 'setMasterVolume'>;
+  readonly bus: EventBus;
+  readonly roundPresentationGate: RoundPresentationGate;
+  readonly host: Pick<PanelHost, 'setBlockingOverlay'>;
+  readonly turnFlow: Pick<TurnFlowController, 'handleVictoryIfNeeded' | 'closeNetworkPanelsForHandoff'>;
+  readonly userSettingsStore: Pick<UserSettingsStore, 'getPersisted' | 'refresh' | 'getMasterVolume' | 'setCustomCivilizations' | 'getOverrides'>;
+  readonly getElementById: (id: string) => HTMLElement | null;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  /** Forward reference to `GameSessionController.startGame` -- see file docblock. */
+  readonly startGame: () => Promise<void>;
+  readonly reloadPage: () => void;
+}
+
+export function createCampaignEntryController(deps: CampaignEntryControllerDeps): CampaignEntryController {
+  function enterCampaign(
+    state: GameState,
+    message: string,
+    persistBeforeReady: boolean = false,
+  ): Promise<void> | null {
+    deps.getElementById('save-panel')?.remove();
+    deps.session.setStateWithoutRefresh(applyPersistedUserSettings(state, deps.userSettingsStore.getPersisted()));
+    if (deps.session.getState().gameOver) {
+      const spritesReady = deps.startGame();
+      deps.turnFlow.handleVictoryIfNeeded();
+      return spritesReady;
+    }
+    const hotSeat = deps.session.getState().hotSeat;
+    if (!hotSeat) {
+      const spritesReady = deps.startGame();
+      deps.showNotification(message, 'info');
+      return spritesReady;
+    }
+
+    deps.audio.setMasterVolume(0);
+    deps.turnFlow.closeNetworkPanelsForHandoff();
+    const player = hotSeat.players.find(candidate => candidate.slotId === deps.session.getState().currentPlayer);
+    deps.host.setBlockingOverlay('turn-handoff');
+    deps.roundPresentationGate.suppress();
+    const controller = showTurnHandoff(
+      deps.uiLayer,
+      deps.session.getState(),
+      deps.session.getState().currentPlayer,
+      player?.name ?? 'Player',
+      {
+        initiallyReady: !persistBeforeReady,
+        preparingLabel: 'Saving campaign…',
+        onReady: async summary => {
+          const viewerId = deps.session.getState().currentPlayer;
+          const acknowledgement = acknowledgeTurnHandoffSummary(
+            deps.session.getState(),
+            viewerId,
+            summary,
+          );
+          deps.session.setStateWithoutRefresh(acknowledgement.state);
+          try {
+            await autoSave(deps.session.getState());
+          } catch {
+            // Entry persistence already succeeded; acknowledgement may safely retry later.
+          }
+          deps.roundPresentationGate.resume();
+          deps.host.setBlockingOverlay(null);
+          deps.startGame();
+          deps.audio.setMasterVolume(deps.userSettingsStore.getMasterVolume());
+          if (acknowledgement.playStrategicWarningAudio) {
+            deps.bus.emit('ai:strategic-warning-audio', {
+              viewerId,
+              turn: summary.turn,
+            });
+          }
+          deps.showNotification(message, 'info');
+        },
+      },
+    );
+
+    if (!persistBeforeReady) return null;
+    const persist = async (): Promise<void> => {
+      try {
+        await autoSave(deps.session.getState());
+        controller.setReady(deps.session.getState());
+      } catch {
+        controller.setError(
+          'The campaign could not be saved. Retry before opening the first turn.',
+          {
+            onRetry: () => void persist(),
+            onReturnToSaves: () => {
+              deps.roundPresentationGate.resume();
+              deps.reloadPage();
+            },
+          },
+        );
+      }
+    };
+    void persist();
+    return null;
+  }
+
+  function enterCampaignForE2E(state: GameState): Promise<void> {
+    if (state.hotSeat) throw new Error('E2E direct entry does not bypass hot-seat handoff.');
+    const spritesReady = enterCampaign(state, `Welcome back! Turn ${state.turn}`);
+    if (!spritesReady) throw new Error('E2E direct entry requires a solo campaign.');
+    return spritesReady;
+  }
+
+  async function showStartSavePanel(): Promise<void> {
+    await createSavePanel(deps.uiLayer, {
+      onNewGame: () => {
+        showGameModeSelection();
+      },
+      onContinue: async invoker => {
+        const loaded = await loadMostRecentAutoSaveEntry();
+        if (!loaded) throw new Error('Autosave no longer exists.');
+        await beginCampaignEntry(
+          { kind: 'stored', loaded },
+          invoker,
+          {
+            persistStoredChoice: rewriteLoadedSaveEntry,
+            persistImport: autoSave,
+            showChallengePrompt: showLegacyOpponentChallengePrompt,
+            onReady: state => enterCampaign(state, `Welcome back! Turn ${state.turn}`),
+          },
+        );
+      },
+      onLoadEntry: async (source, invoker) => {
+        const loaded = await loadSaveEntry(source);
+        if (!loaded) throw new Error('Save no longer exists.');
+        await beginCampaignEntry(
+          { kind: 'stored', loaded },
+          invoker,
+          {
+            persistStoredChoice: rewriteLoadedSaveEntry,
+            persistImport: autoSave,
+            showChallengePrompt: showLegacyOpponentChallengePrompt,
+            onReady: state => enterCampaign(state, `Game loaded! Turn ${state.turn}`),
+          },
+        );
+      },
+      onImportSave: async (state, invoker) => {
+        await beginCampaignEntry(
+          { kind: 'import', state },
+          invoker,
+          {
+            persistStoredChoice: rewriteLoadedSaveEntry,
+            persistImport: autoSave,
+            showChallengePrompt: showLegacyOpponentChallengePrompt,
+            onReady: readyState => enterCampaign(
+              readyState,
+              `Save imported! Turn ${readyState.turn}`,
+            ),
+          },
+        );
+      },
+    });
+  }
+
+  function showGameModeSelection(): void {
+    let modePanel: HTMLElement;
+
+    modePanel = showGameModeSelect(deps.uiLayer, {
+      initialTitle: 'New Campaign',
+      onCancel: () => {},
+      onTitleRequired: () => {
+        deps.showNotification('Campaign title is required', 'warning');
+      },
+      onChooseSolo: async (title) => {
+        const currentSettings = await deps.userSettingsStore.refresh();
+        const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
+        modePanel.remove();
+        showCampaignSetup(deps.uiLayer, {
+          initialTitle: title,
+          onStartSolo: (config) => {
+            deps.session.setStateWithoutRefresh(createNewGame({
+              civType: config.civType,
+              mapSize: config.mapSize,
+              opponentCount: config.opponentCount,
+              gameTitle: config.gameTitle,
+              // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
+              settingsOverrides: { ...deps.userSettingsStore.getOverrides(), ...config.settingsOverrides },
+              customCivilizations: config.customCivilizations,
+              seed: config.seed,
+              mapScript: config.mapScript,
+              startPlacementMode: config.startPlacementMode,
+              opponentChallenge: config.opponentChallenge,
+            }));
+            if (currentSettings.councilTalkLevel) {
+              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
+            }
+            deps.startGame();
+          },
+          onCustomCivilizationsChanged: (customCivilizations) => {
+            deps.userSettingsStore.setCustomCivilizations(customCivilizations);
+          },
+          onCancel: () => showGameModeSelection(),
+        }, {
+          initialCustomCivilizations: savedCustomCivilizations,
+        });
+      },
+      onChooseHotSeat: async (title) => {
+        const currentSettings = await deps.userSettingsStore.refresh();
+        const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
+        modePanel.remove();
+        showHotSeatSetup(deps.uiLayer, {
+          onComplete: (config, opponentChallenge) => {
+            deps.session.setStateWithoutRefresh(createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard'));
+            if (currentSettings.councilTalkLevel) {
+              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
+            }
+            enterCampaign(
+              deps.session.getState(),
+              `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,
+              true,
+            );
+          },
+          onCustomCivilizationsChanged: (customCivilizations) => {
+            deps.userSettingsStore.setCustomCivilizations(customCivilizations);
+          },
+          onCancel: () => {
+            showGameModeSelection();
+          },
+        }, {
+          initialCustomCivilizations: savedCustomCivilizations,
+        });
+      },
+    });
+  }
+
+  return { enterCampaign, enterCampaignForE2E, showStartSavePanel, showGameModeSelection };
+}

--- a/src/app/controllers/game-session-controller.ts
+++ b/src/app/controllers/game-session-controller.ts
@@ -1,0 +1,387 @@
+/**
+ * Owns app startup and the main game loop's one-time setup: `init`,
+ * `createUI`, `startGame`, the `inputInitialized` construct-once guard, and
+ * the window resize listener (#787 phase 10).
+ *
+ * `router`, `notifier`, and several sibling controllers are constructed
+ * elsewhere in `main.ts` with forward-reference cycles this controller sits
+ * inside (`createUI`'s callbacks call `router.open(...)` before `router`
+ * itself is assigned; `init()` constructs the real `Notifier` and must
+ * publish it back to every other main.ts-local consumer that already holds
+ * a lazy getter for it). Both are resolved with `main.ts`'s existing
+ * deferred-but-eager pattern: `router` arrives as a thin wrapper closing
+ * over the outer `let`, and `notifier` is published back via `setNotifier`
+ * rather than this controller owning the binding itself (main.ts keeps
+ * that `let`, matching Phase 10b's decision to defer the rest of the
+ * composition-root move).
+ *
+ * Everything this file calls that is a pure `@/systems/*`, `@/core/*`,
+ * `@/renderer/*`, `@/input/*`, `@/storage/*`, or `@/ui/*` helper is imported
+ * directly, matching the precedent set by every prior controller in this
+ * arc. Only concrete platform services, sibling controllers, and the
+ * main.ts-local functions this phase does NOT move are threaded through as
+ * deps.
+ */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { AudioSystem } from '@/audio/audio-system';
+import type { EventBus } from '@/core/event-bus';
+import type { AdvisorSystem } from '@/ui/advisor-system';
+import type { GameSession, SelectionStore, Notifier } from '@/app/ports';
+import type { PanelHost } from '@/app/panel-host';
+import type { PanelRouter } from '@/app/panel-router';
+import type { UserSettingsStore } from '@/app/user-settings-store';
+import type { TurnFlowController } from '@/app/controllers/turn-flow-controller';
+import type { MapInteractionController } from '@/app/controllers/map-interaction-controller';
+import type { SelectionController } from '@/app/controllers/selection-controller';
+import type { HudController } from '@/app/controllers/hud-controller';
+import type { CampaignEntryController } from '@/app/controllers/campaign-entry-controller';
+import type { GameState } from '@/core/types';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { createGameShell } from '@/ui/game-shell';
+import { createNotificationCenter } from '@/ui/notification-center';
+import { createIconLegendOverlay } from '@/ui/icon-legend';
+import { showPauseMenu } from '@/ui/pause-menu-panel';
+import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
+import { MouseHandler } from '@/input/mouse-handler';
+import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
+import { hexToPixel } from '@/systems/hex-utils';
+import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
+import { initSprites } from '@/renderer/sprites/sprite-loader';
+import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
+import { preloadFamineBadgeMarker } from '@/renderer/improvements/famine-badge-marker';
+import { preloadReligionBadgeMarker } from '@/renderer/improvements/religion-badge-marker';
+import { preloadRailSegment } from '@/renderer/improvements/rail-segment-loader';
+import { preloadTerrainTiles } from '@/renderer/terrain/terrain-tile-loader';
+import { preloadNaturalWonderTiles } from '@/renderer/terrain/wonder-tile-loader';
+import { getVisibleCityBadgeSlots, getVisibleHexViewportCopies } from '@/renderer/city-renderer';
+import { autoSave, loadMostRecentAutoSaveEntry, saveGame } from '@/storage/save-manager';
+import { SFX, routeSfxThrough } from '@/audio/sfx';
+import { installGlobalShortcuts } from '@/app/global-shortcuts';
+import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
+import { initializeDesktopMenu } from '@/platform/desktop-menu';
+import { resolveOpponentChallenge, setPendingOpponentChallenge, resolveChallengeForCiv, setPendingChallengeForCiv } from '@/core/opponent-challenge';
+
+/** The narrow slice of `RenderLoop` this controller needs. */
+export type GameSessionRenderer = Pick<RenderLoop, 'setGameState' | 'setTouchHandler' | 'start' | 'resizeCanvas'> & {
+  readonly camera: RenderLoop['camera'];
+};
+
+/** The narrow slice of `AudioSystem` this controller needs. */
+export type GameSessionAudio = Pick<
+  AudioSystem,
+  'start' | 'setMasterVolume' | 'getSfxRoutingNode' | 'setMusicVolume' | 'setSfxVolume'
+  | 'setStingerVolume' | 'setMusicEnabled' | 'setSfxEnabled' | 'setStingerEnabled' | 'playReligionStinger'
+>;
+
+export interface GameSessionController {
+  init(): Promise<void>;
+  createUI(): void;
+  startGame(): Promise<void>;
+}
+
+export interface GameSessionControllerDeps {
+  readonly session: GameSession;
+  readonly selection: SelectionStore;
+  readonly renderLoop: GameSessionRenderer;
+  readonly audio: GameSessionAudio;
+  readonly bus: EventBus;
+  readonly canvas: HTMLCanvasElement;
+  readonly uiLayer: HTMLDivElement;
+  readonly documentRef: Document;
+  readonly host: Pick<PanelHost, 'isInteractionBlocked'>;
+  /** Lazy wrapper over the outer `let router` -- see file docblock. */
+  readonly router: PanelRouter;
+  readonly roundPresentationGate: RoundPresentationGate;
+  readonly advisorSystem: Pick<AdvisorSystem, 'check'>;
+  readonly userSettingsStore: Pick<UserSettingsStore, 'getMasterVolume' | 'setMasterVolume' | 'refresh'>;
+  readonly turnFlow: Pick<
+    TurnFlowController,
+    'centerOnCurrentPlayer' | 'maybeShowCouncilInterrupt' | 'endTurn'
+    | 'emitCurrentPlayerAudioSnapshot' | 'showRequiredChoicesIfNeeded'
+  >;
+  readonly mapInteraction: Pick<MapInteractionController, 'handleHexTap' | 'handleHexLongPress'>;
+  readonly selectionController: Pick<SelectionController, 'selectNextUnit' | 'selectUnit'>;
+  readonly hud: HudController;
+  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E'>;
+  readonly getElementById: (id: string) => HTMLElement | null;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  /** Phase 13's future home -- passed as a dep until `PlayerActionController` exists. */
+  readonly foundCityAction: () => void;
+  /** Phase 10b's future home -- passed as a dep until it gets a controller. */
+  readonly maybeShowPendingHoardChoice: () => void;
+  /** Publishes the `Notifier` `init()` constructs back to main.ts's own `let notifier`. */
+  readonly setNotifier: (notifier: Notifier) => void;
+  readonly focusNotificationTarget: (target: Parameters<Notifier['toast']>[2]) => void;
+}
+
+export function createGameSessionController(deps: GameSessionControllerDeps): GameSessionController {
+  let inputInitialized = false;
+
+  function createUI(): void {
+    createGameShell(deps.uiLayer, {
+      onOpenCouncil: () => deps.router.open('council'),
+      onOpenTech: () => deps.router.open('tech'),
+      onOpenCity: () => deps.router.open('city-overview'),
+      onOpenEspionage: () => deps.router.open('espionage'),
+      onOpenDiplomacy: () => deps.router.open('diplomacy'),
+      onOpenMarketplace: () => deps.router.open('marketplace'),
+      onEndTurn: () => deps.turnFlow.endTurn(),
+      onNextUnit: () => deps.selectionController.selectNextUnit(),
+      onOpenNotificationLog: () => deps.router.toggle('notification-log'),
+      onOpenPirateWaters: () => deps.router.open('pirate-waters'),
+      onToggleIconLegend: () => {
+        const existing = deps.getElementById('icon-legend');
+        if (existing && existing.style.display !== 'none') {
+          // Already visible — hide it
+          existing.style.display = 'none';
+          return;
+        }
+        // Stale or absent — remove old, rebuild fresh with current techs
+        existing?.remove();
+        const viewerTechs = new Set<string>(
+          deps.session.getState().civilizations[deps.session.getState().currentPlayer]?.techState.completed ?? []
+        );
+        const overlay = createIconLegendOverlay(viewerTechs);
+        deps.uiLayer.appendChild(overlay);
+      },
+      onOpenWonderAtlas: () => deps.router.open('wonder-atlas'),
+      onBottomBarHeightChange: height => deps.hud.setMapViewportBottomInset(height),
+      onOpenMenu: () => {
+        showPauseMenu(deps.uiLayer, {
+          turn: deps.session.getState().turn,
+          civName: deps.session.getState().civilizations[deps.session.getState().currentPlayer].name,
+          onResume: () => {},
+          onSave: async (slotId, name) => {
+            await saveGame(slotId, name, deps.session.getState());
+            deps.showNotification('Game saved.', 'info');
+          },
+          onNewGame: () => deps.campaignEntry.showGameModeSelection(),
+          autoSave: () => autoSave(deps.session.getState()),
+          onOpenBestiary: () => deps.router.open('bestiary'),
+          opponentChallenge: resolveOpponentChallenge(deps.session.getState()),
+          pendingOpponentChallenge: deps.session.getState().pendingOpponentChallenge,
+          onOpponentChallengeChange: (challenge) => {
+            deps.session.setStateWithoutRefresh(setPendingOpponentChallenge(deps.session.getState(), challenge));
+          },
+          personalChallenge: resolveChallengeForCiv(deps.session.getState(), deps.session.getState().currentPlayer),
+          pendingPersonalChallenge: deps.session.getState().civilizations[deps.session.getState().currentPlayer]?.pendingChallenge,
+          onPersonalChallengeChange: (challenge) => {
+            deps.session.setStateWithoutRefresh(setPendingChallengeForCiv(deps.session.getState(), deps.session.getState().currentPlayer, challenge));
+          },
+          // Spec 3: per-channel audio settings
+          audioSettings: {
+            masterVolume:   deps.userSettingsStore.getMasterVolume(),   // tracked in memory across menu reopens
+            musicVolume:    deps.session.getState().settings.musicVolume,
+            sfxVolume:      deps.session.getState().settings.sfxVolume,
+            stingerVolume:  deps.session.getState().settings.stingerVolume  ?? 1.0,
+            musicEnabled:   deps.session.getState().settings.musicEnabled,
+            soundEnabled:   deps.session.getState().settings.soundEnabled,
+            stingerEnabled: deps.session.getState().settings.stingerEnabled ?? true,
+          },
+          onAudioSettingChange: (key, value) => {
+            // Apply to audio system immediately — no restart needed
+            switch (key) {
+              case 'masterVolume':
+                deps.userSettingsStore.setMasterVolume(value as number);
+                deps.audio.setMasterVolume(value as number);
+                return; // master not in GameSettings — skip the settings write below
+              case 'musicVolume':    deps.audio.setMusicVolume(value as number);   break;
+              case 'sfxVolume':      deps.audio.setSfxVolume(value as number);     break;
+              case 'stingerVolume':  deps.audio.setStingerVolume(value as number); break;
+              case 'musicEnabled':   deps.audio.setMusicEnabled(value as boolean); break;
+              case 'soundEnabled':   deps.audio.setSfxEnabled(value as boolean);   break;
+              case 'stingerEnabled': deps.audio.setStingerEnabled(value as boolean); break;
+            }
+            // Persist all non-master settings to GameSettings (saved on next save)
+            (deps.session.getState().settings as unknown as Record<string, number | boolean>)[key] = value;
+          },
+        });
+      },
+    });
+
+    deps.hud.placeAirDefenseButton();
+  }
+
+  function startGame(): Promise<void> {
+    deps.hud.ensureDrawerMounted();
+
+    // Warm sprite cache non-blocking — renderers fall back to emoji while loading
+    const civColors: Record<string, string> = {};
+    for (const [civId, civ] of Object.entries(deps.session.getState().civilizations)) {
+      civColors[civId] = civ.color;
+    }
+    const spritesReady = initSprites(civColors);
+    void spritesReady.catch(() => {});
+    preloadOutpostMarker().catch(() => {});
+    preloadFamineBadgeMarker().catch(() => {});
+    preloadReligionBadgeMarker().catch(() => {});
+    preloadRailSegment().catch(() => {});
+    preloadTerrainTiles().catch(() => {});
+    preloadNaturalWonderTiles().catch(() => {});
+
+    // Center camera on current player's starting position
+    deps.turnFlow.centerOnCurrentPlayer();
+
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.turnFlow.maybeShowCouncilInterrupt();
+    deps.maybeShowPendingHoardChoice();
+
+    // Auto-save immediately so closing before turn 1 doesn't lose the game
+    autoSave(deps.session.getState()).catch(() => {});
+
+    // Input (only set up once)
+    if (!inputInitialized) {
+      deps.canvas.addEventListener('pointerdown', () => { if (deps.hud.isDrawerOpen()) deps.hud.closeDrawer(); });
+
+      const callbacks: InputCallbacks = {
+        onHexTap: deps.mapInteraction.handleHexTap,
+        onHexLongPress: deps.mapInteraction.handleHexLongPress,
+      };
+      const touchHandler = new TouchHandler(deps.canvas, deps.renderLoop.camera, callbacks);
+      deps.renderLoop.setTouchHandler(touchHandler);
+      new MouseHandler(deps.canvas, deps.renderLoop.camera, callbacks, {
+        canInteract: () => !deps.host.isInteractionBlocked(),
+      });
+      installKeyboardShortcuts(deps.documentRef, {
+        onOpenCouncil: () => deps.router.open('council'),
+        onOpenTech: () => deps.router.open('tech'),
+        onEndTurn: () => { void deps.turnFlow.endTurn(); },
+        getSelectedUnitId: () => deps.selection.getSelectedUnitId(),
+        onCenterUnit: () => {
+          const selectedUnitId = deps.selection.getSelectedUnitId();
+          if (!selectedUnitId) return;
+          const unit = deps.session.getState().units[selectedUnitId];
+          if (unit) deps.renderLoop.camera.centerOn(unit.position);
+        },
+        onFortify: () => {
+          const selectedUnitId = deps.selection.getSelectedUnitId();
+          if (!selectedUnitId) return;
+          const unit = deps.session.getState().units[selectedUnitId];
+          if (!unit || unit.hasActed || unit.owner !== deps.session.getState().currentPlayer) return;
+          if (unit.isFortified) {
+            deps.session.setStateWithoutRefresh(unfortifyUnitInState(deps.session.getState(), deps.session.getState().currentPlayer, selectedUnitId));
+            deps.showNotification('Unit unfortified.', 'info');
+          } else {
+            deps.session.setStateWithoutRefresh(fortifyUnitInState(deps.session.getState(), deps.session.getState().currentPlayer, selectedUnitId));
+            deps.showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+          }
+          deps.renderLoop.setGameState(deps.session.getState());
+          deps.hud.update();
+          deps.selectionController.selectUnit(selectedUnitId);
+        },
+        onSettle: () => {
+          const selectedUnitId = deps.selection.getSelectedUnitId();
+          if (!selectedUnitId) return;
+          const unit = deps.session.getState().units[selectedUnitId];
+          if (!unit || unit.type !== 'settler') return;
+          deps.foundCityAction();
+        },
+        onNextUnit: () => deps.selectionController.selectNextUnit(),
+        onStartJourney: () => {
+          const selectedUnitId = deps.selection.getSelectedUnitId();
+          if (!selectedUnitId) return;
+          deps.selection.setPendingIntent({ kind: 'journey', unitId: selectedUnitId });
+          deps.showNotification('Tap a destination for this unit. Press Escape to cancel.', 'info');
+        },
+      }, {
+        canHandle: () => !deps.host.isInteractionBlocked(),
+      });
+      inputInitialized = true;
+    }
+
+    deps.audio.start(
+      deps.session.getState(),
+      deps.bus,
+      () => deps.session.getState(),
+      () => deps.roundPresentationGate.isSuppressed(),
+    );
+    deps.audio.setMasterVolume(deps.userSettingsStore.getMasterVolume());
+    routeSfxThrough(deps.audio.getSfxRoutingNode());
+    deps.turnFlow.emitCurrentPlayerAudioSnapshot(deps.session.getState().currentPlayer);
+
+    // Prevent zoom-out duplication: ensure the camera cannot zoom past one full
+    // map-width. hexToPixel({q: width, r:0}).x equals the wrapSpan used in
+    // wrap-rendering.ts, so minZoom = camera.width / wrapSpan guarantees the
+    // visible world is never wider than one map copy.
+    const mapWidthPx = hexToPixel({ q: deps.session.getState().map.width, r: 0 }, deps.renderLoop.camera.hexSize).x;
+    deps.renderLoop.camera.setMinZoomForMap(mapWidthPx);
+
+    // Initial advisor check
+    deps.advisorSystem.check(deps.session.getState());
+    deps.turnFlow.showRequiredChoicesIfNeeded();
+
+    // Start render loop
+    deps.renderLoop.start();
+    return spritesReady;
+  }
+
+  async function init(): Promise<void> {
+    await registerConquestoriaServiceWorker();
+    await initializeDesktopMenu();
+
+    window.addEventListener('resize', () => deps.renderLoop.resizeCanvas());
+
+    createUI();
+    // #notifications is created by createGameShell() inside createUI(), so notifier
+    // can only be constructed here, not eagerly at module scope (#787 phase 4).
+    const notifier = createNotificationCenter({
+      layer: deps.getElementById('notifications') as HTMLElement,
+      getState: () => deps.session.getState(),
+      isSuppressed: () => deps.roundPresentationGate.isSuppressed(),
+      playCue: (cue) => {
+        // #594 MR7: religion toasts carry a bespoke sfxCue that replaces the generic
+        // synth chime -- see notification-routing.ts's routeReligionFounded/
+        // routeReligionCityConverted/routeLoyaltyWarning/routeCityDefected.
+        if (cue) {
+          void deps.audio.playReligionStinger(cue).catch(() => {});
+        } else {
+          SFX.notification();
+        }
+      },
+      onFocusTarget: deps.focusNotificationTarget,
+    });
+    deps.setNotifier(notifier);
+    // Needs the real `notifier`, so deferred here alongside it rather than
+    // installed eagerly at module scope (#787 phase 5).
+    installGlobalShortcuts({ target: window, selection: deps.selection, router: deps.router, notifier });
+    await deps.userSettingsStore.refresh();
+
+    if (import.meta.env.MODE === 'e2e') {
+      // Browser tests must target the same live camera transform as player input;
+      // exposing only viewport copies keeps game state and camera internals private.
+      window.__CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__ = coord => getVisibleHexViewportCopies(
+        deps.session.getState(),
+        deps.renderLoop.camera,
+        deps.session.getState().currentPlayer,
+        coord,
+      );
+      const { isExactAutosaveE2ERequest } = await import('@/testing/e2e-mode');
+      if (isExactAutosaveE2ERequest(import.meta.env.MODE, window.location.search)) {
+        const { installE2ERuntime } = await import('@/testing/e2e-runtime');
+        await installE2ERuntime({
+          loadAutosave: loadMostRecentAutoSaveEntry,
+          enterSoloCampaign: (state: GameState) => deps.campaignEntry.enterCampaignForE2E(state),
+          getVisibleHexCopies: coord => getVisibleHexViewportCopies(
+            deps.session.getState(),
+            deps.renderLoop.camera,
+            deps.session.getState().currentPlayer,
+            coord,
+          ),
+          getCityBadgeSlots: (cityId, slot) => getVisibleCityBadgeSlots(
+            deps.session.getState(),
+            deps.renderLoop.camera,
+            deps.session.getState().currentPlayer,
+            cityId,
+            slot,
+          ),
+        });
+        return;
+      }
+    }
+
+    await deps.campaignEntry.showStartSavePanel();
+  }
+
+  return { init, createUI, startGame };
+}

--- a/src/app/controllers/hud-controller.ts
+++ b/src/app/controllers/hud-controller.ts
@@ -1,0 +1,201 @@
+/**
+ * Owns the HUD readout, the treasury drawer, the anti-aircraft-overlay
+ * toggle button, and the map viewport bottom inset the primary action bar's
+ * height drives (#787 phase 10).
+ *
+ * The treasury drawer is constructed lazily via `ensureDrawerMounted()`,
+ * matching the original module-scope `let drawer: TreasuryDrawer` -- it stays
+ * `undefined` until the first real game start, exactly as `startGame()`'s
+ * `if (!drawer) { drawer = createTreasuryDrawer(); ... }` guard did.
+ *
+ * `placeAirDefenseButton()` is exposed separately from construction because
+ * the button must be created before `GameSessionController.createUI()` calls
+ * it (the button click handler needs to exist before `#utility-toolbar` does)
+ * but can only be placed into the DOM after `createGameShell()` has built
+ * that toolbar.
+ */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { GameSession } from '@/app/ports';
+import type { PanelRouter } from '@/app/panel-router';
+import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
+import { createGameButton } from '@/ui/ui-kit';
+import { civHasAirDefenseCoverage } from '@/systems/air-defense-system';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { calculateCivEconomy, formatGoldHudText } from '@/systems/economy-system';
+import { resolveCivilizationEra } from '@/systems/tech-definitions';
+import { getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
+import { isAutonomyActivated } from '@/systems/network-plan-system';
+import { getNetworkPanelModel } from '@/ui/network-panel';
+import { getPirateWatersPresentation } from '@/systems/pirate-presentation';
+import { getUnmovedUnits } from '@/systems/unit-system';
+
+/** The narrow slice of `RenderLoop` this controller needs. */
+export type HudRenderer = Pick<RenderLoop, 'isAirDefenseOverlayEnabled' | 'toggleAirDefenseOverlay' | 'resizeCanvas'>;
+
+export interface HudController {
+  update(): void;
+  setMapViewportBottomInset(height: number): void;
+  /** Idempotent -- safe to call every `createUI()` even though it only runs once in practice. */
+  placeAirDefenseButton(): void;
+  /** Idempotent -- constructs the drawer on first call only, matching the original `if (!drawer)` guard. */
+  ensureDrawerMounted(): void;
+  closeDrawer(): void;
+  isDrawerOpen(): boolean;
+}
+
+export interface HudControllerDeps {
+  readonly session: GameSession;
+  readonly renderLoop: HudRenderer;
+  readonly canvas: HTMLCanvasElement;
+  readonly router: Pick<PanelRouter, 'open'>;
+  readonly getElementById: (id: string) => HTMLElement | null;
+  /** Where the treasury drawer mounts -- `#game-shell`, falling back to `document.body`. */
+  readonly getDrawerMountRoot: () => HTMLElement;
+}
+
+export function createHudController(deps: HudControllerDeps): HudController {
+  let drawer: TreasuryDrawer | undefined;
+
+  const airDefenseButton = createGameButton('🛡 Anti-aircraft coverage', 'secondary');
+  airDefenseButton.id = 'btn-air-defense-overlay';
+  airDefenseButton.hidden = true; // shown once the current civ has built AA coverage — see update()
+  airDefenseButton.setAttribute('aria-pressed', 'false');
+  airDefenseButton.addEventListener('click', () => {
+    const enabled = deps.renderLoop.toggleAirDefenseOverlay();
+    airDefenseButton.setAttribute('aria-pressed', String(enabled));
+    airDefenseButton.textContent = enabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
+  });
+
+  return {
+    update(): void {
+      const state = deps.session.getState();
+      const civ = state.civilizations[state.currentPlayer];
+      airDefenseButton.hidden = !civHasAirDefenseCoverage(state, civ.id);
+      const airDefenseEnabled = deps.renderLoop.isAirDefenseOverlayEnabled(state.currentPlayer);
+      airDefenseButton.setAttribute('aria-pressed', String(airDefenseEnabled));
+      airDefenseButton.textContent = airDefenseEnabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
+      const hud = deps.getElementById('hud');
+      if (!hud) return;
+
+      // Sum yields across all cities
+      let totalFood = 0, totalProd = 0, totalScience = 0;
+      for (const cityId of civ.cities) {
+        const city = state.cities[cityId];
+        if (!city) continue;
+        const y = calculateProjectedCityYields(state, cityId);
+        totalFood += y.food;
+        totalProd += y.production;
+        totalScience += y.science;
+      }
+      const economyStatus = calculateCivEconomy(state, civ.id);
+
+      const techName = civ.techState.currentResearch ?? 'None';
+      hud.textContent = '';
+
+      const yieldsRow = document.createElement('div');
+      yieldsRow.dataset.role = 'hud-yields';
+      yieldsRow.style.cssText =
+        'display:flex;align-items:center;gap:10px;flex-wrap:nowrap;overflow:hidden;min-width:0;';
+
+      const yieldSpan = document.createElement('span');
+      yieldSpan.textContent = `🌾 ${totalFood}`;
+      yieldsRow.appendChild(yieldSpan);
+
+      const prodSpan = document.createElement('span');
+      prodSpan.textContent = `⚒️ ${totalProd}`;
+      yieldsRow.appendChild(prodSpan);
+
+      const goldBtn = document.createElement('button');
+      goldBtn.style.cssText =
+        'background:transparent;color:inherit;border:none;font-family:inherit;font-size:inherit;padding:0;cursor:pointer;min-height:44px;display:inline-flex;align-items:center;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:1;';
+      goldBtn.textContent = `💰 ${formatGoldHudText(economyStatus, civ.gold)}`;
+      goldBtn.addEventListener('click', () => drawer?.toggle());
+      yieldsRow.appendChild(goldBtn);
+      drawer?.update(economyStatus, civ.gold);
+
+      const sciSpan = document.createElement('span');
+      sciSpan.style.cssText = 'min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:1;';
+      sciSpan.textContent = `🔬 ${techName !== 'None' ? techName : 'None'} (+${totalScience})`;
+      yieldsRow.appendChild(sciSpan);
+
+      if (isAutonomyActivated(state, civ.id)) {
+        const networkButton = document.createElement('button');
+        networkButton.type = 'button';
+        networkButton.style.cssText = 'background:transparent;color:inherit;border:1px solid rgba(232,193,112,0.45);border-radius:6px;font:inherit;padding:4px 8px;min-height:44px;';
+        networkButton.textContent = getNetworkPanelModel(state, civ.id).statusText;
+        networkButton.addEventListener('click', () => deps.router.open('network'));
+        yieldsRow.appendChild(networkButton);
+      }
+
+      const happiness = getCivHappinessFromResources(state, civ.id);
+      if (happiness > 0) {
+        const happySpan = document.createElement('span');
+        happySpan.title = 'Happiness from luxury resources — each point reduces city unrest pressure by 2';
+        happySpan.textContent = `☺ ${happiness} (stability)`;
+        yieldsRow.appendChild(happySpan);
+      }
+
+      const infoRow = document.createElement('div');
+      if (state.hotSeat && civ.name) {
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = `${civ.name} · `;
+        infoRow.appendChild(nameSpan);
+      }
+      const turnSpan = document.createElement('span');
+      turnSpan.textContent = `Turn ${state.turn} · Your Era ${resolveCivilizationEra(civ.techState.completed)} · World Age ${state.era}`;
+      infoRow.appendChild(turnSpan);
+
+      hud.appendChild(yieldsRow);
+      hud.appendChild(infoRow);
+
+      const pirateWatersButton = deps.getElementById('btn-pirate-waters');
+      if (pirateWatersButton) {
+        pirateWatersButton.hidden = !getPirateWatersPresentation(state, state.currentPlayer).available;
+      }
+
+      // Show "Next Unit" button when there are unmoved units
+      const nextUnitBtn = deps.getElementById('btn-next-unit');
+      if (nextUnitBtn) {
+        const unmovedCount = getUnmovedUnits(state.units, state.currentPlayer).length;
+        nextUnitBtn.style.display = unmovedCount > 0 ? 'block' : 'none';
+        if (unmovedCount > 0) {
+          nextUnitBtn.textContent = `⏩ ${unmovedCount}`;
+        }
+      }
+    },
+
+    setMapViewportBottomInset(height: number): void {
+      deps.canvas.style.bottom = `${height}px`;
+      // With both top and bottom set, an auto height makes the canvas occupy only
+      // the remaining map viewport instead of living behind the action bar.
+      deps.canvas.style.height = 'auto';
+      deps.renderLoop.resizeCanvas();
+    },
+
+    placeAirDefenseButton(): void {
+      // Join the utility toolbar's flex row instead of an independent absolute position —
+      // a second, uncoordinated top-right anchor overlapped the HUD and the toolbar's own
+      // icon buttons (#783).
+      const utilityToolbar = deps.getElementById('utility-toolbar');
+      const pauseMenuButton = deps.getElementById('btn-pause-menu');
+      if (utilityToolbar) {
+        if (pauseMenuButton) utilityToolbar.insertBefore(airDefenseButton, pauseMenuButton);
+        else utilityToolbar.appendChild(airDefenseButton);
+      }
+    },
+
+    ensureDrawerMounted(): void {
+      if (drawer) return;
+      drawer = createTreasuryDrawer();
+      deps.getDrawerMountRoot().appendChild(drawer.element);
+    },
+
+    closeDrawer(): void {
+      drawer?.close();
+    },
+
+    isDrawerOpen(): boolean {
+      return drawer?.isOpen() ?? false;
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,9 @@
-import '@/assets/sprite-animations-v2.css';
-import '@/assets/boar-animations.css';
-import '@/assets/wolf-animations.css';
-import '@/assets/basilisk-animations.css';
-import '@/assets/hydra-animations.css';
-import '@/assets/sea-serpent-animations.css';
-import '@/assets/wurm-animations.css';
-import '@/assets/roc-animations.css';
-import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
-import { createNewGame, createHotSeatGame } from '@/core/game-state';
-import { resolveOpponentChallenge, setPendingOpponentChallenge, resolveChallengeForCiv, setPendingChallengeForCiv } from '@/core/opponent-challenge';
 import { RenderLoop } from '@/renderer/render-loop';
-import {
-  getVisibleCityBadgeSlots,
-  getVisibleHexViewportCopies,
-} from '@/renderer/city-renderer';
-import { initSprites } from '@/renderer/sprites/sprite-loader';
-import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
-import { preloadFamineBadgeMarker } from '@/renderer/improvements/famine-badge-marker';
-import { preloadReligionBadgeMarker } from '@/renderer/improvements/religion-badge-marker';
-import { preloadRailSegment } from '@/renderer/improvements/rail-segment-loader';
-import { preloadTerrainTiles } from '@/renderer/terrain/terrain-tile-loader';
-import { preloadNaturalWonderTiles } from '@/renderer/terrain/wonder-tile-loader';
-import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
-import { MouseHandler } from '@/input/mouse-handler';
-import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
-import { hexKey, hexToPixel, hexesInRange, parseHexKey } from '@/systems/hex-utils';
-import { moveUnit, getMovementCost, UNIT_DEFINITIONS, restUnit, canHeal, getUnmovedUnits, createUnit } from '@/systems/unit-system';
+import { hexKey, hexesInRange, parseHexKey } from '@/systems/hex-utils';
+import { moveUnit, getMovementCost, UNIT_DEFINITIONS, restUnit, canHeal, createUnit } from '@/systems/unit-system';
 import { isMajorCivOwner } from '@/core/owner-kind';
 import { getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
-import { civHasAirDefenseCoverage } from '@/systems/air-defense-system';
 import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
@@ -46,7 +20,6 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
-import { resolveCivilizationEra } from '@/systems/tech-definitions';
 import { resolveCombatEra } from '@/systems/era-resolution';
 import { preach } from '@/systems/religion-system';
 import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
@@ -57,146 +30,67 @@ import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
 import { createBestiaryPanel } from '@/ui/bestiary-panel';
-import {
-  autoSave,
-  loadMostRecentAutoSaveEntry,
-  loadSaveEntry,
-  loadSettings,
-  rewriteLoadedSaveEntry,
-  saveGame,
-  saveSettings,
-} from '@/storage/save-manager';
+import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
-import { SFX, routeSfxThrough } from '@/audio/sfx';
+import { SFX } from '@/audio/sfx';
 import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
 import { createMarketplacePanel } from '@/ui/marketplace-panel';
 import { createEspionagePanel } from '@/ui/espionage-panel';
-import { createSavePanel } from '@/ui/save-panel';
 import { AdvisorSystem } from '@/ui/advisor-system';
 import { createCouncilPanel } from '@/ui/council-panel';
-import { createGameShell } from '@/ui/game-shell';
 import { createNotificationLogPanel } from '@/ui/notification-log-panel';
 import { createPirateWatersPanel } from '@/ui/pirate-waters-panel';
-import { createGameButton } from '@/ui/ui-kit';
 import { getPirateWatersPresentation, type PirateFocusTarget } from '@/systems/pirate-presentation';
 import { hirePirateFlotilla, payPirateTribute, type PirateActionResult } from '@/systems/pirate-actions';
 import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
-import {
-  confirmPirateHeadquartersAssault,
-  preparePirateHeadquartersAssault,
-} from '@/input/pirate-headquarters-assault';
+import { confirmPirateHeadquartersAssault, preparePirateHeadquartersAssault } from '@/input/pirate-headquarters-assault';
 import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
 import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
 import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
 import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
-import { showCampaignSetup } from '@/ui/campaign-setup';
-import { showGameModeSelect } from '@/ui/game-mode-select';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { resolveCivDefinition } from '@/systems/civ-registry';
-import {
-  acceptDiplomaticRequest,
-  applyDiplomaticAction,
-  breakTreaty,
-  declareWar,
-  makePeace,
-  modifyRelationship,
-  rejectDiplomaticRequest,
-  resolveOpponentKind,
-} from '@/systems/diplomacy-system';
-import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { acceptDiplomaticRequest, applyDiplomaticAction, breakTreaty, declareWar, makePeace, modifyRelationship, rejectDiplomaticRequest, resolveOpponentKind } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
-import {
-  assignNetworkPlan,
-  cancelNetworkPlan,
-  holdNetworkPlan,
-  isAutonomyActivated,
-  retargetNetworkPlan,
-} from '@/systems/network-plan-system';
+import { assignNetworkPlan, cancelNetworkPlan, holdNetworkPlan, isAutonomyActivated, retargetNetworkPlan } from '@/systems/network-plan-system';
 import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
-import {
-  acknowledgeTurnHandoffSummary,
-  showTurnHandoff,
-} from '@/ui/turn-handoff';
-import { showHotSeatSetup } from '@/ui/hotseat-setup';
 import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
-import { createIconLegendOverlay } from '@/ui/icon-legend';
 import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupancy';
-import {
-  beginPlayerCityAssaultChoice,
-  shouldPromptForPlayerCityCapture,
-} from '@/input/city-assault-flow';
+import { beginPlayerCityAssaultChoice, shouldPromptForPlayerCityCapture } from '@/input/city-assault-flow';
 import { canUnitOccupyCity } from '@/systems/city-capture-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import {
-  initializeLegendaryWonderProjectsForCity,
-  getLegendaryWonderEligibility,
-  startLegendaryWonderBuild,
-} from '@/systems/legendary-wonder-system';
+import { initializeLegendaryWonderProjectsForCity, getLegendaryWonderEligibility, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
-import {
-  embedSpy,
-  unembedSpy,
-  attemptSweep,
-  getAvailableMissions,
-  getSpyCaptureRelationshipPenalty,
-  expelSpy,
-  executeSpy,
-  startInterrogation,
-  isSpyUnitType,
-  missionRequiresPlacedSpy,
-  recallSpy,
-  resolveMissionResult,
-  startMission,
-  verifyAgent,
-} from '@/systems/espionage-system';
-import {
-  applyUnitUpgradeToState,
-  evaluateUnitUpgrade,
-} from '@/systems/unit-upgrade-system';
+import { embedSpy, unembedSpy, attemptSweep, getAvailableMissions, getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType, missionRequiresPlacedSpy, recallSpy, resolveMissionResult, startMission, verifyAgent } from '@/systems/espionage-system';
+import { applyUnitUpgradeToState, evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
-import {
-  getEmbarkedAssaultTarget,
-  detachCargoForEmbarkedAssault,
-} from '@/systems/transport-system';
+import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
 import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
 import type { CombatResult, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType, TreatyType } from '@/core/types';
-import {
-  appendNotification,
-  getNotificationsForPlayer,
-  type NotificationCityAction,
-  type NotificationEntry,
-} from '@/core/notification-log';
-import {
-  TREATY_LABELS,
-  type NotificationSink,
-} from '@/ui/notification-routing';
-import { createNotificationCenter } from '@/ui/notification-center';
+import { appendNotification, getNotificationsForPlayer, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
+import { TREATY_LABELS, type NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
-import { applyPersistedUserSettings } from '@/storage/settings-merge';
-import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
-import { initializeDesktopMenu } from '@/platform/desktop-menu';
-import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
-import { showPauseMenu } from '@/ui/pause-menu-panel';
-import { beginCampaignEntry } from '@/ui/campaign-entry-flow';
-import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
-import { calculateCivEconomy, formatGoldHudText, rushBuyActiveProduction } from '@/systems/economy-system';
+import { rushBuyActiveProduction } from '@/systems/economy-system';
 import { appeaseFaction, concedeToMovement } from '@/systems/faction-system';
 import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
-import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
-import { getCivHappinessFromResources, getCivAvailableResources, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
+import { getCivAvailableResources, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
 import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
+import { createHudController, type HudController } from '@/app/controllers/hud-controller';
+import { createCampaignEntryController, type CampaignEntryController } from '@/app/controllers/campaign-entry-controller';
+import { createGameSessionController, type GameSessionController } from '@/app/controllers/game-session-controller';
+import { bootstrap } from '@/app/bootstrap';
 import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
@@ -228,18 +122,18 @@ const session: GameSession = createGameSession(undefined as unknown as GameState
  * pending-map-intent union that replaced four independent nullable flags.
  */
 const selection = createSelectionStore();
-let drawer: TreasuryDrawer;
-let inputInitialized = false;
 /** Owns persisted A/V settings + master volume, moved out of module scope (#787 phase 4). */
 const userSettingsStore = createUserSettingsStore({ load: loadSettings });
 /**
  * The single source of player-facing notifications (#787 phase 4).
  *
- * Constructed in `init()`, once `createUI()` has created the `#notifications`
- * element `NotificationCenterDeps.layer` needs. Every function below that
- * reads `notifier` is only ever invoked during real gameplay, well after
- * `init()` completes -- the same deferred-but-eager pattern `session` and
- * `selection` already use for their own module-scope bindings.
+ * Constructed in `GameSessionController.init()`, once `createUI()` has
+ * created the `#notifications` element `NotificationCenterDeps.layer`
+ * needs, then published back here via `setNotifier` (#787 phase 10).
+ * Every function below that reads `notifier` is only ever invoked during
+ * real gameplay, well after `init()` completes -- the same
+ * deferred-but-eager pattern `session` and `selection` already use for
+ * their own module-scope bindings.
  */
 let notifier: Notifier;
 
@@ -296,17 +190,8 @@ const panelContext: PanelContext = {
 // Registered once, here, rather than repeated as a three-statement discipline
 // at each write site. Renderer first, matching the order the manual pairs used.
 session.subscribe(next => renderLoop.setGameState(next));
-session.subscribe(() => updateHUD());
+session.subscribe(() => hud.update());
 
-const airDefenseOverlayButton = createGameButton('🛡 Anti-aircraft coverage', 'secondary');
-airDefenseOverlayButton.id = 'btn-air-defense-overlay';
-airDefenseOverlayButton.hidden = true; // shown once the current civ has built AA coverage — see updateHUD()
-airDefenseOverlayButton.setAttribute('aria-pressed', 'false');
-airDefenseOverlayButton.addEventListener('click', () => {
-  const enabled = renderLoop.toggleAirDefenseOverlay();
-  airDefenseOverlayButton.setAttribute('aria-pressed', String(enabled));
-  airDefenseOverlayButton.textContent = enabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
-});
 function setBlockingOverlay(id: string | null): void {
   host.setBlockingOverlay(id);
 }
@@ -360,7 +245,7 @@ const selectionController: SelectionController = createSelectionController({
   ceremonies,
   getInfoPanel: () => document.getElementById('info-panel'),
   showNotification,
-  updateHUD,
+  updateHUD: () => hud.update(),
   clearUnloadState,
   getUnitTurnFlow,
   foundCityAction,
@@ -407,7 +292,7 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   getElementById: id => document.getElementById(id),
   getNetworkIntentPanel: () => document.querySelector('[aria-label="Network intent"]'),
   showNotification,
-  updateHUD,
+  updateHUD: () => hud.update(),
   setBlockingOverlay,
   currentCiv,
   getUnitTurnFlow,
@@ -416,7 +301,11 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   scanBeastSightings,
   maybeShowPendingHoardChoice,
   checkAdvisors: () => advisorSystem.check(session.getState()),
-  showGameModeSelection,
+  // `campaignEntry` is declared after `turnFlow` (it needs `turnFlow` itself
+  // as a dep) -- same deferred-but-eager forward reference `router`/`notifier`
+  // already use elsewhere in this file; safe because this closure is not
+  // invoked until real gameplay.
+  showGameModeSelection: () => campaignEntry.showGameModeSelection(),
   reloadPage: () => window.location.reload(),
   openCityPanelForCity,
 });
@@ -439,7 +328,7 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   uiLayer,
   getElementById: id => document.getElementById(id),
   showNotification,
-  updateHUD,
+  updateHUD: () => hud.update(),
   clearUnloadState,
   currentCiv,
   openPirateWaters,
@@ -450,6 +339,79 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   executeMinorCivConquest,
   beginPlayerCityAssault,
   finalizePendingCityCaptureChoice: turnFlow.finalizePendingCityCaptureChoice,
+});
+
+/**
+ * Owns the HUD readout, the treasury drawer, the anti-aircraft-overlay
+ * toggle button, and the map viewport bottom inset (#787 phase 10).
+ */
+const hud: HudController = createHudController({
+  session,
+  renderLoop,
+  canvas,
+  router: { open: panel => router.open(panel) },
+  getElementById: id => document.getElementById(id),
+  getDrawerMountRoot: () => document.getElementById('game-shell') ?? document.body,
+});
+
+/**
+ * Owns campaign entry: the start/save panel, mode selection, and
+ * `enterCampaign` (#787 phase 10). `startGame` is a forward reference to
+ * `gameSession` (declared `let` just below and assigned immediately after)
+ * -- the same deferred-but-eager pattern `router`/`notifier` already use,
+ * needed because `gameSession` itself depends on `campaignEntry`.
+ */
+let gameSession: GameSessionController;
+const campaignEntry: CampaignEntryController = createCampaignEntryController({
+  session,
+  uiLayer,
+  audio,
+  bus,
+  roundPresentationGate,
+  host,
+  turnFlow,
+  userSettingsStore,
+  getElementById: id => document.getElementById(id),
+  showNotification,
+  startGame: () => gameSession.startGame(),
+  reloadPage: () => window.location.reload(),
+});
+
+/**
+ * Owns app startup: `init`, `createUI`, `startGame`, and the
+ * `inputInitialized` construct-once guard (#787 phase 10).
+ */
+gameSession = createGameSessionController({
+  session,
+  selection,
+  renderLoop,
+  audio,
+  bus,
+  canvas,
+  uiLayer,
+  documentRef: document,
+  host,
+  router: {
+    toggle: panel => router.toggle(panel),
+    open: panel => router.open(panel),
+    close: panel => router.close(panel),
+    closeGroup: group => router.closeGroup(group),
+    isOpen: panel => router.isOpen(panel),
+  },
+  roundPresentationGate,
+  advisorSystem,
+  userSettingsStore,
+  turnFlow,
+  mapInteraction,
+  selectionController,
+  hud,
+  campaignEntry,
+  getElementById: id => document.getElementById(id),
+  showNotification,
+  foundCityAction,
+  maybeShowPendingHoardChoice,
+  setNotifier: n => { notifier = n; },
+  focusNotificationTarget,
 });
 
 /**
@@ -476,17 +438,6 @@ const presentationContext: PresentationContext = {
   showNotification: (message, type, target) => showNotification(message, type, target),
 };
 
-// --- Resize ---
-window.addEventListener('resize', () => renderLoop.resizeCanvas());
-
-function setMapViewportBottomInset(height: number): void {
-  canvas.style.bottom = `${height}px`;
-  // With both top and bottom set, an auto height makes the canvas occupy only
-  // the remaining map viewport instead of living behind the action bar.
-  canvas.style.height = 'auto';
-  renderLoop.resizeCanvas();
-}
-
 /**
  * `createPacingDebugPanel` self-removes any prior instance from `uiLayer`,
  * so the router's own DOM-derived `isOpen`/`close` need no extra bookkeeping
@@ -501,99 +452,6 @@ function openPacingDebugPanel(): void {
 // `installGlobalShortcuts` (called from `init()`, once `notifier` exists) so
 // it can depend on the real `Notifier`/`PanelRouter` ports instead of
 // reaching into module-scope closures directly (#787 phase 5).
-
-function createUI(): void {
-  createGameShell(uiLayer, {
-    onOpenCouncil: () => router.open('council'),
-    onOpenTech: () => router.open('tech'),
-    onOpenCity: () => router.open('city-overview'),
-    onOpenEspionage: () => router.open('espionage'),
-    onOpenDiplomacy: () => router.open('diplomacy'),
-    onOpenMarketplace: () => router.open('marketplace'),
-    onEndTurn: () => turnFlow.endTurn(),
-    onNextUnit: () => selectionController.selectNextUnit(),
-    onOpenNotificationLog: () => router.toggle('notification-log'),
-    onOpenPirateWaters: () => router.open('pirate-waters'),
-    onToggleIconLegend: () => {
-      const existing = document.getElementById('icon-legend');
-      if (existing && existing.style.display !== 'none') {
-        // Already visible — hide it
-        existing.style.display = 'none';
-        return;
-      }
-      // Stale or absent — remove old, rebuild fresh with current techs
-      existing?.remove();
-      const viewerTechs = new Set<string>(
-        session.getState().civilizations[session.getState().currentPlayer]?.techState.completed ?? []
-      );
-      const overlay = createIconLegendOverlay(viewerTechs);
-      uiLayer.appendChild(overlay);
-    },
-    onOpenWonderAtlas: () => router.open('wonder-atlas'),
-    onBottomBarHeightChange: setMapViewportBottomInset,
-    onOpenMenu: () => {
-      showPauseMenu(uiLayer, {
-        turn: session.getState().turn,
-        civName: session.getState().civilizations[session.getState().currentPlayer].name,
-        onResume: () => {},
-        onSave: async (slotId, name) => {
-          await saveGame(slotId, name, session.getState());
-          showNotification('Game saved.', 'info');
-        },
-        onNewGame: () => showGameModeSelection(),
-        autoSave: () => autoSave(session.getState()),
-        onOpenBestiary: () => router.open('bestiary'),
-        opponentChallenge: resolveOpponentChallenge(session.getState()),
-        pendingOpponentChallenge: session.getState().pendingOpponentChallenge,
-        onOpponentChallengeChange: (challenge) => {
-          session.setStateWithoutRefresh(setPendingOpponentChallenge(session.getState(), challenge));
-        },
-        personalChallenge: resolveChallengeForCiv(session.getState(), session.getState().currentPlayer),
-        pendingPersonalChallenge: session.getState().civilizations[session.getState().currentPlayer]?.pendingChallenge,
-        onPersonalChallengeChange: (challenge) => {
-          session.setStateWithoutRefresh(setPendingChallengeForCiv(session.getState(), session.getState().currentPlayer, challenge));
-        },
-        // Spec 3: per-channel audio settings
-        audioSettings: {
-          masterVolume:   userSettingsStore.getMasterVolume(),   // tracked in memory across menu reopens
-          musicVolume:    session.getState().settings.musicVolume,
-          sfxVolume:      session.getState().settings.sfxVolume,
-          stingerVolume:  session.getState().settings.stingerVolume  ?? 1.0,
-          musicEnabled:   session.getState().settings.musicEnabled,
-          soundEnabled:   session.getState().settings.soundEnabled,
-          stingerEnabled: session.getState().settings.stingerEnabled ?? true,
-        },
-        onAudioSettingChange: (key, value) => {
-          // Apply to audio system immediately — no restart needed
-          switch (key) {
-            case 'masterVolume':
-              userSettingsStore.setMasterVolume(value as number);
-              audio.setMasterVolume(value as number);
-              return; // master not in GameSettings — skip the settings write below
-            case 'musicVolume':    audio.setMusicVolume(value as number);   break;
-            case 'sfxVolume':      audio.setSfxVolume(value as number);     break;
-            case 'stingerVolume':  audio.setStingerVolume(value as number); break;
-            case 'musicEnabled':   audio.setMusicEnabled(value as boolean); break;
-            case 'soundEnabled':   audio.setSfxEnabled(value as boolean);   break;
-            case 'stingerEnabled': audio.setStingerEnabled(value as boolean); break;
-          }
-          // Persist all non-master settings to GameSettings (saved on next save)
-          (session.getState().settings as unknown as Record<string, number | boolean>)[key] = value;
-        },
-      });
-    },
-  });
-
-  // Join the utility toolbar's flex row instead of an independent absolute position —
-  // a second, uncoordinated top-right anchor overlapped the HUD and the toolbar's own
-  // icon buttons (#783).
-  const utilityToolbar = document.getElementById('utility-toolbar');
-  const pauseMenuButton = document.getElementById('btn-pause-menu');
-  if (utilityToolbar) {
-    if (pauseMenuButton) utilityToolbar.insertBefore(airDefenseOverlayButton, pauseMenuButton);
-    else utilityToolbar.appendChild(airDefenseOverlayButton);
-  }
-}
 
 function openBestiary(): void {
   createBestiaryPanel(uiLayer, getBestiaryEntriesForPlayer(session.getState(), session.getState().currentPlayer), {
@@ -633,13 +491,13 @@ function maybeShowPendingHoardChoice(): void {
   createBeastHoardPanel(uiLayer, preview, choice => {
     session.setStateWithoutRefresh(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
     bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
-    updateHUD();
+    hud.update();
     maybeShowPendingHoardChoice();
   });
 }
 
 function openWonderAtlas(initialWonderId?: string): void {
-  drawer?.close();
+  hud.closeDrawer();
   audio.stopNaturalWonderAmbient('codex-page-hidden');
   createWonderAtlasPanel(uiLayer, session.getState(), {
     initialWonderId,
@@ -668,101 +526,6 @@ function currentCiv() {
   return session.getState().civilizations[session.getState().currentPlayer];
 }
 
-function updateHUD(): void {
-  const civ = currentCiv();
-  airDefenseOverlayButton.hidden = !civHasAirDefenseCoverage(session.getState(), civ.id);
-  const airDefenseEnabled = renderLoop.isAirDefenseOverlayEnabled(session.getState().currentPlayer);
-  airDefenseOverlayButton.setAttribute('aria-pressed', String(airDefenseEnabled));
-  airDefenseOverlayButton.textContent = airDefenseEnabled ? '🛡 Anti-aircraft coverage: on' : '🛡 Anti-aircraft coverage';
-  const hud = document.getElementById('hud');
-  if (!hud) return;
-
-  // Sum yields across all cities
-  let totalFood = 0, totalProd = 0, totalScience = 0;
-  for (const cityId of civ.cities) {
-    const city = session.getState().cities[cityId];
-    if (!city) continue;
-    const y = calculateProjectedCityYields(session.getState(), cityId);
-    totalFood += y.food;
-    totalProd += y.production;
-    totalScience += y.science;
-  }
-  const economyStatus = calculateCivEconomy(session.getState(), civ.id);
-
-  const techName = civ.techState.currentResearch ?? 'None';
-  hud.textContent = '';
-
-  const yieldsRow = document.createElement('div');
-  yieldsRow.dataset.role = 'hud-yields';
-  yieldsRow.style.cssText =
-    'display:flex;align-items:center;gap:10px;flex-wrap:nowrap;overflow:hidden;min-width:0;';
-
-  const yieldSpan = document.createElement('span');
-  yieldSpan.textContent = `🌾 ${totalFood}`;
-  yieldsRow.appendChild(yieldSpan);
-
-  const prodSpan = document.createElement('span');
-  prodSpan.textContent = `⚒️ ${totalProd}`;
-  yieldsRow.appendChild(prodSpan);
-
-  const goldBtn = document.createElement('button');
-  goldBtn.style.cssText =
-    'background:transparent;color:inherit;border:none;font-family:inherit;font-size:inherit;padding:0;cursor:pointer;min-height:44px;display:inline-flex;align-items:center;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:1;';
-  goldBtn.textContent = `💰 ${formatGoldHudText(economyStatus, civ.gold)}`;
-  goldBtn.addEventListener('click', () => drawer?.toggle());
-  yieldsRow.appendChild(goldBtn);
-  drawer?.update(economyStatus, civ.gold);
-
-  const sciSpan = document.createElement('span');
-  sciSpan.style.cssText = 'min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:1;';
-  sciSpan.textContent = `🔬 ${techName !== 'None' ? techName : 'None'} (+${totalScience})`;
-  yieldsRow.appendChild(sciSpan);
-
-  if (isAutonomyActivated(session.getState(), civ.id)) {
-    const networkButton = document.createElement('button');
-    networkButton.type = 'button';
-    networkButton.style.cssText = 'background:transparent;color:inherit;border:1px solid rgba(232,193,112,0.45);border-radius:6px;font:inherit;padding:4px 8px;min-height:44px;';
-    networkButton.textContent = getNetworkPanelModel(session.getState(), civ.id).statusText;
-    networkButton.addEventListener('click', () => router.open('network'));
-    yieldsRow.appendChild(networkButton);
-  }
-
-  const happiness = getCivHappinessFromResources(session.getState(), civ.id);
-  if (happiness > 0) {
-    const happySpan = document.createElement('span');
-    happySpan.title = 'Happiness from luxury resources — each point reduces city unrest pressure by 2';
-    happySpan.textContent = `☺ ${happiness} (stability)`;
-    yieldsRow.appendChild(happySpan);
-  }
-
-  const infoRow = document.createElement('div');
-  if (session.getState().hotSeat && civ.name) {
-    const nameSpan = document.createElement('span');
-    nameSpan.textContent = `${civ.name} · `;
-    infoRow.appendChild(nameSpan);
-  }
-  const turnSpan = document.createElement('span');
-  turnSpan.textContent = `Turn ${session.getState().turn} · Your Era ${resolveCivilizationEra(civ.techState.completed)} · World Age ${session.getState().era}`;
-  infoRow.appendChild(turnSpan);
-
-  hud.appendChild(yieldsRow);
-  hud.appendChild(infoRow);
-
-  const pirateWatersButton = document.getElementById('btn-pirate-waters');
-  if (pirateWatersButton) {
-    pirateWatersButton.hidden = !getPirateWatersPresentation(session.getState(), session.getState().currentPlayer).available;
-  }
-
-  // Show "Next Unit" button when there are unmoved units
-  const nextUnitBtn = document.getElementById('btn-next-unit');
-  if (nextUnitBtn) {
-    const unmovedCount = getUnmovedUnits(session.getState().units, session.getState().currentPlayer).length;
-    nextUnitBtn.style.display = unmovedCount > 0 ? 'block' : 'none';
-    if (unmovedCount > 0) {
-      nextUnitBtn.textContent = `⏩ ${unmovedCount}`;
-    }
-  }
-}
 
 // --- Notifications ---
 // The toast queue, the choice modal, and the delivery contract below all live
@@ -824,7 +587,7 @@ function applyPirateActionResult(result: PirateActionResult, successMessage: str
     }
   }
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   showNotification(successMessage, 'success');
 }
 
@@ -933,7 +696,7 @@ function openPirateHeadquartersAssault(factionId: string, unitId: string): void 
       session.setStateWithoutRefresh(result.state);
       panel.remove();
       renderLoop.setGameState(session.getState());
-      updateHUD();
+      hud.update();
       SFX.combat();
       const bountyAwarded = result.events.find(event => event.type === 'faction-destroyed')?.bountyAwarded ?? 0;
       showNotification(
@@ -1008,7 +771,7 @@ function handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): 
     session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(session.getState(), cp, targetCivId, bus));
   }
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
   if (action === 'request_peace') {
     showNotification('Peace requested.', 'info');
@@ -1076,7 +839,7 @@ function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: s
   showNotification(`${cityName} has been conquered!`, 'success');
   SFX.tap();
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
 }
 
 function handleGiftGold(mcId: string): void {
@@ -1089,7 +852,7 @@ function handleGiftGold(mcId: string): void {
   emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
   showNotification('Gift delivered.', 'info');
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
 }
 
@@ -1103,7 +866,7 @@ function handleSponsorFestival(mcId: string): void {
   emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
   showNotification('Festival sponsored.', 'success');
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
 }
 
@@ -1116,7 +879,7 @@ function handleMinorCivReparations(mcId: string): void {
   session.setStateWithoutRefresh(result.state);
   showNotification('Reparations paid.', 'success');
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
 }
 
@@ -1129,7 +892,7 @@ function handleSendAid(crisisId: string): void {
   session.setStateWithoutRefresh(applySendAid(session.getState(), session.getState().currentPlayer, crisisId, bus));
   showNotification('Aid sent.', 'success');
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
 }
 
@@ -1140,12 +903,12 @@ function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
   emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
   showNotification(currentlyAtWar ? 'Peace with city-state' : 'War declared on city-state!', currentlyAtWar ? 'success' : 'warning');
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   openDiplomacyPanel();
 }
 
 function openDiplomacyPanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   document.getElementById('diplomacy-panel')?.remove();
   createDiplomacyPanel(uiLayer, session.getState(), {
     onAction: handleDiplomaticAction,
@@ -1164,7 +927,7 @@ function openDiplomacyPanel(): void {
 }
 
 function openMarketplacePanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   document.getElementById('marketplace-panel')?.remove();
   createMarketplacePanel(uiLayer, session.getState(), {
     onClose: () => {},
@@ -1204,7 +967,7 @@ function openWonderPanelForCityId(selectedCityId: string): void {
         const targetCity = session.getState().cities[buildCityId];
         if (targetCity) {
           renderLoop.setGameState(session.getState());
-          updateHUD();
+          hud.update();
           const productionItemId = `legendary:${wonderId}`;
           if (targetCity.productionQueue[0] === productionItemId) {
             showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
@@ -1224,7 +987,7 @@ function openWonderPanelForCityId(selectedCityId: string): void {
 }
 
 function openCityOverviewPanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   const existing = document.getElementById('city-overview-panel');
   if (existing) existing.remove();
   createCityOverviewPanel(uiLayer, session.getState(), {
@@ -1273,13 +1036,13 @@ function handleConcedeToMovement(cityId: string): GameState {
   bus.emit('faction:unrest-resolved', { cityId, owner: session.getState().currentPlayer });
   bus.emit('faction:concession-made', { cityId, owner: session.getState().currentPlayer, concessionType: 'charter' });
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   showNotification(result.message, 'success');
   return session.getState();
 }
 
 function openCityPanelForCity(city: import('@/core/types').City): void {
-  drawer?.close();
+  hud.closeDrawer();
   if (city.owner !== session.getState().currentPlayer) return;
 
   createCityPanel(uiLayer, city, session.getState(), {
@@ -1420,7 +1183,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
 }
 
 function openCouncilPanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   createCouncilPanel(uiLayer, session.getState(), {
     onClose: () => {
       document.getElementById('council-panel')?.remove();
@@ -1433,7 +1196,7 @@ function openCouncilPanel(): void {
 }
 
 function openTechPanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   createTechPanel(uiLayer, session.getState(), {
     onQueueResearch: (techId) => {
       try {
@@ -1444,7 +1207,7 @@ function openTechPanel(): void {
         return;
       }
       renderLoop.setGameState(session.getState());
-      updateHUD();
+      hud.update();
       showNotification(`Queued research: ${techId}`, 'info');
     },
     onMoveQueuedResearch: (fromIndex, toIndex) => {
@@ -1453,7 +1216,7 @@ function openTechPanel(): void {
         researchQueue: moveQueuedId(currentCiv().techState.researchQueue, fromIndex, toIndex),
       };
       renderLoop.setGameState(session.getState());
-      updateHUD();
+      hud.update();
     },
     onRemoveQueuedResearch: (index) => {
       currentCiv().techState = {
@@ -1461,14 +1224,14 @@ function openTechPanel(): void {
         researchQueue: removeQueuedId(currentCiv().techState.researchQueue, index),
       };
       renderLoop.setGameState(session.getState());
-      updateHUD();
+      hud.update();
     },
     onClose: () => {},
   });
 }
 
 function openEspionagePanel(): void {
-  drawer?.close();
+  hud.closeDrawer();
   const chooseForeignCityTarget = (): { civId: string; cityId: string; position: HexCoord } | null => {
       const choices = Object.values(session.getState().cities)
         .filter(city => city.owner !== session.getState().currentPlayer)
@@ -1882,7 +1645,7 @@ function handleEstablishRoute(caravanId: string): void {
     emitMinorCivQuestTransitions(bus, routeResult.questTransitions, session.getState());
     bus.emit('trade:route-created', { route: routeResult.route });
     renderLoop.setGameState(session.getState());
-    updateHUD();
+    hud.update();
     selectionController.selectUnit(caravanId);
     showNotification('Trade route established!', 'success');
   });
@@ -1900,7 +1663,7 @@ function getUnitTurnFlow() {
     centerOn: coord => renderLoop.camera.centerOn(coord),
     refreshVisibility: selectionController.refreshCurrentPlayerVisibility,
     setRenderState: state => renderLoop.setGameState(state),
-    updateHUD,
+    updateHUD: () => hud.update(),
     showNotification,
     setBlockingOverlay,
     endTurn: options => { void turnFlow.endTurn(options); },
@@ -1945,7 +1708,7 @@ function foundCityAction(): void {
   }
 
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
 }
 
 function performWorkerAction(action: WorkerActionType): void {
@@ -1967,7 +1730,7 @@ function performWorkerAction(action: WorkerActionType): void {
   }
 
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
 
   if (result.workerConsumed || result.workerLost || !session.getState().units[selectedUnitId]) {
     selectionController.deselectUnit();
@@ -2076,7 +1839,7 @@ function beginPlayerCityAssault(
       'warning',
     );
     renderLoop.setGameState(session.getState());
-    updateHUD();
+    hud.update();
     return 'resolved';
   }
 
@@ -2228,7 +1991,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
           );
           SFX.combat();
           renderLoop.setGameState(session.getState());
-          updateHUD();
+          hud.update();
           selectionController.refreshSelectedUnitAfterCombat();
           if (assaultStatus === 'resolved') {
             setTimeout(() => selectionController.selectNextUnit(), 400);
@@ -2244,7 +2007,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
   // `attacker` was captured before applyCombatOutcomeToState — safe even if attacker was destroyed
   SFX.combat();
   renderLoop.setGameState(session.getState());
-  updateHUD();
+  hud.update();
   selectionController.refreshSelectedUnitAfterCombat();
   renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectionController.selectNextUnit());
 }
@@ -2408,407 +2171,17 @@ function showEspionageCaptureChoice(spyId: string, spyOwner: string): void {
   ]);
 }
 
-// --- Event listeners ---
-// All 72 module-scope bus.on(...) registrations that used to live inline here
-// now live in the thirteen domain registrars under src/presentation/,
-// composed into one install/dispose pair (#787 phase 7).
-registerAllPresentation(bus, presentationContext);
-
-registerMinorCivNotificationListeners(bus, () => session.getState(), { appendToCivLog });
-
-// --- Initialization ---
-async function init(): Promise<void> {
-  await registerConquestoriaServiceWorker();
-  await initializeDesktopMenu();
-
-  createUI();
-  // #notifications is created by createGameShell() inside createUI(), so notifier
-  // can only be constructed here, not eagerly at module scope (#787 phase 4).
-  notifier = createNotificationCenter({
-    layer: document.getElementById('notifications') as HTMLElement,
-    getState: () => session.getState(),
-    isSuppressed: () => roundPresentationGate.isSuppressed(),
-    playCue: (cue) => {
-      // #594 MR7: religion toasts carry a bespoke sfxCue that replaces the generic
-      // synth chime -- see notification-routing.ts's routeReligionFounded/
-      // routeReligionCityConverted/routeLoyaltyWarning/routeCityDefected.
-      if (cue) {
-        void audio.playReligionStinger(cue).catch(() => {});
-      } else {
-        SFX.notification();
-      }
-    },
-    onFocusTarget: focusNotificationTarget,
-  });
-  // Needs the real `notifier`, so deferred here alongside it rather than
-  // installed eagerly at module scope (#787 phase 5).
-  installGlobalShortcuts({ target: window, selection, router, notifier });
-  await userSettingsStore.refresh();
-
-  if (import.meta.env.MODE === 'e2e') {
-    // Browser tests must target the same live camera transform as player input;
-    // exposing only viewport copies keeps game state and camera internals private.
-    window.__CONQUESTORIA_E2E_GET_VISIBLE_HEX_COPIES__ = coord => getVisibleHexViewportCopies(
-      session.getState(),
-      renderLoop.camera,
-      session.getState().currentPlayer,
-      coord,
-    );
-    const { isExactAutosaveE2ERequest } = await import('@/testing/e2e-mode');
-    if (isExactAutosaveE2ERequest(import.meta.env.MODE, window.location.search)) {
-      const { installE2ERuntime } = await import('@/testing/e2e-runtime');
-      await installE2ERuntime({
-        loadAutosave: loadMostRecentAutoSaveEntry,
-        enterSoloCampaign: state => enterCampaignForE2E(state),
-        getVisibleHexCopies: coord => getVisibleHexViewportCopies(
-          session.getState(),
-          renderLoop.camera,
-          session.getState().currentPlayer,
-          coord,
-        ),
-        getCityBadgeSlots: (cityId, slot) => getVisibleCityBadgeSlots(
-          session.getState(),
-          renderLoop.camera,
-          session.getState().currentPlayer,
-          cityId,
-          slot,
-        ),
-      });
-      return;
-    }
-  }
-
-  await showStartSavePanel();
-}
-
-function enterCampaign(
-  state: GameState,
-  message: string,
-  persistBeforeReady: boolean = false,
-): Promise<void> | null {
-  document.getElementById('save-panel')?.remove();
-  session.setStateWithoutRefresh(applyPersistedUserSettings(state, userSettingsStore.getPersisted()));
-  if (session.getState().gameOver) {
-    const spritesReady = startGame();
-    turnFlow.handleVictoryIfNeeded();
-    return spritesReady;
-  }
-  const hotSeat = session.getState().hotSeat;
-  if (!hotSeat) {
-    const spritesReady = startGame();
-    showNotification(message, 'info');
-    return spritesReady;
-  }
-
-  audio.setMasterVolume(0);
-  turnFlow.closeNetworkPanelsForHandoff();
-  const player = hotSeat.players.find(candidate => candidate.slotId === session.getState().currentPlayer);
-  setBlockingOverlay('turn-handoff');
-  roundPresentationGate.suppress();
-  const controller = showTurnHandoff(
-    uiLayer,
-    session.getState(),
-    session.getState().currentPlayer,
-    player?.name ?? 'Player',
-    {
-      initiallyReady: !persistBeforeReady,
-      preparingLabel: 'Saving campaign…',
-      onReady: async summary => {
-        const viewerId = session.getState().currentPlayer;
-        const acknowledgement = acknowledgeTurnHandoffSummary(
-          session.getState(),
-          viewerId,
-          summary,
-        );
-        session.setStateWithoutRefresh(acknowledgement.state);
-        try {
-          await autoSave(session.getState());
-        } catch {
-          // Entry persistence already succeeded; acknowledgement may safely retry later.
-        }
-        roundPresentationGate.resume();
-        setBlockingOverlay(null);
-        startGame();
-        audio.setMasterVolume(userSettingsStore.getMasterVolume());
-        if (acknowledgement.playStrategicWarningAudio) {
-          bus.emit('ai:strategic-warning-audio', {
-            viewerId,
-            turn: summary.turn,
-          });
-        }
-        showNotification(message, 'info');
-      },
-    },
-  );
-
-  if (!persistBeforeReady) return null;
-  const persist = async (): Promise<void> => {
-    try {
-      await autoSave(session.getState());
-      controller.setReady(session.getState());
-    } catch {
-      controller.setError(
-        'The campaign could not be saved. Retry before opening the first turn.',
-        {
-          onRetry: () => void persist(),
-          onReturnToSaves: () => {
-            roundPresentationGate.resume();
-            window.location.reload();
-          },
-        },
-      );
-    }
-  };
-  void persist();
-  return null;
-}
-
-function enterCampaignForE2E(state: GameState): Promise<void> {
-  if (state.hotSeat) throw new Error('E2E direct entry does not bypass hot-seat handoff.');
-  const spritesReady = enterCampaign(state, `Welcome back! Turn ${state.turn}`);
-  if (!spritesReady) throw new Error('E2E direct entry requires a solo campaign.');
-  return spritesReady;
-}
-
-async function showStartSavePanel(): Promise<void> {
-  await createSavePanel(uiLayer, {
-    onNewGame: () => {
-      showGameModeSelection();
-    },
-    onContinue: async invoker => {
-      const loaded = await loadMostRecentAutoSaveEntry();
-      if (!loaded) throw new Error('Autosave no longer exists.');
-      await beginCampaignEntry(
-        { kind: 'stored', loaded },
-        invoker,
-        {
-          persistStoredChoice: rewriteLoadedSaveEntry,
-          persistImport: autoSave,
-          showChallengePrompt: showLegacyOpponentChallengePrompt,
-          onReady: state => enterCampaign(state, `Welcome back! Turn ${state.turn}`),
-        },
-      );
-    },
-    onLoadEntry: async (source, invoker) => {
-      const loaded = await loadSaveEntry(source);
-      if (!loaded) throw new Error('Save no longer exists.');
-      await beginCampaignEntry(
-        { kind: 'stored', loaded },
-        invoker,
-        {
-          persistStoredChoice: rewriteLoadedSaveEntry,
-          persistImport: autoSave,
-          showChallengePrompt: showLegacyOpponentChallengePrompt,
-          onReady: state => enterCampaign(state, `Game loaded! Turn ${state.turn}`),
-        },
-      );
-    },
-    onImportSave: async (state, invoker) => {
-      await beginCampaignEntry(
-        { kind: 'import', state },
-        invoker,
-        {
-          persistStoredChoice: rewriteLoadedSaveEntry,
-          persistImport: autoSave,
-          showChallengePrompt: showLegacyOpponentChallengePrompt,
-          onReady: readyState => enterCampaign(
-            readyState,
-            `Save imported! Turn ${readyState.turn}`,
-          ),
-        },
-      );
-    },
-  });
-}
-
-
-function showGameModeSelection(): void {
-  let modePanel: HTMLElement;
-
-  modePanel = showGameModeSelect(uiLayer, {
-    initialTitle: 'New Campaign',
-    onCancel: () => {},
-    onTitleRequired: () => {
-      showNotification('Campaign title is required', 'warning');
-    },
-    onChooseSolo: async (title) => {
-      const currentSettings = await userSettingsStore.refresh();
-      const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
-      modePanel.remove();
-      showCampaignSetup(uiLayer, {
-        initialTitle: title,
-        onStartSolo: (config) => {
-          session.setStateWithoutRefresh(createNewGame({
-            civType: config.civType,
-            mapSize: config.mapSize,
-            opponentCount: config.opponentCount,
-            gameTitle: config.gameTitle,
-            // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
-            settingsOverrides: { ...userSettingsStore.getOverrides(), ...config.settingsOverrides },
-            customCivilizations: config.customCivilizations,
-            seed: config.seed,
-            mapScript: config.mapScript,
-            startPlacementMode: config.startPlacementMode,
-            opponentChallenge: config.opponentChallenge,
-          }));
-          if (currentSettings.councilTalkLevel) {
-            session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
-          }
-          startGame();
-        },
-        onCustomCivilizationsChanged: (customCivilizations) => {
-          userSettingsStore.setCustomCivilizations(customCivilizations);
-        },
-        onCancel: () => showGameModeSelection(),
-      }, {
-        initialCustomCivilizations: savedCustomCivilizations,
-      });
-    },
-    onChooseHotSeat: async (title) => {
-      const currentSettings = await userSettingsStore.refresh();
-      const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
-      modePanel.remove();
-      showHotSeatSetup(uiLayer, {
-        onComplete: (config, opponentChallenge) => {
-          session.setStateWithoutRefresh(createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard'));
-          if (currentSettings.councilTalkLevel) {
-            session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
-          }
-          enterCampaign(
-            session.getState(),
-            `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,
-            true,
-          );
-        },
-        onCustomCivilizationsChanged: (customCivilizations) => {
-          userSettingsStore.setCustomCivilizations(customCivilizations);
-        },
-        onCancel: () => {
-          showGameModeSelection();
-        },
-      }, {
-        initialCustomCivilizations: savedCustomCivilizations,
-      });
-    },
-  });
-}
-
-function startGame(): Promise<void> {
-  // Initialize treasury drawer once
-  if (!drawer) {
-    drawer = createTreasuryDrawer();
-    (document.getElementById('game-shell') ?? document.body).appendChild(drawer.element);
-  }
-
-  // Warm sprite cache non-blocking — renderers fall back to emoji while loading
-  const civColors: Record<string, string> = {};
-  for (const [civId, civ] of Object.entries(session.getState().civilizations)) {
-    civColors[civId] = civ.color;
-  }
-  const spritesReady = initSprites(civColors);
-  void spritesReady.catch(() => {});
-  preloadOutpostMarker().catch(() => {});
-  preloadFamineBadgeMarker().catch(() => {});
-  preloadReligionBadgeMarker().catch(() => {});
-  preloadRailSegment().catch(() => {});
-  preloadTerrainTiles().catch(() => {});
-  preloadNaturalWonderTiles().catch(() => {});
-
-  // Center camera on current player's starting position
-  turnFlow.centerOnCurrentPlayer();
-
-  renderLoop.setGameState(session.getState());
-  updateHUD();
-  turnFlow.maybeShowCouncilInterrupt();
-  maybeShowPendingHoardChoice();
-
-  // Auto-save immediately so closing before turn 1 doesn't lose the game
-  autoSave(session.getState()).catch(() => {});
-
-  // Input (only set up once)
-  if (!inputInitialized) {
-    canvas.addEventListener('pointerdown', () => { if (drawer?.isOpen()) drawer.close(); });
-
-    const callbacks: InputCallbacks = {
-      onHexTap: mapInteraction.handleHexTap,
-      onHexLongPress: mapInteraction.handleHexLongPress,
-    };
-    const touchHandler = new TouchHandler(canvas, renderLoop.camera, callbacks);
-    renderLoop.setTouchHandler(touchHandler);
-    new MouseHandler(canvas, renderLoop.camera, callbacks, {
-      canInteract: () => !host.isInteractionBlocked(),
-    });
-    installKeyboardShortcuts(document, {
-      onOpenCouncil: () => router.open('council'),
-      onOpenTech: () => router.open('tech'),
-      onEndTurn: () => { void turnFlow.endTurn(); },
-      getSelectedUnitId: () => selection.getSelectedUnitId(),
-      onCenterUnit: () => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (!selectedUnitId) return;
-        const unit = session.getState().units[selectedUnitId];
-        if (unit) renderLoop.camera.centerOn(unit.position);
-      },
-      onFortify: () => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (!selectedUnitId) return;
-        const unit = session.getState().units[selectedUnitId];
-        if (!unit || unit.hasActed || unit.owner !== session.getState().currentPlayer) return;
-        if (unit.isFortified) {
-          session.setStateWithoutRefresh(unfortifyUnitInState(session.getState(), session.getState().currentPlayer, selectedUnitId));
-          showNotification('Unit unfortified.', 'info');
-        } else {
-          session.setStateWithoutRefresh(fortifyUnitInState(session.getState(), session.getState().currentPlayer, selectedUnitId));
-          showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
-        }
-        renderLoop.setGameState(session.getState());
-        updateHUD();
-        selectionController.selectUnit(selectedUnitId);
-      },
-      onSettle: () => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (!selectedUnitId) return;
-        const unit = session.getState().units[selectedUnitId];
-        if (!unit || unit.type !== 'settler') return;
-        foundCityAction();
-      },
-      onNextUnit: () => selectionController.selectNextUnit(),
-      onStartJourney: () => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (!selectedUnitId) return;
-        selection.setPendingIntent({ kind: 'journey', unitId: selectedUnitId });
-        showNotification('Tap a destination for this unit. Press Escape to cancel.', 'info');
-      },
-    }, {
-      canHandle: () => !host.isInteractionBlocked(),
-    });
-    inputInitialized = true;
-  }
-
-  audio.start(
-    session.getState(),
-    bus,
-    () => session.getState(),
-    () => roundPresentationGate.isSuppressed(),
-  );
-  audio.setMasterVolume(userSettingsStore.getMasterVolume());
-  routeSfxThrough(audio.getSfxRoutingNode());
-  turnFlow.emitCurrentPlayerAudioSnapshot(session.getState().currentPlayer);
-
-  // Prevent zoom-out duplication: ensure the camera cannot zoom past one full
-  // map-width. hexToPixel({q: width, r:0}).x equals the wrapSpan used in
-  // wrap-rendering.ts, so minZoom = camera.width / wrapSpan guarantees the
-  // visible world is never wider than one map copy.
-  const mapWidthPx = hexToPixel({ q: session.getState().map.width, r: 0 }, renderLoop.camera.hexSize).x;
-  renderLoop.camera.setMinZoomForMap(mapWidthPx);
-
-  // Initial advisor check
-  advisorSystem.check(session.getState());
-  turnFlow.showRequiredChoicesIfNeeded();
-
-  // Start render loop
-  renderLoop.start();
-  return spritesReady;
-}
-
-init();
+// --- Bootstrap ---
+// registerAllPresentation/registerMinorCivNotificationListeners used to run
+// as bare module-scope statements here, immediately followed by a bare
+// init() call. bootstrap() (#787 phase 10) sequences the same three steps
+// explicitly instead of as an import side effect -- see src/app/bootstrap.ts
+// for why it does not yet also construct session/selection/host/ceremonies/
+// router/panelRegistry (Phase 10b).
+void bootstrap({
+  bus,
+  presentationContext,
+  getState: () => session.getState(),
+  appendToCivLog,
+  gameSession,
+});

--- a/tests/app/bootstrap.test.ts
+++ b/tests/app/bootstrap.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import * as registerAllModule from '@/presentation/register-all';
+import * as minorCivListenersModule from '@/ui/minor-civ-notification-listeners';
+import { bootstrap, type AppServices } from '@/app/bootstrap';
+
+vi.mock('@/presentation/register-all', async () => {
+  const actual = await vi.importActual<typeof registerAllModule>('@/presentation/register-all');
+  return { ...actual, registerAllPresentation: vi.fn() };
+});
+
+vi.mock('@/ui/minor-civ-notification-listeners', async () => {
+  const actual = await vi.importActual<typeof minorCivListenersModule>('@/ui/minor-civ-notification-listeners');
+  return { ...actual, registerMinorCivNotificationListeners: vi.fn() };
+});
+
+function makeServices(overrides: Partial<AppServices> = {}): AppServices {
+  return {
+    bus: new EventBus(),
+    presentationContext: {} as AppServices['presentationContext'],
+    getState: vi.fn(),
+    appendToCivLog: vi.fn(),
+    gameSession: { init: vi.fn().mockResolvedValue(undefined) },
+    ...overrides,
+  };
+}
+
+describe('bootstrap', () => {
+  it('registers presentation exactly once, then minor-civ listeners, then initializes the game session, in order', async () => {
+    const services = makeServices();
+    const order: string[] = [];
+    vi.mocked(registerAllModule.registerAllPresentation).mockImplementation(() => {
+      order.push('registerAllPresentation');
+      return () => {};
+    });
+    vi.mocked(minorCivListenersModule.registerMinorCivNotificationListeners).mockImplementation(() => { order.push('registerMinorCivNotificationListeners'); });
+    vi.mocked(services.gameSession.init).mockImplementation(async () => { order.push('gameSession.init'); });
+
+    await bootstrap(services);
+
+    expect(registerAllModule.registerAllPresentation).toHaveBeenCalledTimes(1);
+    expect(registerAllModule.registerAllPresentation).toHaveBeenCalledWith(services.bus, services.presentationContext);
+    expect(minorCivListenersModule.registerMinorCivNotificationListeners).toHaveBeenCalledTimes(1);
+    expect(minorCivListenersModule.registerMinorCivNotificationListeners).toHaveBeenCalledWith(
+      services.bus,
+      services.getState,
+      { appendToCivLog: services.appendToCivLog },
+    );
+    expect(order).toEqual(['registerAllPresentation', 'registerMinorCivNotificationListeners', 'gameSession.init']);
+  });
+
+  it('does not resolve until game session init resolves', async () => {
+    const services = makeServices();
+    let resolved = false;
+    let releaseInit!: () => void;
+    vi.mocked(services.gameSession.init).mockReturnValue(new Promise<void>(resolve => { releaseInit = resolve; }));
+
+    const bootstrapPromise = bootstrap(services).then(() => { resolved = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseInit();
+    await bootstrapPromise;
+    expect(resolved).toBe(true);
+  });
+});

--- a/tests/app/controllers/campaign-entry-controller.test.ts
+++ b/tests/app/controllers/campaign-entry-controller.test.ts
@@ -1,0 +1,338 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import type { GameState, HotSeatPlayer, SoloSetupConfig, HotSeatConfig } from '@/core/types';
+import { createGameSession } from '@/app/game-session';
+import { createPanelHost } from '@/app/panel-host';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import * as saveManager from '@/storage/save-manager';
+import * as savePanelModule from '@/ui/save-panel';
+import * as legacyPrompt from '@/ui/legacy-opponent-challenge-prompt';
+import * as gameModeSelectModule from '@/ui/game-mode-select';
+import * as campaignSetupModule from '@/ui/campaign-setup';
+import * as hotseatSetupModule from '@/ui/hotseat-setup';
+import {
+  createCampaignEntryController,
+  type CampaignEntryControllerDeps,
+} from '@/app/controllers/campaign-entry-controller';
+
+vi.mock('@/storage/save-manager', async () => {
+  const actual = await vi.importActual<typeof saveManager>('@/storage/save-manager');
+  return {
+    ...actual,
+    autoSave: vi.fn().mockResolvedValue(undefined),
+    loadMostRecentAutoSaveEntry: vi.fn(),
+    loadSaveEntry: vi.fn(),
+    rewriteLoadedSaveEntry: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@/ui/save-panel', async () => {
+  const actual = await vi.importActual<typeof savePanelModule>('@/ui/save-panel');
+  return { ...actual, createSavePanel: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('@/ui/game-mode-select', async () => {
+  const actual = await vi.importActual<typeof gameModeSelectModule>('@/ui/game-mode-select');
+  return { ...actual, showGameModeSelect: vi.fn(() => document.createElement('div')) };
+});
+
+vi.mock('@/ui/campaign-setup', async () => {
+  const actual = await vi.importActual<typeof campaignSetupModule>('@/ui/campaign-setup');
+  return { ...actual, showCampaignSetup: vi.fn() };
+});
+
+vi.mock('@/ui/hotseat-setup', async () => {
+  const actual = await vi.importActual<typeof hotseatSetupModule>('@/ui/hotseat-setup');
+  return { ...actual, showHotSeatSetup: vi.fn() };
+});
+
+vi.mock('@/ui/legacy-opponent-challenge-prompt', async () => {
+  const actual = await vi.importActual<typeof legacyPrompt>('@/ui/legacy-opponent-challenge-prompt');
+  return {
+    ...actual,
+    // Resolves beginCampaignEntry's pending promise immediately via cancel —
+    // these tests only assert the prompt was shown, not its continuation.
+    showLegacyOpponentChallengePrompt: vi.fn((_container, options: legacyPrompt.LegacyOpponentChallengePromptOptions) => {
+      options.onCancel();
+      return document.createElement('div');
+    }),
+  };
+});
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'campaign-entry-controller', 'small');
+  state.currentPlayer = 'player';
+  return state;
+}
+
+function makeHotSeatFixture(): GameState {
+  const state = makeFixture();
+  const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+  state.civilizations['player'].isHuman = true;
+  state.civilizations[aiCivId].isHuman = true;
+  const players: HotSeatPlayer[] = [
+    { name: 'Alice', slotId: 'player', civType: state.civilizations['player'].civType, isHuman: true },
+    { name: 'Bob', slotId: aiCivId, civType: state.civilizations[aiCivId].civType, isHuman: true },
+  ];
+  state.hotSeat = { playerCount: 2, mapSize: 'small', players };
+  return state;
+}
+
+function baseDeps(state: GameState, overrides: Partial<CampaignEntryControllerDeps> = {}): CampaignEntryControllerDeps {
+  const session = overrides.session ?? createGameSession(state);
+  const host = createPanelHost(document.createElement('div'));
+  return {
+    session,
+    uiLayer: document.createElement('div'),
+    audio: { setMasterVolume: vi.fn() },
+    bus: new EventBus(),
+    roundPresentationGate: new RoundPresentationGate(),
+    host,
+    turnFlow: { handleVictoryIfNeeded: vi.fn(), closeNetworkPanelsForHandoff: vi.fn() },
+    userSettingsStore: {
+      getPersisted: () => undefined,
+      refresh: vi.fn().mockResolvedValue({ customCivilizations: [] }),
+      getMasterVolume: () => 0.8,
+      setCustomCivilizations: vi.fn(),
+      getOverrides: () => ({}),
+    },
+    getElementById: id => document.getElementById(id),
+    showNotification: vi.fn(),
+    startGame: vi.fn().mockResolvedValue(undefined),
+    reloadPage: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+describe('CampaignEntryController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  describe('enterCampaign — solo', () => {
+    it('starts the game and shows the entry message', () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+
+      campaignEntry.enterCampaign(state, 'Welcome back! Turn 1');
+
+      expect(deps.startGame).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Welcome back! Turn 1', 'info');
+    });
+
+    it('starts the game and checks victory instead of toasting when the entered state is already over', () => {
+      const state = makeFixture();
+      state.gameOver = true;
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+
+      campaignEntry.enterCampaign(state, 'unused');
+
+      expect(deps.startGame).toHaveBeenCalledTimes(1);
+      expect(deps.turnFlow.handleVictoryIfNeeded).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('checks gameOver before the hot-seat branch, even for a hot-seat state', () => {
+      // A hot-seat state that is already over must take the solo-style
+      // gameOver exit, not the handoff path -- otherwise a finished hot-seat
+      // game would mute audio and show a "next player" handoff screen for a
+      // game that has already ended.
+      const state = makeHotSeatFixture();
+      state.gameOver = true;
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+
+      campaignEntry.enterCampaign(state, 'unused');
+
+      expect(deps.turnFlow.handleVictoryIfNeeded).toHaveBeenCalledTimes(1);
+      expect(deps.audio.setMasterVolume).not.toHaveBeenCalled();
+      expect(deps.roundPresentationGate.isSuppressed()).toBe(false);
+      expect(document.querySelector('#turn-handoff-title')).toBeNull();
+    });
+  });
+
+  describe('enterCampaign — hot-seat', () => {
+    it('suppresses presentation, mutes audio, autosaves, restores volume, and starts the game once the handoff resolves', async () => {
+      const state = makeHotSeatFixture();
+      const deps = baseDeps(state, {
+        userSettingsStore: {
+          getPersisted: () => undefined,
+          refresh: vi.fn().mockResolvedValue({ customCivilizations: [] }),
+          getMasterVolume: () => 0.6,
+          setCustomCivilizations: vi.fn(),
+          getOverrides: () => ({}),
+        },
+      });
+      const campaignEntry = createCampaignEntryController(deps);
+
+      campaignEntry.enterCampaign(state, 'Hot seat game started!');
+      expect(deps.roundPresentationGate.isSuppressed()).toBe(true);
+      expect(deps.audio.setMasterVolume).toHaveBeenCalledWith(0);
+
+      await flushMicrotasks();
+      document.querySelector<HTMLButtonElement>('#handoff-confirm')?.click();
+      await flushMicrotasks();
+      document.querySelector<HTMLButtonElement>('#handoff-start')?.click();
+      await flushMicrotasks();
+
+      expect(saveManager.autoSave).toHaveBeenCalled();
+      expect(deps.startGame).toHaveBeenCalledTimes(1);
+      expect(deps.audio.setMasterVolume).toHaveBeenCalledWith(0.6);
+      expect(deps.roundPresentationGate.isSuppressed()).toBe(false);
+      expect(deps.showNotification).toHaveBeenCalledWith('Hot seat game started!', 'info');
+    });
+  });
+
+  describe('enterCampaignForE2E', () => {
+    it('refuses a hot-seat state instead of silently entering it', () => {
+      const state = makeHotSeatFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+
+      expect(() => campaignEntry.enterCampaignForE2E(state)).toThrow(
+        'E2E direct entry does not bypass hot-seat handoff.',
+      );
+    });
+  });
+
+  describe('showStartSavePanel', () => {
+    it('routes onContinue through the legacy challenge prompt for a save with no opponentChallenge', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+      let capturedOptions: Parameters<typeof savePanelModule.createSavePanel>[1] | undefined;
+      vi.mocked(savePanelModule.createSavePanel).mockImplementation(async (_layer, options) => {
+        capturedOptions = options;
+      });
+      const loadedState = structuredClone(state);
+      delete (loadedState as Partial<GameState>).opponentChallenge;
+      vi.mocked(saveManager.loadMostRecentAutoSaveEntry).mockResolvedValue({
+        state: loadedState as never,
+        source: { id: 'auto', kind: 'autosave' },
+      });
+
+      await campaignEntry.showStartSavePanel();
+      expect(capturedOptions).toBeDefined();
+
+      const invoker = document.createElement('button');
+      const savePanel = document.createElement('div');
+      savePanel.id = 'save-panel';
+      savePanel.appendChild(invoker);
+      document.body.appendChild(savePanel);
+
+      await capturedOptions!.onContinue(invoker);
+
+      expect(legacyPrompt.showLegacyOpponentChallengePrompt).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(legacyPrompt.showLegacyOpponentChallengePrompt).mock.calls[0];
+      expect(call[1].hotSeat).toBe(false);
+    });
+
+    it('routes onLoadEntry and onImportSave through the same legacy challenge prompt', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+      let capturedOptions: Parameters<typeof savePanelModule.createSavePanel>[1] | undefined;
+      vi.mocked(savePanelModule.createSavePanel).mockImplementation(async (_layer, options) => {
+        capturedOptions = options;
+      });
+      const loadedState = structuredClone(state);
+      delete (loadedState as Partial<GameState>).opponentChallenge;
+      vi.mocked(saveManager.loadSaveEntry).mockResolvedValue({
+        state: loadedState as never,
+        source: { id: 'slot-1', kind: 'manual' },
+      });
+
+      await campaignEntry.showStartSavePanel();
+      const invoker = document.createElement('button');
+      document.body.appendChild(invoker);
+
+      await capturedOptions!.onLoadEntry({ id: 'slot-1', kind: 'manual' }, invoker);
+      expect(legacyPrompt.showLegacyOpponentChallengePrompt).toHaveBeenCalledTimes(1);
+
+      vi.mocked(legacyPrompt.showLegacyOpponentChallengePrompt).mockClear();
+      await capturedOptions!.onImportSave!(loadedState as GameState, invoker);
+      expect(legacyPrompt.showLegacyOpponentChallengePrompt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('showGameModeSelection', () => {
+    function captureModeSelectCallbacks(): gameModeSelectModule.GameModeSelectCallbacks {
+      let captured!: gameModeSelectModule.GameModeSelectCallbacks;
+      vi.mocked(gameModeSelectModule.showGameModeSelect).mockImplementation((_layer, callbacks) => {
+        captured = callbacks;
+        return document.createElement('div');
+      });
+      return new Proxy({} as gameModeSelectModule.GameModeSelectCallbacks, {
+        get: (_t, prop) => (captured as never)[prop],
+      });
+    }
+
+    it('the solo path constructs a new game via createNewGame and starts it', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+      const callbacks = captureModeSelectCallbacks();
+      let capturedSoloCallbacks: campaignSetupModule.CampaignSetupCallbacks | undefined;
+      vi.mocked(campaignSetupModule.showCampaignSetup).mockImplementation((_layer, cb) => {
+        capturedSoloCallbacks = cb;
+        return document.createElement('div');
+      });
+
+      campaignEntry.showGameModeSelection();
+      await callbacks.onChooseSolo('My Solo Campaign');
+      expect(capturedSoloCallbacks).toBeDefined();
+
+      const beforeState = deps.session.getState();
+      const soloConfig: SoloSetupConfig = {
+        civType: beforeState.civilizations['player'].civType,
+        mapSize: 'small',
+        opponentCount: 1,
+        gameTitle: 'My Solo Campaign',
+      };
+      capturedSoloCallbacks!.onStartSolo(soloConfig);
+
+      expect(deps.session.getState()).not.toBe(beforeState);
+      expect(deps.session.getState().gameTitle).toBe('My Solo Campaign');
+      expect(deps.startGame).toHaveBeenCalledTimes(1);
+    });
+
+    it('the hot-seat path constructs a new game via createHotSeatGame and persists before entering', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const campaignEntry = createCampaignEntryController(deps);
+      const callbacks = captureModeSelectCallbacks();
+      let capturedHotSeatCallbacks: hotseatSetupModule.HotSeatSetupCallbacks | undefined;
+      vi.mocked(hotseatSetupModule.showHotSeatSetup).mockImplementation((_layer, cb) => {
+        capturedHotSeatCallbacks = cb;
+      });
+
+      campaignEntry.showGameModeSelection();
+      await callbacks.onChooseHotSeat('My Hot Seat Campaign');
+      expect(capturedHotSeatCallbacks).toBeDefined();
+
+      const beforeState = deps.session.getState();
+      const players: HotSeatPlayer[] = [
+        { name: 'Alice', slotId: 'player', civType: beforeState.civilizations['player'].civType, isHuman: true },
+      ];
+      const hotSeatConfig: HotSeatConfig = { playerCount: 2, mapSize: 'small', players };
+
+      capturedHotSeatCallbacks!.onComplete(hotSeatConfig, 'standard');
+
+      // enterCampaign's hot-seat branch with persistBeforeReady=true autosaves
+      // before the handoff screen becomes interactive -- a bug here would
+      // silently drop a brand-new hot-seat game's first save.
+      expect(saveManager.autoSave).toHaveBeenCalled();
+      expect(deps.session.getState()).not.toBe(beforeState);
+      expect(deps.session.getState().hotSeat).toBeDefined();
+    });
+  });
+});

--- a/tests/app/controllers/game-session-controller.test.ts
+++ b/tests/app/controllers/game-session-controller.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import type { GameState } from '@/core/types';
+import { createGameSession } from '@/app/game-session';
+import { createSelectionStore } from '@/app/selection-store';
+import { createPanelHost } from '@/app/panel-host';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import * as saveManager from '@/storage/save-manager';
+import {
+  createGameSessionController,
+  type GameSessionControllerDeps,
+  type GameSessionRenderer,
+  type GameSessionAudio,
+} from '@/app/controllers/game-session-controller';
+
+vi.mock('@/storage/save-manager', async () => {
+  const actual = await vi.importActual<typeof saveManager>('@/storage/save-manager');
+  return { ...actual, autoSave: vi.fn().mockResolvedValue(undefined) };
+});
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'game-session-controller', 'small');
+  state.currentPlayer = 'player';
+  return state;
+}
+
+function fakeRenderer(overrides: Partial<GameSessionRenderer> = {}): GameSessionRenderer {
+  return {
+    setGameState: vi.fn(),
+    setTouchHandler: vi.fn(),
+    start: vi.fn(),
+    resizeCanvas: vi.fn(),
+    camera: {
+      centerOn: vi.fn(), setMinZoomForMap: vi.fn(), hexSize: 32,
+      screenToHex: vi.fn(() => ({ q: 0, r: 0 })),
+    } as unknown as GameSessionRenderer['camera'],
+    ...overrides,
+  };
+}
+
+function fakeAudio(overrides: Partial<GameSessionAudio> = {}): GameSessionAudio {
+  return {
+    start: vi.fn(),
+    setMasterVolume: vi.fn(),
+    getSfxRoutingNode: vi.fn(() => ({ context: {} }) as unknown as AudioNode),
+    setMusicVolume: vi.fn(),
+    setSfxVolume: vi.fn(),
+    setStingerVolume: vi.fn(),
+    setMusicEnabled: vi.fn(),
+    setSfxEnabled: vi.fn(),
+    setStingerEnabled: vi.fn(),
+    playReligionStinger: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function fakeHud() {
+  return {
+    update: vi.fn(),
+    setMapViewportBottomInset: vi.fn(),
+    placeAirDefenseButton: vi.fn(),
+    ensureDrawerMounted: vi.fn(),
+    closeDrawer: vi.fn(),
+    isDrawerOpen: vi.fn(() => false),
+  };
+}
+
+function baseDeps(state: GameState, overrides: Partial<GameSessionControllerDeps> = {}): GameSessionControllerDeps {
+  document.body.innerHTML = '<div id="ui-layer"></div>';
+  const uiLayer = document.getElementById('ui-layer') as unknown as HTMLDivElement;
+  const elements = new Map<string, HTMLElement>();
+  return {
+    session: createGameSession(state),
+    selection: createSelectionStore(),
+    renderLoop: fakeRenderer(),
+    audio: fakeAudio(),
+    bus: new EventBus(),
+    canvas: document.createElement('canvas'),
+    uiLayer,
+    documentRef: document,
+    host: createPanelHost(uiLayer),
+    router: { toggle: vi.fn(), open: vi.fn(), close: vi.fn(), closeGroup: vi.fn(), isOpen: vi.fn(() => false) },
+    roundPresentationGate: new RoundPresentationGate(),
+    advisorSystem: { check: vi.fn() },
+    userSettingsStore: { getMasterVolume: () => 0.8, setMasterVolume: vi.fn(), refresh: vi.fn().mockResolvedValue({}) },
+    turnFlow: {
+      centerOnCurrentPlayer: vi.fn(),
+      maybeShowCouncilInterrupt: vi.fn(),
+      endTurn: vi.fn().mockResolvedValue(undefined),
+      emitCurrentPlayerAudioSnapshot: vi.fn(),
+      showRequiredChoicesIfNeeded: vi.fn(() => false),
+    },
+    mapInteraction: { handleHexTap: vi.fn(), handleHexLongPress: vi.fn() },
+    selectionController: { selectNextUnit: vi.fn(), selectUnit: vi.fn() },
+    hud: fakeHud() as never,
+    campaignEntry: {
+      showStartSavePanel: vi.fn().mockResolvedValue(undefined),
+      showGameModeSelection: vi.fn(),
+      enterCampaignForE2E: vi.fn().mockResolvedValue(undefined),
+    },
+    getElementById: id => elements.get(id) ?? document.getElementById(id),
+    showNotification: vi.fn(),
+    foundCityAction: vi.fn(),
+    maybeShowPendingHoardChoice: vi.fn(),
+    setNotifier: vi.fn(),
+    focusNotificationTarget: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('GameSessionController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createUI', () => {
+    it('builds the game shell and places the anti-aircraft button', () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+
+      gameSession.createUI();
+
+      expect(document.getElementById('hud')).not.toBeNull();
+      expect(deps.hud.placeAirDefenseButton).toHaveBeenCalledTimes(1);
+    });
+
+    it('toggles the icon legend overlay open and closed', () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+      gameSession.createUI();
+
+      const toggleButton = document.getElementById('btn-icon-legend') as HTMLButtonElement | null;
+      expect(toggleButton).not.toBeNull();
+      toggleButton!.click();
+      expect(document.getElementById('icon-legend')).not.toBeNull();
+    });
+  });
+
+  describe('startGame', () => {
+    it('mounts the drawer, refreshes the map/HUD, autosaves, and starts the render loop', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+
+      // `startGame`'s returned promise is the (non-blocking, fire-and-forget)
+      // sprite preload -- it never resolves under jsdom's fake image loading,
+      // so every assertion below targets the synchronous work that completes
+      // before that promise is returned, matching how the real caller
+      // (CampaignEntryController) treats it as a background load, not
+      // something to await before continuing.
+      void gameSession.startGame();
+
+      expect(deps.hud.ensureDrawerMounted).toHaveBeenCalledTimes(1);
+      expect(deps.turnFlow.centerOnCurrentPlayer).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalledWith(state);
+      expect(deps.hud.update).toHaveBeenCalledTimes(1);
+      expect(deps.turnFlow.maybeShowCouncilInterrupt).toHaveBeenCalledTimes(1);
+      expect(deps.maybeShowPendingHoardChoice).toHaveBeenCalledTimes(1);
+      expect(saveManager.autoSave).toHaveBeenCalled();
+      expect(deps.audio.start).toHaveBeenCalledTimes(1);
+      expect(deps.advisorSystem.check).toHaveBeenCalledTimes(1);
+      expect(deps.turnFlow.showRequiredChoicesIfNeeded).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('wires input handlers only once across repeated calls', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+
+      void gameSession.startGame();
+      void gameSession.startGame();
+
+      expect(deps.renderLoop.setTouchHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a canvas tap through MapInteractionController.handleHexTap and a right-click through handleHexLongPress', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+      void gameSession.startGame();
+
+      deps.canvas.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 10, clientY: 10 }));
+      deps.canvas.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 10, clientY: 10 }));
+      expect(deps.mapInteraction.handleHexTap).toHaveBeenCalledTimes(1);
+
+      deps.canvas.dispatchEvent(new MouseEvent('contextmenu', { clientX: 10, clientY: 10 }));
+      expect(deps.mapInteraction.handleHexLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends the turn through the keyboard shortcut wiring', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+      void gameSession.startGame();
+
+      deps.documentRef.dispatchEvent(new KeyboardEvent('keydown', { key: 'e', bubbles: true }));
+
+      expect(deps.turnFlow.endTurn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('init', () => {
+    it('builds the notifier, publishes it, and shows the start/save panel outside e2e mode', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+
+      await gameSession.init();
+
+      expect(deps.setNotifier).toHaveBeenCalledTimes(1);
+      const publishedNotifier = vi.mocked(deps.setNotifier).mock.calls[0][0];
+      expect(typeof publishedNotifier.toast).toBe('function');
+      expect(deps.campaignEntry.showStartSavePanel).toHaveBeenCalledTimes(1);
+    });
+
+    it('wires a window resize listener that resizes the canvas', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state);
+      const gameSession = createGameSessionController(deps);
+
+      await gameSession.init();
+      window.dispatchEvent(new Event('resize'));
+
+      expect(deps.renderLoop.resizeCanvas).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/app/controllers/game-session-controller.test.ts
+++ b/tests/app/controllers/game-session-controller.test.ts
@@ -8,6 +8,7 @@ import { createSelectionStore } from '@/app/selection-store';
 import { createPanelHost } from '@/app/panel-host';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import * as saveManager from '@/storage/save-manager';
+import type { HudController } from '@/app/controllers/hud-controller';
 import {
   createGameSessionController,
   type GameSessionControllerDeps,
@@ -56,7 +57,7 @@ function fakeAudio(overrides: Partial<GameSessionAudio> = {}): GameSessionAudio 
   };
 }
 
-function fakeHud() {
+function fakeHud(): HudController {
   return {
     update: vi.fn(),
     setMapViewportBottomInset: vi.fn(),
@@ -94,7 +95,7 @@ function baseDeps(state: GameState, overrides: Partial<GameSessionControllerDeps
     },
     mapInteraction: { handleHexTap: vi.fn(), handleHexLongPress: vi.fn() },
     selectionController: { selectNextUnit: vi.fn(), selectUnit: vi.fn() },
-    hud: fakeHud() as never,
+    hud: fakeHud(),
     campaignEntry: {
       showStartSavePanel: vi.fn().mockResolvedValue(undefined),
       showGameModeSelection: vi.fn(),

--- a/tests/app/controllers/hud-controller.test.ts
+++ b/tests/app/controllers/hud-controller.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { createGameSession } from '@/app/game-session';
+import { createPanelHost } from '@/app/panel-host';
+import { createPanelRouter } from '@/app/panel-router';
+import type { PanelContext, PanelRegistry } from '@/app/panel-registry';
+import {
+  createHudController,
+  type HudController,
+  type HudControllerDeps,
+  type HudRenderer,
+} from '@/app/controllers/hud-controller';
+
+function makeFixture(): GameState {
+  const state = createNewGame(undefined, 'hud-controller', 'small');
+  state.currentPlayer = 'player';
+  return state;
+}
+
+function fakeRenderer(overrides: Partial<HudRenderer> = {}): HudRenderer {
+  return {
+    isAirDefenseOverlayEnabled: () => false,
+    toggleAirDefenseOverlay: vi.fn(() => true),
+    resizeCanvas: vi.fn(),
+    ...overrides,
+  };
+}
+
+function baseDeps(state: GameState, overrides: Partial<HudControllerDeps> = {}): HudControllerDeps {
+  document.body.innerHTML = '<div id="hud"></div><div id="game-shell"></div>';
+  return {
+    session: createGameSession(state),
+    renderLoop: fakeRenderer(),
+    canvas: document.createElement('canvas'),
+    router: { open: vi.fn() },
+    getElementById: id => document.getElementById(id),
+    getDrawerMountRoot: () => document.getElementById('game-shell') ?? document.body,
+    ...overrides,
+  };
+}
+
+describe('HudController', () => {
+  it('renders the gold total into the HUD and refreshes it after a state commit', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    const hud: HudController = createHudController(deps);
+
+    hud.update();
+    const hudEl = document.getElementById('hud')!;
+    expect(hudEl.textContent).toContain(String(state.civilizations['player'].gold));
+
+    deps.session.commit({
+      ...deps.session.getState(),
+      civilizations: {
+        ...deps.session.getState().civilizations,
+        player: { ...deps.session.getState().civilizations['player'], gold: 9999 },
+      },
+    });
+    hud.update();
+    expect(hudEl.textContent).toContain('9999');
+  });
+
+  it('starts hidden and stays hidden after update() when the civ has no air-defense coverage', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    document.body.innerHTML = '<div id="hud"></div><div id="utility-toolbar"><button id="btn-pause-menu"></button></div>';
+    const hud = createHudController(deps);
+    hud.placeAirDefenseButton();
+    const button = document.getElementById('btn-air-defense-overlay') as HTMLButtonElement;
+
+    // Starts hidden so it never flashes visible before the first update() call.
+    expect(button.hidden).toBe(true);
+
+    hud.update();
+    expect(button.hidden).toBe(true);
+  });
+
+  it('places the anti-aircraft button next to the pause menu button once the toolbar exists', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    document.body.innerHTML = '<div id="hud"></div><div id="utility-toolbar"><button id="btn-pause-menu"></button></div>';
+    const hud = createHudController(deps);
+
+    hud.placeAirDefenseButton();
+
+    const toolbar = document.getElementById('utility-toolbar')!;
+    const button = document.getElementById('btn-air-defense-overlay');
+    expect(button).not.toBeNull();
+    expect(toolbar.contains(button)).toBe(true);
+    expect(button?.nextElementSibling?.id).toBe('btn-pause-menu');
+    // Regression for #783: this button used to carry its own
+    // `position:absolute;right:12px;top:64px` and land directly on `uiLayer`,
+    // overlapping the utility toolbar's own icon buttons and the HUD's
+    // turn/era text at the same screen coordinates. It joins the toolbar's
+    // flex row instead, so it must not reintroduce a competing absolute anchor.
+    expect(button?.style.position).not.toBe('absolute');
+  });
+
+  it('mounts the treasury drawer once, idempotently, and closes it on demand', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    const hud = createHudController(deps);
+
+    expect(hud.isDrawerOpen()).toBe(false);
+    hud.ensureDrawerMounted();
+    const shell = document.getElementById('game-shell')!;
+    expect(shell.children.length).toBe(1);
+
+    hud.ensureDrawerMounted();
+    expect(shell.children.length).toBe(1); // idempotent — no second drawer
+
+    hud.closeDrawer();
+    expect(hud.isDrawerOpen()).toBe(false);
+  });
+
+  it('closes the treasury drawer when a main panel opens through the real PanelRouter', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    const hud = createHudController(deps);
+    hud.ensureDrawerMounted();
+
+    const host = createPanelHost(document.getElementById('game-shell') ?? document.body);
+    const context = {} as PanelContext;
+    const registry: Partial<PanelRegistry> = {
+      council: { domId: 'council-panel', group: 'main', open: () => {
+        const el = document.createElement('div');
+        el.id = 'council-panel';
+        host.layer.appendChild(el);
+      } },
+    };
+    const router = createPanelRouter({ host, registry, context, onBeforeOpen: () => hud.closeDrawer() });
+
+    // Force the drawer open the same way clicking the gold button would.
+    hud.update();
+    const goldBtn = document.getElementById('hud')!.querySelector('button')!;
+    goldBtn.click();
+    expect(hud.isDrawerOpen()).toBe(true);
+
+    router.open('council');
+    expect(hud.isDrawerOpen()).toBe(false);
+  });
+
+  it('sets the canvas bottom inset and triggers a resize', () => {
+    const state = makeFixture();
+    const deps = baseDeps(state);
+    const hud = createHudController(deps);
+
+    hud.setMapViewportBottomInset(64);
+
+    expect(deps.canvas.style.bottom).toBe('64px');
+    expect(deps.canvas.style.height).toBe('auto');
+    expect((deps.renderLoop.resizeCanvas as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -5,52 +5,25 @@ import { resolve } from 'node:path';
 const PROJECT_ROOT = resolve(__dirname, '..');
 
 describe('campaign entry wiring', () => {
-  it('routes Continue, exact save rows, and imports through the shared entry gate', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-
-    expect(main).toContain('async function showStartSavePanel()');
-    expect(main).toContain('loadMostRecentAutoSaveEntry()');
-    expect(main).toContain('loadSaveEntry(source)');
-    expect(main).toContain("{ kind: 'import', state }");
-    expect(main.match(/await beginCampaignEntry\(/g)).toHaveLength(3);
-    expect(main).not.toContain('loadAutoSave()');
-    expect(main).not.toContain('loadGame(slotId)');
-  });
-
-  it('restores terminal saves before entering a hot-seat handoff', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const entry = main.slice(
-      main.indexOf('function enterCampaign('),
-      main.indexOf('async function showStartSavePanel'),
-    );
-
-    expect(entry.indexOf('if (session.getState().gameOver)'))
-      .toBeLessThan(entry.indexOf('const hotSeat = session.getState().hotSeat;'));
-    expect(entry).toContain('handleVictoryIfNeeded()');
-  });
-
+  // #787 phase 10: showStartSavePanel, enterCampaign, and startGame all moved
+  // out of main.ts into CampaignEntryController/GameSessionController. Their
+  // real behavior (all three entry routes through the shared challenge-prompt
+  // gate, the gameOver-before-hotSeat ordering + handleVictoryIfNeeded, and
+  // startGame's showRequiredChoicesIfNeeded call) is now proven at runtime by
+  // campaign-entry-controller.test.ts and game-session-controller.test.ts.
+  // Only the e2e-mode gating (never behaviorally tested even before this
+  // phase -- it depends on Vite's build-time import.meta.env.MODE, not
+  // something worth stubbing for a structural regression guard) stays a
+  // source check, relocated to its new home.
   it('gates direct E2E autosave entry before the save-panel UI and exposes no mutable runtime globals', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const controller = readFileSync(resolve(PROJECT_ROOT, 'src/app/controllers/game-session-controller.ts'), 'utf8');
 
-    expect(main).toContain("if (import.meta.env.MODE === 'e2e')");
-    expect(main).toContain("await import('@/testing/e2e-runtime')");
-    expect(main.indexOf("import.meta.env.MODE === 'e2e'"))
-      .toBeLessThan(main.indexOf('await showStartSavePanel()'));
-    expect(main).not.toContain('window.gameState');
-    expect(main).not.toContain('window.renderLoop');
-  });
-
-  it('opens required research choices once startGame hands control to the viewer', () => {
-    // #787 phase 9: releaseHandoffToViewer (renamed enterViewerTurn) and
-    // endTurn's own post-round showRequiredChoicesIfNeeded call both moved
-    // into TurnFlowController -- their call-order guarantee is now proven at
-    // runtime by turn-flow-controller.test.ts's "required choices open after
-    // the viewer can act" describe block, not by slicing main.ts source text.
-    // Only startGame's own one-line delegation still lives in main.ts.
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const start = main.slice(main.indexOf('function startGame()'), main.indexOf('\ninit();'));
-
-    expect(start).toContain('turnFlow.showRequiredChoicesIfNeeded();');
+    expect(controller).toContain("if (import.meta.env.MODE === 'e2e')");
+    expect(controller).toContain("await import('@/testing/e2e-runtime')");
+    expect(controller.indexOf("import.meta.env.MODE === 'e2e'"))
+      .toBeLessThan(controller.indexOf('await deps.campaignEntry.showStartSavePanel()'));
+    expect(controller).not.toContain('window.gameState');
+    expect(controller).not.toContain('window.renderLoop');
   });
 });
 
@@ -141,9 +114,15 @@ describe('completed-round AI wiring', () => {
     // ai:strategic-warning's real consumer moved to registerGeneralPresentation,
     // composed into registerAllPresentation (#787 phase 7) --
     // register-general-presentation.test.ts and register-all.test.ts prove the
-    // registrar itself routes the event and is actually installed; this only
-    // proves main.ts installs the composed set.
-    expect(main).toContain('registerAllPresentation(bus, presentationContext)');
+    // registrar itself routes the event and is actually installed. #787 phase
+    // 10 moved the actual registerAllPresentation(...) call out of main.ts's
+    // module scope into bootstrap() (src/app/bootstrap.ts) -- bootstrap.test.ts
+    // proves it is called with these exact bus/presentationContext values;
+    // this only proves main.ts still hands them to bootstrap().
+    const bootstrapCall = main.slice(main.indexOf('void bootstrap({'), main.indexOf('});', main.indexOf('void bootstrap({')));
+    expect(bootstrapCall).toContain('bus,');
+    expect(bootstrapCall).toContain('presentationContext,');
+    expect(bootstrapCall).toContain('gameSession,');
   });
 });
 
@@ -235,29 +214,11 @@ describe('shared city assault wiring', () => {
   });
 });
 
-describe('air-defense overlay button placement (#783)', () => {
-  it('joins the utility toolbar flex row instead of an independent absolute position', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const createUI = main.slice(main.indexOf('function createUI(): void {'), main.indexOf('function openBestiary('));
-
-    // Regression for #783: this button used to carry its own
-    // `position:absolute;right:12px;top:64px` and land directly on `uiLayer`, which put it
-    // on top of the utility toolbar's own icon buttons and the HUD's turn/era text at the
-    // same screen coordinates. It must not reintroduce a competing absolute anchor.
-    expect(main).not.toMatch(/airDefenseOverlayButton\.style\.cssText[^;]*position:\s*absolute/);
-    expect(createUI).toContain("document.getElementById('utility-toolbar')");
-    expect(createUI).toMatch(/utilityToolbar\.(insertBefore|appendChild)\(airDefenseOverlayButton/);
-  });
-
-  it('only shows the button once the current civ has built AA coverage', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-
-    // Starts hidden so it never flashes visible before the first updateHUD() call.
-    expect(main).toContain('airDefenseOverlayButton.hidden = true;');
-    const updateHud = main.slice(main.indexOf('function updateHUD(): void {'), main.indexOf('\nfunction ', main.indexOf('function updateHUD(): void {') + 1));
-    expect(updateHud).toContain('airDefenseOverlayButton.hidden = !civHasAirDefenseCoverage(session.getState(), civ.id);');
-  });
-});
+// #783 air-defense overlay button placement: both grep assertions that used
+// to live here (no competing absolute position; hidden until the civ has
+// coverage) moved into hud-controller.test.ts as real DOM tests once
+// HudController owned this button (#787 phase 10) -- a real test on the
+// actual controller supersedes a source-text check on where it used to live.
 
 describe('map interaction controller wiring (#787 phase 8d)', () => {
   it('handleHexTap dispatches on resolveMapTapIntent through an exhaustive switch', () => {
@@ -293,12 +254,10 @@ describe('map interaction controller wiring (#787 phase 8d)', () => {
     }
   });
 
-  it('constructs MapInteractionController and routes touch/mouse input through it', () => {
+  it('constructs MapInteractionController', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
 
     expect(main).toContain('createMapInteractionController(');
-    expect(main).toContain('onHexTap: mapInteraction.handleHexTap,');
-    expect(main).toContain('onHexLongPress: mapInteraction.handleHexLongPress,');
 
     // These four used to be local `function` declarations in main.ts;
     // map-interaction-controller.test.ts now owns their behavioral coverage.
@@ -312,6 +271,12 @@ describe('map interaction controller wiring (#787 phase 8d)', () => {
       expect(main).not.toContain(declaration);
     }
   });
+
+  // #787 phase 10: the onHexTap/onHexLongPress -> mapInteraction wiring moved
+  // from main.ts's startGame() into GameSessionController.startGame(); the
+  // routing behavior itself is now proven at runtime by
+  // game-session-controller.test.ts's "routes a canvas tap through
+  // MapInteractionController.handleHexTap..." test instead of a source check.
 });
 
 describe('selection controller wiring (#787 phase 8c)', () => {


### PR DESCRIPTION
## Summary

Part of the #787 composition-root decomposition arc. Moves Phase 10's named scope out of `main.ts` (2814 → 2187 lines) into three new controllers plus `src/app/bootstrap.ts`:

- **`HudController`** — HUD readout, treasury drawer, anti-aircraft overlay button, map-viewport bottom inset.
- **`CampaignEntryController`** — start/save panel, mode selection, `enterCampaign`'s hot-seat-handoff-aware entry ritual.
- **`GameSessionController`** — `init`, `createUI`, `startGame`, the `inputInitialized` construct-once guard, the window resize listener.
- **`bootstrap()`** — sequences `registerAllPresentation` → `registerMinorCivNotificationListeners` → `gameSession.init()`, replacing the bare module-scope statements + `init()` call that used to run as an import side effect.

Also adds **Phase 10b** to the plan doc (separate docs-only commit, already pushed on this branch): a real gap found during Phase 10 planning where ~35 panel-opener/handler functions and the rest of the composition-root wiring (`host`/`ceremonies`/`router`/`panelRegistry`) were never assigned to any phase, meaning Phase 11's `<150 line` boundary test can't pass without it.

## Deviation from the plan doc (documented in `bootstrap.ts`'s docblock)

The plan's Phase 10 sketch shows `bootstrap()` as the full composition root (constructing `session`/`selection`/`host`/`ceremonies`/`router`/`panelRegistry` itself, reducing `main.ts` to ~15 lines). This PR's `bootstrap()` does not do that — `panelRegistry`'s ~15 entries reference the same ~35 unmoved functions Phase 10b now covers, and moving `router`/`panelRegistry` construction before those functions have a real home would mean threading them all through unchanged, which is churn without payoff. `main.ts` still constructs all of that today, same as before this phase; `bootstrap()` only owns the three genuinely-new-this-phase controllers' construction plus the presentation-registration sequencing.

## `tests/main.integration.test.ts` is not deleted

The plan's Step 6 assumed it would end up empty. It doesn't — ~7 describe blocks (player combat wiring, shared city-founding/unit-upgrade/city-assault wiring, selection/map-interaction controller wiring) still guard functions Phase 13 hasn't moved yet (that phase's own text was already flagged stale in the handoff for a different reason — this is a second, independent instance of the same "plan drifted from actual code" class). Only the two describe blocks Phase 10's move actually broke were converted: `campaign entry wiring`'s 4 sub-tests and `air-defense overlay button placement`'s 2 sub-tests — plus 2 more the plan didn't predict (`completed-round AI wiring`'s registrar-install check, `map interaction controller wiring`'s touch/mouse routing check) that only surfaced by actually running the suite. 8 real failures total, not the plan's estimated 5.

## Verification

- Exhaustive line-diff + call-count parity audit (`SFX.*`, `bus.emit`, `session.commit`/`setStateWithoutRefresh`, `showNotification`, `renderLoop.setGameState`, `router.open/close/toggle`, `host.setBlockingOverlay`, `createTreasuryDrawer`) against the pre-move source — every delta traced to a legitimate new wrapper closure or comment, zero unexplained drift.
- 50 newly-dead imports removed from `main.ts`; the pre-existing 13-import baseline (unrelated to this phase) is untouched.
- `yarn build` and `yarn test` (475 files / 7664 tests) both green.
- `yarn test:web-smoke` (8/8), including `issue-437-hud-alignment.spec.ts`, which exercises the exact Continue → challenge-prompt → `enterCampaign` → `startGame` → HUD-render pipeline this phase touches, end-to-end in a real browser.
- Manual browser pass: save panel, campaign setup screen, and HUD toolbar all render correctly post-refactor.

## Review pass

Found one real gap before closing: `showGameModeSelection`'s solo and hot-seat paths — including `enterCampaign`'s `persistBeforeReady` autosave-before-first-turn branch — had zero test coverage (the original code was only ever guarded by source-grep assertions). Added real tests for both paths.

## Test plan

- [x] `yarn build` / `yarn test` green
- [x] `yarn test:web-smoke` green (8/8)
- [x] Manual browser verification (save panel, campaign setup, HUD)
- [x] Exhaustive diff + call-count parity vs. pre-move source
- [x] Dead-import cleanup, baseline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)