### PR TITLE
feat(787): extract the two largest panel openers (phase 10b-d)

### DIFF
--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -1,7 +1,6 @@
 /**
- * Owns the panel openers extracted from `main.ts` across #787 phases 10b-b and
- * 10b-c (see 10b-d for the two remaining, largest panels: `openCityPanelForCity`,
- * `openEspionagePanel`).
+ * Owns every panel opener extracted from `main.ts` across #787 phases
+ * 10b-b, 10b-c, and 10b-d -- the full `PanelActionsController`.
  *
  * Phase 10b-b (part 1, utility/world-event panels): `openPacingDebugPanel`,
  * `openBestiary`, `openWonderAtlas`, `openPirateWaters`,
@@ -12,22 +11,38 @@
  * `openCouncilPanel`, `openTechPanel`, `openUnitStackPicker`,
  * `openNetworkIntentPanel`, `openNetworkPanel`.
  *
+ * Phase 10b-d (part 3, the two largest/riskiest panels): `openCityPanelForCity`
+ * (~141 lines pre-move), `openEspionagePanel` (~279 lines pre-move, the
+ * largest single function in this arc).
+ *
  * `openWonderAtlas`, `openNotificationLog`, and `openCityOverviewPanel` all open
- * `openCityPanelForCity` (a not-yet-extracted panel opener, phase 10b-d) --
- * arrives as an injected dep to avoid a forward reference. `openWonderPanelForCityId`
- * itself is now a sibling function in this file (phase 10b-c), so `openNotificationLog`'s
- * `onOpenWonderCity` calls it directly instead of through a dep, same pattern as
- * `openPirateWaters`/`openPirateHeadquartersAssault` calling each other directly.
+ * `openCityPanelForCity`, which is now a sibling function in this file (phase
+ * 10b-d) -- their calls stay bare local-function calls, same pattern as
+ * `openWonderPanelForCityId` becoming a sibling in 10b-c. `openCityPanelForCity`
+ * also calls itself recursively (`onPrevCity`/`onNextCity` city-cycling).
  *
  * `showNotification`, `focusNotificationTarget`, `focusPirateTarget`,
- * `applyPirateActionResult`, and `currentCiv` are cross-cutting helpers (phase
- * 10b-f's domain) still living in `main.ts` -- threaded through as deps until
- * that phase gives them a real home.
+ * `applyPirateActionResult`, `currentCiv`, and `currentCivDef` are cross-cutting
+ * helpers (phase 10b-f's domain) still living in `main.ts` -- threaded through
+ * as deps until that phase gives them a real home.
  *
  * `diplomacyActions` (phase 10b-a's `DiplomacyActionsController`) is threaded
- * through as a dep for `openDiplomacyPanel`'s and `openCityOverviewPanel`'s
- * handler callbacks -- it's constructed before `panelActions` in `main.ts`, so
- * a direct reference works with no lazy wrapper needed.
+ * through as a dep for `openDiplomacyPanel`'s, `openCityOverviewPanel`'s, and
+ * `openCityPanelForCity`'s handler callbacks -- it's constructed before
+ * `panelActions` in `main.ts`, so a direct reference works with no lazy
+ * wrapper needed.
+ *
+ * `router` is threaded through as a lazy wrapper (`{ open: panel =>
+ * router.open(panel) }`), not a direct reference -- `router` is a `let` not
+ * assigned until `createPanelRouter(...)` much later in `main.ts` module
+ * evaluation (after `panelRegistry`, which itself needs this controller's
+ * methods), so a direct reference here would capture `undefined` at
+ * construction time. Same deferred-but-eager pattern `turnFlow` already uses
+ * for its own `router` dep.
+ *
+ * `executeUpgrade` stays a `main.ts`-local function (phase 13's
+ * `PlayerActionController` domain, not this controller's) -- threaded through
+ * as a dep for `openCityPanelForCity`'s `onUpgradeUnit` callback.
  *
  * Everything this file calls that is a pure `@/systems/*`, `@/input/*`, or
  * `@/ui/*` helper is imported directly, matching the precedent set by every
@@ -42,7 +57,8 @@ import type { GameSession, SelectionStore } from '@/app/ports';
 import type { HudController } from '@/app/controllers/hud-controller';
 import type { SelectionController } from '@/app/controllers/selection-controller';
 import type { DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
-import type { City, Civilization, HexCoord } from '@/core/types';
+import type { PanelRouter } from '@/app/panel-router';
+import type { City, CivDefinition, Civilization, GameState, HexCoord, SpyMissionType, UnitType } from '@/core/types';
 import type { NotificationEntry } from '@/core/notification-log';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
@@ -58,8 +74,8 @@ import { getNotificationsForPlayer } from '@/core/notification-log';
 import { markNotificationRead, resolvePirateNotificationReview } from '@/ui/pirate-notification-listeners';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getLegendaryWonderEligibility, initializeLegendaryWonderProjectsForCity, startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
-import { getProductionDisplayName } from '@/systems/city-system';
-import { enqueueResearch, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+import { getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
+import { enqueueCityProduction, enqueueResearch, moveQueuedId, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
 import { canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { assignNetworkPlan, cancelNetworkPlan, holdNetworkPlan, isAutonomyActivated, retargetNetworkPlan } from '@/systems/network-plan-system';
 import { beginAutonomySurge, requestAutonomyPosture } from '@/systems/autonomy-postures';
@@ -73,6 +89,20 @@ import { createTechPanel } from '@/ui/tech-panel';
 import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { createNetworkPanel, getNetworkPanelModel } from '@/ui/network-panel';
+import { createCityPanel } from '@/ui/city-panel';
+import { createEspionagePanel } from '@/ui/espionage-panel';
+import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
+import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
+import { rushBuyActiveProduction } from '@/systems/economy-system';
+import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
+import { UNIT_DEFINITIONS, createUnit } from '@/systems/unit-system';
+import { evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
+import { hexKey, hexesInRange } from '@/systems/hex-utils';
+import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
+import {
+  embedSpy, unembedSpy, attemptSweep, getAvailableMissions, missionRequiresPlacedSpy,
+  recallSpy, startMission, verifyAgent,
+} from '@/systems/espionage-system';
 import { SFX } from '@/audio/sfx';
 
 export interface PanelActionsController {
@@ -91,12 +121,14 @@ export interface PanelActionsController {
   openUnitStackPicker(coord: HexCoord, unitIds: string[]): void;
   openNetworkIntentPanel(sourceUnitId: string): void;
   openNetworkPanel(): void;
+  openCityPanelForCity(city: City): void;
+  openEspionagePanel(): void;
 }
 
 /** The narrow slice of `RenderLoop` this controller needs. */
 export type PanelActionsRenderer = Pick<
   RenderLoop,
-  'setSelectedPirateFactionId' | 'applyPirateHeadquartersAssaultVisual' | 'setGameState'
+  'setSelectedPirateFactionId' | 'applyPirateHeadquartersAssaultVisual' | 'setGameState' | 'setHighlights'
 > & { readonly camera: Pick<RenderLoop['camera'], 'centerOn'> };
 
 /** The narrow slice of `AudioSystem` this controller needs. */
@@ -121,15 +153,22 @@ export interface PanelActionsControllerDeps {
   readonly focusPirateTarget: (target: PirateFocusTarget) => void;
   readonly applyPirateActionResult: (result: PirateActionResult, successMessage: string) => void;
   readonly currentCiv: () => Civilization;
+  readonly currentCivDef: () => CivDefinition | undefined;
   readonly diplomacyActions: Pick<
     DiplomacyActionsController,
     | 'handleDiplomaticAction' | 'handleAcceptPeaceRequest' | 'handleRejectPeaceRequest'
     | 'handleAcceptTreatyProposal' | 'handleDeclineTreatyProposal' | 'handleBreakTreaty'
     | 'handleGiftGold' | 'handleSponsorFestival' | 'handleMinorCivReparations' | 'handleSendAid'
-    | 'handleMinorCivWarPeace' | 'handleAppeaseFaction' | 'handleConcedeToMovement'
+    | 'handleMinorCivWarPeace' | 'handleAppeaseFaction' | 'handleConcedeToMovement' | 'handleEstablishRoute'
   >;
-  /** `PanelActionsController`'s own function (phase 10b-d) -- injected to avoid a forward reference. */
-  readonly openCityPanelForCity: (city: City) => void;
+  /** `main.ts`-local function (phase 13's `PlayerActionController` domain) -- injected to avoid a forward reference. */
+  readonly executeUpgrade: (unitId: string, targetType: UnitType) => boolean;
+  /**
+   * Lazy wrapper, not a direct reference -- `router` is a `let` not assigned
+   * until `createPanelRouter(...)` much later in `main.ts` module evaluation.
+   * Same deferred-but-eager pattern `turnFlow`'s own `router` dep already uses.
+   */
+  readonly router: Pick<PanelRouter, 'open'>;
 }
 
 export function createPanelActionsController(deps: PanelActionsControllerDeps): PanelActionsController {
@@ -159,7 +198,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
       },
       onOpenCity: cityId => {
         const city = deps.session.getState().cities[cityId];
-        if (city) deps.openCityPanelForCity(city);
+        if (city) openCityPanelForCity(city);
       },
       onNaturalWonderPageShown: wonderId => {
         void deps.audio.startNaturalWonderCodexAmbient(wonderId);
@@ -310,7 +349,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
       onOpenCity: (cityId) => {
         panel.remove();
         const city = deps.session.getState()?.cities[cityId];
-        if (city) deps.openCityPanelForCity(city);
+        if (city) openCityPanelForCity(city);
       },
       onOpenWonderCity: action => {
         const city = deps.session.getState()?.cities[action.cityId];
@@ -425,7 +464,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         const overview = deps.getElementById('city-overview-panel');
         overview?.remove();
         const city = deps.session.getState().cities[cityId];
-        if (city) deps.openCityPanelForCity(city);
+        if (city) openCityPanelForCity(city);
       },
       onAppeaseFaction: (cityId) => {
         deps.diplomacyActions.handleAppeaseFaction(cityId);
@@ -505,7 +544,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         deps.getElementById('marketplace-panel')?.remove();
         deps.getElementById('council-panel')?.remove();
         deps.selectionController.deselectUnit();
-        deps.openCityPanelForCity(city);
+        openCityPanelForCity(city);
       },
       onClose: () => deps.selectionController.deselectUnit(),
     }, { selectedUnitId: deps.selection.getSelectedUnitId() });
