### PR TITLE
feat(787): extract 9 unit/network/civ-management panel openers (phase 10b-c)

### DIFF
--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -1,19 +1,33 @@
 /**
- * Owns the utility and world-event panel openers (#787 phase 10b-b, part 1 of 3
- * for `PanelActionsController` -- see 10b-c/10b-d for the remaining panels):
- * `openPacingDebugPanel`, `openBestiary`, `openWonderAtlas`, `openPirateWaters`,
+ * Owns the panel openers extracted from `main.ts` across #787 phases 10b-b and
+ * 10b-c (see 10b-d for the two remaining, largest panels: `openCityPanelForCity`,
+ * `openEspionagePanel`).
+ *
+ * Phase 10b-b (part 1, utility/world-event panels): `openPacingDebugPanel`,
+ * `openBestiary`, `openWonderAtlas`, `openPirateWaters`,
  * `openPirateHeadquartersAssault`, `openNotificationLog`.
  *
- * `openWonderAtlas` and `openNotificationLog` both open `openCityPanelForCity`
- * (a not-yet-extracted panel opener, phase 10b-c/d); `openNotificationLog` also
- * opens `openWonderPanelForCityId` (same). Both arrive as injected deps to
- * avoid a forward reference regardless of which sub-phase lands first, same
- * pattern as 10b-a's `openDiplomacyPanel` dep.
+ * Phase 10b-c (part 2, unit/network/civ-management panels): `openDiplomacyPanel`,
+ * `openMarketplacePanel`, `openWonderPanelForCityId`, `openCityOverviewPanel`,
+ * `openCouncilPanel`, `openTechPanel`, `openUnitStackPicker`,
+ * `openNetworkIntentPanel`, `openNetworkPanel`.
  *
- * `showNotification`, `focusNotificationTarget`, `focusPirateTarget`, and
- * `applyPirateActionResult` are cross-cutting helpers (phase 10b-f's domain)
- * still living in `main.ts` -- threaded through as deps until that phase
- * gives them a real home.
+ * `openWonderAtlas`, `openNotificationLog`, and `openCityOverviewPanel` all open
+ * `openCityPanelForCity` (a not-yet-extracted panel opener, phase 10b-d) --
+ * arrives as an injected dep to avoid a forward reference. `openWonderPanelForCityId`
+ * itself is now a sibling function in this file (phase 10b-c), so `openNotificationLog`'s
+ * `onOpenWonderCity` calls it directly instead of through a dep, same pattern as
+ * `openPirateWaters`/`openPirateHeadquartersAssault` calling each other directly.
+ *
+ * `showNotification`, `focusNotificationTarget`, `focusPirateTarget`,
+ * `applyPirateActionResult`, and `currentCiv` are cross-cutting helpers (phase
+ * 10b-f's domain) still living in `main.ts` -- threaded through as deps until
+ * that phase gives them a real home.
+ *
+ * `diplomacyActions` (phase 10b-a's `DiplomacyActionsController`) is threaded
+ * through as a dep for `openDiplomacyPanel`'s and `openCityOverviewPanel`'s
+ * handler callbacks -- it's constructed before `panelActions` in `main.ts`, so
+ * a direct reference works with no lazy wrapper needed.
  *
  * Everything this file calls that is a pure `@/systems/*`, `@/input/*`, or
  * `@/ui/*` helper is imported directly, matching the precedent set by every
@@ -27,7 +41,8 @@ import type { EventBus } from '@/core/event-bus';
 import type { GameSession, SelectionStore } from '@/app/ports';
 import type { HudController } from '@/app/controllers/hud-controller';
 import type { SelectionController } from '@/app/controllers/selection-controller';
-import type { City } from '@/core/types';
+import type { DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
+import type { City, Civilization, HexCoord } from '@/core/types';
 import type { NotificationEntry } from '@/core/notification-log';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
@@ -42,7 +57,22 @@ import { createNotificationLogPanel } from '@/ui/notification-log-panel';
 import { getNotificationsForPlayer } from '@/core/notification-log';
 import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
-import { getLegendaryWonderEligibility } from '@/systems/legendary-wonder-system';
+import { getLegendaryWonderEligibility, initializeLegendaryWonderProjectsForCity, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
+import { getProductionDisplayName } from '@/systems/city-system';
+import { enqueueResearch, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+import { canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
+import { assignNetworkPlan, cancelNetworkPlan, holdNetworkPlan, isAutonomyActivated, retargetNetworkPlan } from '@/systems/network-plan-system';
+import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
+import { saveSettings } from '@/storage/save-manager';
+import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
+import { createMarketplacePanel } from '@/ui/marketplace-panel';
+import { createWonderPanel } from '@/ui/wonder-panel';
+import { createCityOverviewPanel } from '@/ui/city-overview-panel';
+import { createCouncilPanel } from '@/ui/council-panel';
+import { createTechPanel } from '@/ui/tech-panel';
+import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
+import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
+import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
 import { SFX } from '@/audio/sfx';
 
 export interface PanelActionsController {
@@ -52,6 +82,15 @@ export interface PanelActionsController {
   openPirateWaters(focus?: { factionId?: string; historyId?: string }): void;
   openPirateHeadquartersAssault(factionId: string, unitId: string): void;
   openNotificationLog(): void;
+  openDiplomacyPanel(): void;
+  openMarketplacePanel(): void;
+  openWonderPanelForCityId(selectedCityId: string): void;
+  openCityOverviewPanel(): void;
+  openCouncilPanel(): void;
+  openTechPanel(): void;
+  openUnitStackPicker(coord: HexCoord, unitIds: string[]): void;
+  openNetworkIntentPanel(sourceUnitId: string): void;
+  openNetworkPanel(): void;
 }
 
 /** The narrow slice of `RenderLoop` this controller needs. */
@@ -81,10 +120,16 @@ export interface PanelActionsControllerDeps {
   readonly focusNotificationTarget: (target: NotificationEntry['target']) => void;
   readonly focusPirateTarget: (target: PirateFocusTarget) => void;
   readonly applyPirateActionResult: (result: PirateActionResult, successMessage: string) => void;
-  /** `PanelActionsController`'s own function (phase 10b-c/d) -- injected to avoid a forward reference. */
+  readonly currentCiv: () => Civilization;
+  readonly diplomacyActions: Pick<
+    DiplomacyActionsController,
+    | 'handleDiplomaticAction' | 'handleAcceptPeaceRequest' | 'handleRejectPeaceRequest'
+    | 'handleAcceptTreatyProposal' | 'handleDeclineTreatyProposal' | 'handleBreakTreaty'
+    | 'handleGiftGold' | 'handleSponsorFestival' | 'handleMinorCivReparations' | 'handleSendAid'
+    | 'handleMinorCivWarPeace' | 'handleAppeaseFaction' | 'handleConcedeToMovement'
+  >;
+  /** `PanelActionsController`'s own function (phase 10b-d) -- injected to avoid a forward reference. */
   readonly openCityPanelForCity: (city: City) => void;
-  /** `PanelActionsController`'s own function (phase 10b-c/d) -- injected to avoid a forward reference. */
-  readonly openWonderPanelForCityId: (selectedCityId: string) => void;
 }
 
 export function createPanelActionsController(deps: PanelActionsControllerDeps): PanelActionsController {
@@ -276,7 +321,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
           return;
         }
         panel.remove();
-        deps.openWonderPanelForCityId(city.id);
+        openWonderPanelForCityId(city.id);
       },
       onMarkRead: notificationId => {
         deps.session.setStateWithoutRefresh(markNotificationRead(deps.session.getState(), deps.session.getState().currentPlayer, notificationId));
@@ -302,6 +347,273 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
     }, 100);
   }
 
