### PR TITLE
refactor(app): extract PanelActionsController part 1 -- utility panels (#787 phase 10b-b)

### DIFF
--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -1,0 +1,313 @@
+/**
+ * Owns the utility and world-event panel openers (#787 phase 10b-b, part 1 of 3
+ * for `PanelActionsController` -- see 10b-c/10b-d for the remaining panels):
+ * `openPacingDebugPanel`, `openBestiary`, `openWonderAtlas`, `openPirateWaters`,
+ * `openPirateHeadquartersAssault`, `openNotificationLog`.
+ *
+ * `openWonderAtlas` and `openNotificationLog` both open `openCityPanelForCity`
+ * (a not-yet-extracted panel opener, phase 10b-c/d); `openNotificationLog` also
+ * opens `openWonderPanelForCityId` (same). Both arrive as injected deps to
+ * avoid a forward reference regardless of which sub-phase lands first, same
+ * pattern as 10b-a's `openDiplomacyPanel` dep.
+ *
+ * `showNotification`, `focusNotificationTarget`, `focusPirateTarget`, and
+ * `applyPirateActionResult` are cross-cutting helpers (phase 10b-f's domain)
+ * still living in `main.ts` -- threaded through as deps until that phase
+ * gives them a real home.
+ *
+ * Everything this file calls that is a pure `@/systems/*`, `@/input/*`, or
+ * `@/ui/*` helper is imported directly, matching the precedent set by every
+ * prior controller in this arc. Only concrete platform services, sibling
+ * controllers/stores, and the main.ts-local functions this phase does NOT
+ * move are threaded through as deps.
+ */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { AudioSystem } from '@/audio/audio-system';
+import type { EventBus } from '@/core/event-bus';
+import type { GameSession, SelectionStore } from '@/app/ports';
+import type { HudController } from '@/app/controllers/hud-controller';
+import type { SelectionController } from '@/app/controllers/selection-controller';
+import type { City } from '@/core/types';
+import type { NotificationEntry } from '@/core/notification-log';
+import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
+import { getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
+import { createBestiaryPanel } from '@/ui/bestiary-panel';
+import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
+import { createPirateWatersPanel } from '@/ui/pirate-waters-panel';
+import { getPirateWatersPresentation, type PirateFocusTarget } from '@/systems/pirate-presentation';
+import { hirePirateFlotilla, payPirateTribute, type PirateActionResult } from '@/systems/pirate-actions';
+import { confirmPirateHeadquartersAssault, preparePirateHeadquartersAssault } from '@/input/pirate-headquarters-assault';
+import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
+import { createNotificationLogPanel } from '@/ui/notification-log-panel';
+import { getNotificationsForPlayer } from '@/core/notification-log';
+import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderEligibility } from '@/systems/legendary-wonder-system';
+import { SFX } from '@/audio/sfx';
+
+export interface PanelActionsController {
+  openPacingDebugPanel(): void;
+  openBestiary(): void;
+  openWonderAtlas(initialWonderId?: string): void;
+  openPirateWaters(focus?: { factionId?: string; historyId?: string }): void;
+  openPirateHeadquartersAssault(factionId: string, unitId: string): void;
+  openNotificationLog(): void;
+}
+
+/** The narrow slice of `RenderLoop` this controller needs. */
+export type PanelActionsRenderer = Pick<
+  RenderLoop,
+  'setSelectedPirateFactionId' | 'applyPirateHeadquartersAssaultVisual' | 'setGameState'
+> & { readonly camera: Pick<RenderLoop['camera'], 'centerOn'> };
+
+/** The narrow slice of `AudioSystem` this controller needs. */
+export type PanelActionsAudio = Pick<
+  AudioSystem,
+  'stopNaturalWonderAmbient' | 'startNaturalWonderCodexAmbient' | 'playNaturalWonderReplay'
+  | 'stopPirateAmbience' | 'startPirateHeadquartersAmbience'
+>;
+
+export interface PanelActionsControllerDeps {
+  readonly session: GameSession;
+  readonly bus: EventBus;
+  readonly uiLayer: HTMLDivElement;
+  readonly getElementById: (id: string) => HTMLElement | null;
+  readonly selection: Pick<SelectionStore, 'setPirateSelection' | 'getPirateSelection' | 'getSelectedUnitId'>;
+  readonly selectionController: Pick<SelectionController, 'selectUnit' | 'deselectUnit'>;
+  readonly hud: Pick<HudController, 'closeDrawer' | 'update'>;
+  readonly audio: PanelActionsAudio;
+  readonly renderLoop: PanelActionsRenderer;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  readonly focusNotificationTarget: (target: NotificationEntry['target']) => void;
+  readonly focusPirateTarget: (target: PirateFocusTarget) => void;
+  readonly applyPirateActionResult: (result: PirateActionResult, successMessage: string) => void;
+  /** `PanelActionsController`'s own function (phase 10b-c/d) -- injected to avoid a forward reference. */
+  readonly openCityPanelForCity: (city: City) => void;
+  /** `PanelActionsController`'s own function (phase 10b-c/d) -- injected to avoid a forward reference. */
+  readonly openWonderPanelForCityId: (selectedCityId: string) => void;
+}
+
+export function createPanelActionsController(deps: PanelActionsControllerDeps): PanelActionsController {
+  /**
+   * `createPacingDebugPanel` self-removes any prior instance from `uiLayer`,
+   * so the router's own DOM-derived `isOpen`/`close` need no extra bookkeeping
+   * here (#787 phase 5).
+   */
+  function openPacingDebugPanel(): void {
+    if (deps.session.getState()) createPacingDebugPanel(deps.uiLayer, deps.session.getState());
+  }
+
+  function openBestiary(): void {
+    createBestiaryPanel(deps.uiLayer, getBestiaryEntriesForPlayer(deps.session.getState(), deps.session.getState().currentPlayer), {
+      onClose: () => {},
+      slayerNameFor: (civId) => deps.session.getState().civilizations[civId]?.name ?? civId,
+    });
+  }
+
+  function openWonderAtlas(initialWonderId?: string): void {
+    deps.hud.closeDrawer();
+    deps.audio.stopNaturalWonderAmbient('codex-page-hidden');
+    createWonderAtlasPanel(deps.uiLayer, deps.session.getState(), {
+      initialWonderId,
+      onViewOnMap: coord => {
+        deps.renderLoop.camera.centerOn(coord);
+      },
+      onOpenCity: cityId => {
+        const city = deps.session.getState().cities[cityId];
+        if (city) deps.openCityPanelForCity(city);
+      },
+      onNaturalWonderPageShown: wonderId => {
+        void deps.audio.startNaturalWonderCodexAmbient(wonderId);
+      },
+      onNaturalWonderPageHidden: () => {
+        deps.audio.stopNaturalWonderAmbient('codex-page-hidden');
+      },
+      onNaturalWonderReplay: wonderId => {
+        void deps.audio.playNaturalWonderReplay(wonderId);
+      },
+      onClose: () => {},
+    });
+  }
+
+  function openPirateWaters(focus?: { factionId?: string; historyId?: string }): void {
+    if (focus?.factionId) {
+      deps.selection.setPirateSelection(focus.factionId, null);
+    } else if (focus?.historyId) {
+      deps.selection.setPirateSelection(null, focus.historyId);
+    }
+
+    const renderPanel = (): void => {
+      const base = getPirateWatersPresentation(deps.session.getState(), deps.session.getState().currentPlayer);
+      if (!base.available) return;
+      const { factionId: selectedPirateFactionId, historyId: selectedPirateHistoryId } = deps.selection.getPirateSelection();
+      const factionId = selectedPirateFactionId && base.factions.some(faction => faction.factionId === selectedPirateFactionId)
+        ? selectedPirateFactionId
+        : base.factions[0]?.factionId;
+      let historyId = selectedPirateHistoryId && base.history.some(entry => entry.id === selectedPirateHistoryId)
+        ? selectedPirateHistoryId
+        : undefined;
+      if (!historyId && selectedPirateFactionId && !base.factions.some(faction => faction.factionId === selectedPirateFactionId)) {
+        historyId = [...base.history].reverse().find(entry => entry.factionId === selectedPirateFactionId)?.id;
+        deps.selection.setPirateSelection(selectedPirateFactionId, historyId ?? null);
+      }
+      if (!historyId) deps.selection.setPirateSelection(factionId ?? null, deps.selection.getPirateSelection().historyId);
+      deps.renderLoop.setSelectedPirateFactionId(historyId ? null : (factionId ?? null));
+      if (historyId || !factionId) deps.audio.stopPirateAmbience('focus-changed');
+      else void deps.audio.startPirateHeadquartersAmbience(factionId);
+      const presentation = {
+        ...base,
+        ...(factionId && !historyId ? { selectedFactionId: factionId } : {}),
+        ...(historyId ? { selectedHistoryId: historyId } : {}),
+      };
+      createPirateWatersPanel(deps.uiLayer, presentation, {
+        onClose: () => {
+          deps.getElementById('pirate-waters-panel')?.remove();
+          deps.renderLoop.setSelectedPirateFactionId(null);
+          deps.audio.stopPirateAmbience('panel-closed');
+        },
+        onSelectFaction: nextFactionId => {
+          deps.selection.setPirateSelection(nextFactionId, null);
+          renderPanel();
+        },
+        onSelectHistory: nextHistoryId => {
+          deps.selection.setPirateSelection(null, nextHistoryId);
+          renderPanel();
+        },
+        onFocus: deps.focusPirateTarget,
+        onPayTribute: faction => {
+          const result = payPirateTribute(deps.session.getState(), faction, deps.session.getState().currentPlayer);
+          deps.applyPirateActionResult(result, 'Pirate tribute paid.');
+          renderPanel();
+          return result;
+        },
+        onHireFlotilla: (faction, targetId) => {
+          const result = hirePirateFlotilla(deps.session.getState(), faction, deps.session.getState().currentPlayer, targetId);
+          deps.applyPirateActionResult(result, 'Pirate flotilla hired.');
+          renderPanel();
+          return result;
+        },
+        onOpenAssault: faction => {
+          const selectedUnitId = deps.selection.getSelectedUnitId();
+          if (selectedUnitId) {
+            const pending = preparePirateHeadquartersAssault(deps.session.getState(), faction, selectedUnitId);
+            if (pending.preview.available) {
+              openPirateHeadquartersAssault(faction, selectedUnitId);
+              return;
+            }
+          }
+          const target = base.factions.find(entry => entry.factionId === faction)?.focusTarget;
+          if (target) deps.focusPirateTarget(target);
+          deps.showNotification('Select an adjacent available naval combat unit to assault this enclave.', 'info');
+        },
+      });
+    };
+
+    renderPanel();
+  }
+
+  function openPirateHeadquartersAssault(factionId: string, unitId: string): void {
+    const pending = preparePirateHeadquartersAssault(deps.session.getState(), factionId, unitId);
+    if (!pending.preview.available) {
+      deps.showNotification(pending.preview.reason ?? 'This enclave cannot be assaulted now.', 'warning');
+      return;
+    }
+    const panel = createPirateHeadquartersAssaultPanel(deps.uiLayer, pending, {
+      onCancel: () => panel.remove(),
+      onConfirm: () => {
+        const result = confirmPirateHeadquartersAssault(deps.session.getState(), pending);
+        if (!result.success) {
+          panel.remove();
+          deps.showNotification(result.reason ?? 'The assault is no longer available.', 'warning');
+          if (deps.session.getState().units[unitId]) deps.selectionController.selectUnit(unitId);
+          return;
+        }
+        deps.renderLoop.applyPirateHeadquartersAssaultVisual(factionId, unitId, {
+          destroyed: Boolean(result.destroyed),
+          attackerSurvived: Boolean(result.state.units[unitId]),
+        });
+        if (result.destroyed) {
+          deps.bus.emit('pirate:headquarters-destroyed', {
+            factionId,
+            viewerIds: [deps.session.getState().currentPlayer],
+          });
+        }
+        deps.session.setStateWithoutRefresh(result.state);
+        panel.remove();
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        SFX.combat();
+        const bountyAwarded = result.events.find(event => event.type === 'faction-destroyed')?.bountyAwarded ?? 0;
+        deps.showNotification(
+          result.destroyed
+            ? `Pirate enclave destroyed. Bounty awarded: ${bountyAwarded} gold.`
+            : `Pirate enclave damaged for ${result.damageToHeadquarters ?? 0} integrity.`,
+          result.destroyed ? 'success' : 'info',
+        );
+        if (deps.session.getState().units[unitId]) deps.selectionController.selectUnit(unitId);
+        else deps.selectionController.deselectUnit();
+        openPirateWaters({ factionId });
+      },
+    });
+  }
+
+  /**
+   * The "close if already open" behavior moved to `router.toggle('notification-log')`
+   * (#787 phase 5) -- `isOpen`/`close` are DOM-derived, so this only needs to
+   * build and append the panel now.
+   */
+  function openNotificationLog(): void {
+    const entries = deps.session.getState()
+      ? getNotificationsForPlayer(deps.session.getState().notificationLog ?? {}, deps.session.getState().currentPlayer)
+      : [];
+    const panel = createNotificationLogPanel(entries, {
+      onClose: () => panel.remove(),
+      onFocusTarget: deps.focusNotificationTarget,
+      onOpenCity: (cityId) => {
+        panel.remove();
+        const city = deps.session.getState()?.cities[cityId];
+        if (city) deps.openCityPanelForCity(city);
+      },
+      onOpenWonderCity: action => {
+        const city = deps.session.getState()?.cities[action.cityId];
+        const definition = getLegendaryWonderDefinition(action.wonderId);
+        if (!city || !definition || city.owner !== deps.session.getState().currentPlayer
+          || !getLegendaryWonderEligibility(deps.session.getState(), deps.session.getState().currentPlayer, city.id, definition).buildable) {
+          deps.showNotification('That wonder is no longer available in this city.', 'warning');
+          return;
+        }
+        panel.remove();
+        deps.openWonderPanelForCityId(city.id);
+      },
+      onMarkRead: notificationId => {
+        deps.session.setStateWithoutRefresh(markNotificationRead(deps.session.getState(), deps.session.getState().currentPlayer, notificationId));
+      },
+      onReviewPirate: review => {
+        const resolved = resolvePirateNotificationReview(deps.session.getState(), deps.session.getState().currentPlayer, review);
+        panel.remove();
+        if (resolved?.kind === 'active') openPirateWaters({ factionId: resolved.factionId });
+        if (resolved?.kind === 'history') openPirateWaters({ historyId: resolved.historyId });
+      },
+    });
+
+    deps.uiLayer.appendChild(panel);
+
+    setTimeout(() => {
+      const handler = (e: Event) => {
+        if (!panel.contains(e.target as Node)) {
+          panel.remove();
+          document.removeEventListener('click', handler);
+        }
+      };
+      document.addEventListener('click', handler);
+    }, 100);
+  }
+
+  return {
+    openPacingDebugPanel,
+    openBestiary,
+    openWonderAtlas,
+    openPirateWaters,
+    openPirateHeadquartersAssault,
+    openNotificationLog,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
-import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
@@ -28,8 +27,7 @@ import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast } from '@/systems/beast-system';
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
-import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
-import { createBestiaryPanel } from '@/ui/bestiary-panel';
+import { recordBeastSightings } from '@/systems/beast-presentation';
 import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX } from '@/audio/sfx';
@@ -38,19 +36,13 @@ import { createMarketplacePanel } from '@/ui/marketplace-panel';
 import { createEspionagePanel } from '@/ui/espionage-panel';
 import { AdvisorSystem } from '@/ui/advisor-system';
 import { createCouncilPanel } from '@/ui/council-panel';
-import { createNotificationLogPanel } from '@/ui/notification-log-panel';
-import { createPirateWatersPanel } from '@/ui/pirate-waters-panel';
-import { getPirateWatersPresentation, type PirateFocusTarget } from '@/systems/pirate-presentation';
-import { hirePirateFlotilla, payPirateTribute, type PirateActionResult } from '@/systems/pirate-actions';
-import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
-import { confirmPirateHeadquartersAssault, preparePirateHeadquartersAssault } from '@/input/pirate-headquarters-assault';
-import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
+import type { PirateFocusTarget } from '@/systems/pirate-presentation';
+import type { PirateActionResult } from '@/systems/pirate-actions';
 import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
 import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
 import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
-import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { declareWar, makePeace, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
@@ -65,8 +57,7 @@ import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupa
 import { beginPlayerCityAssaultChoice, shouldPromptForPlayerCityCapture } from '@/input/city-assault-flow';
 import { canUnitOccupyCity } from '@/systems/city-capture-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import { initializeLegendaryWonderProjectsForCity, getLegendaryWonderEligibility, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
-import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { initializeLegendaryWonderProjectsForCity, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
 import { embedSpy, unembedSpy, attemptSweep, getAvailableMissions, getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType, missionRequiresPlacedSpy, recallSpy, resolveMissionResult, startMission, verifyAgent } from '@/systems/espionage-system';
 import { applyUnitUpgradeToState, evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
@@ -74,7 +65,7 @@ import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/syste
 import { createSelectionStore } from '@/app/selection-store';
 import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
 import type { CombatResult, GameState, HexCoord, Unit, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
-import { appendNotification, getNotificationsForPlayer, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
+import { appendNotification, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
 import type { NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
@@ -85,6 +76,7 @@ import { canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resour
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
+import { createPanelActionsController, type PanelActionsController } from '@/app/controllers/panel-actions-controller';
 import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
 import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
 import { createHudController, type HudController } from '@/app/controllers/hud-controller';
@@ -213,7 +205,7 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
   playDiscoveryAudio: wonderId => {
     void audio.playNaturalWonderDiscovery(wonderId);
   },
-  openAtlas: wonderId => openWonderAtlas(wonderId),
+  openAtlas: wonderId => panelActions.openWonderAtlas(wonderId),
   openCity: cityId => {
     const city = session.getState().cities[cityId];
     if (city) openCityPanelForCity(city);
@@ -252,6 +244,34 @@ const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsContr
   selectionController: { selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts) },
 });
 
+/**
+ * Owns the utility and world-event panel openers (#787 phase 10b-b -- part 1
+ * of 3 for `PanelActionsController`, see 10b-c/10b-d for the rest). `hud` and
+ * `selectionController` use the same deferred-but-eager lazy-wrapper pattern
+ * as `diplomacyActions` above, for the same reason (neither is assigned yet
+ * at this point in module evaluation).
+ */
+const panelActions: PanelActionsController = createPanelActionsController({
+  session,
+  bus,
+  uiLayer,
+  getElementById: id => document.getElementById(id),
+  selection,
+  audio,
+  renderLoop,
+  showNotification,
+  focusNotificationTarget,
+  focusPirateTarget,
+  applyPirateActionResult,
+  openCityPanelForCity,
+  openWonderPanelForCityId,
+  hud: { closeDrawer: () => hud.closeDrawer(), update: () => hud.update() },
+  selectionController: {
+    selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts),
+    deselectUnit: () => selectionController.deselectUnit(),
+  },
+});
+
 const selectionController: SelectionController = createSelectionController({
   session,
   selection,
@@ -271,7 +291,7 @@ const selectionController: SelectionController = createSelectionController({
   restAction,
   openNetworkIntentPanel,
   openUnitStackPicker,
-  openPirateHeadquartersAssault,
+  openPirateHeadquartersAssault: panelActions.openPirateHeadquartersAssault,
   handleEstablishRoute: diplomacyActions.handleEstablishRoute,
   executeUpgrade,
   ensurePlayerWarState,
@@ -348,10 +368,10 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   updateHUD: () => hud.update(),
   clearUnloadState,
   currentCiv,
-  openPirateWaters,
+  openPirateWaters: panelActions.openPirateWaters,
   openUnitStackPicker,
   openCityPanelForCity,
-  openWonderAtlas,
+  openWonderAtlas: panelActions.openWonderAtlas,
   executeAttack,
   executeMinorCivConquest,
   beginPlayerCityAssault,
@@ -455,27 +475,11 @@ const presentationContext: PresentationContext = {
   showNotification: (message, type, target) => showNotification(message, type, target),
 };
 
-/**
- * `createPacingDebugPanel` self-removes any prior instance from `uiLayer`,
- * so the router's own DOM-derived `isOpen`/`close` need no extra bookkeeping
- * here (#787 phase 5).
- */
-function openPacingDebugPanel(): void {
-  if (session.getState()) createPacingDebugPanel(uiLayer, session.getState());
-}
-
 // Escape-cancels-journey and backtick-toggles-pacing-debug used to live in a
 // module-scope `window.addEventListener('keydown', ...)` here. Moved to
 // `installGlobalShortcuts` (called from `init()`, once `notifier` exists) so
 // it can depend on the real `Notifier`/`PanelRouter` ports instead of
 // reaching into module-scope closures directly (#787 phase 5).
-
-function openBestiary(): void {
-  createBestiaryPanel(uiLayer, getBestiaryEntriesForPlayer(session.getState(), session.getState().currentPlayer), {
-    onClose: () => {},
-    slayerNameFor: (civId) => session.getState().civilizations[civId]?.name ?? civId,
-  });
-}
 
 function scanBeastSightings(): void {
   const visTiles = currentCiv()?.visibility?.tiles;
@@ -510,31 +514,6 @@ function maybeShowPendingHoardChoice(): void {
     bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
     hud.update();
     maybeShowPendingHoardChoice();
-  });
-}
-
-function openWonderAtlas(initialWonderId?: string): void {
-  hud.closeDrawer();
-  audio.stopNaturalWonderAmbient('codex-page-hidden');
-  createWonderAtlasPanel(uiLayer, session.getState(), {
-    initialWonderId,
-    onViewOnMap: coord => {
-      renderLoop.camera.centerOn(coord);
-    },
-    onOpenCity: cityId => {
-      const city = session.getState().cities[cityId];
-      if (city) openCityPanelForCity(city);
-    },
-    onNaturalWonderPageShown: wonderId => {
-      void audio.startNaturalWonderCodexAmbient(wonderId);
-    },
-    onNaturalWonderPageHidden: () => {
-      audio.stopNaturalWonderAmbient('codex-page-hidden');
-    },
-    onNaturalWonderReplay: wonderId => {
-      void audio.playNaturalWonderReplay(wonderId);
-    },
-    onClose: () => {},
   });
 }
 
@@ -606,179 +585,6 @@ function applyPirateActionResult(result: PirateActionResult, successMessage: str
   renderLoop.setGameState(session.getState());
   hud.update();
   showNotification(successMessage, 'success');
-}
-
-function openPirateWaters(focus?: { factionId?: string; historyId?: string }): void {
-  if (focus?.factionId) {
-    selection.setPirateSelection(focus.factionId, null);
-  } else if (focus?.historyId) {
-    selection.setPirateSelection(null, focus.historyId);
-  }
-
-  const renderPanel = (): void => {
-    const base = getPirateWatersPresentation(session.getState(), session.getState().currentPlayer);
-    if (!base.available) return;
-    const { factionId: selectedPirateFactionId, historyId: selectedPirateHistoryId } = selection.getPirateSelection();
-    const factionId = selectedPirateFactionId && base.factions.some(faction => faction.factionId === selectedPirateFactionId)
-      ? selectedPirateFactionId
-      : base.factions[0]?.factionId;
-    let historyId = selectedPirateHistoryId && base.history.some(entry => entry.id === selectedPirateHistoryId)
-      ? selectedPirateHistoryId
-      : undefined;
-    if (!historyId && selectedPirateFactionId && !base.factions.some(faction => faction.factionId === selectedPirateFactionId)) {
-      historyId = [...base.history].reverse().find(entry => entry.factionId === selectedPirateFactionId)?.id;
-      selection.setPirateSelection(selectedPirateFactionId, historyId ?? null);
-    }
-    if (!historyId) selection.setPirateSelection(factionId ?? null, selection.getPirateSelection().historyId);
-    renderLoop.setSelectedPirateFactionId(historyId ? null : (factionId ?? null));
-    if (historyId || !factionId) audio.stopPirateAmbience('focus-changed');
-    else void audio.startPirateHeadquartersAmbience(factionId);
-    const presentation = {
-      ...base,
-      ...(factionId && !historyId ? { selectedFactionId: factionId } : {}),
-      ...(historyId ? { selectedHistoryId: historyId } : {}),
-    };
-    createPirateWatersPanel(uiLayer, presentation, {
-      onClose: () => {
-        document.getElementById('pirate-waters-panel')?.remove();
-        renderLoop.setSelectedPirateFactionId(null);
-        audio.stopPirateAmbience('panel-closed');
-      },
-      onSelectFaction: nextFactionId => {
-        selection.setPirateSelection(nextFactionId, null);
-        renderPanel();
-      },
-      onSelectHistory: nextHistoryId => {
-        selection.setPirateSelection(null, nextHistoryId);
-        renderPanel();
-      },
-      onFocus: focusPirateTarget,
-      onPayTribute: faction => {
-        const result = payPirateTribute(session.getState(), faction, session.getState().currentPlayer);
-        applyPirateActionResult(result, 'Pirate tribute paid.');
-        renderPanel();
-        return result;
-      },
-      onHireFlotilla: (faction, targetId) => {
-        const result = hirePirateFlotilla(session.getState(), faction, session.getState().currentPlayer, targetId);
-        applyPirateActionResult(result, 'Pirate flotilla hired.');
-        renderPanel();
-        return result;
-      },
-      onOpenAssault: faction => {
-        const selectedUnitId = selection.getSelectedUnitId();
-        if (selectedUnitId) {
-          const pending = preparePirateHeadquartersAssault(session.getState(), faction, selectedUnitId);
-          if (pending.preview.available) {
-            openPirateHeadquartersAssault(faction, selectedUnitId);
-            return;
-          }
-        }
-        const target = base.factions.find(entry => entry.factionId === faction)?.focusTarget;
-        if (target) focusPirateTarget(target);
-        showNotification('Select an adjacent available naval combat unit to assault this enclave.', 'info');
-      },
-    });
-  };
-
-  renderPanel();
-}
-
-function openPirateHeadquartersAssault(factionId: string, unitId: string): void {
-  const pending = preparePirateHeadquartersAssault(session.getState(), factionId, unitId);
-  if (!pending.preview.available) {
-    showNotification(pending.preview.reason ?? 'This enclave cannot be assaulted now.', 'warning');
-    return;
-  }
-  const panel = createPirateHeadquartersAssaultPanel(uiLayer, pending, {
-    onCancel: () => panel.remove(),
-    onConfirm: () => {
-      const result = confirmPirateHeadquartersAssault(session.getState(), pending);
-      if (!result.success) {
-        panel.remove();
-        showNotification(result.reason ?? 'The assault is no longer available.', 'warning');
-        if (session.getState().units[unitId]) selectionController.selectUnit(unitId);
-        return;
-      }
-      renderLoop.applyPirateHeadquartersAssaultVisual(factionId, unitId, {
-        destroyed: Boolean(result.destroyed),
-        attackerSurvived: Boolean(result.state.units[unitId]),
-      });
-      if (result.destroyed) {
-        bus.emit('pirate:headquarters-destroyed', {
-          factionId,
-          viewerIds: [session.getState().currentPlayer],
-        });
-      }
-      session.setStateWithoutRefresh(result.state);
-      panel.remove();
-      renderLoop.setGameState(session.getState());
-      hud.update();
-      SFX.combat();
-      const bountyAwarded = result.events.find(event => event.type === 'faction-destroyed')?.bountyAwarded ?? 0;
-      showNotification(
-        result.destroyed
-          ? `Pirate enclave destroyed. Bounty awarded: ${bountyAwarded} gold.`
-          : `Pirate enclave damaged for ${result.damageToHeadquarters ?? 0} integrity.`,
-        result.destroyed ? 'success' : 'info',
-      );
-      if (session.getState().units[unitId]) selectionController.selectUnit(unitId);
-      else selectionController.deselectUnit();
-      openPirateWaters({ factionId });
-    },
-  });
-}
-
-/**
- * The "close if already open" behavior moved to `router.toggle('notification-log')`
- * (#787 phase 5) -- `isOpen`/`close` are DOM-derived, so this only needs to
- * build and append the panel now.
- */
-function openNotificationLog(): void {
-  const entries = session.getState()
-    ? getNotificationsForPlayer(session.getState().notificationLog ?? {}, session.getState().currentPlayer)
-    : [];
-  const panel = createNotificationLogPanel(entries, {
-    onClose: () => panel.remove(),
-    onFocusTarget: focusNotificationTarget,
-    onOpenCity: (cityId) => {
-      panel.remove();
-      const city = session.getState()?.cities[cityId];
-      if (city) openCityPanelForCity(city);
-    },
-    onOpenWonderCity: action => {
-      const city = session.getState()?.cities[action.cityId];
-      const definition = getLegendaryWonderDefinition(action.wonderId);
-      if (!city || !definition || city.owner !== session.getState().currentPlayer
-        || !getLegendaryWonderEligibility(session.getState(), session.getState().currentPlayer, city.id, definition).buildable) {
-        showNotification('That wonder is no longer available in this city.', 'warning');
-        return;
-      }
-      panel.remove();
-      openWonderPanelForCityId(city.id);
-    },
-    onMarkRead: notificationId => {
-      session.setStateWithoutRefresh(markNotificationRead(session.getState(), session.getState().currentPlayer, notificationId));
-    },
-    onReviewPirate: review => {
-      const resolved = resolvePirateNotificationReview(session.getState(), session.getState().currentPlayer, review);
-      panel.remove();
-      if (resolved?.kind === 'active') openPirateWaters({ factionId: resolved.factionId });
-      if (resolved?.kind === 'history') openPirateWaters({ historyId: resolved.historyId });
-    },
-  });
-
-  uiLayer.appendChild(panel);
-
-  setTimeout(() => {
-    const handler = (e: Event) => {
-      if (!panel.contains(e.target as Node)) {
-        panel.remove();
-        document.removeEventListener('click', handler);
-      }
-    };
-    document.addEventListener('click', handler);
-  }, 100);
 }
 
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
@@ -1355,10 +1161,10 @@ const panelRegistry = {
       throw new Error("'wonder' is parameterized -- call openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
     },
   },
-  'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => openWonderAtlas() },
-  bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => openBestiary() },
-  'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => openPirateWaters() },
-  'notification-log': { domId: 'notification-log', group: 'transient', open: () => openNotificationLog() },
+  'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => panelActions.openWonderAtlas() },
+  bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => panelActions.openBestiary() },
+  'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => panelActions.openPirateWaters() },
+  'notification-log': { domId: 'notification-log', group: 'transient', open: () => panelActions.openNotificationLog() },
   'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => openCityOverviewPanel() },
   'territory-inspection': {
     domId: 'territory-inspection-panel',
@@ -1369,7 +1175,7 @@ const panelRegistry = {
       );
     },
   },
-  'pacing-debug': { domId: 'pacing-debug-panel', group: 'transient', open: () => openPacingDebugPanel() },
+  'pacing-debug': { domId: 'pacing-debug-panel', group: 'transient', open: () => panelActions.openPacingDebugPanel() },
 } satisfies PanelRegistry;
 
 router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { createGameSession } from '@/app/game-session';
+import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
+import { createUnit } from '@/systems/unit-system';
+import type { PirateFocusTarget } from '@/systems/pirate-presentation';
+import type { NotificationMapTarget } from '@/core/notification-log';
+import type { GameState, HexCoord } from '@/core/types';
+import {
+  createPanelActionsController,
+  type PanelActionsControllerDeps,
+} from '@/app/controllers/panel-actions-controller';
+
+vi.mock('@/ui/pacing-debug-panel', () => ({ createPacingDebugPanel: vi.fn() }));
+vi.mock('@/ui/bestiary-panel', () => ({ createBestiaryPanel: vi.fn() }));
+vi.mock('@/ui/wonder-atlas-panel', () => ({ createWonderAtlasPanel: vi.fn() }));
+vi.mock('@/ui/pirate-waters-panel', () => ({ createPirateWatersPanel: vi.fn() }));
+vi.mock('@/ui/pirate-headquarters-assault-panel', () => ({ createPirateHeadquartersAssaultPanel: vi.fn() }));
+vi.mock('@/ui/notification-log-panel', () => ({ createNotificationLogPanel: vi.fn() }));
+
+import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
+import { createBestiaryPanel } from '@/ui/bestiary-panel';
+import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
+import { createPirateWatersPanel } from '@/ui/pirate-waters-panel';
+import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
+import { createNotificationLogPanel } from '@/ui/notification-log-panel';
+
+function mockedCallArg<T = unknown>(mockFn: unknown, callIndex: number, argIndex: number): T {
+  return (mockFn as ReturnType<typeof vi.fn>).mock.calls[callIndex][argIndex] as T;
+}
+
+function makeFixture(seed = 'panel-actions-controller'): { state: GameState; aiCivId: string } {
+  const state = createNewGame(undefined, seed, 'small');
+  state.currentPlayer = 'player';
+  const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+  return { state, aiCivId };
+}
+
+/** A coastal-enclave pirate faction adjacent to a real player unit, with intel already gathered. */
+function addPirateFixture(state: GameState, hqPosition: HexCoord, unitPosition: HexCoord, unitId: string): void {
+  state.map.tiles[`${hqPosition.q},${hqPosition.r}`] = {
+    coord: hqPosition, terrain: 'plains', elevation: 'lowland', resource: null,
+    improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+  };
+  state.map.tiles[`${unitPosition.q},${unitPosition.r}`] = {
+    coord: unitPosition, terrain: 'coast', elevation: 'lowland', resource: null,
+    improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+  };
+  const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+  state.units[unitId] = { ...createUnit('trireme', 'player', unitPosition, idCounters), id: unitId };
+  state.civilizations.player.units.push(unitId);
+  state.pirates = createEmptyPirateState();
+  state.pirates.factions['pirate-1'] = {
+    id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'raiding',
+    maritimeStage: 3, notoriety: 2, shipIds: [],
+    headquarters: { kind: 'coastal-enclave', position: hqPosition, integrity: 100, maxIntegrity: 100 },
+    tributeByCiv: {}, demandByCiv: {}, contract: null, intent: null,
+    transitionGuards: { emittedEventKeys: [] },
+  } satisfies PirateFactionState;
+  state.civilizations.player.visibility.tiles[`${hqPosition.q},${hqPosition.r}`] = 'visible';
+  state.pirates.intelByCiv.player = {
+    'pirate-1': {
+      factionId: 'pirate-1', level: 'sighted', discoveredRound: 1, lastUpdatedRound: 1,
+      lastKnownHeadquarters: { kind: 'coastal-enclave', position: hqPosition, observedRound: 1, integrityBand: 'healthy' },
+      knownBehavior: 'raiding', knownMaritimeStage: 3, observedUnitIds: [],
+    },
+  };
+}
+
+function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDeps> = {}) {
+  return {
+    session: createGameSession(state),
+    bus: new EventBus(),
+    uiLayer: document.createElement('div'),
+    getElementById: vi.fn((id: string) => document.getElementById(id)),
+    selection: {
+      setPirateSelection: vi.fn(),
+      getPirateSelection: vi.fn(() => ({ factionId: null, historyId: null })),
+      getSelectedUnitId: vi.fn(() => null),
+    },
+    selectionController: { selectUnit: vi.fn(), deselectUnit: vi.fn() },
+    hud: { closeDrawer: vi.fn(), update: vi.fn() },
+    audio: {
+      stopNaturalWonderAmbient: vi.fn(), startNaturalWonderCodexAmbient: vi.fn(), playNaturalWonderReplay: vi.fn(),
+      stopPirateAmbience: vi.fn(), startPirateHeadquartersAmbience: vi.fn(),
+    },
+    renderLoop: {
+      camera: { centerOn: vi.fn() }, setSelectedPirateFactionId: vi.fn(),
+      applyPirateHeadquartersAssaultVisual: vi.fn(), setGameState: vi.fn(),
+    },
+    showNotification: vi.fn(),
+    focusNotificationTarget: vi.fn(),
+    focusPirateTarget: vi.fn(),
+    applyPirateActionResult: vi.fn(),
+    openCityPanelForCity: vi.fn(),
+    openWonderPanelForCityId: vi.fn(),
+    ...overrides,
+  };
+}
+
+function build(state: GameState, overrides: Partial<PanelActionsControllerDeps> = {}) {
+  const deps = makeDeps(state, overrides);
+  const controller = createPanelActionsController(deps);
+  return { deps, controller };
+}
+
+describe('PanelActionsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('openPacingDebugPanel', () => {
+    it('builds the panel from the current session state', () => {
+      const { state } = makeFixture('pacing-debug');
+      const { deps, controller } = build(state);
+
+      controller.openPacingDebugPanel();
+
+      expect(createPacingDebugPanel).toHaveBeenCalledWith(deps.uiLayer, deps.session.getState());
+    });
+  });
+
+  describe('openBestiary', () => {
+    it('resolves slayer names against the live session civ roster', () => {
+      const { state, aiCivId } = makeFixture('bestiary');
+      const { controller } = build(state);
+
+      controller.openBestiary();
+
+      const options = mockedCallArg<{ slayerNameFor: (id: string) => string }>(createBestiaryPanel, 0, 2);
+      expect(options.slayerNameFor(aiCivId)).toBe(state.civilizations[aiCivId].name);
+      expect(options.slayerNameFor('no-such-civ')).toBe('no-such-civ');
+    });
+  });
+
+  describe('openWonderAtlas', () => {
+    it('closes the drawer, stops ambient audio, and wires the atlas callbacks', () => {
+      const { state } = makeFixture('wonder-atlas');
+      const { deps, controller } = build(state);
+
+      controller.openWonderAtlas('great-lighthouse');
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      expect(deps.audio.stopNaturalWonderAmbient).toHaveBeenCalledWith('codex-page-hidden');
+      const options = mockedCallArg<{
+        onViewOnMap: (coord: HexCoord) => void;
+        onOpenCity: (cityId: string) => void;
+        onNaturalWonderPageShown: (id: string) => void;
+        onNaturalWonderPageHidden: () => void;
+        onNaturalWonderReplay: (id: string) => void;
+      }>(createWonderAtlasPanel, 0, 2);
+
+      options.onViewOnMap({ q: 3, r: 3 });
+      expect(deps.renderLoop.camera.centerOn).toHaveBeenCalledWith({ q: 3, r: 3 });
+
+      options.onOpenCity('nonexistent-city');
+      expect(deps.openCityPanelForCity).not.toHaveBeenCalled();
+
+      options.onNaturalWonderPageShown('great-lighthouse');
+      expect(deps.audio.startNaturalWonderCodexAmbient).toHaveBeenCalledWith('great-lighthouse');
+
+      options.onNaturalWonderPageHidden();
+      expect(deps.audio.stopNaturalWonderAmbient).toHaveBeenCalledTimes(2);
+
+      options.onNaturalWonderReplay('great-lighthouse');
+      expect(deps.audio.playNaturalWonderReplay).toHaveBeenCalledWith('great-lighthouse');
+    });
+
+    it('opens the founded city via the injected dep when one exists', () => {
+      const { state } = makeFixture('wonder-atlas-city');
+      state.cities['test-city'] = {
+        id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      };
+      const { deps, controller } = build(state);
+
+      controller.openWonderAtlas();
+      const options = mockedCallArg<{ onOpenCity: (cityId: string) => void }>(createWonderAtlasPanel, 0, 2);
+      options.onOpenCity('test-city');
+
+      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+    });
+  });
+
+  describe('openPirateWaters', () => {
+    it('does not build a panel when no pirate intel or history is available', () => {
+      const { state } = makeFixture('pirate-waters-unavailable');
+      const { controller } = build(state);
+      controller.openPirateWaters();
+      expect(createPirateWatersPanel).not.toHaveBeenCalled();
+    });
+
+    it('renders with real presentation data and wires tribute/flotilla/focus callbacks', () => {
+      const { state } = makeFixture('pirate-waters-available');
+      addPirateFixture(state, { q: 5, r: 5 }, { q: 5, r: 4 }, 'attacker');
+      state.civilizations.player.gold = 99999;
+      const { deps, controller } = build(state);
+
+      controller.openPirateWaters();
+
+      expect(createPirateWatersPanel).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{
+        onFocus: (target: PirateFocusTarget) => void;
+        onPayTribute: (factionId: string) => void;
+        onSelectFaction: (factionId: string) => void;
+      }>(createPirateWatersPanel, 0, 2);
+      const presentation = mockedCallArg<{ factions: Array<{ factionId: string }> }>(createPirateWatersPanel, 0, 1);
+      expect(presentation.factions.map(f => f.factionId)).toContain('pirate-1');
+
+      options.onFocus({ kind: 'region', center: { q: 5, r: 5 }, radius: 1, label: 'x' });
+      expect(deps.focusPirateTarget).toHaveBeenCalledTimes(1);
+
+      options.onPayTribute('pirate-1');
+      expect(deps.applyPirateActionResult).toHaveBeenCalledWith(expect.anything(), 'Pirate tribute paid.');
+      // onPayTribute re-renders the panel -- a second createPirateWatersPanel call
+      expect(createPirateWatersPanel).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('openPirateHeadquartersAssault', () => {
+    it('shows a warning and never builds a panel when the assault is unavailable', () => {
+      const { state } = makeFixture('assault-unavailable');
+      const { deps, controller } = build(state);
+
+      controller.openPirateHeadquartersAssault('no-such-faction', 'no-such-unit');
+
+      expect(createPirateHeadquartersAssaultPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+
+    it('confirms a real assault: damages the target, refreshes, notifies, and reselects the unit', () => {
+      const { state } = makeFixture('assault-ok');
+      addPirateFixture(state, { q: 5, r: 5 }, { q: 5, r: 4 }, 'attacker');
+      const fakePanel = { remove: vi.fn() };
+      (createPirateHeadquartersAssaultPanel as ReturnType<typeof vi.fn>).mockReturnValue(fakePanel);
+      const { deps, controller } = build(state);
+
+      controller.openPirateHeadquartersAssault('pirate-1', 'attacker');
+
+      expect(createPirateHeadquartersAssaultPanel).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onConfirm: () => void; onCancel: () => void }>(createPirateHeadquartersAssaultPanel, 0, 2);
+
+      options.onConfirm();
+
+      expect(fakePanel.remove).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.applyPirateHeadquartersAssaultVisual).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('Pirate enclave'), expect.any(String));
+      expect(deps.selectionController.selectUnit).toHaveBeenCalledWith('attacker');
+      // onConfirm always reopens the waters panel for the assaulted faction afterward
+      expect(createPirateWatersPanel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('openNotificationLog', () => {
+    it('appends the panel and wires city/wonder/read/close callbacks against real state', () => {
+      const { state } = makeFixture('notification-log');
+      state.cities['test-city'] = {
+        id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      };
+      state.notificationLog = { player: [{ id: 'notification-1', message: 'Test', type: 'info', turn: state.turn, read: false }] };
+      const fakePanel = document.createElement('div');
+      const removeSpy = vi.spyOn(fakePanel, 'remove');
+      (createNotificationLogPanel as ReturnType<typeof vi.fn>).mockReturnValue(fakePanel);
+      const { deps, controller } = build(state);
+
+      controller.openNotificationLog();
+
+      expect(deps.uiLayer.contains(fakePanel)).toBe(true);
+      const options = mockedCallArg<{
+        onClose: () => void;
+        onFocusTarget: (target: NotificationMapTarget) => void;
+        onOpenCity: (cityId: string) => void;
+        onMarkRead: (id: string) => void;
+      }>(createNotificationLogPanel, 0, 1);
+
+      options.onOpenCity('test-city');
+      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+
+      options.onClose();
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+
+      options.onFocusTarget({ kind: 'map', coord: { q: 1, r: 1 }, label: 'x' });
+      expect(deps.focusNotificationTarget).toHaveBeenCalledTimes(1);
+
+      options.onMarkRead('notification-1');
+      expect(deps.session.getState().notificationLog?.player?.[0].read).toBe(true);
+    });
+
+    it('shows a warning instead of opening a wonder panel for an unbuildable city', () => {
+      const { state } = makeFixture('notification-log-wonder-fail');
+      const { deps, controller } = build(state);
+
+      controller.openNotificationLog();
+      const options = mockedCallArg<{ onOpenWonderCity: (action: { cityId: string; wonderId: string }) => void }>(createNotificationLogPanel, 0, 1);
+
+      options.onOpenWonderCity({ cityId: 'no-such-city', wonderId: 'great-lighthouse' });
+
+      expect(deps.openWonderPanelForCityId).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts 6 utility/world-event panel openers (`openPacingDebugPanel`, `openBestiary`, `openWonderAtlas`, `openPirateWaters`, `openPirateHeadquartersAssault`, `openNotificationLog`) from `main.ts` into a new `PanelActionsController` — Phase 10b-b of the #787 composition-root decomposition arc, first of three sub-phases for `PanelActionsController` (per PR #807's split; 10b-c/10b-d cover the remaining panels).
- `main.ts`: 2036 → 1842 lines.
- `openCityPanelForCity`/`openWonderPanelForCityId` (not-yet-extracted panel openers, phase 10b-c/d) arrive as injected deps to avoid a forward reference, same pattern as 10b-a's `openDiplomacyPanel` dep.
- Verified via the arc's established exhaustive-diff + call-count-parity technique against the pre-move source; the only mismatches (`hud.update()`/`hud.closeDrawer()`/`selectionController.`) were fully explained by the one legitimate new lazy-wrapper construction block this phase needed (same category as 10b-a's finding).
- Inline review pass done proactively before opening the PR: found and fixed one real issue — a raw `document.getElementById` call in the new controller, now threaded as a `getElementById` dep, matching this arc's port-purity convention ahead of Phase 11's enforcement test. Also removed all `as unknown as`/`as never` casts from the test fixtures in favor of real factories (`createUnit`) and properly-typed callback signatures.
- Dead-import hygiene: confirmed the pre-existing 13-name baseline is unchanged; removed 17 newly-orphaned imports from `main.ts`. Zero dead imports in the new controller/test files.

## Test plan
- [x] `yarn build` — clean, zero type errors
- [x] `yarn test` — full suite, 478 files / 7731 passed, 3 skipped (pre-existing)
- [x] `yarn test:web-smoke` — 8/8 Playwright smoke tests pass (this phase touches panel rendering)
- [x] New `tests/app/controllers/panel-actions-controller.test.ts` — 10 tests covering each panel opener's real callback wiring against real system state (real pirate faction/intel fixtures, real notification-log entries, real city fixtures), not just render shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)