@@ -614,6 +653,376 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
     rerender();
   }
 
+  function openCityPanelForCity(city: City): void {
+    deps.hud.closeDrawer();
+    if (city.owner !== deps.session.getState().currentPlayer) return;
+
+    createCityPanel(deps.uiLayer, city, deps.session.getState(), {
+      onBuild: (cityId, itemId) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (targetCity) {
+          try {
+            deps.session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
+            deps.renderLoop.setGameState(deps.session.getState());
+            deps.showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Queue limit reached';
+            deps.showNotification(`${targetCity.name}: ${message}`, 'warning');
+          }
+        }
+      },
+      onMoveQueueItem: (cityId, fromIndex, toIndex) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = reorderCityProduction(targetCity, fromIndex, toIndex);
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+      onRemoveQueueItem: (cityId, index) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = {
+          ...targetCity,
+          productionQueue: removeQueuedId(targetCity.productionQueue, index),
+          productionProgress: index === 0 ? 0 : targetCity.productionProgress,
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+      onOpenWonderPanel: (selectedCityId) => {
+        openWonderPanelForCityId(selectedCityId);
+      },
+      onSetCityFocus: (cityId, focus) => {
+        const result = assignCityFocus(deps.session.getState(), cityId, focus);
+        deps.session.commit(result.state);
+        deps.showNotification(`${deps.session.getState().cities[cityId].name} reassigned citizens for ${focus} focus.`, 'info');
+        return deps.session.getState();
+      },
+      onToggleWorkedTile: (cityId, coord, worked) => {
+        const result = setCityWorkedTile(deps.session.getState(), cityId, coord, worked);
+        deps.session.commit(result.state);
+        if (!result.changed && result.reason === 'claimed') {
+          deps.showNotification('That tile is already worked by another city.', 'warning');
+        }
+        return deps.session.getState();
+      },
+      onClose: () => {},
+      onTip: (message) => { deps.showNotification(message, 'info'); },
+      onSelectUnit: (unitId) => deps.selectionController.selectUnit(unitId),
+      onEstablishRoute: deps.diplomacyActions.handleEstablishRoute,
+      onPrevCity: () => {
+        const cities = deps.currentCiv().cities;
+        if (cities.length <= 1) return;
+        const currentIdx = cities.indexOf(city.id);
+        const prevIdx = (currentIdx - 1 + cities.length) % cities.length;
+        const prevCity = deps.session.getState().cities[cities[prevIdx]];
+        if (prevCity) openCityPanelForCity(prevCity);
+      },
+      onNextCity: () => {
+        const cities = deps.currentCiv().cities;
+        if (cities.length <= 1) return;
+        const currentIdx = cities.indexOf(city.id);
+        const nextIdx = (currentIdx + 1) % cities.length;
+        const nextCity = deps.session.getState().cities[cities[nextIdx]];
+        if (nextCity) openCityPanelForCity(nextCity);
+      },
+      onUpgradeUnit: (unitId) => {
+        const unit = deps.session.getState().units[unitId];
+        if (!unit || unit.owner !== deps.session.getState().currentPlayer) return;
+        const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
+        if (!targetType) return;
+        const upgrade = evaluateUnitUpgrade(deps.session.getState(), unitId, targetType);
+        if (!upgrade.canUpgrade || !upgrade.targetType) return;
+        if (deps.executeUpgrade(unitId, upgrade.targetType)) {
+          deps.showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
+        }
+      },
+      onSetIdleProduction: (cityId, mode) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = setIdleProduction(targetCity, mode);
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+      onRushBuyActiveProduction: (cityId) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return deps.session.getState();
+        const result = rushBuyActiveProduction(deps.session.getState(), deps.session.getState().currentPlayer, cityId, deps.bus);
+        if (!result.success) {
+          deps.showNotification(result.message, 'warning');
+          return deps.session.getState();
+        }
+        deps.session.commit(result.state);
+        deps.showNotification(`${targetCity.name}: rush bought ${result.label} for ${result.cost} gold.`, 'success');
+        return deps.session.getState();
+      },
+      onAppeaseFaction: (cityId) => deps.diplomacyActions.handleAppeaseFaction(cityId),
+      onConcedeToMovement: (cityId) => deps.diplomacyActions.handleConcedeToMovement(cityId),
+      onQuarantineCrisis: (crisisId, cityId) => {
+        const result = applyQuarantine(deps.session.getState(), crisisId, cityId);
+        if (!result.success) {
+          deps.showNotification(result.message, 'warning');
+          return deps.session.getState();
+        }
+        deps.session.commit(result.state);
+        deps.showNotification(result.message, 'success');
+        return deps.session.getState();
+      },
+      onRemedyCrisis: (crisisId, cityId) => {
+        const result = applyRemedy(deps.session.getState(), crisisId, cityId);
+        if (!result.success) {
+          deps.showNotification(result.message, 'warning');
+          return deps.session.getState();
+        }
+        deps.session.commit(result.state);
+        deps.showNotification(result.message, 'success');
+        return deps.session.getState();
+      },
+      onFindResources: (highlights, toasts) => {
+        deps.renderLoop.setHighlights(highlights.map(coord => ({ coord, type: 'worker-buildable' as const })));
+        for (const t of toasts) deps.showNotification(t.message, t.type);
+      },
+      onChooseCircularManufacturingMaterial: (material) => {
+        try {
+          deps.session.setStateWithoutRefresh(chooseCircularManufacturingMaterial(deps.session.getState(), deps.session.getState().currentPlayer, material));
+        } catch (error) {
+          deps.showNotification(error instanceof Error ? error.message : 'That material choice is unavailable.', 'warning');
+          return;
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.showNotification(`Circular Manufacturing Network will substitute ${material.replaceAll('-', ' ')} when it helps.`, 'success');
+        const refreshedCity = deps.session.getState().cities[city.id];
+        if (refreshedCity) openCityPanelForCity(refreshedCity);
+      },
+    });
+  }
+
+  function openEspionagePanel(): void {
+    deps.hud.closeDrawer();
+    const chooseForeignCityTarget = (): { civId: string; cityId: string; position: HexCoord } | null => {
+      const choices = Object.values(deps.session.getState().cities)
+        .filter(city => city.owner !== deps.session.getState().currentPlayer)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      if (choices.length === 0) {
+        deps.showNotification('No foreign cities available for espionage.', 'info');
+        return null;
+      }
+      const selection = window.prompt(
+        `Choose target city by id:\n${choices.map(city => `${city.id} (${city.owner})`).join('\n')}`,
+        choices[0].id,
+      );
+      if (!selection) return null;
+      const city = deps.session.getState().cities[selection];
+      if (!city || city.owner === deps.session.getState().currentPlayer) {
+        deps.showNotification('Invalid espionage target.', 'warning');
+        return null;
+      }
+      return { civId: city.owner, cityId: city.id, position: city.position };
+    };
+
+    const chooseFriendlyCityTarget = (): { cityId: string; position: HexCoord } | null => {
+      const choices = deps.currentCiv().cities
+        .map(cityId => deps.session.getState().cities[cityId])
+        .filter((city): city is NonNullable<GameState['cities'][string]> => city !== undefined);
+      if (choices.length === 0) {
+        deps.showNotification('No cities available for defensive espionage.', 'info');
+        return null;
+      }
+      const selection = window.prompt(
+        `Choose friendly city by id:\n${choices.map(city => city.id).join('\n')}`,
+        choices[0].id,
+      );
+      if (!selection) return null;
+      const city = deps.session.getState().cities[selection];
+      if (!city || city.owner !== deps.session.getState().currentPlayer) {
+        deps.showNotification('Invalid defensive target.', 'warning');
+        return null;
+      }
+      return { cityId: city.id, position: city.position };
+    };
+
+    const chooseMission = (spyId: string): SpyMissionType | null => {
+      const spy = deps.session.getState().espionage?.[deps.session.getState().currentPlayer]?.spies[spyId];
+      const completedTechs = deps.currentCiv().techState.completed ?? [];
+      // #524 MR2a review fix: flip_loyalty can never succeed against a capital (see
+      // resolveMissionResult's guard in espionage-system.ts) -- don't offer it as a
+      // choice when the spy's current target already is one. Without this, a spy
+      // stationed in an enemy capital could "succeed" an 8-turn flip_loyalty mission
+      // that silently does nothing, with no explanation.
+      const spyTargetsCapital = Boolean(
+        spy?.targetCivId && spy.targetCityId
+          && getCapitalCityId(deps.session.getState(), spy.targetCivId) === spy.targetCityId,
+      );
+      const missions = getAvailableMissions(completedTechs)
+        .filter(mission => !missionRequiresPlacedSpy(mission) || Boolean(spy?.targetCivId))
+        .filter(mission => mission !== 'flip_loyalty' || !spyTargetsCapital);
+      if (missions.length === 0) {
+        deps.showNotification('No missions available for this spy.', 'info');
+        return null;
+      }
+      // `window.prompt` always returns a plain string -- cast once here to the real
+      // union type instead of casting at each downstream use site with `as any`.
+      return window.prompt(`Choose mission:\n${missions.join('\n')}`, missions[0]) as SpyMissionType | null;
+    };
+
+    deps.uiLayer.appendChild(createEspionagePanel(deps.session.getState(), {
+      onClose: () => deps.getElementById('espionage-panel')?.remove(),
+      onAssignDefensive: (spyId) => {
+        const target = chooseFriendlyCityTarget();
+        if (!target) return;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = embedSpy(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+          target.cityId,
+          target.position,
+        );
+        const unit = deps.session.getState().units[spyId];
+        if (unit) {
+          delete deps.session.getState().units[spyId];
+          deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
+            deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.filter(id => id !== spyId);
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        const cityName = deps.session.getState().cities[target.cityId]?.name ?? target.cityId;
+        deps.showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
+      },
+      onStartMission: (spyId) => {
+        const spy = deps.session.getState().espionage?.[deps.session.getState().currentPlayer]?.spies[spyId];
+        if (!spy) return;
+        const mission = chooseMission(spyId);
+        if (!mission) return;
+        let targetCivId = spy.targetCivId ?? undefined;
+        let targetCityId = spy.targetCityId ?? undefined;
+        if (!missionRequiresPlacedSpy(mission)) {
+          const target = chooseForeignCityTarget();
+          if (!target) return;
+          targetCivId = target.civId;
+          targetCityId = target.cityId;
+        }
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = startMission(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+          mission,
+          deps.currentCivDef()?.bonusEffect,
+          targetCivId,
+          targetCityId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification(`Mission ${mission} started.`, 'info');
+      },
+      onRecall: (spyId) => {
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = recallSpy(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification('Spy recalled.', 'info');
+      },
+      onVerifyAgent: (spyId) => {
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = verifyAgent(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification('Agent verified and cleared.', 'success');
+      },
+      onExfiltrate: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'stationed') return;
+        const capital = getCapitalCity(deps.session.getState(), deps.session.getState().currentPlayer);
+        if (!capital) { deps.showNotification('Cannot exfiltrate — no capital found.', 'warning'); return; }
+
+        // Spawn occupancy: find a free tile at/near the capital
+        const existingPositions = new Set(
+          Object.values(deps.session.getState().units).map(u => `${u.position.q},${u.position.r}`),
+        );
+        let spawnPos = capital.position;
+        if (existingPositions.has(`${spawnPos.q},${spawnPos.r}`)) {
+          const adjacent = hexesInRange(capital.position, 1).filter(
+            c => !(c.q === capital.position.q && c.r === capital.position.r) &&
+                 !existingPositions.has(`${c.q},${c.r}`) &&
+                 deps.session.getState().map.tiles[hexKey(c)],
+          );
+          if (adjacent.length === 0) {
+            deps.showNotification('Cannot exfiltrate — no free tile near capital.', 'warning');
+            return;
+          }
+          spawnPos = adjacent[0];
+        }
+
+        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, spawnPos, deps.session.getState().idCounters);
+        deps.session.getState().units[newUnit.id] = newUnit;
+        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
+          [...(deps.session.getState().civilizations[deps.session.getState().currentPlayer].units ?? []), newUnit.id];
+        const updatedSpy = {
+          ...spy, id: newUnit.id, status: 'cooldown' as const,
+          cooldownTurns: 8, infiltrationCityId: null, cityVisionTurnsLeft: 0, targetCivId: null, cooldownMode: undefined,
+        };
+        const { [spyId]: _old, ...rest } = ownerEsp!.spies;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } };
+        deps.renderLoop.setGameState(deps.session.getState());
+        // Refresh panel in place
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification('Spy exfiltrated. Available again in 8 turns.', 'info');
+      },
+      onToggleCooldownMode: (spyId) => {
+        const civEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = civEsp?.spies[spyId];
+        if (!spy || spy.status !== 'cooldown') return;
+        const next: 'stay_low' | 'passive_observe' =
+          (spy.cooldownMode ?? 'stay_low') === 'passive_observe' ? 'stay_low' : 'passive_observe';
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: {
+            ...deps.session.getState().espionage!,
+            [deps.session.getState().currentPlayer]: {
+              ...civEsp!,
+              spies: { ...civEsp!.spies, [spyId]: { ...spy, cooldownMode: next } },
+            },
+          },
+        });
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+      },
+      onUnembed: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
+        const city = deps.session.getState().cities[spy.targetCityId];
+        if (!city) return;
+        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, city.position, deps.session.getState().idCounters);
+        deps.session.getState().units[newUnit.id] = newUnit;
+        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.push(newUnit.id);
+        const unembedded = unembedSpy(ownerEsp!, spyId);
+        const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
+        const { [spyId]: _old, ...rest } = unembedded.spies;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
+      },
+      onSweep: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        if (!ownerEsp) return;
+        const seed = `sweep-${spyId}-${deps.session.getState().turn}`;
+        const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, deps.session.getState());
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = updatedEsp;
+        if (detectedSpyIds.length > 0) {
+          deps.showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
+        } else {
+          deps.showNotification('Sweep complete — no enemy spies detected.', 'info');
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+      },
+    }));
+  }
+
   return {
     openPacingDebugPanel,
     openBestiary,
@@ -630,5 +1039,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
     openUnitStackPicker,
     openNetworkIntentPanel,
     openNetworkPanel,
+    openCityPanelForCity,
+    openEspionagePanel,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,10 @@
 import { EventBus } from '@/core/event-bus';
 import { RenderLoop } from '@/renderer/render-loop';
-import { hexKey, hexesInRange, parseHexKey } from '@/systems/hex-utils';
+import { hexKey, parseHexKey } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, restUnit, canHeal, createUnit } from '@/systems/unit-system';
 import { isMajorCivOwner } from '@/core/owner-kind';