+  function openDiplomacyPanel(): void {
+    deps.hud.closeDrawer();
+    deps.getElementById('diplomacy-panel')?.remove();
+    createDiplomacyPanel(deps.uiLayer, deps.session.getState(), {
+      onAction: deps.diplomacyActions.handleDiplomaticAction,
+      onAcceptPeaceRequest: deps.diplomacyActions.handleAcceptPeaceRequest,
+      onRejectPeaceRequest: deps.diplomacyActions.handleRejectPeaceRequest,
+      onAcceptTreatyProposal: deps.diplomacyActions.handleAcceptTreatyProposal,
+      onDeclineTreatyProposal: deps.diplomacyActions.handleDeclineTreatyProposal,
+      onBreakTreaty: deps.diplomacyActions.handleBreakTreaty,
+      onGiftGold: deps.diplomacyActions.handleGiftGold,
+      onSponsorFestival: deps.diplomacyActions.handleSponsorFestival,
+      onMinorCivReparations: deps.diplomacyActions.handleMinorCivReparations,
+      onMinorCivWarPeace: deps.diplomacyActions.handleMinorCivWarPeace,
+      onSendAid: deps.diplomacyActions.handleSendAid,
+      onClose: () => {},
+    });
+  }
+
+  function openMarketplacePanel(): void {
+    deps.hud.closeDrawer();
+    deps.getElementById('marketplace-panel')?.remove();
+    createMarketplacePanel(deps.uiLayer, deps.session.getState(), {
+      onClose: () => {},
+      onSelectUnit: (unitId) => {
+        deps.getElementById('marketplace-panel')?.remove();
+        deps.selectionController.selectUnit(unitId);
+        const unit = deps.session.getState().units[unitId];
+        if (unit) deps.renderLoop.camera.centerOn(unit.position);
+      },
+      onBuyResourceAccess: (sellerCivId, resource) => {
+        if (!canBuyResourceAccess(deps.session.getState(), deps.session.getState().currentPlayer, sellerCivId, resource)) return;
+        deps.session.commit(performBuyResourceAccess(deps.session.getState(), deps.session.getState().currentPlayer, sellerCivId, resource));
+        deps.showNotification(`Purchased ${resource} access for 10 turns.`, 'success');
+        openMarketplacePanel(); // re-render panel with updated state
+      },
+    });
+  }
+
+  function openWonderPanelForCityId(selectedCityId: string): void {
+    if (!deps.session.getState().cities[selectedCityId]) return;
+
+    const openWonderPanel = () => {
+      deps.getElementById('wonder-panel')?.remove();
+      createWonderPanel(deps.uiLayer, deps.session.getState(), selectedCityId, {
+        onStartBuild: (buildCityId, wonderId) => {
+          deps.session.setStateWithoutRefresh(startLegendaryWonderBuild(deps.session.getState(), deps.session.getState().currentPlayer, buildCityId, wonderId, deps.bus));
+          const targetCity = deps.session.getState().cities[buildCityId];
+          if (targetCity) {
+            deps.renderLoop.setGameState(deps.session.getState());
+            deps.hud.update();
+            const productionItemId = `legendary:${wonderId}`;
+            if (targetCity.productionQueue[0] === productionItemId) {
+              deps.showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
+            } else {
+              deps.showNotification(`${targetCity.name}: ${getProductionDisplayName(productionItemId)} is not ready to start.`, 'warning');
+            }
+            openWonderPanel();
+          }
+        },
+        onClose: () => {
+          deps.getElementById('wonder-panel')?.remove();
+        },
+      });
+    };
+    deps.session.setStateWithoutRefresh(initializeLegendaryWonderProjectsForCity(deps.session.getState(), deps.session.getState().currentPlayer, selectedCityId));
+    openWonderPanel();
+  }
+
+  function openCityOverviewPanel(): void {
+    deps.hud.closeDrawer();
+    const existing = deps.getElementById('city-overview-panel');
+    if (existing) existing.remove();
+    createCityOverviewPanel(deps.uiLayer, deps.session.getState(), {
+      onOpenCity: (cityId) => {
+        const overview = deps.getElementById('city-overview-panel');
+        overview?.remove();
+        const city = deps.session.getState().cities[cityId];
+        if (city) deps.openCityPanelForCity(city);
+      },
+      onAppeaseFaction: (cityId) => {
+        deps.diplomacyActions.handleAppeaseFaction(cityId);
+        openCityOverviewPanel(); // re-render with updated unrest/gold state
+      },
+      onConcedeToMovement: (cityId) => {
+        deps.diplomacyActions.handleConcedeToMovement(cityId);
+        openCityOverviewPanel(); // re-render with updated unrest/gold state
+      },
+      onClose: () => {
+        deps.getElementById('city-overview-panel')?.remove();
+      },
+    });
+  }
+
+  function openCouncilPanel(): void {
+    deps.hud.closeDrawer();
+    createCouncilPanel(deps.uiLayer, deps.session.getState(), {
+      onClose: () => {
+        deps.getElementById('council-panel')?.remove();
+      },
+      onTalkLevelChange: (level) => {
+        deps.session.getState().settings.councilTalkLevel = level;
+        void saveSettings(deps.session.getState().settings);
+      },
+    });
+  }
+
+  function openTechPanel(): void {
+    deps.hud.closeDrawer();
+    createTechPanel(deps.uiLayer, deps.session.getState(), {
+      onQueueResearch: (techId) => {
+        try {
+          deps.currentCiv().techState = enqueueResearch(deps.currentCiv().techState, techId);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Queue limit reached';
+          deps.showNotification(message, 'warning');
+          return;
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.showNotification(`Queued research: ${techId}`, 'info');
+      },
+      onMoveQueuedResearch: (fromIndex, toIndex) => {
+        deps.currentCiv().techState = {
+          ...deps.currentCiv().techState,
+          researchQueue: moveQueuedId(deps.currentCiv().techState.researchQueue, fromIndex, toIndex),
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+      },
+      onRemoveQueuedResearch: (index) => {
+        deps.currentCiv().techState = {
+          ...deps.currentCiv().techState,
+          researchQueue: removeQueuedId(deps.currentCiv().techState.researchQueue, index),
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+      },
+      onClose: () => {},
+    });
+  }
+
+  function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
+    const panel = deps.getElementById('info-panel');
+    if (!panel) return;
+
+    renderUnitStackPanel(panel, deps.session.getState(), coord, unitIds, {
+      onSelectUnit: (unitId) => deps.selectionController.selectUnit(unitId),
+      onOpenCity: (cityId) => {
+        const city = deps.session.getState().cities[cityId];
+        if (!city) return;
+        deps.getElementById('tech-panel')?.remove();
+        deps.getElementById('city-panel')?.remove();
+        deps.getElementById('espionage-panel')?.remove();
+        deps.getElementById('diplomacy-panel')?.remove();
+        deps.getElementById('marketplace-panel')?.remove();
+        deps.getElementById('council-panel')?.remove();
+        deps.selectionController.deselectUnit();
+        deps.openCityPanelForCity(city);
+      },
+      onClose: () => deps.selectionController.deselectUnit(),
+    }, { selectedUnitId: deps.selection.getSelectedUnitId() });
+  }
+
+  function openNetworkIntentPanel(sourceUnitId: string): void {
+    const source = deps.session.getState().units[sourceUnitId];
+    const ownerCivId = deps.session.getState().currentPlayer;
+    if (!source || source.owner !== ownerCivId || !isAutonomyActivated(deps.session.getState(), ownerCivId)) {
+      deps.showNotification('This unit cannot coordinate the network right now.', 'warning');
+      return;
+    }
+    if (source.type === 'drone_controller') {
+      // Formation targets are generated and previewed by the same full Network
+      // panel used for city plans, so the controller never receives a UI-only
+      // legality shortcut.
+      openNetworkPanel();
+      return;
+    }
+    if (source.type !== 'cyber_unit') {
+      deps.showNotification('Only a Cyber Unit or Drone Controller can coordinate the network.', 'warning');
+      return;
+    }
+
+    let panel: HTMLElement | undefined;
+    const close = () => panel?.remove();
+    panel = createNetworkIntentPanel(deps.session.getState(), ownerCivId, sourceUnitId, {
+      onAssign: (definitionId, cityId) => {
+        const current = Object.values(deps.session.getState().autonomyByCiv?.[ownerCivId]?.plans ?? {})
+          .find(plan => plan.sourceUnitId === sourceUnitId);
+        const stateForAssignment = current && current.definitionId !== definitionId
+          ? holdNetworkPlan(deps.session.getState(), ownerCivId, sourceUnitId).state
+          : deps.session.getState();
+        const result = current && current.definitionId === definitionId
+          ? retargetNetworkPlan(deps.session.getState(), ownerCivId, current.id, { kind: 'city', cityId })
+          : assignNetworkPlan(stateForAssignment, {
+            ownerCivId,
+            sourceUnitId,
+            definitionId,
+            target: { kind: 'city', cityId },
+          });
+        if (!result.validation.ok) {
+          deps.showNotification('That network intent is no longer available. Choose another target.', 'warning');
+          close();
+          openNetworkIntentPanel(sourceUnitId);
+          return;
+        }
+        deps.session.commit(result.state);
+        close();
+        deps.selectionController.selectUnit(sourceUnitId);
+        const cityName = deps.session.getState().cities[cityId]?.name ?? 'the city';
+        deps.showNotification(`${definitionId === 'harden' ? 'Harden' : 'Exploit'} assigned to ${cityName}.`, 'success');
+      },
+      onHold: () => {
+        const result = holdNetworkPlan(deps.session.getState(), ownerCivId, sourceUnitId);
+        deps.session.commit(result.state);
+        close();
+        deps.selectionController.selectUnit(sourceUnitId);
+        deps.showNotification('Cyber Unit is holding.', 'info');
+      },
+      onClose: close,
+    });
+    deps.uiLayer.appendChild(panel);
+  }
+
+  function openNetworkPanel(): void {
+    const civId = deps.session.getState().currentPlayer;
+    if (!isAutonomyActivated(deps.session.getState(), civId)) return;
+    let panel: HTMLElement | undefined;
+    const rerender = () => {
+      panel?.remove();
+      panel = createNetworkPanel(getNetworkPanelModel(deps.session.getState(), civId), {
+        onAssign: request => {
+          const result = assignNetworkPlan(deps.session.getState(), request);
+          if (!result.validation.ok) {
+            deps.showNotification('That plan is no longer available.', 'warning');
+            rerender();
+            return;
+          }
+          deps.session.commit(result.state);
+          deps.showNotification('Network plan assigned.', 'success');
+          rerender();
+        },
+        onCancel: planId => {
+          deps.session.commit(cancelNetworkPlan(deps.session.getState(), civId, planId).state);
+          rerender();
+        },
+        onSurge: planId => {
+          const result = beginAutonomySurge(deps.session.getState(), civId, planId);
+          if (!result.validation.ok) deps.showNotification('Surge is unavailable while the network recovers or cools down.', 'warning');
+          else {
+            deps.session.commit(result.state);
+            deps.bus.emit('network:audio-cue', { cue: 'surge', viewerIds: [civId] });
+            deps.showNotification('Network Surge confirmed.', 'success');
+          }
+          rerender();
+        },
+        onPosture: posture => {
+          deps.session.commit(requestAutonomyPosture(deps.session.getState(), civId, posture));
+          rerender();
+        },
+        onClose: () => panel?.remove(),
+      });
+      deps.uiLayer.appendChild(panel);
+    };
+    rerender();
+  }
+
   return {
     openPacingDebugPanel,
     openBestiary,
@@ -309,5 +621,14 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
     openPirateWaters,
     openPirateHeadquartersAssault,
     openNotificationLog,
+    openDiplomacyPanel,
+    openMarketplacePanel,
+    openWonderPanelForCityId,
+    openCityOverviewPanel,
+    openCouncilPanel,
+    openTechPanel,
+    openUnitStackPicker,
+    openNetworkIntentPanel,
+    openNetworkPanel,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,11 +8,9 @@ import { chooseCircularManufacturingMaterial } from '@/systems/national-project-
 import { foundCityInState } from '@/systems/city-founding-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
-import { enqueueCityProduction, enqueueResearch, moveQueuedId, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
-import { createTechPanel } from '@/ui/tech-panel';
+import { enqueueCityProduction, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
 import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
-import { createWonderPanel } from '@/ui/wonder-panel';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
@@ -28,26 +26,18 @@ import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoic
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { recordBeastSightings } from '@/systems/beast-presentation';
-import { loadSettings, saveSettings } from '@/storage/save-manager';
+import { loadSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX } from '@/audio/sfx';
-import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
-import { createMarketplacePanel } from '@/ui/marketplace-panel';
 import { createEspionagePanel } from '@/ui/espionage-panel';
 import { AdvisorSystem } from '@/ui/advisor-system';
-import { createCouncilPanel } from '@/ui/council-panel';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { PirateActionResult } from '@/systems/pirate-actions';
 import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
-import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
-import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
-import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { declareWar, makePeace, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
-import { assignNetworkPlan, cancelNetworkPlan, holdNetworkPlan, isAutonomyActivated, retargetNetworkPlan } from '@/systems/network-plan-system';
-import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
 import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
@@ -57,14 +47,13 @@ import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupa
 import { beginPlayerCityAssaultChoice, shouldPromptForPlayerCityCapture } from '@/input/city-assault-flow';
 import { canUnitOccupyCity } from '@/systems/city-capture-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import { initializeLegendaryWonderProjectsForCity, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
 import { embedSpy, unembedSpy, attemptSweep, getAvailableMissions, getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType, missionRequiresPlacedSpy, recallSpy, resolveMissionResult, startMission, verifyAgent } from '@/systems/espionage-system';
 import { applyUnitUpgradeToState, evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
 import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
-import type { CombatResult, GameState, HexCoord, Unit, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
 import { appendNotification, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
 import type { NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
@@ -72,7 +61,6 @@ import type { Notifier } from '@/app/ports';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { rushBuyActiveProduction } from '@/systems/economy-system';
 import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
-import { canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
@@ -88,7 +76,6 @@ import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-syst
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
-import { createCityOverviewPanel } from '@/ui/city-overview-panel';
 import type { GameSession } from '@/app/ports';
 import { createGameSession } from '@/app/game-session';
 import { createPanelHost, type PanelHost } from '@/app/panel-host';
@@ -211,7 +198,7 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
     if (city) openCityPanelForCity(city);
   },
   openJournal: cityId => {
-    if (session.getState().cities[cityId]) openWonderPanelForCityId(cityId);
+    if (session.getState().cities[cityId]) panelActions.openWonderPanelForCityId(cityId);
   },
 });
 
@@ -231,7 +218,10 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
  * in module evaluation (`selectionController` right below this, `hud` further
  * down), so a direct reference here would capture `undefined` at construction
  * time. Same deferred-but-eager closure pattern `selectionController` itself
- * already uses for `updateHUD: () => hud.update()` below.
+ * already uses for `updateHUD: () => hud.update()` below. `openDiplomacyPanel`
+ * is now `PanelActionsController`'s own function (phase 10b-c), but `panelActions`
+ * is constructed just below `diplomacyActions`, so the same lazy-wrapper
+ * treatment applies here too, not a direct reference.
  */
 const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsController({
   session,
@@ -239,17 +229,18 @@ const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsContr
   renderLoop,
   uiLayer,
   showNotification,
-  openDiplomacyPanel,
+  openDiplomacyPanel: () => panelActions.openDiplomacyPanel(),
   hud: { update: () => hud.update() },
   selectionController: { selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts) },
 });
 
 /**
- * Owns the utility and world-event panel openers (#787 phase 10b-b -- part 1
- * of 3 for `PanelActionsController`, see 10b-c/10b-d for the rest). `hud` and
- * `selectionController` use the same deferred-but-eager lazy-wrapper pattern
- * as `diplomacyActions` above, for the same reason (neither is assigned yet
- * at this point in module evaluation).
+ * Owns the panel openers extracted across #787 phases 10b-b (utility/world-event
+ * panels) and 10b-c (unit/network/civ-management panels), see 10b-d for the
+ * rest. `hud` and `selectionController` use the same deferred-but-eager
+ * lazy-wrapper pattern as `diplomacyActions` above, for the same reason
+ * (neither is assigned yet at this point in module evaluation). `diplomacyActions`
+ * needs no such wrapper here since it is constructed just above.
  */
 const panelActions: PanelActionsController = createPanelActionsController({
   session,
@@ -263,8 +254,9 @@ const panelActions: PanelActionsController = createPanelActionsController({
   focusNotificationTarget,
   focusPirateTarget,
   applyPirateActionResult,
+  currentCiv,
+  diplomacyActions,
   openCityPanelForCity,
-  openWonderPanelForCityId,
   hud: { closeDrawer: () => hud.closeDrawer(), update: () => hud.update() },
   selectionController: {
     selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts),
@@ -289,8 +281,8 @@ const selectionController: SelectionController = createSelectionController({
   performWorkerAction,
   performPreach,
   restAction,
-  openNetworkIntentPanel,
-  openUnitStackPicker,
+  openNetworkIntentPanel: panelActions.openNetworkIntentPanel,
+  openUnitStackPicker: panelActions.openUnitStackPicker,
   openPirateHeadquartersAssault: panelActions.openPirateHeadquartersAssault,
   handleEstablishRoute: diplomacyActions.handleEstablishRoute,
   executeUpgrade,
@@ -369,7 +361,7 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   clearUnloadState,
   currentCiv,
   openPirateWaters: panelActions.openPirateWaters,
-  openUnitStackPicker,
+  openUnitStackPicker: panelActions.openUnitStackPicker,
   openCityPanelForCity,
   openWonderAtlas: panelActions.openWonderAtlas,
   executeAttack,
@@ -608,45 +600,6 @@ function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: s
   hud.update();
 }
 
-function openDiplomacyPanel(): void {
-  hud.closeDrawer();
-  document.getElementById('diplomacy-panel')?.remove();
-  createDiplomacyPanel(uiLayer, session.getState(), {
-    onAction: diplomacyActions.handleDiplomaticAction,
-    onAcceptPeaceRequest: diplomacyActions.handleAcceptPeaceRequest,
-    onRejectPeaceRequest: diplomacyActions.handleRejectPeaceRequest,
-    onAcceptTreatyProposal: diplomacyActions.handleAcceptTreatyProposal,
-    onDeclineTreatyProposal: diplomacyActions.handleDeclineTreatyProposal,
-    onBreakTreaty: diplomacyActions.handleBreakTreaty,
-    onGiftGold: diplomacyActions.handleGiftGold,
-    onSponsorFestival: diplomacyActions.handleSponsorFestival,
-    onMinorCivReparations: diplomacyActions.handleMinorCivReparations,
-    onMinorCivWarPeace: diplomacyActions.handleMinorCivWarPeace,
-    onSendAid: diplomacyActions.handleSendAid,
-    onClose: () => {},
-  });
-}
-
-function openMarketplacePanel(): void {
-  hud.closeDrawer();
-  document.getElementById('marketplace-panel')?.remove();
-  createMarketplacePanel(uiLayer, session.getState(), {
-    onClose: () => {},
-    onSelectUnit: (unitId) => {
-      document.getElementById('marketplace-panel')?.remove();
-      selectionController.selectUnit(unitId);
-      const unit = session.getState().units[unitId];
-      if (unit) renderLoop.camera.centerOn(unit.position);
-    },
-    onBuyResourceAccess: (sellerCivId, resource) => {
-      if (!canBuyResourceAccess(session.getState(), session.getState().currentPlayer, sellerCivId, resource)) return;
-      session.commit(performBuyResourceAccess(session.getState(), session.getState().currentPlayer, sellerCivId, resource));
-      showNotification(`Purchased ${resource} access for 10 turns.`, 'success');
-      openMarketplacePanel(); // re-render panel with updated state
-    },
-  });
-}
-
 function executeUpgrade(
   unitId: string,
   targetType: import('@/core/types').UnitType,
@@ -655,61 +608,6 @@ function executeUpgrade(
   if (!result.upgraded) return false;
   session.commit(result.state);
   return true;
-}
-
-function openWonderPanelForCityId(selectedCityId: string): void {
-  if (!session.getState().cities[selectedCityId]) return;
-
-  const openWonderPanel = () => {
-    document.getElementById('wonder-panel')?.remove();
-    createWonderPanel(uiLayer, session.getState(), selectedCityId, {
-      onStartBuild: (buildCityId, wonderId) => {
-        session.setStateWithoutRefresh(startLegendaryWonderBuild(session.getState(), session.getState().currentPlayer, buildCityId, wonderId, bus));
-        const targetCity = session.getState().cities[buildCityId];
-        if (targetCity) {
-          renderLoop.setGameState(session.getState());
-          hud.update();
-          const productionItemId = `legendary:${wonderId}`;
-          if (targetCity.productionQueue[0] === productionItemId) {
-            showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
-          } else {
-            showNotification(`${targetCity.name}: ${getProductionDisplayName(productionItemId)} is not ready to start.`, 'warning');
-          }
-          openWonderPanel();
-        }
-      },
-      onClose: () => {
-        document.getElementById('wonder-panel')?.remove();
-      },
-    });
-  };
-  session.setStateWithoutRefresh(initializeLegendaryWonderProjectsForCity(session.getState(), session.getState().currentPlayer, selectedCityId));
-  openWonderPanel();
-}
-
-function openCityOverviewPanel(): void {
-  hud.closeDrawer();
-  const existing = document.getElementById('city-overview-panel');
-  if (existing) existing.remove();
-  createCityOverviewPanel(uiLayer, session.getState(), {
-    onOpenCity: (cityId) => {
-      const overview = document.getElementById('city-overview-panel');
-      overview?.remove();
-      const city = session.getState().cities[cityId];
-      if (city) openCityPanelForCity(city);
-    },
-    onAppeaseFaction: (cityId) => {
-      diplomacyActions.handleAppeaseFaction(cityId);
-      openCityOverviewPanel(); // re-render with updated unrest/gold state
-    },
-    onConcedeToMovement: (cityId) => {
-      diplomacyActions.handleConcedeToMovement(cityId);
-      openCityOverviewPanel(); // re-render with updated unrest/gold state
-    },
-    onClose: () => {
-      document.getElementById('city-overview-panel')?.remove();
-    },
-  });
 }
 
 function openCityPanelForCity(city: import('@/core/types').City): void {
@@ -747,7 +645,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       renderLoop.setGameState(session.getState());
     },
     onOpenWonderPanel: (selectedCityId) => {
-      openWonderPanelForCityId(selectedCityId);
+      panelActions.openWonderPanelForCityId(selectedCityId);
     },
     onSetCityFocus: (cityId, focus) => {
       const result = assignCityFocus(session.getState(), cityId, focus);
@@ -850,54 +748,6 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       const refreshedCity = session.getState().cities[city.id];
       if (refreshedCity) openCityPanelForCity(refreshedCity);
     },
-  });
-}
-
-function openCouncilPanel(): void {
-  hud.closeDrawer();
-  createCouncilPanel(uiLayer, session.getState(), {
-    onClose: () => {
-      document.getElementById('council-panel')?.remove();
-    },
-    onTalkLevelChange: (level) => {
-      session.getState().settings.councilTalkLevel = level;
-      void saveSettings(session.getState().settings);
-    },
-  });
-}
-
-function openTechPanel(): void {
-  hud.closeDrawer();
-  createTechPanel(uiLayer, session.getState(), {
-    onQueueResearch: (techId) => {
-      try {
-        currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Queue limit reached';
-        showNotification(message, 'warning');
-        return;
-      }
-      renderLoop.setGameState(session.getState());
-      hud.update();
-      showNotification(`Queued research: ${techId}`, 'info');
-    },
-    onMoveQueuedResearch: (fromIndex, toIndex) => {
-      currentCiv().techState = {
-        ...currentCiv().techState,
-        researchQueue: moveQueuedId(currentCiv().techState.researchQueue, fromIndex, toIndex),
-      };
-      renderLoop.setGameState(session.getState());
-      hud.update();
-    },
-    onRemoveQueuedResearch: (index) => {
-      currentCiv().techState = {
-        ...currentCiv().techState,
-        researchQueue: removeQueuedId(currentCiv().techState.researchQueue, index),
-      };
-      renderLoop.setGameState(session.getState());
-      hud.update();
-    },
-    onClose: () => {},
   });
 }
 
@@ -1134,15 +984,16 @@ function openEspionagePanel(): void {
  * parameterless "open the current one" call, so their `open` throws; they
  * still need a registry entry so `closeGroup`/`isOpen`/`close` (all
  * DOM-derived off `domId`) behave correctly when a 'main' or 'transient'
- * sweep runs. Their real entry points (`openCityPanelForCity`,
- * `openWonderPanelForCityId`) stay directly-callable functions, untouched
- * by this phase. The territory-inspection panel has no such entry point of
+ * sweep runs. `openCityPanelForCity`'s real entry point stays a
+ * directly-callable function, untouched by this phase (10b-d);
+ * `openWonderPanelForCityId`'s moved into `PanelActionsController` (10b-c).
+ * The territory-inspection panel has no such entry point of
  * its own -- it opens only as a side effect of `mapInteraction.handleHexLongPress`
  * (#787 phase 8d), which is not itself in this registry.
  */
 const panelRegistry = {
-  council: { domId: 'council-panel', group: 'main', open: () => openCouncilPanel() },
-  tech: { domId: 'tech-panel', group: 'main', open: () => openTechPanel() },
+  council: { domId: 'council-panel', group: 'main', open: () => panelActions.openCouncilPanel() },
+  tech: { domId: 'tech-panel', group: 'main', open: () => panelActions.openTechPanel() },
   city: {
     domId: 'city-panel',
     group: 'main',
@@ -1151,21 +1002,21 @@ const panelRegistry = {
     },
   },
   espionage: { domId: 'espionage-panel', group: 'main', open: () => openEspionagePanel() },
-  diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => openDiplomacyPanel() },
-  marketplace: { domId: 'marketplace-panel', group: 'main', open: () => openMarketplacePanel() },
-  network: { domId: 'network-panel', group: 'transient', open: () => openNetworkPanel() },
+  diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => panelActions.openDiplomacyPanel() },
+  marketplace: { domId: 'marketplace-panel', group: 'main', open: () => panelActions.openMarketplacePanel() },
+  network: { domId: 'network-panel', group: 'transient', open: () => panelActions.openNetworkPanel() },
   wonder: {
     domId: 'wonder-panel',
     group: 'transient',
     open: () => {
-      throw new Error("'wonder' is parameterized -- call openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
+      throw new Error("'wonder' is parameterized -- call panelActions.openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
     },
   },
   'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => panelActions.openWonderAtlas() },
   bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => panelActions.openBestiary() },
   'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => panelActions.openPirateWaters() },
   'notification-log': { domId: 'notification-log', group: 'transient', open: () => panelActions.openNotificationLog() },
-  'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => openCityOverviewPanel() },
+  'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => panelActions.openCityOverviewPanel() },
   'territory-inspection': {
     domId: 'territory-inspection-panel',
     group: 'transient',
@@ -1179,131 +1030,6 @@ const panelRegistry = {
 } satisfies PanelRegistry;
 
 router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });
-
-function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
-  const panel = document.getElementById('info-panel');
-  if (!panel) return;
-
-  renderUnitStackPanel(panel, session.getState(), coord, unitIds, {
-    onSelectUnit: (unitId) => selectionController.selectUnit(unitId),
-    onOpenCity: (cityId) => {
-      const city = session.getState().cities[cityId];
-      if (!city) return;
-      document.getElementById('tech-panel')?.remove();
-      document.getElementById('city-panel')?.remove();
-      document.getElementById('espionage-panel')?.remove();
-      document.getElementById('diplomacy-panel')?.remove();
-      document.getElementById('marketplace-panel')?.remove();
-      document.getElementById('council-panel')?.remove();
-      selectionController.deselectUnit();
-      openCityPanelForCity(city);
-    },
-    onClose: () => selectionController.deselectUnit(),
-  }, { selectedUnitId: selection.getSelectedUnitId() });
-}
-
-function openNetworkIntentPanel(sourceUnitId: string): void {
-  const source = session.getState().units[sourceUnitId];
-  const ownerCivId = session.getState().currentPlayer;
-  if (!source || source.owner !== ownerCivId || !isAutonomyActivated(session.getState(), ownerCivId)) {
-    showNotification('This unit cannot coordinate the network right now.', 'warning');
-    return;
-  }
-  if (source.type === 'drone_controller') {
-    // Formation targets are generated and previewed by the same full Network
-    // panel used for city plans, so the controller never receives a UI-only
-    // legality shortcut.
-    openNetworkPanel();
-    return;
-  }
-  if (source.type !== 'cyber_unit') {
-    showNotification('Only a Cyber Unit or Drone Controller can coordinate the network.', 'warning');
-    return;
-  }
-
-  let panel: HTMLElement | undefined;
-  const close = () => panel?.remove();
-  panel = createNetworkIntentPanel(session.getState(), ownerCivId, sourceUnitId, {
-    onAssign: (definitionId, cityId) => {
-      const current = Object.values(session.getState().autonomyByCiv?.[ownerCivId]?.plans ?? {})
-        .find(plan => plan.sourceUnitId === sourceUnitId);
-      const stateForAssignment = current && current.definitionId !== definitionId
-        ? holdNetworkPlan(session.getState(), ownerCivId, sourceUnitId).state
-        : session.getState();
-      const result = current && current.definitionId === definitionId
-        ? retargetNetworkPlan(session.getState(), ownerCivId, current.id, { kind: 'city', cityId })
-        : assignNetworkPlan(stateForAssignment, {
-          ownerCivId,
-          sourceUnitId,
-          definitionId,
-          target: { kind: 'city', cityId },
-        });
-      if (!result.validation.ok) {
-        showNotification('That network intent is no longer available. Choose another target.', 'warning');
-        close();
-        openNetworkIntentPanel(sourceUnitId);
-        return;
-      }
-      session.commit(result.state);
-      close();
-      selectionController.selectUnit(sourceUnitId);
-      const cityName = session.getState().cities[cityId]?.name ?? 'the city';
-      showNotification(`${definitionId === 'harden' ? 'Harden' : 'Exploit'} assigned to ${cityName}.`, 'success');
-    },
-    onHold: () => {
-      const result = holdNetworkPlan(session.getState(), ownerCivId, sourceUnitId);
-      session.commit(result.state);
-      close();
-      selectionController.selectUnit(sourceUnitId);
-      showNotification('Cyber Unit is holding.', 'info');
-    },
-    onClose: close,
-  });
-  uiLayer.appendChild(panel);
-}
-
-function openNetworkPanel(): void {
-  const civId = session.getState().currentPlayer;
-  if (!isAutonomyActivated(session.getState(), civId)) return;
-  let panel: HTMLElement | undefined;
-  const rerender = () => {
-    panel?.remove();
-    panel = createNetworkPanel(getNetworkPanelModel(session.getState(), civId), {
-      onAssign: request => {
-        const result = assignNetworkPlan(session.getState(), request);
-        if (!result.validation.ok) {
-          showNotification('That plan is no longer available.', 'warning');
-          rerender();
-          return;
-        }
-        session.commit(result.state);
-        showNotification('Network plan assigned.', 'success');
-        rerender();
-      },
-      onCancel: planId => {
-        session.commit(cancelNetworkPlan(session.getState(), civId, planId).state);
-        rerender();
-      },
-      onSurge: planId => {
-        const result = beginAutonomySurge(session.getState(), civId, planId);
-        if (!result.validation.ok) showNotification('Surge is unavailable while the network recovers or cools down.', 'warning');
-        else {
-          session.commit(result.state);
-          bus.emit('network:audio-cue', { cue: 'surge', viewerIds: [civId] });
-          showNotification('Network Surge confirmed.', 'success');
-        }
-        rerender();
-      },
-      onPosture: posture => {
-        session.commit(requestAutonomyPosture(session.getState(), civId, posture));
-        rerender();
-      },
-      onClose: () => panel?.remove(),
-    });
-    uiLayer.appendChild(panel);
-  };
-  rerender();
-}
 
 function getUnitTurnFlow() {
   return createUnitTurnFlow({

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -4,6 +4,7 @@ import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import { createGameSession } from '@/app/game-session';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
+import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
 import { createUnit } from '@/systems/unit-system';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { NotificationMapTarget } from '@/core/notification-log';
@@ -19,6 +20,19 @@ vi.mock('@/ui/wonder-atlas-panel', () => ({ createWonderAtlasPanel: vi.fn() }));
 vi.mock('@/ui/pirate-waters-panel', () => ({ createPirateWatersPanel: vi.fn() }));
 vi.mock('@/ui/pirate-headquarters-assault-panel', () => ({ createPirateHeadquartersAssaultPanel: vi.fn() }));
 vi.mock('@/ui/notification-log-panel', () => ({ createNotificationLogPanel: vi.fn() }));
+vi.mock('@/ui/diplomacy-panel', () => ({ createDiplomacyPanel: vi.fn() }));
+vi.mock('@/ui/marketplace-panel', () => ({ createMarketplacePanel: vi.fn() }));
+vi.mock('@/ui/wonder-panel', () => ({ createWonderPanel: vi.fn() }));
+vi.mock('@/ui/city-overview-panel', () => ({ createCityOverviewPanel: vi.fn() }));
+vi.mock('@/ui/council-panel', () => ({ createCouncilPanel: vi.fn() }));
+vi.mock('@/ui/tech-panel', () => ({ createTechPanel: vi.fn() }));
+vi.mock('@/ui/unit-stack-panel', () => ({ renderUnitStackPanel: vi.fn() }));
+vi.mock('@/ui/network-intent-panel', () => ({ createNetworkIntentPanel: vi.fn(() => document.createElement('div')) }));
+vi.mock('@/ui/network-panel', async () => {
+  const actual = await vi.importActual<typeof import('@/ui/network-panel')>('@/ui/network-panel');
+  return { createNetworkPanel: vi.fn(() => document.createElement('div')), getNetworkPanelModel: actual.getNetworkPanelModel };
+});
+vi.mock('@/storage/save-manager', () => ({ saveSettings: vi.fn(() => Promise.resolve()) }));
 
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { createBestiaryPanel } from '@/ui/bestiary-panel';
@@ -26,6 +40,16 @@ import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { createPirateWatersPanel } from '@/ui/pirate-waters-panel';
 import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
 import { createNotificationLogPanel } from '@/ui/notification-log-panel';
+import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
+import { createMarketplacePanel } from '@/ui/marketplace-panel';
+import { createWonderPanel } from '@/ui/wonder-panel';
+import { createCityOverviewPanel } from '@/ui/city-overview-panel';
+import { createCouncilPanel } from '@/ui/council-panel';
+import { createTechPanel } from '@/ui/tech-panel';
+import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
+import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
+import { createNetworkPanel } from '@/ui/network-panel';
+import { saveSettings } from '@/storage/save-manager';
 
 function mockedCallArg<T = unknown>(mockFn: unknown, callIndex: number, argIndex: number): T {
   return (mockFn as ReturnType<typeof vi.fn>).mock.calls[callIndex][argIndex] as T;
@@ -36,6 +60,13 @@ function makeFixture(seed = 'panel-actions-controller'): { state: GameState; aiC
   state.currentPlayer = 'player';
   const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
   return { state, aiCivId };
+}
+
+/** Places a real player-owned unit of the given type at a position, for network-panel tests. */
+function placeUnit(state: GameState, type: Parameters<typeof createUnit>[0], unitId: string, position: HexCoord): void {
+  const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+  state.units[unitId] = { ...createUnit(type, 'player', position, idCounters), id: unitId };
+  state.civilizations.player.units.push(unitId);
 }
 
 /** A coastal-enclave pirate faction adjacent to a real player unit, with intel already gathered. */
@@ -94,8 +125,23 @@ function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDep
     focusNotificationTarget: vi.fn(),
     focusPirateTarget: vi.fn(),
     applyPirateActionResult: vi.fn(),
+    currentCiv: vi.fn(() => state.civilizations[state.currentPlayer]),
+    diplomacyActions: {
+      handleDiplomaticAction: vi.fn(),
+      handleAcceptPeaceRequest: vi.fn(),
+      handleRejectPeaceRequest: vi.fn(),
+      handleAcceptTreatyProposal: vi.fn(),
+      handleDeclineTreatyProposal: vi.fn(),
+      handleBreakTreaty: vi.fn(),
+      handleGiftGold: vi.fn(),
+      handleSponsorFestival: vi.fn(),
+      handleMinorCivReparations: vi.fn(),
+      handleSendAid: vi.fn(),
+      handleMinorCivWarPeace: vi.fn(),
+      handleAppeaseFaction: vi.fn(() => state),
+      handleConcedeToMovement: vi.fn(() => state),
+    },
     openCityPanelForCity: vi.fn(),
-    openWonderPanelForCityId: vi.fn(),
     ...overrides,
   };
 }
@@ -305,8 +351,275 @@ describe('PanelActionsController', () => {
 
       options.onOpenWonderCity({ cityId: 'no-such-city', wonderId: 'great-lighthouse' });
 
-      expect(deps.openWonderPanelForCityId).not.toHaveBeenCalled();
+      // openWonderPanelForCityId is now a real sibling function (phase 10b-c), not an
+      // injected mock -- assert its visible effect (no wonder panel built) instead.
+      expect(createWonderPanel).not.toHaveBeenCalled();
       expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+  });
+
+  describe('openDiplomacyPanel', () => {
+    it('closes the drawer, removes any prior panel, and wires the action callback to diplomacyActions', () => {
+      const { state } = makeFixture('diplomacy-panel');
+      const { deps, controller } = build(state);
+
+      controller.openDiplomacyPanel();
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      expect(createDiplomacyPanel).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onAction: (civId: string, action: string) => void }>(createDiplomacyPanel, 0, 2);
+      options.onAction('ai-1', 'declare_war');
+      expect(deps.diplomacyActions.handleDiplomaticAction).toHaveBeenCalledWith('ai-1', 'declare_war');
+    });
+  });
+
+  describe('openMarketplacePanel', () => {
+    it('closes the drawer and selects/centers on a unit chosen from the panel', () => {
+      const { state } = makeFixture('marketplace-panel');
+      addPirateFixture(state, { q: 5, r: 5 }, { q: 5, r: 4 }, 'attacker');
+      const { deps, controller } = build(state);
+
+      controller.openMarketplacePanel();
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onSelectUnit: (unitId: string) => void }>(createMarketplacePanel, 0, 2);
+      options.onSelectUnit('attacker');
+
+      expect(deps.selectionController.selectUnit).toHaveBeenCalledWith('attacker');
+      expect(deps.renderLoop.camera.centerOn).toHaveBeenCalledWith(state.units.attacker.position);
+    });
+
+    it('does not re-render (real canBuyResourceAccess guard blocks it) for an uncontacted civ', () => {
+      // Real system call, not mocked: `canBuyResourceAccess` returns false for a civ the
+      // player hasn't met (no entry in `diplomacy.relationships`), so the early return
+      // must prevent both the purchase and the panel re-render.
+      const { state, aiCivId } = makeFixture('marketplace-buy-blocked');
+      const { controller } = build(state);
+
+      controller.openMarketplacePanel();
+      const options = mockedCallArg<{ onBuyResourceAccess: (sellerCivId: string, resource: string) => void }>(createMarketplacePanel, 0, 2);
+      options.onBuyResourceAccess(aiCivId, 'iron');
+
+      expect(createMarketplacePanel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('openWonderPanelForCityId', () => {
+    it('does nothing when the city does not exist', () => {
+      const { state } = makeFixture('wonder-panel-missing-city');
+      const { controller } = build(state);
+
+      controller.openWonderPanelForCityId('no-such-city');
+
+      expect(createWonderPanel).not.toHaveBeenCalled();
+    });
+
+    it('builds the panel for a real owned city and removes it on close', () => {
+      const { state } = makeFixture('wonder-panel-real-city');
+      state.cities['test-city'] = {
+        id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      };
+      const { deps, controller } = build(state);
+
+      controller.openWonderPanelForCityId('test-city');
+
+      expect(createWonderPanel).toHaveBeenCalledTimes(1);
+      expect(mockedCallArg<string>(createWonderPanel, 0, 2)).toBe('test-city');
+
+      const options = mockedCallArg<{ onClose: () => void }>(createWonderPanel, 0, 3);
+      options.onClose();
+      expect(deps.getElementById).toHaveBeenCalledWith('wonder-panel');
+    });
+  });
+
+  describe('openCityOverviewPanel', () => {
+    function makeOverviewCity(): NonNullable<GameState['cities'][string]> {
+      return {
+        id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      };
+    }
+
+    it('closes the drawer, removes any prior panel, and opens the injected city panel dep', () => {
+      const { state } = makeFixture('city-overview');
+      state.cities['test-city'] = makeOverviewCity();
+      const { deps, controller } = build(state);
+
+      controller.openCityOverviewPanel();
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onOpenCity: (cityId: string) => void }>(createCityOverviewPanel, 0, 2);
+      options.onOpenCity('test-city');
+      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+    });
+
+    it('appeases a faction via diplomacyActions and re-renders the panel', () => {
+      const { state } = makeFixture('city-overview-appease');
+      state.cities['test-city'] = makeOverviewCity();
+      const { deps, controller } = build(state);
+
+      controller.openCityOverviewPanel();
+      const options = mockedCallArg<{ onAppeaseFaction: (cityId: string) => void }>(createCityOverviewPanel, 0, 2);
+      options.onAppeaseFaction('test-city');
+
+      expect(deps.diplomacyActions.handleAppeaseFaction).toHaveBeenCalledWith('test-city');
+      expect(createCityOverviewPanel).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('openCouncilPanel', () => {
+    it('closes the drawer and persists a talk-level change to live session settings', () => {
+      const { state } = makeFixture('council-panel');
+      const { deps, controller } = build(state);
+
+      controller.openCouncilPanel();
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onTalkLevelChange: (level: string) => void }>(createCouncilPanel, 0, 2);
+      options.onTalkLevelChange('detailed');
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('detailed');
+      expect(saveSettings).toHaveBeenCalledWith(expect.objectContaining({ councilTalkLevel: 'detailed' }));
+    });
+  });
+
+  describe('openTechPanel', () => {
+    it('queues real research via the live civ tech state and refreshes the renderer/HUD', () => {
+      const { state } = makeFixture('tech-panel-queue');
+      const { deps, controller } = build(state);
+
+      controller.openTechPanel();
+
+      const options = mockedCallArg<{ onQueueResearch: (techId: string) => void }>(createTechPanel, 0, 2);
+      options.onQueueResearch('fire');
+
+      expect(state.civilizations.player.techState.currentResearch).toBe('fire');
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('fire'), 'info');
+    });
+
+    it('reorders and removes queued research via the real planning-system helpers', () => {
+      const { state } = makeFixture('tech-panel-reorder');
+      state.civilizations.player.techState.currentResearch = 'fire';
+      state.civilizations.player.techState.researchQueue = ['writing', 'wheel'];
+      const { controller } = build(state);
+
+      controller.openTechPanel();
+      const options = mockedCallArg<{
+        onMoveQueuedResearch: (fromIndex: number, toIndex: number) => void;
+        onRemoveQueuedResearch: (index: number) => void;
+      }>(createTechPanel, 0, 2);
+
+      options.onMoveQueuedResearch(0, 1);
+      expect(state.civilizations.player.techState.researchQueue).toEqual(['wheel', 'writing']);
+
+      options.onRemoveQueuedResearch(0);
+      expect(state.civilizations.player.techState.researchQueue).toEqual(['writing']);
+    });
+  });
+
+  describe('openUnitStackPicker', () => {
+    it('does nothing when the info panel is not present', () => {
+      const { state } = makeFixture('unit-stack-missing-panel');
+      const { deps, controller } = build(state, { getElementById: vi.fn(() => null) });
+
+      controller.openUnitStackPicker({ q: 0, r: 0 }, ['attacker']);
+
+      expect(renderUnitStackPanel).not.toHaveBeenCalled();
+      expect(deps.getElementById).toHaveBeenCalledWith('info-panel');
+    });
+
+    it('opens the injected city panel dep and deselects when a stacked unit opens its city', () => {
+      const { state } = makeFixture('unit-stack-open-city');
+      state.cities['test-city'] = {
+        id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      };
+      const infoPanel = document.createElement('div');
+      const { deps, controller } = build(state, { getElementById: vi.fn(() => infoPanel) });
+
+      controller.openUnitStackPicker({ q: 0, r: 0 }, ['attacker']);
+
+      expect(renderUnitStackPanel).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onOpenCity: (cityId: string) => void }>(renderUnitStackPanel, 0, 4);
+      options.onOpenCity('test-city');
+
+      expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
+      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+    });
+  });
+
+  describe('openNetworkIntentPanel', () => {
+    it('shows a warning and builds no panel when autonomy is not activated', () => {
+      const { state } = makeFixture('network-intent-inactive');
+      placeUnit(state, 'cyber_unit', 'cyber-1', { q: 5, r: 4 });
+      const { deps, controller } = build(state);
+
+      controller.openNetworkIntentPanel('cyber-1');
+
+      expect(createNetworkIntentPanel).not.toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+
+    it('opens the Network panel directly for a drone controller source once autonomy is activated', () => {
+      const { state } = makeFixture('network-intent-drone');
+      state.civilizations.player.techState.completed = ['quantum-computing'];
+      placeUnit(state, 'drone_controller', 'drone-1', { q: 5, r: 4 });
+      const { controller } = build(state);
+
+      controller.openNetworkIntentPanel('drone-1');
+
+      expect(createNetworkIntentPanel).not.toHaveBeenCalled();
+      expect(createNetworkPanel).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens the intent panel for a real cyber unit source once autonomy is activated', () => {
+      const { state } = makeFixture('network-intent-cyber');
+      state.civilizations.player.techState.completed = ['quantum-computing'];
+      placeUnit(state, 'cyber_unit', 'cyber-1', { q: 5, r: 4 });
+      const { deps, controller } = build(state);
+
+      controller.openNetworkIntentPanel('cyber-1');
+
+      expect(createNetworkIntentPanel).toHaveBeenCalledTimes(1);
+      expect(deps.uiLayer.children.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('openNetworkPanel', () => {
+    it('builds no panel when autonomy is not activated', () => {
+      const { state } = makeFixture('network-panel-inactive');
+      const { controller } = build(state);
+
+      controller.openNetworkPanel();
+
+      expect(createNetworkPanel).not.toHaveBeenCalled();
+    });
+
+    it('builds the panel from real network state once autonomy is activated and commits posture changes', () => {
+      const { state } = makeFixture('network-panel-active');
+      state.civilizations.player.techState.completed = ['quantum-computing'];
+      state.autonomyByCiv = { player: createEmptyAutonomyCivState() };
+      const { deps, controller } = build(state);
+
+      controller.openNetworkPanel();
+
+      expect(createNetworkPanel).toHaveBeenCalledTimes(1);
+      const options = mockedCallArg<{ onPosture: (posture: string) => void }>(createNetworkPanel, 0, 1);
+      options.onPosture('defensive');
+
+      expect(createNetworkPanel).toHaveBeenCalledTimes(2);
+      // requestAutonomyPosture stages the change as `pendingPosture`, applied on a later turn --
+      // not an immediate `posture` mutation.
+      expect(deps.session.getState().autonomyByCiv?.player?.pendingPosture).toEqual({ id: 'defensive', appliesOnTurn: state.turn + 1 });
     });
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -153,7 +153,9 @@ describe('shared unit upgrade wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const handler = main.slice(
       main.indexOf('function executeUpgrade('),
-      main.indexOf('function openWonderPanelForCityId'),
+      // #787 phase 10b-c: openWonderPanelForCityId moved into PanelActionsController;
+      // openCityPanelForCity is what now immediately follows executeUpgrade.
+      main.indexOf('function openCityPanelForCity('),
     );
 
     expect(handler).toContain('applyUnitUpgradeToState(');
@@ -204,9 +206,9 @@ describe('shared city assault wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const minorCaptureFlow = main.slice(
       main.indexOf('function executeMinorCivConquest('),
-      // #787 phase 10b-a: handleGiftGold moved into DiplomacyActionsController;
-      // openDiplomacyPanel is what now immediately follows executeMinorCivConquest.
-      main.indexOf('function openDiplomacyPanel('),
+      // #787 phase 10b-c: openDiplomacyPanel moved into PanelActionsController;
+      // executeUpgrade is what now immediately follows executeMinorCivConquest.
+      main.indexOf('function executeUpgrade('),
     );
 
     expect(minorCaptureFlow).toContain(


### PR DESCRIPTION
## Summary

Part of the composition-root decomposition arc ([#787](https://github.com/a1flecke/conquestoria/issues/787)), continuing Phase 10b's split into sub-phases (10b-a through 10b-g, see [PR #807](https://github.com/a1flecke/conquestoria/pull/807)).

Extends `PanelActionsController` (created in 10b-b, [PR #810](https://github.com/a1flecke/conquestoria/pull/810)) with 9 more panel openers — the unit/network/civ-management group:

- `openDiplomacyPanel`
- `openMarketplacePanel`
- `openWonderPanelForCityId`
- `openCityOverviewPanel`
- `openCouncilPanel`
- `openTechPanel`
- `openUnitStackPicker`
- `openNetworkIntentPanel`
- `openNetworkPanel`

Each was moved verbatim out of `main.ts` with mechanical dep-substitution only (bare `x(` → `deps.x(`, `session` → `deps.session`, etc.) — no behavior changes.

**`main.ts`: 1842 → 1568 lines.**

## Notable wiring

- `diplomacyActions`' `openDiplomacyPanel` dep now points at the real `panelActions.openDiplomacyPanel` via a lazy wrapper (`() => panelActions.openDiplomacyPanel()`), not a direct reference — `diplomacyActions` is constructed *before* `panelActions` in `main.ts`, so a direct reference would capture `undefined`. Same deferred-but-eager pattern already used for the `hud`/`selectionController` deps in this exact construction block.
- `openWonderPanelForCityId` is now a sibling function inside `PanelActionsController` itself. `openNotificationLog`'s `onOpenWonderCity` callback (added in 10b-b) now calls it as a direct local-function call instead of through an injected dep, matching the `openPirateWaters`/`openPirateHeadquartersAssault` sibling-call pattern already established in that file.
- `selectionController`, `mapInteraction`, and `panelRegistry` call sites (19 total occurrences across the 9 functions) were all updated to reference `panelActions.<fn>` instead of the now-removed bare hoisted-function references.
- `tests/main.integration.test.ts`'s two `main.slice(...)` boundary markers that used `openWonderPanelForCityId`/`openDiplomacyPanel` as slice endpoints were updated to the new adjacent functions (`openCityPanelForCity`, `executeUpgrade` respectively) — both docblocked with the reason.

## Verification

- **Exhaustive call-count parity audit**: compared pre-move `main.ts` + pre-move `panel-actions-controller.ts` (from `HEAD`) against post-move versions across 11 markers (`session.commit(`, `session.setStateWithoutRefresh(`, `session.getState()`, `bus.emit(`, `showNotification(`, `hud.update()`, `hud.closeDrawer()`, `selectionController.`, `renderLoop.setGameState(`, `renderLoop.camera.centerOn(`, `getElementById`) — **zero drift on every marker**.
- **Dead-import hygiene**: baseline (13 pre-existing unrelated dead imports) re-confirmed unchanged in `main.ts`. Found and fixed one real newly-dead import: the `Unit` type, which was only ever "used" in `main.ts` via two string-literal coincidences (`'Cyber Unit ...'` notification text) that moved with `openNetworkIntentPanel`/`openNetworkPanel` — never a real type usage. The new/extended controller file itself has zero dead imports.
- 20 new tests added to `tests/app/controllers/panel-actions-controller.test.ts` (7 → 27 total), using real system-state fixtures (real `enqueueResearch`/`moveQueuedId`/`removeQueuedId`, real `isAutonomyActivated`/`requestAutonomyPosture`, real `canBuyResourceAccess` guard) rather than mocking the underlying pure functions — only the `@/ui/*` panel factories are mocked.
- Full suite green: 478 files / 7752 tests, `yarn build` clean, `yarn test:web-smoke` 8/8.
- Inline review pass done proactively before opening this PR (testing/architecture/SRP/SOLID/TypeScript/proper-implementation dimensions) — zero `as any`/`as never`/`as unknown as` casts, zero new raw `document.getElementById` calls (all use the `getElementById` dep, ahead of Phase 11's port-purity test), `diplomacyActions`/`currentCiv` deps narrowed to exactly the fields actually used. Strengthened one test (`openCouncilPanel`) to also assert the real `saveSettings` call during review.

## Test plan

- [x] `yarn build`
- [x] `yarn test` (full suite, 478 files / 7752 tests)
- [x] `yarn test:web-smoke` (8/8)
- [x] Manual diff review of `main.ts` changes (pure removal + rewiring, no leftover artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)