### PR TITLE
refactor(app): extract DiplomacyActionsController (#787 phase 10b-a)

### DIFF
--- a/src/app/controllers/diplomacy-actions-controller.ts
+++ b/src/app/controllers/diplomacy-actions-controller.ts
@@ -1,0 +1,268 @@
+/**
+ * Owns the diplomacy, minor-civ, and crisis-interaction handlers that mutate
+ * state on behalf of the player's diplomacy panel and city/city-overview
+ * panels (#787 phase 10b-a): `handleDiplomaticAction`,
+ * `handleAcceptPeaceRequest`, `handleRejectPeaceRequest`,
+ * `handleAcceptTreatyProposal`, `handleDeclineTreatyProposal`,
+ * `handleBreakTreaty`, `handleGiftGold`, `handleSponsorFestival`,
+ * `handleMinorCivReparations`, `handleSendAid`, `handleMinorCivWarPeace`,
+ * `handleAppeaseFaction`, `handleConcedeToMovement`, `handleEstablishRoute`.
+ *
+ * Most of these end by calling `openDiplomacyPanel()` to refresh the open
+ * panel with post-mutation state -- that function belongs to
+ * `PanelActionsController` (phase 10b-b/c/d), so it arrives here as an
+ * injected dep rather than a direct import, avoiding a forward reference
+ * regardless of which sub-phase lands first. `handleAppeaseFaction` and
+ * `handleConcedeToMovement` are the exception: they return `GameState` and
+ * let their caller (the city panel or city-overview panel) decide whether
+ * and how to re-render -- preserve that return-value contract verbatim,
+ * `createCityPanel`'s `onAppeaseFaction`/`onConcedeToMovement` callbacks
+ * depend on it.
+ *
+ * Everything this file calls that is a pure `@/systems/*` or `@/ui/*` helper
+ * is imported directly, matching the precedent set by every prior controller
+ * in this arc. Only concrete platform services, sibling controllers, and the
+ * main.ts-local `openDiplomacyPanel` function are threaded through as deps.
+ */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { EventBus } from '@/core/event-bus';
+import type { GameSession } from '@/app/ports';
+import type { HudController } from '@/app/controllers/hud-controller';
+import type { SelectionController } from '@/app/controllers/selection-controller';
+import type { DiplomaticAction, GameState, TreatyType } from '@/core/types';
+import {
+  acceptDiplomaticRequest,
+  applyDiplomaticAction,
+  breakTreaty,
+  rejectDiplomaticRequest,
+} from '@/systems/diplomacy-system';
+import { TREATY_LABELS } from '@/ui/notification-routing';
+import { appeaseFaction, concedeToMovement } from '@/systems/faction-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
+import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
+import {
+  performMinorCivFestival,
+  performMinorCivGift,
+  performMinorCivReparations,
+  setMinorCivWarState,
+} from '@/systems/minor-civ-actions';
+import { applyOpportunisticWarPenaltyIfCrisisStruck, applySendAid, canSendAid } from '@/systems/crisis-interaction-system';
+import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
+
+export interface DiplomacyActionsController {
+  handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): void;
+  handleAcceptPeaceRequest(requestId: string): void;
+  handleRejectPeaceRequest(requestId: string): void;
+  handleAcceptTreatyProposal(requestId: string): void;
+  handleDeclineTreatyProposal(requestId: string): void;
+  handleBreakTreaty(civId: string, treatyType: TreatyType): void;
+  handleGiftGold(mcId: string): void;
+  handleSponsorFestival(mcId: string): void;
+  handleMinorCivReparations(mcId: string): void;
+  handleSendAid(crisisId: string): void;
+  handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void;
+  handleAppeaseFaction(cityId: string): GameState;
+  handleConcedeToMovement(cityId: string): GameState;
+  handleEstablishRoute(caravanId: string): void;
+}
+
+export interface DiplomacyActionsControllerDeps {
+  readonly session: GameSession;
+  readonly bus: EventBus;
+  readonly renderLoop: Pick<RenderLoop, 'setGameState'>;
+  readonly hud: Pick<HudController, 'update'>;
+  readonly selectionController: Pick<SelectionController, 'selectUnit'>;
+  readonly uiLayer: HTMLDivElement;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  /** `PanelActionsController`'s function (phase 10b-b/c/d) -- injected to avoid a forward reference. */
+  readonly openDiplomacyPanel: () => void;
+}
+
+export function createDiplomacyActionsController(deps: DiplomacyActionsControllerDeps): DiplomacyActionsController {
+  function handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): void {
+    const cp = deps.session.getState().currentPlayer;
+    deps.session.setStateWithoutRefresh(applyDiplomaticAction(deps.session.getState(), cp, targetCivId, action, deps.bus));
+    if (action === 'declare_war') {
+      deps.session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(deps.session.getState(), cp, targetCivId, deps.bus));
+    }
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+    if (action === 'request_peace') {
+      deps.showNotification('Peace requested.', 'info');
+    } else {
+      deps.showNotification(`Diplomatic action: ${action.replace(/_/g, ' ')}`, 'info');
+    }
+  }
+
+  function handleAcceptPeaceRequest(requestId: string): void {
+    deps.session.commit(acceptDiplomaticRequest(deps.session.getState(), deps.session.getState().currentPlayer, requestId, deps.bus));
+    deps.openDiplomacyPanel();
+    deps.showNotification('Peace accepted.', 'success');
+  }
+
+  function handleRejectPeaceRequest(requestId: string): void {
+    deps.session.commit(rejectDiplomaticRequest(deps.session.getState(), deps.session.getState().currentPlayer, requestId));
+    deps.openDiplomacyPanel();
+    deps.showNotification('Peace request rejected.', 'info');
+  }
+
+  function handleAcceptTreatyProposal(requestId: string): void {
+    deps.session.commit(acceptDiplomaticRequest(deps.session.getState(), deps.session.getState().currentPlayer, requestId, deps.bus));
+    deps.openDiplomacyPanel();
+    deps.showNotification('Treaty signed.', 'success');
+  }
+
+  function handleDeclineTreatyProposal(requestId: string): void {
+    deps.session.commit(rejectDiplomaticRequest(deps.session.getState(), deps.session.getState().currentPlayer, requestId));
+    deps.openDiplomacyPanel();
+    deps.showNotification('Proposal declined.', 'info');
+  }
+
+  function handleBreakTreaty(civId: string, treatyType: TreatyType): void {
+    const actorId = deps.session.getState().currentPlayer;
+    const actor = deps.session.getState().civilizations[actorId];
+    const target = deps.session.getState().civilizations[civId];
+    if (!actor || !target) return;
+    deps.session.commit({
+      ...deps.session.getState(),
+      civilizations: {
+        ...deps.session.getState().civilizations,
+        [actorId]: { ...actor, diplomacy: breakTreaty(actor.diplomacy, civId, treatyType, deps.session.getState().turn) },
+        [civId]: { ...target, diplomacy: breakTreaty(target.diplomacy, actorId, treatyType, deps.session.getState().turn) },
+      },
+    });
+    deps.openDiplomacyPanel();
+    deps.showNotification(`${TREATY_LABELS[treatyType]} broken with ${target.name}.`, 'warning');
+  }
+
+  function handleGiftGold(mcId: string): void {
+    const result = performMinorCivGift(deps.session.getState(), deps.session.getState().currentPlayer, mcId);
+    if (!result.ok) {
+      deps.showNotification(result.reason ?? 'Gift unavailable.', 'warning');
+      return;
+    }
+    deps.session.setStateWithoutRefresh(result.state);
+    emitMinorCivQuestTransitions(deps.bus, result.transitions, deps.session.getState());
+    deps.showNotification('Gift delivered.', 'info');
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+  }
+
+  function handleSponsorFestival(mcId: string): void {
+    const result = performMinorCivFestival(deps.session.getState(), deps.session.getState().currentPlayer, mcId);
+    if (!result.ok) {
+      deps.showNotification(result.reason ?? 'Festival unavailable.', 'warning');
+      return;
+    }
+    deps.session.setStateWithoutRefresh(result.state);
+    emitMinorCivQuestTransitions(deps.bus, result.transitions, deps.session.getState());
+    deps.showNotification('Festival sponsored.', 'success');
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+  }
+
+  function handleMinorCivReparations(mcId: string): void {
+    const result = performMinorCivReparations(deps.session.getState(), deps.session.getState().currentPlayer, mcId);
+    if (!result.ok) {
+      deps.showNotification(result.reason ?? 'Reparations unavailable.', 'warning');
+      return;
+    }
+    deps.session.setStateWithoutRefresh(result.state);
+    deps.showNotification('Reparations paid.', 'success');
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+  }
+
+  function handleSendAid(crisisId: string): void {
+    const check = canSendAid(deps.session.getState(), deps.session.getState().currentPlayer, crisisId);
+    if (!check.ok) {
+      deps.showNotification('Send Aid unavailable.', 'warning');
+      return;
+    }
+    deps.session.setStateWithoutRefresh(applySendAid(deps.session.getState(), deps.session.getState().currentPlayer, crisisId, deps.bus));
+    deps.showNotification('Aid sent.', 'success');
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+  }
+
+  function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
+    const result = setMinorCivWarState(deps.session.getState(), deps.session.getState().currentPlayer, mcId, !currentlyAtWar);
+    if (!result.ok) return;
+    deps.session.setStateWithoutRefresh(result.state);
+    emitMinorCivQuestTransitions(deps.bus, result.transitions, deps.session.getState());
+    deps.showNotification(currentlyAtWar ? 'Peace with city-state' : 'War declared on city-state!', currentlyAtWar ? 'success' : 'warning');
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.openDiplomacyPanel();
+  }
+
+  function handleAppeaseFaction(cityId: string): GameState {
+    const targetCity = deps.session.getState().cities[cityId];
+    if (!targetCity) return deps.session.getState();
+    const result = appeaseFaction(deps.session.getState(), cityId, deps.session.getState().currentPlayer);
+    if (!result.success) {
+      deps.showNotification(result.message, 'warning');
+      return deps.session.getState();
+    }
+    deps.session.commit(result.state);
+    deps.showNotification(result.message, 'success');
+    return deps.session.getState();
+  }
+
+  function handleConcedeToMovement(cityId: string): GameState {
+    const targetCity = deps.session.getState().cities[cityId];
+    if (!targetCity) return deps.session.getState();
+    const result = concedeToMovement(deps.session.getState(), cityId, deps.session.getState().currentPlayer);
+    if (!result.success) {
+      deps.showNotification(result.message, 'warning');
+      return deps.session.getState();
+    }
+    deps.session.setStateWithoutRefresh(result.state);
+    deps.bus.emit('faction:unrest-resolved', { cityId, owner: deps.session.getState().currentPlayer });
+    deps.bus.emit('faction:concession-made', { cityId, owner: deps.session.getState().currentPlayer, concessionType: 'charter' });
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+    deps.showNotification(result.message, 'success');
+    return deps.session.getState();
+  }
+
+  // Trade Routes Overhaul (#553 MR4/4) — extracted so the City panel's Trade Routes
+  // section and selected-unit-info's Establish Route button trigger the exact same code
+  // path (per ui-panels.md's Extracted UI Flows rule), not two copies that could drift.
+  function handleEstablishRoute(caravanId: string): void {
+    openEstablishRoutePanel(deps.uiLayer, deps.session.getState(), caravanId, (toCityId) => {
+      const resourceDiversity = getCivAvailableResources(deps.session.getState(), deps.session.getState().currentPlayer).size;
+      const routeResult = establishQuestAwareRoute(deps.session.getState(), caravanId, toCityId, resourceDiversity);
+      deps.session.setStateWithoutRefresh(routeResult.state);
+      emitMinorCivQuestTransitions(deps.bus, routeResult.questTransitions, deps.session.getState());
+      deps.bus.emit('trade:route-created', { route: routeResult.route });
+      deps.renderLoop.setGameState(deps.session.getState());
+      deps.hud.update();
+      deps.selectionController.selectUnit(caravanId);
+      deps.showNotification('Trade route established!', 'success');
+    });
+  }
+
+  return {
+    handleDiplomaticAction,
+    handleAcceptPeaceRequest,
+    handleRejectPeaceRequest,
+    handleAcceptTreatyProposal,
+    handleDeclineTreatyProposal,
+    handleBreakTreaty,
+    handleGiftGold,
+    handleSponsorFestival,
+    handleMinorCivReparations,
+    handleSendAid,
+    handleMinorCivWarPeace,
+    handleAppeaseFaction,
+    handleConcedeToMovement,
+    handleEstablishRoute,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { resolveCivDefinition } from '@/systems/civ-registry';
-import { acceptDiplomaticRequest, applyDiplomaticAction, breakTreaty, declareWar, makePeace, modifyRelationship, rejectDiplomaticRequest, resolveOpponentKind } from '@/systems/diplomacy-system';
+import { declareWar, makePeace, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
 import { assignNetworkPlan, cancelNetworkPlan, holdNetworkPlan, isAutonomyActivated, retargetNetworkPlan } from '@/systems/network-plan-system';
 import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
@@ -73,18 +73,18 @@ import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
 import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
-import type { CombatResult, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType, TreatyType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, Unit, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
 import { appendNotification, getNotificationsForPlayer, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
-import { TREATY_LABELS, type NotificationSink } from '@/ui/notification-routing';
+import type { NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { rushBuyActiveProduction } from '@/systems/economy-system';
-import { appeaseFaction, concedeToMovement } from '@/systems/faction-system';
 import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
-import { getCivAvailableResources, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
+import { canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
+import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
 import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
 import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
 import { createHudController, type HudController } from '@/app/controllers/hud-controller';
@@ -93,11 +93,8 @@ import { createGameSessionController, type GameSessionController } from '@/app/c
 import { bootstrap } from '@/app/bootstrap';
 import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
-import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
-import { performMinorCivFestival, performMinorCivGift, performMinorCivReparations, setMinorCivWarState } from '@/systems/minor-civ-actions';
-import { canSendAid, applySendAid, applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
-import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
+import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import { createCityOverviewPanel } from '@/ui/city-overview-panel';
 import type { GameSession } from '@/app/ports';
@@ -235,6 +232,26 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
  * until real gameplay, well after module evaluation finishes. The same
  * deferred-but-eager pattern `notifier` and `router` already use.
  */
+/**
+ * Owns the diplomacy, minor-civ, and crisis-interaction handlers (#787 phase
+ * 10b-a). `hud` and `selectionController` are wrapped in thin lazily-evaluating
+ * objects, not passed directly -- both are `const`s not assigned until later
+ * in module evaluation (`selectionController` right below this, `hud` further
+ * down), so a direct reference here would capture `undefined` at construction
+ * time. Same deferred-but-eager closure pattern `selectionController` itself
+ * already uses for `updateHUD: () => hud.update()` below.
+ */
+const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsController({
+  session,
+  bus,
+  renderLoop,
+  uiLayer,
+  showNotification,
+  openDiplomacyPanel,
+  hud: { update: () => hud.update() },
+  selectionController: { selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts) },
+});
+
 const selectionController: SelectionController = createSelectionController({
   session,
   selection,
@@ -255,7 +272,7 @@ const selectionController: SelectionController = createSelectionController({
   openNetworkIntentPanel,
   openUnitStackPicker,
   openPirateHeadquartersAssault,
-  handleEstablishRoute,
+  handleEstablishRoute: diplomacyActions.handleEstablishRoute,
   executeUpgrade,
   ensurePlayerWarState,
   scanBeastSightings,
@@ -764,63 +781,6 @@ function openNotificationLog(): void {
   }, 100);
 }
 
-function handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): void {
-  const cp = session.getState().currentPlayer;
-  session.setStateWithoutRefresh(applyDiplomaticAction(session.getState(), cp, targetCivId, action, bus));
-  if (action === 'declare_war') {
-    session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(session.getState(), cp, targetCivId, bus));
-  }
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-  if (action === 'request_peace') {
-    showNotification('Peace requested.', 'info');
-  } else {
-    showNotification(`Diplomatic action: ${action.replace(/_/g, ' ')}`, 'info');
-  }
-}
-
-function handleAcceptPeaceRequest(requestId: string): void {
-  session.commit(acceptDiplomaticRequest(session.getState(), session.getState().currentPlayer, requestId, bus));
-  openDiplomacyPanel();
-  showNotification('Peace accepted.', 'success');
-}
-
-function handleRejectPeaceRequest(requestId: string): void {
-  session.commit(rejectDiplomaticRequest(session.getState(), session.getState().currentPlayer, requestId));
-  openDiplomacyPanel();
-  showNotification('Peace request rejected.', 'info');
-}
-
-function handleAcceptTreatyProposal(requestId: string): void {
-  session.commit(acceptDiplomaticRequest(session.getState(), session.getState().currentPlayer, requestId, bus));
-  openDiplomacyPanel();
-  showNotification('Treaty signed.', 'success');
-}
-
-function handleDeclineTreatyProposal(requestId: string): void {
-  session.commit(rejectDiplomaticRequest(session.getState(), session.getState().currentPlayer, requestId));
-  openDiplomacyPanel();
-  showNotification('Proposal declined.', 'info');
-}
-
-function handleBreakTreaty(civId: string, treatyType: TreatyType): void {
-  const actorId = session.getState().currentPlayer;
-  const actor = session.getState().civilizations[actorId];
-  const target = session.getState().civilizations[civId];
-  if (!actor || !target) return;
-  session.commit({
-    ...session.getState(),
-    civilizations: {
-      ...session.getState().civilizations,
-      [actorId]: { ...actor, diplomacy: breakTreaty(actor.diplomacy, civId, treatyType, session.getState().turn) },
-      [civId]: { ...target, diplomacy: breakTreaty(target.diplomacy, actorId, treatyType, session.getState().turn) },
-    },
-  });
-  openDiplomacyPanel();
-  showNotification(`${TREATY_LABELS[treatyType]} broken with ${target.name}.`, 'warning');
-}
-
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = session.getState().cities[cityId]?.name ?? 'City-State';
   const movement = selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(session.getState(), unitId, target, {
@@ -842,86 +802,21 @@ function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: s
   hud.update();
 }
 
-function handleGiftGold(mcId: string): void {
-  const result = performMinorCivGift(session.getState(), session.getState().currentPlayer, mcId);
-  if (!result.ok) {
-    showNotification(result.reason ?? 'Gift unavailable.', 'warning');
-    return;
-  }
-  session.setStateWithoutRefresh(result.state);
-  emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
-  showNotification('Gift delivered.', 'info');
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-}
-
-function handleSponsorFestival(mcId: string): void {
-  const result = performMinorCivFestival(session.getState(), session.getState().currentPlayer, mcId);
-  if (!result.ok) {
-    showNotification(result.reason ?? 'Festival unavailable.', 'warning');
-    return;
-  }
-  session.setStateWithoutRefresh(result.state);
-  emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
-  showNotification('Festival sponsored.', 'success');
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-}
-
-function handleMinorCivReparations(mcId: string): void {
-  const result = performMinorCivReparations(session.getState(), session.getState().currentPlayer, mcId);
-  if (!result.ok) {
-    showNotification(result.reason ?? 'Reparations unavailable.', 'warning');
-    return;
-  }
-  session.setStateWithoutRefresh(result.state);
-  showNotification('Reparations paid.', 'success');
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-}
-
-function handleSendAid(crisisId: string): void {
-  const check = canSendAid(session.getState(), session.getState().currentPlayer, crisisId);
-  if (!check.ok) {
-    showNotification('Send Aid unavailable.', 'warning');
-    return;
-  }
-  session.setStateWithoutRefresh(applySendAid(session.getState(), session.getState().currentPlayer, crisisId, bus));
-  showNotification('Aid sent.', 'success');
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-}
-
-function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
-  const result = setMinorCivWarState(session.getState(), session.getState().currentPlayer, mcId, !currentlyAtWar);
-  if (!result.ok) return;
-  session.setStateWithoutRefresh(result.state);
-  emitMinorCivQuestTransitions(bus, result.transitions, session.getState());
-  showNotification(currentlyAtWar ? 'Peace with city-state' : 'War declared on city-state!', currentlyAtWar ? 'success' : 'warning');
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  openDiplomacyPanel();
-}
-
 function openDiplomacyPanel(): void {
   hud.closeDrawer();
   document.getElementById('diplomacy-panel')?.remove();
   createDiplomacyPanel(uiLayer, session.getState(), {
-    onAction: handleDiplomaticAction,
-    onAcceptPeaceRequest: handleAcceptPeaceRequest,
-    onRejectPeaceRequest: handleRejectPeaceRequest,
-    onAcceptTreatyProposal: handleAcceptTreatyProposal,
-    onDeclineTreatyProposal: handleDeclineTreatyProposal,
-    onBreakTreaty: handleBreakTreaty,
-    onGiftGold: handleGiftGold,
-    onSponsorFestival: handleSponsorFestival,
-    onMinorCivReparations: handleMinorCivReparations,
-    onMinorCivWarPeace: handleMinorCivWarPeace,
-    onSendAid: handleSendAid,
+    onAction: diplomacyActions.handleDiplomaticAction,
+    onAcceptPeaceRequest: diplomacyActions.handleAcceptPeaceRequest,
+    onRejectPeaceRequest: diplomacyActions.handleRejectPeaceRequest,
+    onAcceptTreatyProposal: diplomacyActions.handleAcceptTreatyProposal,
+    onDeclineTreatyProposal: diplomacyActions.handleDeclineTreatyProposal,
+    onBreakTreaty: diplomacyActions.handleBreakTreaty,
+    onGiftGold: diplomacyActions.handleGiftGold,
+    onSponsorFestival: diplomacyActions.handleSponsorFestival,
+    onMinorCivReparations: diplomacyActions.handleMinorCivReparations,
+    onMinorCivWarPeace: diplomacyActions.handleMinorCivWarPeace,
+    onSendAid: diplomacyActions.handleSendAid,
     onClose: () => {},
   });
 }
@@ -998,47 +893,17 @@ function openCityOverviewPanel(): void {
       if (city) openCityPanelForCity(city);
     },
     onAppeaseFaction: (cityId) => {
-      handleAppeaseFaction(cityId);
+      diplomacyActions.handleAppeaseFaction(cityId);
       openCityOverviewPanel(); // re-render with updated unrest/gold state
     },
     onConcedeToMovement: (cityId) => {
-      handleConcedeToMovement(cityId);
+      diplomacyActions.handleConcedeToMovement(cityId);
       openCityOverviewPanel(); // re-render with updated unrest/gold state
     },
     onClose: () => {
       document.getElementById('city-overview-panel')?.remove();
     },
   });
-}
-
-function handleAppeaseFaction(cityId: string): GameState {
-  const targetCity = session.getState().cities[cityId];
-  if (!targetCity) return session.getState();
-  const result = appeaseFaction(session.getState(), cityId, session.getState().currentPlayer);
-  if (!result.success) {
-    showNotification(result.message, 'warning');
-    return session.getState();
-  }
-  session.commit(result.state);
-  showNotification(result.message, 'success');
-  return session.getState();
-}
-
-function handleConcedeToMovement(cityId: string): GameState {
-  const targetCity = session.getState().cities[cityId];
-  if (!targetCity) return session.getState();
-  const result = concedeToMovement(session.getState(), cityId, session.getState().currentPlayer);
-  if (!result.success) {
-    showNotification(result.message, 'warning');
-    return session.getState();
-  }
-  session.setStateWithoutRefresh(result.state);
-  bus.emit('faction:unrest-resolved', { cityId, owner: session.getState().currentPlayer });
-  bus.emit('faction:concession-made', { cityId, owner: session.getState().currentPlayer, concessionType: 'charter' });
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  showNotification(result.message, 'success');
-  return session.getState();
 }
 
 function openCityPanelForCity(city: import('@/core/types').City): void {
@@ -1095,7 +960,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
     onClose: () => {},
     onTip: (message) => { showNotification(message, 'info'); },
     onSelectUnit: (unitId) => selectionController.selectUnit(unitId),
-    onEstablishRoute: handleEstablishRoute,
+    onEstablishRoute: diplomacyActions.handleEstablishRoute,
     onPrevCity: () => {
       const cities = currentCiv().cities;
       if (cities.length <= 1) return;
@@ -1141,8 +1006,8 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       showNotification(`${targetCity.name}: rush bought ${result.label} for ${result.cost} gold.`, 'success');
       return session.getState();
     },
-    onAppeaseFaction: (cityId) => handleAppeaseFaction(cityId),
-    onConcedeToMovement: (cityId) => handleConcedeToMovement(cityId),
+    onAppeaseFaction: (cityId) => diplomacyActions.handleAppeaseFaction(cityId),
+    onConcedeToMovement: (cityId) => diplomacyActions.handleConcedeToMovement(cityId),
     onQuarantineCrisis: (crisisId, cityId) => {
       const result = applyQuarantine(session.getState(), crisisId, cityId);
       if (!result.success) {
@@ -1632,23 +1497,6 @@ function openNetworkPanel(): void {
     uiLayer.appendChild(panel);
   };
   rerender();
-}
-
-// Trade Routes Overhaul (#553 MR4/4) — extracted so the City panel's Trade Routes
-// section and selected-unit-info's Establish Route button trigger the exact same code
-// path (per ui-panels.md's Extracted UI Flows rule), not two copies that could drift.
-function handleEstablishRoute(caravanId: string): void {
-  openEstablishRoutePanel(uiLayer, session.getState(), caravanId, (toCityId) => {
-    const resourceDiversity = getCivAvailableResources(session.getState(), session.getState().currentPlayer).size;
-    const routeResult = establishQuestAwareRoute(session.getState(), caravanId, toCityId, resourceDiversity);
-    session.setStateWithoutRefresh(routeResult.state);
-    emitMinorCivQuestTransitions(bus, routeResult.questTransitions, session.getState());
-    bus.emit('trade:route-created', { route: routeResult.route });
-    renderLoop.setGameState(session.getState());
-    hud.update();
-    selectionController.selectUnit(caravanId);
-    showNotification('Trade route established!', 'success');
-  });
 }
 
 function getUnitTurnFlow() {

--- a/tests/app/controllers/diplomacy-actions-controller.test.ts
+++ b/tests/app/controllers/diplomacy-actions-controller.test.ts
@@ -1,0 +1,468 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { createGameSession } from '@/app/game-session';
+import {
+  enqueuePeaceRequest,
+  enqueueTreatyProposal,
+  signTreaty,
+} from '@/systems/diplomacy-system';
+import { createUnit } from '@/systems/unit-system';
+import type { City, GameState, HexCoord } from '@/core/types';
+import {
+  createDiplomacyActionsController,
+  type DiplomacyActionsController,
+  type DiplomacyActionsControllerDeps,
+} from '@/app/controllers/diplomacy-actions-controller';
+
+// createNewGame only seeds a settler for major civs (minor civs start with an
+// already-founded city) -- tests exercising a real player/AI-owned city must
+// found one by hand. Field set matches faction-system.test.ts's makeCity.
+function placeCity(state: GameState, id: string, owner: string, position: HexCoord, overrides: Partial<City> = {}): City {
+  const city: City = {
+    id, name: id, owner, position,
+    population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+  state.cities[id] = city;
+  if (!state.civilizations[owner].cities.includes(id)) state.civilizations[owner].cities.push(id);
+  return city;
+}
+
+vi.mock('@/ui/establish-route-panel', () => ({
+  openEstablishRoutePanel: vi.fn(),
+}));
+import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
+
+function makeFixture(seed = 'diplomacy-actions-controller'): { state: GameState; aiCivId: string; mcId: string } {
+  const state = createNewGame(undefined, seed, 'small');
+  state.currentPlayer = 'player';
+  state.pendingDiplomacyRequests = [];
+  const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+  const mcId = Object.keys(state.minorCivs)[0];
+  return { state, aiCivId, mcId };
+}
+
+function makeDeps(state: GameState, overrides: Partial<DiplomacyActionsControllerDeps> = {}) {
+  return {
+    session: createGameSession(state),
+    bus: new EventBus(),
+    renderLoop: { setGameState: vi.fn() },
+    hud: { update: vi.fn() },
+    selectionController: { selectUnit: vi.fn() },
+    uiLayer: document.createElement('div'),
+    showNotification: vi.fn(),
+    openDiplomacyPanel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function build(state: GameState, overrides: Partial<DiplomacyActionsControllerDeps> = {}) {
+  const deps = makeDeps(state, overrides);
+  const controller = createDiplomacyActionsController(deps);
+  return { deps, controller };
+}
+
+describe('DiplomacyActionsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleDiplomaticAction', () => {
+    it('request_peace enqueues a request, refreshes, and shows the peace-specific message', () => {
+      const { state, aiCivId } = makeFixture('diplomatic-action-peace');
+      const { deps, controller } = build(state);
+
+      controller.handleDiplomaticAction(aiCivId, 'request_peace');
+
+      expect(deps.session.getState().pendingDiplomacyRequests).toContainEqual(
+        expect.objectContaining({ fromCivId: 'player', toCivId: aiCivId, type: 'peace' }),
+      );
+      expect(deps.renderLoop.setGameState).toHaveBeenCalledWith(deps.session.getState());
+      expect(deps.hud.update).toHaveBeenCalledTimes(1);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Peace requested.', 'info');
+    });
+
+    it('declare_war applies the opportunistic-war-penalty check and shows the generic action message', () => {
+      const { state, aiCivId } = makeFixture('diplomatic-action-war');
+      // #435 guard: declare_war requires the two civs to have already met.
+      state.civilizations.player.knownCivilizations = [aiCivId];
+      const { deps, controller } = build(state);
+
+      controller.handleDiplomaticAction(aiCivId, 'declare_war');
+
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toContain(aiCivId);
+      expect(deps.showNotification).toHaveBeenCalledWith('Diplomatic action: declare war', 'info');
+    });
+  });
+
+  describe('handleAcceptPeaceRequest / handleRejectPeaceRequest', () => {
+    function warFixture(seed: string) {
+      const { state, aiCivId } = makeFixture(seed);
+      state.civilizations.player.diplomacy.atWarWith = [aiCivId];
+      state.civilizations[aiCivId].diplomacy.atWarWith = ['player'];
+      const withRequest = enqueuePeaceRequest(state, aiCivId, 'player');
+      const requestId = withRequest.pendingDiplomacyRequests![0].id;
+      return { state: withRequest, aiCivId, requestId };
+    }
+
+    it('accepting clears the request, ends the war, refreshes the panel, and confirms', () => {
+      const { state, aiCivId, requestId } = warFixture('accept-peace');
+      const { deps, controller } = build(state);
+
+      controller.handleAcceptPeaceRequest(requestId);
+
+      expect(deps.session.getState().pendingDiplomacyRequests).toEqual([]);
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).not.toContain(aiCivId);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Peace accepted.', 'success');
+    });
+
+    it('rejecting clears the request but keeps the war active', () => {
+      const { state, aiCivId, requestId } = warFixture('reject-peace');
+      const { deps, controller } = build(state);
+
+      controller.handleRejectPeaceRequest(requestId);
+
+      expect(deps.session.getState().pendingDiplomacyRequests).toEqual([]);
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toContain(aiCivId);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Peace request rejected.', 'info');
+    });
+  });
+
+  describe('handleAcceptTreatyProposal / handleDeclineTreatyProposal', () => {
+    function proposalFixture(seed: string) {
+      const { state, aiCivId } = makeFixture(seed);
+      const withProposal = enqueueTreatyProposal(state, aiCivId, 'player', 'trade_agreement', 10);
+      const requestId = withProposal.pendingDiplomacyRequests![0].id;
+      return { state: withProposal, aiCivId, requestId };
+    }
+
+    it('accepting signs the treaty on both sides and confirms', () => {
+      const { state, aiCivId, requestId } = proposalFixture('accept-treaty');
+      const { deps, controller } = build(state);
+
+      controller.handleAcceptTreatyProposal(requestId);
+
+      const next = deps.session.getState();
+      expect(next.pendingDiplomacyRequests).toEqual([]);
+      expect(next.civilizations.player.diplomacy.treaties.some(t => t.type === 'trade_agreement' && t.civB === aiCivId)).toBe(true);
+      expect(next.civilizations[aiCivId].diplomacy.treaties.some(t => t.type === 'trade_agreement' && t.civB === 'player')).toBe(true);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Treaty signed.', 'success');
+    });
+
+    it('declining clears the proposal without signing a treaty', () => {
+      const { state, aiCivId, requestId } = proposalFixture('decline-treaty');
+      const { deps, controller } = build(state);
+
+      controller.handleDeclineTreatyProposal(requestId);
+
+      const next = deps.session.getState();
+      expect(next.pendingDiplomacyRequests).toEqual([]);
+      expect(next.civilizations.player.diplomacy.treaties.some(t => t.civB === aiCivId)).toBe(false);
+      expect(deps.showNotification).toHaveBeenCalledWith('Proposal declined.', 'info');
+    });
+  });
+
+  describe('handleBreakTreaty', () => {
+    it('breaks the treaty on both sides and names it in the notification', () => {
+      const { state, aiCivId } = makeFixture('break-treaty');
+      state.civilizations.player.diplomacy = signTreaty(state.civilizations.player.diplomacy, 'player', aiCivId, 'trade_agreement', 10, state.turn);
+      state.civilizations[aiCivId].diplomacy = signTreaty(state.civilizations[aiCivId].diplomacy, aiCivId, 'player', 'trade_agreement', 10, state.turn);
+      const { deps, controller } = build(state);
+
+      controller.handleBreakTreaty(aiCivId, 'trade_agreement');
+
+      const next = deps.session.getState();
+      expect(next.civilizations.player.diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(false);
+      expect(next.civilizations[aiCivId].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(false);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('broken with'), 'warning');
+    });
+
+    it('is a no-op for an unknown civ id -- no commit, no notification', () => {
+      const { state } = makeFixture('break-treaty-unknown');
+      const { deps, controller } = build(state);
+
+      controller.handleBreakTreaty('no-such-civ', 'trade_agreement');
+
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleGiftGold', () => {
+    it('deducts gold, completes the quest transition, refreshes, and confirms', () => {
+      const { state, mcId } = makeFixture('gift-gold');
+      state.civilizations.player.gold = 200;
+      const { deps, controller } = build(state);
+
+      controller.handleGiftGold(mcId);
+
+      expect(deps.session.getState().civilizations.player.gold).toBeLessThan(200);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Gift delivered.', 'info');
+    });
+
+    it('shows a warning and does not refresh when gold is insufficient', () => {
+      const { state, mcId } = makeFixture('gift-gold-poor');
+      state.civilizations.player.gold = 0;
+      const { deps, controller } = build(state);
+
+      controller.handleGiftGold(mcId);
+
+      expect(deps.session.getState().civilizations.player.gold).toBe(0);
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('gold'), 'warning');
+    });
+  });
+
+  describe('handleSponsorFestival', () => {
+    it('deducts gold, completes the quest transition, refreshes, and confirms', () => {
+      const { state, mcId } = makeFixture('sponsor-festival-ok');
+      state.civilizations.player.techState.completed.push('pottery');
+      state.marketplace!.purchasedResources = [{ civId: 'player', resource: 'wine', expiresOnTurn: state.turn + 5 }];
+      state.civilizations.player.gold = 99999;
+      state.minorCivs[mcId].activeQuests.player = {
+        id: 'quest-festival', type: 'sponsor_festival', description: 'Sponsor a festival',
+        target: { type: 'sponsor_festival', amount: 50, requiresLuxury: true }, reward: { relationshipBonus: 20 },
+        progress: 0, status: 'active', turnIssued: state.turn, expiresOnTurn: state.turn + 20,
+      };
+      const { deps, controller } = build(state);
+
+      controller.handleSponsorFestival(mcId);
+
+      expect(deps.session.getState().civilizations.player.gold).toBeLessThan(99999);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Festival sponsored.', 'success');
+    });
+
+    it('shows a warning and does not refresh when the festival is unavailable', () => {
+      const { state, mcId } = makeFixture('sponsor-festival-fail');
+      const { deps, controller } = build(state);
+
+      controller.handleSponsorFestival(mcId);
+
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+  });
+
+  describe('handleMinorCivReparations', () => {
+    it('pays reparations, reduces grievance pressure, refreshes, and confirms', () => {
+      const { state, mcId } = makeFixture('reparations-ok');
+      state.civilizations.player.gold = 99999;
+      state.minorCivs[mcId].regionalGrievanceByCiv = {
+        player: { targetCivId: 'player', pressure: 40, status: 'wary', lastUpdatedTurn: state.turn, causes: [] },
+      };
+      const { deps, controller } = build(state);
+
+      controller.handleMinorCivReparations(mcId);
+
+      expect(deps.session.getState().minorCivs[mcId].regionalGrievanceByCiv!.player.pressure).toBeLessThan(40);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Reparations paid.', 'success');
+    });
+
+    it('shows a warning and does not refresh with no active grievance', () => {
+      const { state, mcId } = makeFixture('reparations-fail');
+      const { deps, controller } = build(state);
+
+      controller.handleMinorCivReparations(mcId);
+
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith('No active regional grievance.', 'warning');
+    });
+  });
+
+  describe('handleSendAid', () => {
+    function crisisFixture(seed: string, overrides: { actorGold?: number; actorTechs?: string[] } = {}) {
+      const { state, aiCivId } = makeFixture(seed);
+      const targetCityId = 'crisis-city';
+      placeCity(state, targetCityId, aiCivId, { q: 3, r: 3 });
+      state.civilizations.player.gold = overrides.actorGold ?? 99999;
+      state.civilizations.player.techState.completed = overrides.actorTechs ?? ['medicine'];
+      state.activeCrises = {
+        'crisis-1': {
+          id: 'crisis-1',
+          flavorId: 'outbreak-flavor',
+          archetype: 'outbreak',
+          targetCivId: aiCivId,
+          cityIds: [targetCityId],
+          tileKeys: [],
+          startedTurn: state.turn,
+          stage: 'active',
+          turnsInStage: 1,
+        },
+      };
+      return { state, crisisId: 'crisis-1' };
+    }
+
+    it('pays gold, sends aid, refreshes, and confirms', () => {
+      const { state, crisisId } = crisisFixture('send-aid-ok');
+      const goldBefore = state.civilizations.player.gold;
+      const { deps, controller } = build(state);
+
+      controller.handleSendAid(crisisId);
+
+      expect(deps.session.getState().civilizations.player.gold).toBeLessThan(goldBefore);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('Aid sent.', 'success');
+    });
+
+    it('shows a generic warning and does not refresh when the actor lacks the required tech', () => {
+      const { state, crisisId } = crisisFixture('send-aid-no-tech', { actorTechs: [] });
+      const { deps, controller } = build(state);
+
+      controller.handleSendAid(crisisId);
+
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith('Send Aid unavailable.', 'warning');
+    });
+  });
+
+  describe('handleMinorCivWarPeace', () => {
+    it('declares war on a city-state when not currently at war', () => {
+      const { state, mcId } = makeFixture('mc-war');
+      const { deps, controller } = build(state);
+
+      controller.handleMinorCivWarPeace(mcId, false);
+
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toContain(mcId);
+      expect(deps.openDiplomacyPanel).toHaveBeenCalledTimes(1);
+      expect(deps.showNotification).toHaveBeenCalledWith('War declared on city-state!', 'warning');
+    });
+
+    it('makes peace with a city-state when currently at war', () => {
+      const { state, mcId } = makeFixture('mc-peace');
+      state.civilizations.player.diplomacy.atWarWith = [mcId];
+      const { deps, controller } = build(state);
+
+      controller.handleMinorCivWarPeace(mcId, true);
+
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).not.toContain(mcId);
+      expect(deps.showNotification).toHaveBeenCalledWith('Peace with city-state', 'success');
+    });
+
+    it('is a no-op for an unknown minor civ -- no refresh, no notification', () => {
+      const { state } = makeFixture('mc-war-unknown');
+      const { deps, controller } = build(state);
+
+      controller.handleMinorCivWarPeace('no-such-mc', false);
+
+      expect(deps.openDiplomacyPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleAppeaseFaction', () => {
+    it('spends gold, clears unrest, and returns the updated state', () => {
+      const { state } = makeFixture('appease-ok');
+      const cityId = 'player-city';
+      placeCity(state, cityId, 'player', { q: 1, r: 1 }, { unrestLevel: 1 });
+      state.civilizations.player.gold = 99999;
+      const { deps, controller } = build(state);
+
+      const result = controller.handleAppeaseFaction(cityId);
+
+      expect(result).toBe(deps.session.getState());
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('appeased'), 'success');
+    });
+
+    it('returns state unchanged and warns for a city with no unrest', () => {
+      const { state } = makeFixture('appease-none');
+      const cityId = 'player-city';
+      placeCity(state, cityId, 'player', { q: 1, r: 1 });
+      const { deps, controller } = build(state);
+      const before = deps.session.getState();
+
+      const result = controller.handleAppeaseFaction(cityId);
+
+      expect(result).toBe(before);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('no unrest'), 'warning');
+    });
+
+    it('returns state unchanged for an unknown city id, without notifying', () => {
+      const { state } = makeFixture('appease-unknown');
+      const { deps, controller } = build(state);
+      const before = deps.session.getState();
+
+      const result = controller.handleAppeaseFaction('no-such-city');
+
+      expect(result).toBe(before);
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleConcedeToMovement', () => {
+    it('spends gold, grants a charter, emits faction events, refreshes, and returns the updated state', () => {
+      const { state } = makeFixture('concede-ok');
+      const cityId = 'player-city';
+      placeCity(state, cityId, 'player', { q: 1, r: 1 }, { unrestLevel: 1 });
+      state.civilizations.player.gold = 99999;
+      const bus = new EventBus();
+      const emitSpy = vi.spyOn(bus, 'emit');
+      const { deps, controller } = build(state, { bus });
+
+      const result = controller.handleConcedeToMovement(cityId);
+
+      expect(result).toBe(deps.session.getState());
+      expect(emitSpy).toHaveBeenCalledWith('faction:unrest-resolved', { cityId, owner: 'player' });
+      expect(emitSpy).toHaveBeenCalledWith('faction:concession-made', { cityId, owner: 'player', concessionType: 'charter' });
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('charter'), 'success');
+    });
+
+    it('returns state unchanged for an unknown city id, without notifying', () => {
+      const { state } = makeFixture('concede-unknown');
+      const { deps, controller } = build(state);
+      const before = deps.session.getState();
+
+      const result = controller.handleConcedeToMovement('no-such-city');
+
+      expect(result).toBe(before);
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleEstablishRoute', () => {
+    it('opens the establish-route panel and wires establishment through to a real trade route', () => {
+      const { state } = makeFixture('establish-route');
+      const caravanId = 'caravan-1';
+      const toCityId = Object.keys(state.cities)[0]; // an existing, already-reachable minor-civ city
+      const playerStartPosition = Object.values(state.units).find(u => u.owner === 'player')!.position;
+      const fromCityId = 'player-city';
+      placeCity(state, fromCityId, 'player', playerStartPosition);
+      const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+      state.units[caravanId] = { ...createUnit('caravan', 'player', playerStartPosition, idCounters), id: caravanId };
+
+      const { deps, controller } = build(state);
+
+      controller.handleEstablishRoute(caravanId);
+
+      expect(openEstablishRoutePanel).toHaveBeenCalledTimes(1);
+      const onEstablish = (openEstablishRoutePanel as ReturnType<typeof vi.fn>).mock.calls[0][3] as (toCityId: string) => void;
+
+      onEstablish(toCityId);
+
+      expect(deps.session.getState().marketplace?.tradeRoutes.some(route => route.toCityId === toCityId)).toBe(true);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.selectionController.selectUnit).toHaveBeenCalledWith(caravanId);
+      expect(deps.showNotification).toHaveBeenCalledWith('Trade route established!', 'success');
+    });
+  });
+});

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -204,7 +204,9 @@ describe('shared city assault wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const minorCaptureFlow = main.slice(
       main.indexOf('function executeMinorCivConquest('),
-      main.indexOf('function handleGiftGold('),
+      // #787 phase 10b-a: handleGiftGold moved into DiplomacyActionsController;
+      // openDiplomacyPanel is what now immediately follows executeMinorCivConquest.
+      main.indexOf('function openDiplomacyPanel('),
     );
 
     expect(minorCaptureFlow).toContain(


### PR DESCRIPTION
## Summary
- Extracts the 14 diplomacy/minor-civ/crisis-interaction handlers (`handleDiplomaticAction`, `handleAcceptPeaceRequest`, `handleRejectPeaceRequest`, `handleAcceptTreatyProposal`, `handleDeclineTreatyProposal`, `handleBreakTreaty`, `handleGiftGold`, `handleSponsorFestival`, `handleMinorCivReparations`, `handleSendAid`, `handleMinorCivWarPeace`, `handleAppeaseFaction`, `handleConcedeToMovement`, `handleEstablishRoute`) from `main.ts` into a new `DiplomacyActionsController` — Phase 10b-a of the #787 composition-root decomposition arc (sub-phase split documented in PR #807).
- `main.ts`: 2188 → 2036 lines.
- `openDiplomacyPanel` (owned by the not-yet-extracted `PanelActionsController`, phase 10b-b/c/d) is threaded in as an injected dep so neither sub-phase blocks on landing order.
- `handleAppeaseFaction`/`handleConcedeToMovement` keep their `GameState` return-value contract verbatim — `createCityPanel`'s `onAppeaseFaction`/`onConcedeToMovement` callbacks depend on it.
- Verified via the arc's established exhaustive-diff + call-count-parity technique against the pre-move source; the only mismatches were expected (one new lazy-wrapper closure line each for `hud`/`selectionController`, plus a docblock comment that happened to match the same grep string).
- Fixed one `tests/main.integration.test.ts` slice-boundary assertion that used `handleGiftGold` as an end marker (now `openDiplomacyPanel`, which is what actually follows `executeMinorCivConquest` post-move).
- Dead-import hygiene: confirmed the pre-existing 13-name baseline is unchanged; removed the newly-orphaned imports (`acceptDiplomaticRequest`, `applyDiplomaticAction`, `breakTreaty`, `rejectDiplomaticRequest`, `DiplomaticAction`, `TreatyType`, `TREATY_LABELS`, `appeaseFaction`, `concedeToMovement`, `getCivAvailableResources`, `establishQuestAwareRoute`, `performMinorCivFestival`, `performMinorCivGift`, `performMinorCivReparations`, `setMinorCivWarState`, `canSendAid`, `applySendAid`, `openEstablishRoutePanel`). Zero dead imports in the new controller/test files.

## Test plan
- [x] `yarn build` — clean, zero type errors
- [x] `yarn test` — full suite, 477 files / 7710 passed, 3 skipped (pre-existing)
- [x] `yarn test:web-smoke` — 8/8 Playwright smoke tests pass
- [x] New `tests/app/controllers/diplomacy-actions-controller.test.ts` — 25 tests covering every handler's happy path plus negative/failure branches where one exists
- [x] Inline review pass (testing/architecture/SRP/SOLID/TypeScript/hot-seat dimensions) — found and fixed one missing happy-path test (`handleSponsorFestival`) and two unnecessary `as unknown as` casts in the test fixtures (replaced with a real `EventBus` + `vi.spyOn` and the real `createUnit` factory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)