-import { getProductionDisplayName, TRAINABLE_UNITS } from '@/systems/city-system';
-import { chooseCircularManufacturingMaterial } from '@/systems/national-project-system';
 import { foundCityInState } from '@/systems/city-founding-system';
-import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
-import { enqueueCityProduction, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
-import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@/systems/combat-context';
@@ -29,7 +24,6 @@ import { recordBeastSightings } from '@/systems/beast-presentation';
 import { loadSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX } from '@/audio/sfx';
-import { createEspionagePanel } from '@/ui/espionage-panel';
 import { AdvisorSystem } from '@/ui/advisor-system';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { PirateActionResult } from '@/systems/pirate-actions';
@@ -47,20 +41,18 @@ import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupa
 import { beginPlayerCityAssaultChoice, shouldPromptForPlayerCityCapture } from '@/input/city-assault-flow';
 import { canUnitOccupyCity } from '@/systems/city-capture-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import { embedSpy, unembedSpy, attemptSweep, getAvailableMissions, getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType, missionRequiresPlacedSpy, recallSpy, resolveMissionResult, startMission, verifyAgent } from '@/systems/espionage-system';
-import { applyUnitUpgradeToState, evaluateUnitUpgrade } from '@/systems/unit-upgrade-system';
+import { getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType } from '@/systems/espionage-system';
+import { applyUnitUpgradeToState } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
-import { getCapitalCity, getCapitalCityId } from '@/systems/capital-system';
+import { getCapitalCity } from '@/systems/capital-system';
 import type { CombatResult, GameState, HexCoord, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
 import { appendNotification, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
 import type { NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
-import { rushBuyActiveProduction } from '@/systems/economy-system';
-import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
 import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
@@ -195,7 +187,7 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
   openAtlas: wonderId => panelActions.openWonderAtlas(wonderId),
   openCity: cityId => {
     const city = session.getState().cities[cityId];
-    if (city) openCityPanelForCity(city);
+    if (city) panelActions.openCityPanelForCity(city);
   },
   openJournal: cityId => {
     if (session.getState().cities[cityId]) panelActions.openWonderPanelForCityId(cityId);
@@ -235,12 +227,18 @@ const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsContr
 });
 
 /**
- * Owns the panel openers extracted across #787 phases 10b-b (utility/world-event
- * panels) and 10b-c (unit/network/civ-management panels), see 10b-d for the
- * rest. `hud` and `selectionController` use the same deferred-but-eager
- * lazy-wrapper pattern as `diplomacyActions` above, for the same reason
- * (neither is assigned yet at this point in module evaluation). `diplomacyActions`
- * needs no such wrapper here since it is constructed just above.
+ * Owns every panel opener extracted across #787 phases 10b-b (utility/world-event
+ * panels), 10b-c (unit/network/civ-management panels), and 10b-d (the two
+ * largest panels: `openCityPanelForCity`, `openEspionagePanel`). `hud` and
+ * `selectionController` use the same deferred-but-eager lazy-wrapper pattern
+ * as `diplomacyActions` above, for the same reason (neither is assigned yet
+ * at this point in module evaluation). `diplomacyActions` needs no such
+ * wrapper here since it is constructed just above. `router` DOES need the
+ * wrapper -- it is a `let` not assigned until `createPanelRouter(...)` much
+ * later in module evaluation (after `panelRegistry`, which itself needs this
+ * controller's methods) -- same pattern `turnFlow`'s own `router` dep below
+ * already uses. `executeUpgrade` and `currentCivDef` are plain hoisted
+ * function declarations (like `currentCiv`), so no wrapper needed for them.
  */
 const panelActions: PanelActionsController = createPanelActionsController({
   session,
@@ -255,8 +253,10 @@ const panelActions: PanelActionsController = createPanelActionsController({
   focusPirateTarget,
   applyPirateActionResult,
   currentCiv,
+  currentCivDef,
   diplomacyActions,
-  openCityPanelForCity,
+  executeUpgrade,
+  router: { open: panel => router.open(panel) },
   hud: { closeDrawer: () => hud.closeDrawer(), update: () => hud.update() },
   selectionController: {
     selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts),
@@ -336,16 +336,19 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   // invoked until real gameplay.
   showGameModeSelection: () => campaignEntry.showGameModeSelection(),
   reloadPage: () => window.location.reload(),
-  openCityPanelForCity,
+  openCityPanelForCity: panelActions.openCityPanelForCity,
 });
 
 /**
  * Owns the two map-input entry points, `handleHexTap` and
  * `handleHexLongPress` (#787 phase 8d). References several functions
- * defined later in this file (`openCityPanelForCity`, `executeAttack`,
+ * defined later in this file (`executeAttack`, `executeMinorCivConquest`,
  * etc.) -- safe because they are hoisted function declarations and none of
  * them run until real gameplay, well after module evaluation finishes. The
  * same deferred-but-eager pattern `selectionController` above already uses.
+ * `openCityPanelForCity` is a `panelActions` method now (10b-d), not a
+ * hoisted function, but `mapInteraction` is constructed after `panelActions`
+ * so a direct reference still works with no wrapper needed.
  */
 const mapInteraction: MapInteractionController = createMapInteractionController({
   session,
@@ -362,7 +365,7 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   currentCiv,
   openPirateWaters: panelActions.openPirateWaters,
   openUnitStackPicker: panelActions.openUnitStackPicker,
-  openCityPanelForCity,
+  openCityPanelForCity: panelActions.openCityPanelForCity,
   openWonderAtlas: panelActions.openWonderAtlas,
   executeAttack,
   executeMinorCivConquest,
@@ -610,383 +613,14 @@ function executeUpgrade(
   return true;
 }
 
-function openCityPanelForCity(city: import('@/core/types').City): void {
-  hud.closeDrawer();
-  if (city.owner !== session.getState().currentPlayer) return;
-
-  createCityPanel(uiLayer, city, session.getState(), {
-    onBuild: (cityId, itemId) => {
-      const targetCity = session.getState().cities[cityId];
-      if (targetCity) {
-        try {
-          session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
-          renderLoop.setGameState(session.getState());
-          showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'Queue limit reached';
-          showNotification(`${targetCity.name}: ${message}`, 'warning');
-        }
-      }
-    },
-    onMoveQueueItem: (cityId, fromIndex, toIndex) => {
-      const targetCity = session.getState().cities[cityId];
-      if (!targetCity) return;
-      session.getState().cities[cityId] = reorderCityProduction(targetCity, fromIndex, toIndex);
-      renderLoop.setGameState(session.getState());
-    },
-    onRemoveQueueItem: (cityId, index) => {
-      const targetCity = session.getState().cities[cityId];
-      if (!targetCity) return;
-      session.getState().cities[cityId] = {
-        ...targetCity,
-        productionQueue: removeQueuedId(targetCity.productionQueue, index),
-        productionProgress: index === 0 ? 0 : targetCity.productionProgress,
-      };
-      renderLoop.setGameState(session.getState());
-    },
-    onOpenWonderPanel: (selectedCityId) => {
-      panelActions.openWonderPanelForCityId(selectedCityId);
-    },
-    onSetCityFocus: (cityId, focus) => {
-      const result = assignCityFocus(session.getState(), cityId, focus);
-      session.commit(result.state);
-      showNotification(`${session.getState().cities[cityId].name} reassigned citizens for ${focus} focus.`, 'info');
-      return session.getState();
-    },
-    onToggleWorkedTile: (cityId, coord, worked) => {
-      const result = setCityWorkedTile(session.getState(), cityId, coord, worked);
-      session.commit(result.state);
-      if (!result.changed && result.reason === 'claimed') {
-        showNotification('That tile is already worked by another city.', 'warning');
-      }
-      return session.getState();
-    },
-    onClose: () => {},
-    onTip: (message) => { showNotification(message, 'info'); },
-    onSelectUnit: (unitId) => selectionController.selectUnit(unitId),
-    onEstablishRoute: diplomacyActions.handleEstablishRoute,
-    onPrevCity: () => {
-      const cities = currentCiv().cities;
-      if (cities.length <= 1) return;
-      const currentIdx = cities.indexOf(city.id);
-      const prevIdx = (currentIdx - 1 + cities.length) % cities.length;
-      const prevCity = session.getState().cities[cities[prevIdx]];
-      if (prevCity) openCityPanelForCity(prevCity);
-    },
-    onNextCity: () => {
-      const cities = currentCiv().cities;
-      if (cities.length <= 1) return;
-      const currentIdx = cities.indexOf(city.id);
-      const nextIdx = (currentIdx + 1) % cities.length;
-      const nextCity = session.getState().cities[cities[nextIdx]];
-      if (nextCity) openCityPanelForCity(nextCity);
-    },
-    onUpgradeUnit: (unitId) => {
-      const unit = session.getState().units[unitId];
-      if (!unit || unit.owner !== session.getState().currentPlayer) return;
-      const targetType = TRAINABLE_UNITS.find(entry => entry.type === unit.type)?.upgradesTo;
-      if (!targetType) return;
-      const upgrade = evaluateUnitUpgrade(session.getState(), unitId, targetType);
-      if (!upgrade.canUpgrade || !upgrade.targetType) return;
-      if (executeUpgrade(unitId, upgrade.targetType)) {
-        showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
-      }
-    },
-    onSetIdleProduction: (cityId, mode) => {
-      const targetCity = session.getState().cities[cityId];
-      if (!targetCity) return;
-      session.getState().cities[cityId] = setIdleProduction(targetCity, mode);
-      renderLoop.setGameState(session.getState());
-    },
-    onRushBuyActiveProduction: (cityId) => {
-      const targetCity = session.getState().cities[cityId];
-      if (!targetCity) return session.getState();
-      const result = rushBuyActiveProduction(session.getState(), session.getState().currentPlayer, cityId, bus);
-      if (!result.success) {
-        showNotification(result.message, 'warning');
-        return session.getState();
-      }
-      session.commit(result.state);
-      showNotification(`${targetCity.name}: rush bought ${result.label} for ${result.cost} gold.`, 'success');
-      return session.getState();
-    },
-    onAppeaseFaction: (cityId) => diplomacyActions.handleAppeaseFaction(cityId),
-    onConcedeToMovement: (cityId) => diplomacyActions.handleConcedeToMovement(cityId),
-    onQuarantineCrisis: (crisisId, cityId) => {
-      const result = applyQuarantine(session.getState(), crisisId, cityId);
-      if (!result.success) {
-        showNotification(result.message, 'warning');
-        return session.getState();
-      }
-      session.commit(result.state);
-      showNotification(result.message, 'success');
-      return session.getState();
-    },
-    onRemedyCrisis: (crisisId, cityId) => {
-      const result = applyRemedy(session.getState(), crisisId, cityId);
-      if (!result.success) {
-        showNotification(result.message, 'warning');
-        return session.getState();
-      }
-      session.commit(result.state);
-      showNotification(result.message, 'success');
-      return session.getState();
-    },
-    onFindResources: (highlights, toasts) => {
-      renderLoop.setHighlights(highlights.map(coord => ({ coord, type: 'worker-buildable' as const })));
-      for (const t of toasts) showNotification(t.message, t.type);
-    },
-    onChooseCircularManufacturingMaterial: (material) => {
-      try {
-        session.setStateWithoutRefresh(chooseCircularManufacturingMaterial(session.getState(), session.getState().currentPlayer, material));
-      } catch (error) {
-        showNotification(error instanceof Error ? error.message : 'That material choice is unavailable.', 'warning');
-        return;
-      }
-      renderLoop.setGameState(session.getState());
-      showNotification(`Circular Manufacturing Network will substitute ${material.replaceAll('-', ' ')} when it helps.`, 'success');
-      const refreshedCity = session.getState().cities[city.id];
-      if (refreshedCity) openCityPanelForCity(refreshedCity);
-    },
-  });
-}
-
-function openEspionagePanel(): void {
-  hud.closeDrawer();
-  const chooseForeignCityTarget = (): { civId: string; cityId: string; position: HexCoord } | null => {
-      const choices = Object.values(session.getState().cities)
-        .filter(city => city.owner !== session.getState().currentPlayer)
-        .sort((a, b) => a.name.localeCompare(b.name));
-      if (choices.length === 0) {
-        showNotification('No foreign cities available for espionage.', 'info');
-        return null;
-      }
-      const selection = window.prompt(
-        `Choose target city by id:\n${choices.map(city => `${city.id} (${city.owner})`).join('\n')}`,
-        choices[0].id,
-      );
-      if (!selection) return null;
-      const city = session.getState().cities[selection];
-      if (!city || city.owner === session.getState().currentPlayer) {
-        showNotification('Invalid espionage target.', 'warning');
-        return null;
-      }
-      return { civId: city.owner, cityId: city.id, position: city.position };
-    };
-
-    const chooseFriendlyCityTarget = (): { cityId: string; position: HexCoord } | null => {
-      const choices = currentCiv().cities
-        .map(cityId => session.getState().cities[cityId])
-        .filter((city): city is NonNullable<GameState['cities'][string]> => city !== undefined);
-      if (choices.length === 0) {
-        showNotification('No cities available for defensive espionage.', 'info');
-        return null;
-      }
-      const selection = window.prompt(
-        `Choose friendly city by id:\n${choices.map(city => city.id).join('\n')}`,
-        choices[0].id,
-      );
-      if (!selection) return null;
-      const city = session.getState().cities[selection];
-      if (!city || city.owner !== session.getState().currentPlayer) {
-        showNotification('Invalid defensive target.', 'warning');
-        return null;
-      }
-      return { cityId: city.id, position: city.position };
-    };
-
-    const chooseMission = (spyId: string): string | null => {
-      const spy = session.getState().espionage?.[session.getState().currentPlayer]?.spies[spyId];
-      const completedTechs = currentCiv().techState.completed ?? [];
-      // #524 MR2a review fix: flip_loyalty can never succeed against a capital (see
-      // resolveMissionResult's guard in espionage-system.ts) -- don't offer it as a
-      // choice when the spy's current target already is one. Without this, a spy
-      // stationed in an enemy capital could "succeed" an 8-turn flip_loyalty mission
-      // that silently does nothing, with no explanation.
-      const spyTargetsCapital = Boolean(
-        spy?.targetCivId && spy.targetCityId
-          && getCapitalCityId(session.getState(), spy.targetCivId) === spy.targetCityId,
-      );
-      const missions = getAvailableMissions(completedTechs)
-        .filter(mission => !missionRequiresPlacedSpy(mission) || Boolean(spy?.targetCivId))
-        .filter(mission => mission !== 'flip_loyalty' || !spyTargetsCapital);
-      if (missions.length === 0) {
-        showNotification('No missions available for this spy.', 'info');
-        return null;
-      }
-      return window.prompt(`Choose mission:\n${missions.join('\n')}`, missions[0]);
-    };
-
-    uiLayer.appendChild(createEspionagePanel(session.getState(), {
-      onClose: () => document.getElementById('espionage-panel')?.remove(),
-      onAssignDefensive: (spyId) => {
-        const target = chooseFriendlyCityTarget();
-        if (!target) return;
-        session.getState().espionage![session.getState().currentPlayer] = embedSpy(
-          session.getState().espionage![session.getState().currentPlayer],
-          spyId,
-          target.cityId,
-          target.position,
-        );
-        const unit = session.getState().units[spyId];
-        if (unit) {
-          delete session.getState().units[spyId];
-          session.getState().civilizations[session.getState().currentPlayer].units =
-            session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== spyId);
-        }
-        renderLoop.setGameState(session.getState());
-        router.open('espionage');
-        const cityName = session.getState().cities[target.cityId]?.name ?? target.cityId;
-        showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
-      },
-      onStartMission: (spyId) => {
-        const spy = session.getState().espionage?.[session.getState().currentPlayer]?.spies[spyId];
-        if (!spy) return;
-        const mission = chooseMission(spyId);
-        if (!mission) return;
-        let targetCivId = spy.targetCivId ?? undefined;
-        let targetCityId = spy.targetCityId ?? undefined;
-        if (!missionRequiresPlacedSpy(mission as any)) {
-          const target = chooseForeignCityTarget();
-          if (!target) return;
-          targetCivId = target.civId;
-          targetCityId = target.cityId;
-        }
-        session.getState().espionage![session.getState().currentPlayer] = startMission(
-          session.getState().espionage![session.getState().currentPlayer],
-          spyId,
-          mission as any,
-          currentCivDef()?.bonusEffect,
-          targetCivId,
-          targetCityId,
-        );
-        renderLoop.setGameState(session.getState());
-        router.open('espionage');
-        showNotification(`Mission ${mission} started.`, 'info');
-      },
-      onRecall: (spyId) => {
-        session.getState().espionage![session.getState().currentPlayer] = recallSpy(
-          session.getState().espionage![session.getState().currentPlayer],
-          spyId,
-        );
-        renderLoop.setGameState(session.getState());
-        router.open('espionage');
-        showNotification('Spy recalled.', 'info');
-      },
-      onVerifyAgent: (spyId) => {
-        session.getState().espionage![session.getState().currentPlayer] = verifyAgent(
-          session.getState().espionage![session.getState().currentPlayer],
-          spyId,
-        );
-        renderLoop.setGameState(session.getState());
-        router.open('espionage');
-        showNotification('Agent verified and cleared.', 'success');
-      },
-      onExfiltrate: (spyId) => {
-        const ownerEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        const spy = ownerEsp?.spies[spyId];
-        if (!spy || spy.status !== 'stationed') return;
-        const capital = getCapitalCity(session.getState(), session.getState().currentPlayer);
-        if (!capital) { showNotification('Cannot exfiltrate — no capital found.', 'warning'); return; }
-
-        // Spawn occupancy: find a free tile at/near the capital
-        const existingPositions = new Set(
-          Object.values(session.getState().units).map(u => `${u.position.q},${u.position.r}`),
-        );
-        let spawnPos = capital.position;
-        if (existingPositions.has(`${spawnPos.q},${spawnPos.r}`)) {
-          const adjacent = hexesInRange(capital.position, 1).filter(
-            c => !(c.q === capital.position.q && c.r === capital.position.r) &&
-                 !existingPositions.has(`${c.q},${c.r}`) &&
-                 session.getState().map.tiles[hexKey(c)],
-          );
-          if (adjacent.length === 0) {
-            showNotification('Cannot exfiltrate — no free tile near capital.', 'warning');
-            return;
-          }
-          spawnPos = adjacent[0];
-        }
-
-        const newUnit = createUnit(spy.unitType, session.getState().currentPlayer, spawnPos, session.getState().idCounters);
-        session.getState().units[newUnit.id] = newUnit;
-        session.getState().civilizations[session.getState().currentPlayer].units =
-          [...(session.getState().civilizations[session.getState().currentPlayer].units ?? []), newUnit.id];
-        const updatedSpy = {
-          ...spy, id: newUnit.id, status: 'cooldown' as const,
-          cooldownTurns: 8, infiltrationCityId: null, cityVisionTurnsLeft: 0, targetCivId: null, cooldownMode: undefined,
-        };
-        const { [spyId]: _old, ...rest } = ownerEsp!.spies;
-        session.getState().espionage![session.getState().currentPlayer] = { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } };
-        renderLoop.setGameState(session.getState());
-        // Refresh panel in place
-        document.getElementById('espionage-panel')?.remove();
-        router.open('espionage');
-        showNotification('Spy exfiltrated. Available again in 8 turns.', 'info');
-      },
-      onToggleCooldownMode: (spyId) => {
-        const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        const spy = civEsp?.spies[spyId];
-        if (!spy || spy.status !== 'cooldown') return;
-        const next: 'stay_low' | 'passive_observe' =
-          (spy.cooldownMode ?? 'stay_low') === 'passive_observe' ? 'stay_low' : 'passive_observe';
-        session.commit({
-          ...session.getState(),
-          espionage: {
-            ...session.getState().espionage!,
-            [session.getState().currentPlayer]: {
-              ...civEsp!,
-              spies: { ...civEsp!.spies, [spyId]: { ...spy, cooldownMode: next } },
-            },
-          },
-        });
-        document.getElementById('espionage-panel')?.remove();
-        router.open('espionage');
-      },
-      onUnembed: (spyId) => {
-        const ownerEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        const spy = ownerEsp?.spies[spyId];
-        if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
-        const city = session.getState().cities[spy.targetCityId];
-        if (!city) return;
-        const newUnit = createUnit(spy.unitType, session.getState().currentPlayer, city.position, session.getState().idCounters);
-        session.getState().units[newUnit.id] = newUnit;
-        session.getState().civilizations[session.getState().currentPlayer].units.push(newUnit.id);
-        const unembedded = unembedSpy(ownerEsp!, spyId);
-        const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
-        const { [spyId]: _old, ...rest } = unembedded.spies;
-        session.getState().espionage![session.getState().currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
-        renderLoop.setGameState(session.getState());
-        document.getElementById('espionage-panel')?.remove();
-        router.open('espionage');
-        showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
-      },
-      onSweep: (spyId) => {
-        const ownerEsp = session.getState().espionage?.[session.getState().currentPlayer];
-        if (!ownerEsp) return;
-        const seed = `sweep-${spyId}-${session.getState().turn}`;
-        const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, session.getState());
-        session.getState().espionage![session.getState().currentPlayer] = updatedEsp;
-        if (detectedSpyIds.length > 0) {
-          showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
-        } else {
-          showNotification('Sweep complete — no enemy spies detected.', 'info');
-        }
-        renderLoop.setGameState(session.getState());
-        document.getElementById('espionage-panel')?.remove();
-        router.open('espionage');
-      },
-    }));
-}
-
 /**
  * Replaces `togglePanel`'s 288-line `else if` chain (#787 phase 5). Panels
  * that require a specific target -- a city id, a hex coord -- have no
  * parameterless "open the current one" call, so their `open` throws; they
  * still need a registry entry so `closeGroup`/`isOpen`/`close` (all
  * DOM-derived off `domId`) behave correctly when a 'main' or 'transient'
- * sweep runs. `openCityPanelForCity`'s real entry point stays a
- * directly-callable function, untouched by this phase (10b-d);
- * `openWonderPanelForCityId`'s moved into `PanelActionsController` (10b-c).
+ * sweep runs. `openCityPanelForCity`'s and `openWonderPanelForCityId`'s real
+ * entry points both now live in `PanelActionsController` (10b-c, 10b-d).
  * The territory-inspection panel has no such entry point of
  * its own -- it opens only as a side effect of `mapInteraction.handleHexLongPress`
  * (#787 phase 8d), which is not itself in this registry.
@@ -998,10 +632,10 @@ const panelRegistry = {
     domId: 'city-panel',
     group: 'main',
     open: () => {
-      throw new Error("'city' is parameterized -- call openCityPanelForCity(city) directly, not router.open('city').");
+      throw new Error("'city' is parameterized -- call panelActions.openCityPanelForCity(city) directly, not router.open('city').");
     },
   },
-  espionage: { domId: 'espionage-panel', group: 'main', open: () => openEspionagePanel() },
+  espionage: { domId: 'espionage-panel', group: 'main', open: () => panelActions.openEspionagePanel() },
   diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => panelActions.openDiplomacyPanel() },
   marketplace: { domId: 'marketplace-panel', group: 'main', open: () => panelActions.openMarketplacePanel() },
   network: { domId: 'network-panel', group: 'transient', open: () => panelActions.openNetworkPanel() },

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -6,9 +6,10 @@ import { createGameSession } from '@/app/game-session';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
 import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
 import { createUnit } from '@/systems/unit-system';
+import { createEspionageCivState } from '@/systems/espionage-system';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { NotificationMapTarget } from '@/core/notification-log';
-import type { GameState, HexCoord } from '@/core/types';
+import type { GameState, HexCoord, Spy } from '@/core/types';
 import {
   createPanelActionsController,
   type PanelActionsControllerDeps,
@@ -33,6 +34,8 @@ vi.mock('@/ui/network-panel', async () => {
   return { createNetworkPanel: vi.fn(() => document.createElement('div')), getNetworkPanelModel: actual.getNetworkPanelModel };
 });
 vi.mock('@/storage/save-manager', () => ({ saveSettings: vi.fn(() => Promise.resolve()) }));
+vi.mock('@/ui/city-panel', () => ({ createCityPanel: vi.fn() }));
+vi.mock('@/ui/espionage-panel', () => ({ createEspionagePanel: vi.fn(() => document.createElement('div')) }));
 
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { createBestiaryPanel } from '@/ui/bestiary-panel';
@@ -50,6 +53,8 @@ import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { createNetworkPanel } from '@/ui/network-panel';
 import { saveSettings } from '@/storage/save-manager';
+import { createCityPanel } from '@/ui/city-panel';
+import { createEspionagePanel } from '@/ui/espionage-panel';
 
 function mockedCallArg<T = unknown>(mockFn: unknown, callIndex: number, argIndex: number): T {
   return (mockFn as ReturnType<typeof vi.fn>).mock.calls[callIndex][argIndex] as T;
@@ -67,6 +72,30 @@ function placeUnit(state: GameState, type: Parameters<typeof createUnit>[0], uni
   const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
   state.units[unitId] = { ...createUnit(type, 'player', position, idCounters), id: unitId };
   state.civilizations.player.units.push(unitId);
+}
+
+function makeCity(id: string, overrides: Partial<NonNullable<GameState['cities'][string]>> = {}): NonNullable<GameState['cities'][string]> {
+  return {
+    id, name: `City ${id}`, owner: 'player', position: { q: 0, r: 0 },
+    population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+/** Places a real player-owned spy in `state.espionage`, for espionage-panel tests. */
+function placeSpy(state: GameState, spyId: string, overrides: Partial<Spy> = {}): void {
+  const spy: Spy = {
+    id: spyId, owner: 'player', name: `Agent ${spyId}`, unitType: 'spy_scout',
+    targetCivId: null, targetCityId: null, position: null,
+    status: 'idle', experience: 0, currentMission: null,
+    cooldownTurns: 0, promotion: undefined, promotionAvailable: false,
+    feedsFalseIntel: false,
+    ...overrides,
+  };
+  const existing = state.espionage?.player ?? createEspionageCivState();
+  state.espionage = { ...state.espionage, player: { ...existing, spies: { ...existing.spies, [spyId]: spy } } };
 }
 
 /** A coastal-enclave pirate faction adjacent to a real player unit, with intel already gathered. */
@@ -119,13 +148,14 @@ function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDep
     },
     renderLoop: {
       camera: { centerOn: vi.fn() }, setSelectedPirateFactionId: vi.fn(),
-      applyPirateHeadquartersAssaultVisual: vi.fn(), setGameState: vi.fn(),
+      applyPirateHeadquartersAssaultVisual: vi.fn(), setGameState: vi.fn(), setHighlights: vi.fn(),
     },
     showNotification: vi.fn(),
     focusNotificationTarget: vi.fn(),
     focusPirateTarget: vi.fn(),
     applyPirateActionResult: vi.fn(),
     currentCiv: vi.fn(() => state.civilizations[state.currentPlayer]),
+    currentCivDef: vi.fn(() => undefined),
     diplomacyActions: {
       handleDiplomaticAction: vi.fn(),
       handleAcceptPeaceRequest: vi.fn(),
@@ -140,8 +170,10 @@ function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDep
       handleMinorCivWarPeace: vi.fn(),
       handleAppeaseFaction: vi.fn(() => state),
       handleConcedeToMovement: vi.fn(() => state),
+      handleEstablishRoute: vi.fn(),
     },
-    openCityPanelForCity: vi.fn(),
+    executeUpgrade: vi.fn(() => false),
+    router: { open: vi.fn() },
     ...overrides,
   };
 }
@@ -202,7 +234,7 @@ describe('PanelActionsController', () => {
       expect(deps.renderLoop.camera.centerOn).toHaveBeenCalledWith({ q: 3, r: 3 });
 
       options.onOpenCity('nonexistent-city');
-      expect(deps.openCityPanelForCity).not.toHaveBeenCalled();
+      expect(createCityPanel).not.toHaveBeenCalled();
 
       options.onNaturalWonderPageShown('great-lighthouse');
       expect(deps.audio.startNaturalWonderCodexAmbient).toHaveBeenCalledWith('great-lighthouse');
@@ -214,7 +246,7 @@ describe('PanelActionsController', () => {
       expect(deps.audio.playNaturalWonderReplay).toHaveBeenCalledWith('great-lighthouse');
     });
 
-    it('opens the founded city via the injected dep when one exists', () => {
+    it('opens the founded city via the real openCityPanelForCity when one exists', () => {
       const { state } = makeFixture('wonder-atlas-city');
       state.cities['test-city'] = {
         id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
@@ -228,7 +260,7 @@ describe('PanelActionsController', () => {
       const options = mockedCallArg<{ onOpenCity: (cityId: string) => void }>(createWonderAtlasPanel, 0, 2);
       options.onOpenCity('test-city');
 
-      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+      expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
     });
   });
 
@@ -329,7 +361,7 @@ describe('PanelActionsController', () => {
       }>(createNotificationLogPanel, 0, 1);
 
       options.onOpenCity('test-city');
-      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+      expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
       expect(removeSpy).toHaveBeenCalledTimes(1);
 
       options.onClose();
@@ -445,7 +477,7 @@ describe('PanelActionsController', () => {
       };
     }
 
-    it('closes the drawer, removes any prior panel, and opens the injected city panel dep', () => {
+    it('closes the drawer, removes any prior panel, and opens the real city panel', () => {
       const { state } = makeFixture('city-overview');
       state.cities['test-city'] = makeOverviewCity();
       const { deps, controller } = build(state);
@@ -455,7 +487,7 @@ describe('PanelActionsController', () => {
       expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
       const options = mockedCallArg<{ onOpenCity: (cityId: string) => void }>(createCityOverviewPanel, 0, 2);
       options.onOpenCity('test-city');
-      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+      expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
     });
 
     it('appeases a faction via diplomacyActions and re-renders the panel', () => {
@@ -535,7 +567,7 @@ describe('PanelActionsController', () => {
       expect(deps.getElementById).toHaveBeenCalledWith('info-panel');
     });
 
-    it('opens the injected city panel dep and deselects when a stacked unit opens its city', () => {
+    it('opens the real city panel and deselects when a stacked unit opens its city', () => {
       const { state } = makeFixture('unit-stack-open-city');
       state.cities['test-city'] = {
         id: 'test-city', name: 'Testopolis', owner: 'player', position: { q: 0, r: 0 },
@@ -553,7 +585,7 @@ describe('PanelActionsController', () => {
       options.onOpenCity('test-city');
 
       expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
-      expect(deps.openCityPanelForCity).toHaveBeenCalledWith(state.cities['test-city']);
+      expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
     });
   });
 
@@ -620,6 +652,183 @@ describe('PanelActionsController', () => {
       // requestAutonomyPosture stages the change as `pendingPosture`, applied on a later turn --
       // not an immediate `posture` mutation.
       expect(deps.session.getState().autonomyByCiv?.player?.pendingPosture).toEqual({ id: 'defensive', appliesOnTurn: state.turn + 1 });
+    });
+  });
+
+  describe('openCityPanelForCity', () => {
+    it('closes the drawer but builds no panel for a city the player does not own', () => {
+      const { state, aiCivId } = makeFixture('city-panel-foreign');
+      state.cities['foreign-city'] = makeCity('foreign-city', { owner: aiCivId });
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['foreign-city']);
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      expect(createCityPanel).not.toHaveBeenCalled();
+    });
+
+    it('builds the panel for an owned city with the live session state', () => {
+      const { state } = makeFixture('city-panel-owned');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+
+      expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
+    });
+
+    it('queues real production via the live city state and refreshes the renderer', () => {
+      const { state } = makeFixture('city-panel-build');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{ onBuild: (cityId: string, itemId: string) => void }>(createCityPanel, 0, 3);
+      options.onBuild('test-city', 'warrior');
+
+      expect(state.cities['test-city'].productionQueue).toContain('warrior');
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('Warrior'), 'info');
+    });
+
+    it('cycles to the next and previous city among the civ\'s real roster, recursively calling itself', () => {
+      const { state } = makeFixture('city-panel-cycle');
+      state.cities['city-a'] = makeCity('city-a');
+      state.cities['city-b'] = makeCity('city-b');
+      state.civilizations.player.cities = ['city-a', 'city-b'];
+      const { controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['city-a']);
+      const firstOptions = mockedCallArg<{ onNextCity: () => void }>(createCityPanel, 0, 3);
+      firstOptions.onNextCity();
+
+      // The recursive self-call re-invokes createCityPanel for city-b.
+      expect(createCityPanel).toHaveBeenCalledTimes(2);
+      expect(mockedCallArg<{ id: string }>(createCityPanel, 1, 1).id).toBe('city-b');
+
+      const secondOptions = mockedCallArg<{ onPrevCity: () => void }>(createCityPanel, 1, 3);
+      secondOptions.onPrevCity();
+
+      expect(createCityPanel).toHaveBeenCalledTimes(3);
+      expect(mockedCallArg<{ id: string }>(createCityPanel, 2, 1).id).toBe('city-a');
+    });
+
+    it('wires onEstablishRoute, onAppeaseFaction, and onConcedeToMovement to diplomacyActions', () => {
+      const { state } = makeFixture('city-panel-diplomacy');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{
+        onEstablishRoute: (caravanId: string) => void;
+        onAppeaseFaction: (cityId: string) => void;
+        onConcedeToMovement: (cityId: string) => void;
+      }>(createCityPanel, 0, 3);
+
+      options.onEstablishRoute('caravan-1');
+      expect(deps.diplomacyActions.handleEstablishRoute).toHaveBeenCalledWith('caravan-1');
+
+      options.onAppeaseFaction('test-city');
+      expect(deps.diplomacyActions.handleAppeaseFaction).toHaveBeenCalledWith('test-city');
+
+      options.onConcedeToMovement('test-city');
+      expect(deps.diplomacyActions.handleConcedeToMovement).toHaveBeenCalledWith('test-city');
+    });
+
+    it('does nothing when the selected unit has no real upgrade path available', () => {
+      const { state } = makeFixture('city-panel-no-upgrade');
+      state.cities['test-city'] = makeCity('test-city');
+      placeUnit(state, 'settler', 'settler-1', { q: 0, r: 0 });
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{ onUpgradeUnit: (unitId: string) => void }>(createCityPanel, 0, 3);
+      options.onUpgradeUnit('settler-1');
+
+      // `settler` has no `upgradesTo` in TRAINABLE_UNITS, so the real guard returns
+      // before ever reaching the injected `executeUpgrade` dep.
+      expect(deps.executeUpgrade).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openEspionagePanel', () => {
+    it('closes the drawer and builds the panel from real session state', () => {
+      const { state } = makeFixture('espionage-panel-open');
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+
+      expect(deps.hud.closeDrawer).toHaveBeenCalledTimes(1);
+      expect(createEspionagePanel).toHaveBeenCalledWith(deps.session.getState(), expect.anything());
+      expect(deps.uiLayer.children.length).toBeGreaterThan(0);
+    });
+
+    it('recalls a stationed spy via the real system call and reopens the panel through router', () => {
+      const { state } = makeFixture('espionage-recall');
+      placeSpy(state, 'spy-1', { status: 'stationed', targetCivId: 'ai-1', targetCityId: 'foreign-city' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onRecall: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onRecall('spy-1');
+
+      expect(state.espionage!.player.spies['spy-1'].status).not.toBe('stationed');
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('recalled'), 'info');
+    });
+
+    it('verifies a captured-then-cleared agent via the real system call', () => {
+      const { state } = makeFixture('espionage-verify');
+      placeSpy(state, 'spy-1', { status: 'stationed' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onVerifyAgent: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onVerifyAgent('spy-1');
+
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+      expect(deps.showNotification).toHaveBeenCalledWith('Agent verified and cleared.', 'success');
+    });
+
+    it('sweeps with a real seed and reports no enemy spies detected', () => {
+      const { state } = makeFixture('espionage-sweep');
+      placeSpy(state, 'spy-1', { status: 'embedded', targetCityId: 'test-city' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onSweep: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onSweep('spy-1');
+
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('no enemy spies detected'), 'info');
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+    });
+
+    it('toggles cooldown mode for a real spy on cooldown', () => {
+      const { state } = makeFixture('espionage-cooldown');
+      placeSpy(state, 'spy-1', { status: 'cooldown', cooldownMode: 'stay_low' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onToggleCooldownMode: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onToggleCooldownMode('spy-1');
+
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].cooldownMode).toBe('passive_observe');
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+    });
+
+    it('does nothing when toggling cooldown mode for a spy that is not on cooldown', () => {
+      const { state } = makeFixture('espionage-cooldown-guard');
+      placeSpy(state, 'spy-1', { status: 'idle' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onToggleCooldownMode: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onToggleCooldownMode('spy-1');
+
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].status).toBe('idle');
+      expect(deps.router.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -749,6 +749,50 @@ describe('PanelActionsController', () => {
       // before ever reaching the injected `executeUpgrade` dep.
       expect(deps.executeUpgrade).not.toHaveBeenCalled();
     });
+
+    it('reassigns city focus via the real city-work-system call', () => {
+      const { state } = makeFixture('city-panel-focus');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{ onSetCityFocus: (cityId: string, focus: string) => unknown }>(createCityPanel, 0, 3);
+      options.onSetCityFocus('test-city', 'production');
+
+      expect(deps.session.getState().cities['test-city'].focus).toBe('production');
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('production'), 'info');
+    });
+
+    it('shows a warning instead of committing when the real rush-buy quote is unavailable', () => {
+      const { state } = makeFixture('city-panel-rushbuy');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{ onRushBuyActiveProduction: (cityId: string) => unknown }>(createCityPanel, 0, 3);
+      options.onRushBuyActiveProduction('test-city');
+
+      // Empty production queue -> real getRushBuyQuote reports unavailable.
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), 'warning');
+    });
+
+    it('highlights real worker-buildable tiles and surfaces every toast from onFindResources', () => {
+      const { state } = makeFixture('city-panel-find-resources');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{
+        onFindResources: (highlights: HexCoord[], toasts: Array<{ message: string; type: 'info' | 'warning' | 'success' }>) => void;
+      }>(createCityPanel, 0, 3);
+      options.onFindResources([{ q: 1, r: 1 }, { q: 2, r: 2 }], [{ message: 'Found 2 resources', type: 'info' }]);
+
+      expect(deps.renderLoop.setHighlights).toHaveBeenCalledWith([
+        { coord: { q: 1, r: 1 }, type: 'worker-buildable' },
+        { coord: { q: 2, r: 2 }, type: 'worker-buildable' },
+      ]);
+      expect(deps.showNotification).toHaveBeenCalledWith('Found 2 resources', 'info');
+    });
   });
 
   describe('openEspionagePanel', () => {
@@ -829,6 +873,45 @@ describe('PanelActionsController', () => {
 
       expect(deps.session.getState().espionage!.player.spies['spy-1'].status).toBe('idle');
       expect(deps.router.open).not.toHaveBeenCalled();
+    });
+
+    it('starts a real placed-spy mission chosen via window.prompt without prompting for a target', () => {
+      const { state } = makeFixture('espionage-start-mission');
+      state.civilizations.player.techState.completed = ['espionage-scouting'];
+      placeSpy(state, 'spy-1', { status: 'stationed', targetCivId: 'ai-1', targetCityId: 'foreign-city' });
+      const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('scout_area');
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onStartMission: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onStartMission('spy-1');
+
+      // `scout_area` requires a placed spy, so the mission-choice prompt fires once
+      // but the foreign-city-target prompt never does -- the spy's existing target is reused.
+      expect(promptSpy).toHaveBeenCalledTimes(1);
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].currentMission?.type).toBe('scout_area');
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('scout_area'), 'info');
+      promptSpy.mockRestore();
+    });
+
+    it('exfiltrates a stationed spy to a real capital with a free tile', () => {
+      const { state } = makeFixture('espionage-exfiltrate');
+      state.cities['capital-city'] = makeCity('capital-city');
+      state.civilizations.player.cities = ['capital-city'];
+      placeSpy(state, 'spy-1', { status: 'stationed', unitType: 'spy_scout', targetCivId: 'ai-1', targetCityId: 'foreign-city' });
+      const { deps, controller } = build(state);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onExfiltrate: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onExfiltrate('spy-1');
+
+      const spies = deps.session.getState().espionage!.player.spies;
+      expect(spies['spy-1']).toBeUndefined();
+      const exfiltrated = Object.values(spies).find(spy => spy.status === 'cooldown');
+      expect(exfiltrated).toMatchObject({ cooldownTurns: 8, targetCivId: null });
+      expect(deps.session.getState().units[exfiltrated!.id].position).toEqual(state.cities['capital-city'].position);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('exfiltrated'), 'info');
     });
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -153,9 +153,9 @@ describe('shared unit upgrade wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const handler = main.slice(
       main.indexOf('function executeUpgrade('),
-      // #787 phase 10b-c: openWonderPanelForCityId moved into PanelActionsController;
-      // openCityPanelForCity is what now immediately follows executeUpgrade.
-      main.indexOf('function openCityPanelForCity('),
+      // #787 phase 10b-d: openCityPanelForCity moved into PanelActionsController;
+      // getUnitTurnFlow is what now immediately follows executeUpgrade.
+      main.indexOf('function getUnitTurnFlow('),
     );
 
     expect(handler).toContain('applyUnitUpgradeToState(');


### PR DESCRIPTION
## Summary

Part of the composition-root decomposition arc ([#787](https://github.com/a1flecke/conquestoria/issues/787)), continuing Phase 10b's sub-phase split (10b-a through 10b-g, see [PR #807](https://github.com/a1flecke/conquestoria/pull/807)). Builds on merged Phase 10b-c ([PR #811](https://github.com/a1flecke/conquestoria/pull/811)).

Extends `PanelActionsController` with the final two, largest/riskiest panel openers:

- `openCityPanelForCity` (~141 lines pre-move)
- `openEspionagePanel` (~279 lines pre-move — the single largest function moved anywhere in this arc)

Each was moved verbatim out of `main.ts` with mechanical dep-substitution only — no behavior changes.

**`main.ts`: 1568 → 1199 lines.**

## Notable wiring

- `router` is threaded through as a lazy wrapper (`{ open: panel => router.open(panel) }`), not a direct reference — `router` is a `let` not assigned until `createPanelRouter(...)` much later in `main.ts` module evaluation (after `panelRegistry`, which itself needs this controller's methods). Same deferred-but-eager pattern `turnFlow`'s own `router` dep already uses.
- `executeUpgrade` and `currentCivDef` are `main.ts`-local hoisted function declarations (like `currentCiv`), threaded through directly with no wrapper needed.
- `diplomacyActions`' injected `Pick` was widened to include `handleEstablishRoute` for `openCityPanelForCity`'s `onEstablishRoute` callback.
- `renderLoop.setHighlights` was added to `PanelActionsRenderer`'s `Pick` for `onFindResources`.
- `openCityPanelForCity` calls itself recursively for `onPrevCity`/`onNextCity` city-cycling — preserved as-is.
- Four pre-existing `deps.openCityPanelForCity(...)` call sites inside the controller file (from 10b-b/10b-c's `openWonderAtlas`, `openNotificationLog`, `openCityOverviewPanel`, `openUnitStackPicker`) were updated to bare sibling-function calls now that `openCityPanelForCity` lives in the same file, same pattern as `openWonderPanelForCityId` becoming a sibling in 10b-c.

## TypeScript improvement

Eliminated two pre-existing `mission as any` casts (inherited verbatim from `main.ts`, not introduced by this move) by properly typing `chooseMission`'s return as `SpyMissionType | null` instead of `string | null` — `window.prompt`'s return is cast once at the source instead of at each downstream use site. Zero behavior change, zero `as any`/`as never`/`as unknown as` casts remain in the file.

## Verification

- **Exhaustive call-count parity audit**: 15 markers compared against pre-move `main.ts` + pre-move `panel-actions-controller.ts` (from merged `HEAD`) — zero real drift. The one non-zero delta (`router.open(`, +2) was hand-verified: all 8 pre-existing `router.open('espionage')` calls moved verbatim as `deps.router.open('espionage')`; the +2 is fully explained by one legitimate new `panelActions.router` wrapper line plus one incidental docblock-comment mention (not real code) — the same two false-alarm categories this arc's process doc predicts.
- **Dead-import hygiene**: baseline (13 pre-existing unrelated dead imports) re-confirmed unchanged. Cleaned up 26 imports that became genuinely dead in `main.ts` after the move, plus caught one already-dead import (`resolveMissionResult`) that had been masked by an incidental comment-string match before this move — never actually used in real code.
- 12 new tests added (27 → 39 total in `tests/app/controllers/panel-actions-controller.test.ts`), all using real system-state fixtures: real `enqueueCityProduction`, real recursive city-cycling through the civ's actual city roster, real `recallSpy`/`verifyAgent`/`attemptSweep`/cooldown-toggle espionage system calls — only the `@/ui/*` panel factories are mocked.
- Full suite green: 478 files / 7764 tests, `yarn build` clean, `yarn test:web-smoke` 8/8.
- **Full review across all requested dimensions performed before opening this PR** (gameplay balance, fun, new mechanics, player ages 7-43, play styles, difficulty modes, computer players, UI, UX, architecture, extensibility, data, SFX, saved games, testing, regressions solo+hot-seat, proper implementation): confirmed via grep that no AI code path touches either moved function (both are player-only UI); confirmed zero hardcoded `'player'` strings (hot-seat safe, `state.currentPlayer` used exclusively); confirmed the pre-existing `SFX.combat()` call and `document.addEventListener` click-outside-close handler are untouched carry-overs from 10b-b, not new; no save-schema changes. Live-verified the exact wiring pattern (deps.getElementById/hud/session/router/panelRegistry routing) end-to-end in-browser during 10b-c's review — this phase reuses the identical pattern.

## Test plan

- [x] `yarn build`
- [x] `yarn test` (full suite, 478 files / 7764 tests)
- [x] `yarn test:web-smoke` (8/8)
- [x] Manual diff review of `main.ts` changes (pure removal + rewiring, no leftover artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)