### PR TITLE
feat(fort): add Worker-built Citadels (#690)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-issue-690-fort-citadel.md
+++ b/docs/superpowers/plans/2026-08-08-issue-690-fort-citadel.md
@@ -1,0 +1,186 @@
+# Issue 690 Fort/Citadel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Worker-built Fort that becomes a Citadel at Fortification Engineering and gives a friendly land combat unit bounded, counterable defense.
+
+**Architecture:** Persist one `fort` value in the existing tile improvement field and derive its Fort/Citadel tier from the owning civilization's technologies. A pure fortification system owns legality, cap, tier, and combat facts; the worker, combat context, AI, persistence, and renderer consume it rather than adding duplicate ID checks.
+
+**Tech Stack:** TypeScript, Canvas 2D, Vitest.
+
+---
+
+## Pre-audit
+
+- Base: `origin/main` `293a3a7b`; all blockers #667, #669, #684, and #686 are closed.
+- The original audit base predates a 436-file delta. The shared `buildCombatContextForDefender` and typed combat facts now cover player, AI, world, preview, and air callers, and are the correct Fort seam.
+- No Fort exists. The current improvement catalogue, worker mutation/completion, replacement confirmation, generic AI actions, and pillage reward are stable extension seams.
+- Pillage intentionally sets `improvement` to `none`; no ruined-improvement state exists. Retain that model: rebuilding takes the normal five turns. Existing `restore_land` repairs catastrophe devastation while preserving a Fort. No new save shape or schema version is needed.
+- This is Task 26 only. Task 27's dedicated cap/status/defense UI remains out of scope. The existing Worker catalogue and a temporary map treatment are sufficient to avoid a dead player action.
+- Current AI Workers do not travel to an improvement site deliberately. Add one bounded, deterministic candidate helper using only owned tiles and visible threats.
+
+## File map
+
+- Create `src/systems/fortification-system.ts`: Fort/Citadel tier, cap/frontier legality, candidate selection, and defense resolver.
+- Modify `src/core/types.ts`, `src/systems/improvement-system.ts`, `src/systems/worker-action-system.ts`: typed `fort`, definition, and canonical five-turn build.
+- Modify `src/systems/unit-system.ts`, `src/systems/combat-context.ts`, `src/systems/combat-system.ts`: typed half penetration and shared defense facts.
+- Modify `src/ai/ai-tactics.ts`, `src/storage/save-migrations.ts`, `src/renderer/improvements/improvement-treatment.ts`, `src/renderer/hex-renderer.ts`; update the mirrored system/AI/storage/renderer tests.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Worker is on legal owned land with Fortresses | Click `Build Fort` | Normal active worker task begins at five turns and the action disappears. |
+| Friendly land combat unit occupies Fort | Fortify or preview combat | Separate Fort and Fortify facts appear; they are not described as one layer. |
+| Owner completes Fortification Engineering | Preview combat | The persisted tile stays `fort`; its fact says Citadel and uses +20%. |
+| Enemy occupies a complete Fort | Click `Pillage` | Existing confirmation/reward/action path removes it; no defense remains. |
+| A catastrophe devastates an occupied Fort tile | Click `Restore Land` | Existing restore action removes devastation and retains the Fort. |
+
+## Misleading UI Risks
+
+- Empty, building, pillaged, naval, transported, or hostile occupants must receive no Fortification defense.
+- Fortify's +25% and the Fort/Citadel multiplier are independent public facts.
+- Citadel is a derived technology tier, never a second saved improvement ID.
+- The full detailed Fort status/cap presentation is explicitly deferred to Task 27; no new filtered catalogue is introduced.
+
+## Inline review corrections
+
+| Dimension | Review result and required correction |
+| --- | --- |
+| Balance and fun | A Fort must reward preparation without becoming a default answer. The balance fixture now compares a builder's supported Fort against an explorer's mobile response, a defender's ordinary garrison, and the four approved siege counters; it rejects any result outside the four-to-eight successful-engagement envelope. |
+| Ages 7–43 and play styles | `Build Fort — protect a friendly land unit` is the first, 7-word explanation. The action also shows `5 turns`, `+10% defense`, and the visible Citadel upgrade condition; the later status surface retains detailed breakdowns for optimizers. Explorer, builder, defender, expansionist, and casual fixtures prove the action stays optional, readable, and non-dominant. |
+| Difficulty and computer players | Explorer, Standard, and Veteran must share the same placement legality, Fort/Citadel values, penetration, information boundary, and candidate set. Tests may permit existing decision-quality ranking differences only after the common legal candidate set is identical. |
+| UI, UX, and hot seat | The selected Worker panel must refresh immediately after start/replacement, keep every other legal action reachable, use the existing 44-pixel button, and render from the selected owner/current viewer. Tests switch `currentPlayer` before opening panels and before completion/pillage presentation. |
+| Architecture/extensibility/data | Capability data stays typed on improvements/units; no `trebuchet`/`fort` ID switch is allowed in combat. The AI makes one ordered owned-tile pass, and the public combat fact is computed in the shared context. |
+| SFX and accessibility | #690 adds no unique sound or passive looping audio: the approved dedicated construction/damage/pillage/repair audio belongs to Wave 8 task 54. The existing owner-targeted text notification, map treatment, and combat fact are the accessible feedback path. Add regression coverage that no Fort completion/pillage presentation is delivered or played for the non-current hot-seat player. |
+| Saves | Add an idempotent `normalizeImprovementValues` load normalizer that accepts every current legal improvement including `fort`, coerces unknown/malformed values to `none`, and clamps invalid construction turns to the definition's legal range. It runs after numbered migrations without pre-reserving a schema version. |
+| Testing and regression | Each mutation gets RED/GREEN evidence; targeted suites cover solo, AI/world, all difficulties, two-human hot seat, current-viewer isolation, malformed/current/legacy/mid-action saves, renderer/DOM behavior, and the exact balance boundary. |
+
+### Task 1: Add the pure Fortification contract
+
+**Files:** Create `src/systems/fortification-system.ts`; modify `src/core/types.ts`; test `tests/systems/fortification-system.test.ts`.
+
+- [ ] Write failing tier and legality tests:
+
+```ts
+expect(getFortificationTier(['fortresses'])).toEqual({ id: 'fort', label: 'Fort', multiplier: 1.1 });
+expect(getFortificationTier(['fortresses', 'fortification-engineering'])).toEqual({ id: 'citadel', label: 'Citadel', multiplier: 1.2 });
+expect(getFortificationPlacement(state, owner, target)).toMatchObject({ ok: true, isFrontier: true });
+expect(getFortificationPlacement(stateAtCap, owner, interior).reason).toBe('empire-cap');
+expect(getFortificationPlacement(stateWithAdjacentFort, owner, target).reason).toBe('adjacent-fort');
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/fortification-system.test.ts`; confirm RED.
+- [ ] Add `fort` to `ImprovementType`, serializable tier/placement/defense result types, and pure helpers. Reject city centers, ocean/coast, mountains, unowned tiles, `resource_outpost`, adjacent completed/building Forts, and a full cap. Permit `cityCount` Forts anywhere legal, then only `Math.floor(cityCount / 3)` extra Forts on tiles adjacent to null/foreign ownership. Use wrapped neighbours and count in-progress Forts once.
+- [ ] Re-run the suite; confirm GREEN. Commit: `feat(690): define Fortification contract`.
+
+### Task 2: Build Forts through the ordinary Worker path
+
+**Files:** `src/systems/improvement-system.ts`, `src/systems/worker-action-system.ts`; tests `tests/systems/improvement-system.test.ts`, `tests/systems/worker-action-system.test.ts`, `tests/systems/improvement-turn-system.test.ts`.
+
+- [ ] Write failing tests:
+
+```ts
+expect(IMPROVEMENT_DEFINITIONS.fort).toMatchObject({ buildTurns: 5, requiredTech: 'fortresses' });
+expect(canBuildImprovement(tile, 'fort', ['fortresses'], owner, fortOptions)).toBe(true);
+expect(canBuildImprovement(tile, 'fort', [], owner, fortOptions)).toBe(false);
+expect(applyWorkerAction(state, worker.id, 'fort').state.map.tiles[key]).toMatchObject({ improvement: 'fort', improvementTurnsLeft: 5 });
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/improvement-system.test.ts tests/systems/worker-action-system.test.ts tests/systems/improvement-turn-system.test.ts`; confirm RED.
+- [ ] Add zero-yield `fort`, the `Build Fort` label, and a narrow state-aware Fort eligibility context that delegates to `getFortificationPlacement`. Thread that same context through `applyWorkerAction`; preserve charges, replacement confirmation, worker task cleanup, start/completion events, and notification behavior.
+- [ ] Change the visible Worker text to `Build Fort — protect a friendly land unit (5 turns, +10%; Citadel +20%)`. Add DOM assertions that it is visible only after Fortresses, stays alongside every other legal Worker action, and that the panel rerenders immediately after the action.
+- [ ] Re-run the suites; confirm GREEN. Commit: `feat(690): add Worker-built Fort`.
+
+### Task 3: Resolve defense and siege penetration in shared combat
+
+**Files:** `src/systems/fortification-system.ts`, `src/systems/unit-system.ts`, `src/systems/combat-context.ts`, `src/systems/combat-system.ts`; tests `tests/systems/fortification-system.test.ts`, `tests/systems/combat-system.test.ts`, `tests/systems/combat-context.test.ts`.
+
+- [ ] Write failing tests:
+
+```ts
+expect(resolveFortificationDefense(state, defender, attacker)).toMatchObject({ multiplier: 1.1, label: 'Fort +10%' });
+expect(resolveFortificationDefense(citadelState, defender, trebuchet)).toMatchObject({ multiplier: 1.1, label: 'Citadel +20% (50% penetrated)' });
+expect(resolveFortificationDefense(state, emptyFortRepresentative, attacker).multiplier).toBe(1);
+expect(resolveFortificationDefense(state, navalDefender, attacker).multiplier).toBe(1);
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/fortification-system.test.ts tests/systems/combat-system.test.ts tests/systems/combat-context.test.ts`; confirm RED.
+- [ ] Add typed optional `fortificationPenetration` to `UnitDefinition`, set to `0.5` only for Trebuchet, Grenadier, Artillery, and Rocket Artillery, and add no Fort-specific unit switch. Resolve only finished owned Forts beneath friendly non-transported land combat units; calculate penetration as `1 + (tier.multiplier - 1) * penetration`.
+- [ ] Put the applied/ignored public fact and multiplier into `buildCombatContextForDefender`, then apply it separately from ordinary Fortify in `calculateCombatStrengths`. Return facts through existing results for preview/player/AI/world parity.
+- [ ] Re-run the suites; confirm GREEN. Commit: `feat(690): resolve Fortification defense`.
+
+### Task 4: Preserve canonical pillage, recovery, and saves
+
+**Files:** `src/systems/pillage-system.ts` only for exhaustive typing, `src/storage/save-migrations.ts`; tests `tests/systems/pillage-system.test.ts`, `tests/storage/save-migrations.test.ts`, `tests/storage/save-migrations-v12.test.ts`, `tests/systems/worker-action-system.test.ts`.
+
+- [ ] Write failing regressions:
+
+```ts
+expect(getPillageGoldReward('fort')).toBe(5 * GOLD_PER_PILLAGE_BUILD_TURN);
+expect(applyPillageToState(enemyFortState, raider.id).state.map.tiles[key].improvement).toBe('none');
+expect(applyWorkerAction(devastatedFortState, worker.id, 'restore_land').state.map.tiles[key].improvement).toBe('fort');
+expect(migrateSaveToCurrent(malformedFortSave).map.tiles[key].improvement).toBe('none');
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/pillage-system.test.ts tests/storage/save-migrations.test.ts tests/storage/save-migrations-v12.test.ts tests/systems/worker-action-system.test.ts`; confirm RED.
+- [ ] Let the existing build-turn reward calculate Fort gold. Normalize valid Fort strings and malformed strings safely, without a version bump because `HexTile` gains no field. Test schema 0, 11, 12, malformed, and a mid-construction Fort round trip.
+- [ ] Implement and test an idempotent post-migration `normalizeImprovementValues`: accept every declared improvement, coerce an unknown value to `none`, set invalid/negative/overlong construction turns to the matching definition's valid range, and never rewrite a valid saved `fort` into `citadel`.
+- [ ] Re-run the suites; confirm GREEN. Commit: `test(690): cover Fort recovery and persistence`.
+
+### Task 5: Give AI a bounded, observable Fort decision
+
+**Files:** `src/systems/fortification-system.ts`, `src/ai/ai-tactics.ts`; tests `tests/systems/fortification-system.test.ts`, `tests/ai/ai-tactics.test.ts`.
+
+- [ ] Write RED tests:
+
+```ts
+expect(findFortificationCandidate(state, aiId)).toMatchObject({ coord: frontierCoord });
+expect(findFortificationCandidate(stateWithHiddenThreat, aiId)).toBeNull();
+expect(chooseUnitTacticalAction(context(state, plan), worker.id)).toMatchObject({ kind: 'move', destination: frontierCoord });
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/systems/fortification-system.test.ts tests/ai/ai-tactics.test.ts`; confirm RED.
+- [ ] Scan owned tiles once per decision, sorted by coordinate. Score only legal frontier candidates with a hostile unit visible to the owner on the nearby approach; move to the winner, then use generic `applyWorkerAction('fort')`. Do not inspect hidden rivals or rescan per candidate.
+- [ ] Run the same candidate fixture for Explorer, Standard, and Veteran. Assert identical legal placements, tier, cap, and visible-threat inputs; only an already-typed decision-quality tie-break may differ.
+- [ ] Re-run the suites; confirm GREEN. Commit: `feat(690): place AI frontier forts`.
+
+### Task 6: Surface a usable temporary Fort treatment
+
+**Files:** `src/ui/selected-unit-info.ts`, `src/renderer/improvements/improvement-treatment.ts`, `src/renderer/hex-renderer.ts`; tests `tests/ui/selected-unit-info.test.ts`, `tests/renderer/improvements/improvement-treatment.test.ts`, `tests/renderer/hex-renderer.test.ts`.
+
+- [ ] Write failing DOM/canvas tests:
+
+```ts
+expect(findButtons(container).map(button => button.textContent)).toContain('Build Fort');
+expect(findButtons(noFortresses).map(button => button.textContent)).not.toContain('Build Fort');
+expect(getImprovementTreatmentFamily('fort')).toBe('fortification');
+expect(IMPROVEMENT_ICONS.fort).toBeDefined();
+```
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn test --run tests/ui/selected-unit-info.test.ts tests/renderer/improvements/improvement-treatment.test.ts tests/renderer/hex-renderer.test.ts`; confirm RED.
+- [ ] Use the existing 44-pixel Worker button and complete legal catalogue; add an earthy non-animated Canvas treatment and compatible icon. Do not add a second rendering path, status panel, cap explanation, or repair control reserved for Task 27.
+- [ ] Add a two-human replay: Player A starts/completes/pillages a Fort, then hand off to Player B before presentation. Assert Player B receives no stale Fort notification, animation, or audio; Player A's later panel/preview renders only their own current facts.
+- [ ] Re-run the suites; confirm GREEN. Commit: `feat(690): render Fort fallback`.
+
+### Task 7: Balance and verify the delivery
+
+- [ ] Add deterministic fixtures for Fortify-only, Fort, Citadel, approved siege, and a same-era generalist; then play-style fixtures for a builder, defender, explorer, expansionist, optimizer, and casual first-use path. Assert +25% Fortify, +10%/+20% Fortification, half penetration only for the four approved units, no strict same-era upgrade, and four-to-eight successful engagements for a supported position.
+- [ ] Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/fortification-system.ts src/systems/improvement-system.ts src/systems/worker-action-system.ts src/systems/combat-context.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ai/ai-tactics.ts src/storage/save-migrations.ts src/renderer/improvements/improvement-treatment.ts src/renderer/hex-renderer.ts src/ui/selected-unit-info.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/fortification-system.test.ts tests/systems/improvement-system.test.ts tests/systems/worker-action-system.test.ts tests/systems/improvement-turn-system.test.ts tests/systems/combat-system.test.ts tests/systems/combat-context.test.ts tests/systems/pillage-system.test.ts tests/ai/ai-tactics.test.ts tests/storage/save-migrations.test.ts tests/storage/save-migrations-v12.test.ts tests/ui/selected-unit-info.test.ts tests/renderer/improvements/improvement-treatment.test.ts tests/renderer/hex-renderer.test.ts
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test:durable
+bash scripts/run-with-mise.sh yarn test:durable:status
+git diff --check
+git diff --stat origin/main...HEAD
+git diff --stat
+```
+
+- [ ] Inspect committed and uncommitted diffs. Record fixture results and Task 27's UI deferral in the PR; confirm the web build preserves `/conquestoria/` asset paths.
+
+## Self-review
+
+This plan covers exact tiers, cap/frontier and terrain negatives, Fortify stacking, all four typed counters, empty/pillaged/non-land negatives, player/AI/world parity, hot-seat owner-tech isolation, existing pillage/catastrophe semantics, schema 0/previous/current/malformed/mid-action saves, temporary visible treatment, and deterministic balance. It intentionally keeps detailed status/placement UI in Task 27 while delivering a complete Worker action and map result.

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -65,6 +65,7 @@ import {
 } from '@/systems/worker-action-system';
 import { chooseRoadBuilderUnit } from '@/systems/road-network';
 import { canBuildRoad } from '@/systems/road-system';
+import { findFortificationCandidate } from '@/systems/fortification-system';
 import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
 import { isAIHostileOwner } from './ai-hostility';
 import { getLegalRebaseDestinations, resolveAirStrike, resolveReconMission, rebaseAircraft, startIntercept } from '@/systems/air-operations-system';
@@ -541,6 +542,17 @@ function rankCivilianAndTransportActions(
       }
     }
 
+    const fortCandidate = findFortificationCandidate(context.state, context.actorId);
+    if (fortCandidate) {
+      if (hexKey(unit.position) === hexKey(fortCandidate.coord)) {
+        return [ranked({ kind: 'worker-action', unitId: unit.id, action: 'fort' }, 635)];
+      }
+      const path = findPath(unit.position, fortCandidate.coord, context.state.map, 'land', { unit, completedTechs });
+      if (path && path.length > 1) {
+        return [ranked({ kind: 'move', unitId: unit.id, destination: path[1]! }, 635)];
+      }
+    }
+
     const actions = getAvailableWorkerActions(
       tile,
       completedTechs,
@@ -551,6 +563,7 @@ function rankCivilianAndTransportActions(
           ? getKnownTileResourceForWorkerAction(tile, completedTechs)
           : null,
         currentTurn: context.state.turn,
+        state: context.state,
       },
     );
     return actions.map((action, index) => ranked({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -268,7 +268,7 @@ export interface TribalVillage {
 export type VisibilityState = 'unexplored' | 'fog' | 'visible';
 
 export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill'
-  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'oil_well' | 'resource_outpost' | 'none';
+  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'oil_well' | 'fort' | 'resource_outpost' | 'none';
 // resource_outpost is excluded: only Expeditions can establish outposts, not Workers
 export type BuildableImprovementType = Exclude<ImprovementType, 'none' | 'resource_outpost'>;
 export type WorkerActionType = BuildableImprovementType | 'drain_swamp' | 'build_road' | 'restore_land';
@@ -430,6 +430,8 @@ export interface UnitDefinition {
   cargoSize?: number;
   cityAssaultMultiplier?: number;
   combinedArms?: UnitCombinedArmsCapability;
+  /** Portion of an improvement-derived Fort/Citadel multiplier that remains. */
+  fortificationPenetration?: number;
 }
 
 export interface UnitCombinedArmsCapability {

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -24,6 +24,7 @@ export const IMPROVEMENT_ICONS: Record<string, string> = {
   camp: '⛺',
   quarry: '⚒️',
   oil_well: '🛢️',
+  fort: '🏰',
   resource_outpost: '🚩',  // emoji fallback; SVG drawn via getOutpostMarkerImage when loaded
 };
 

--- a/src/renderer/improvements/improvement-treatment.ts
+++ b/src/renderer/improvements/improvement-treatment.ts
@@ -5,7 +5,8 @@ export type ImprovementTreatmentFamily =
   | 'water-wheel'
   | 'orchard-rows'
   | 'fence-lines'
-  | 'small-camp';
+  | 'small-camp'
+  | 'fortification';
 
 const TREATMENT_FAMILIES: Record<string, ImprovementTreatmentFamily> = {
   farm: 'field-rows',
@@ -17,6 +18,7 @@ const TREATMENT_FAMILIES: Record<string, ImprovementTreatmentFamily> = {
   pasture: 'fence-lines',
   camp: 'small-camp',
   oil_well: 'worked-rock',
+  fort: 'fortification',
 };
 
 export function getImprovementTreatmentFamily(improvement: string): ImprovementTreatmentFamily | null {
@@ -186,6 +188,13 @@ export function drawImprovementTreatment(
       ctx.arc(cx + size * 0.3, cy + size * 0.28, size * 0.055, 0, Math.PI * 2);
       ctx.fillStyle = 'rgba(226,145,48,0.9)';
       ctx.fill();
+      break;
+    case 'fort':
+      ctx.fillStyle = 'rgba(104, 91, 72, 0.92)';
+      ctx.fillRect(cx - size * 0.3, cy, size * 0.6, size * 0.28);
+      ctx.strokeStyle = 'rgba(53, 43, 34, 0.95)';
+      ctx.lineWidth = Math.max(1, size * 0.04);
+      ctx.strokeRect(cx - size * 0.3, cy, size * 0.6, size * 0.28);
       break;
   }
 

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -13,6 +13,8 @@ import { resolveWorldAge } from '@/systems/tech-definitions';
 import { CIRCULAR_MANUFACTURING_MATERIALS } from '@/systems/national-project-system';
 import { appendNotification } from '@/core/notification-log';
 import { syncTransportCargoPositions } from '@/systems/transport-system';
+import { IMPROVEMENT_BUILD_TURNS } from '@/systems/improvement-system';
+import type { ImprovementType } from '@/core/types';
 
 export const CURRENT_SAVE_SCHEMA_VERSION = 12;
 
@@ -726,6 +728,27 @@ function readSchemaVersion(raw: Record<string, unknown>): number {
   return Number(version);
 }
 
+/** Additive validation for serialized tile improvements; safe for every schema version. */
+export function normalizeImprovementValues(state: GameState): GameState {
+  const tiles = state.map?.tiles;
+  if (!tiles) return state;
+  let changed = false;
+  const nextTiles = { ...tiles };
+  for (const [key, tile] of Object.entries(tiles)) {
+    const improvement = tile.improvement;
+    const valid = typeof improvement === 'string' && improvement in IMPROVEMENT_BUILD_TURNS;
+    const normalized = valid ? improvement as ImprovementType : 'none';
+    const maxTurns = IMPROVEMENT_BUILD_TURNS[normalized];
+    const turns = Number.isInteger(tile.improvementTurnsLeft) && tile.improvementTurnsLeft >= 0
+      ? Math.min(tile.improvementTurnsLeft, maxTurns) : 0;
+    if (normalized !== improvement || turns !== tile.improvementTurnsLeft) {
+      nextTiles[key] = { ...tile, improvement: normalized, improvementTurnsLeft: turns };
+      changed = true;
+    }
+  }
+  return changed ? { ...state, map: { ...state.map, tiles: nextTiles } } : state;
+}
+
 export function migrateSaveToCurrent(raw: unknown): GameState {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new TypeError('Save data must be an object.');
@@ -750,5 +773,5 @@ export function migrateSaveToCurrent(raw: unknown): GameState {
   const techGrace = normalizeLegacyTechGrace(manufacturing);
   const crises = normalizeCrisisArchetypes(techGrace);
   const religions = withReligionDefaults(crises);
-  return normalizeRetimedBiplaneQueues(normalizeCityFaithConversionProgress(religions));
+  return normalizeImprovementValues(normalizeRetimedBiplaneQueues(normalizeCityFaithConversionProgress(religions)));
 }

--- a/src/systems/combat-context.ts
+++ b/src/systems/combat-context.ts
@@ -10,6 +10,7 @@ import { getCombatAdjacentOccupiedTileCount } from './zone-of-control-system';
 import { getNetworkCombatCoordination } from './network-combat-coordination';
 import { resolveAirDefenseCoverage } from './air-defense-system';
 import { resolveCombinedArms } from './combined-arms-system';
+import { resolveFortificationDefense } from './fortification-system';
 
 export interface CombatContextOptions {
   amphibiousAssault?: boolean;
@@ -87,6 +88,7 @@ export function buildCombatContextForDefender(
     : undefined;
   const attackerCombinedArms = resolveCombinedArms(state, attacker);
   const defenderCombinedArms = resolveCombinedArms(state, defender);
+  const fortification = resolveFortificationDefense(state, defender, attacker);
 
   return {
     attackerBonus: resolveCivDefinition(
@@ -142,6 +144,8 @@ export function buildCombatContextForDefender(
     defenderCombinedArmsMultiplier: defenderCombinedArms.multiplier,
     attackerCombinedArmsFact: attackerCombinedArms.fact,
     defenderCombinedArmsFact: defenderCombinedArms.fact,
+    defenderFortificationMultiplier: fortification.multiplier,
+    defenderFortificationFact: fortification.label ? { key: 'fortification', label: fortification.label, sourceVisibility: 'public', operation: 'multiplier', value: fortification.multiplier, outcome: 'applied' } : undefined,
     attackerPositioningPart: flankingTiles > 0 ? { label: `Flanked +${flankingTiles * 10}%`, kind: 'mult' } : undefined,
     defenderPositioningPart: supportTiles > 0 ? { label: `Supported +${supportTiles * 10}%`, kind: 'mult' } : undefined,
     attackerNetworkStrengthBonus: getNetworkCombatCoordination(state, attacker, 'attack').strengthBonus,

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -168,6 +168,8 @@ export interface CombatContext {
   defenderCombinedArmsMultiplier?: number;
   attackerCombinedArmsFact?: CombatModifierFact;
   defenderCombinedArmsFact?: CombatModifierFact;
+  defenderFortificationMultiplier?: number;
+  defenderFortificationFact?: CombatModifierFact;
   attackerNetworkStrengthBonus?: number;
   defenderNetworkStrengthBonus?: number;
 }
@@ -306,6 +308,7 @@ export function calculateCombatStrengths(
   if (defender.isFortified) {
     defenderStrength *= 1.25;
   }
+  defenderStrength *= context?.defenderFortificationMultiplier ?? 1;
 
   // Unit-modifier engine (MR4): tech/national-project combat modifiers + class counters.
   // Order: after terrain/fortify/civ-bonus multipliers above, before MR3 city-defense below.
@@ -342,7 +345,7 @@ export function calculateCombatStrengths(
     attackerModifierParts: [...(context?.attackerModifiers?.parts ?? []), ...(context?.attackerPositioningPart ? [context.attackerPositioningPart] : []), ...(context?.attackerAmphibiousParts ?? []), ...(context?.attackerInterceptionPart ? [context.attackerInterceptionPart] : [])],
     defenderModifierParts: [...(context?.defenderModifiers?.parts ?? []), ...(context?.defenderPositioningPart ? [context.defenderPositioningPart] : [])],
     attackerModifierFacts: [...(context?.attackerModifiers?.facts ?? []), ...(context?.attackerInterceptionFact ? [context.attackerInterceptionFact] : []), ...(context?.attackerCombinedArmsFact ? [context.attackerCombinedArmsFact] : [])],
-    defenderModifierFacts: [...(context?.defenderModifiers?.facts ?? []), ...(context?.airDefenseCoverage?.facts ?? []), ...(context?.defenderCombinedArmsFact ? [context.defenderCombinedArmsFact] : [])],
+    defenderModifierFacts: [...(context?.defenderModifiers?.facts ?? []), ...(context?.airDefenseCoverage?.facts ?? []), ...(context?.defenderCombinedArmsFact ? [context.defenderCombinedArmsFact] : []), ...(context?.defenderFortificationFact ? [context.defenderFortificationFact] : [])],
     defenderDefendsPoorly: defendsPoorly(defenderDefinition.attackProfile),
     exchange: getCombatExchangeModifiers(attacker, defender),
   };

--- a/src/systems/fortification-system.ts
+++ b/src/systems/fortification-system.ts
@@ -1,0 +1,112 @@
+import type { GameState, HexCoord, Unit } from '@/core/types';
+import { hexDistance, hexKey, mapNeighbors, wrappedHexDistance } from './hex-utils';
+import { UNIT_DEFINITIONS } from './unit-system';
+import { isAtWar } from './diplomacy-system';
+
+export interface FortificationTier {
+  id: 'fort' | 'citadel';
+  label: 'Fort' | 'Citadel';
+  multiplier: number;
+}
+
+const FORT_TIER: FortificationTier = {
+  id: 'fort',
+  label: 'Fort',
+  multiplier: 1.1,
+};
+
+const CITADEL_TIER: FortificationTier = {
+  id: 'citadel',
+  label: 'Citadel',
+  multiplier: 1.2,
+};
+
+/** Citadel is derived from technology; the saved tile improvement remains `fort`. */
+export function getFortificationTier(completedTechs: readonly string[]): FortificationTier {
+  return completedTechs.includes('fortification-engineering') ? CITADEL_TIER : FORT_TIER;
+}
+
+export type FortificationPlacement =
+  | { ok: true; isFrontier: boolean }
+  | { ok: false; reason: 'missing-tile' | 'outside-territory' | 'city-center' | 'invalid-terrain' | 'already-improved' | 'adjacent-fort' | 'empire-cap' };
+
+export interface FortificationPlacementOptions {
+  allowReplacement?: boolean;
+}
+
+export function getFortificationPlacement(
+  state: Pick<GameState, 'map' | 'cities'>,
+  ownerId: string,
+  coord: HexCoord,
+  options: FortificationPlacementOptions = {},
+): FortificationPlacement {
+  const tile = state.map.tiles[hexKey(coord)];
+  if (!tile) return { ok: false, reason: 'missing-tile' };
+  if (tile.owner !== ownerId) return { ok: false, reason: 'outside-territory' };
+  if (Object.values(state.cities).some(city => hexKey(city.position) === hexKey(coord))) return { ok: false, reason: 'city-center' };
+  if (tile.terrain === 'ocean' || tile.terrain === 'coast' || tile.terrain === 'mountain') return { ok: false, reason: 'invalid-terrain' };
+  if (tile.improvement === 'resource_outpost'
+    || (tile.improvement !== 'none' && (!options.allowReplacement || tile.improvement === 'fort'))) {
+    return { ok: false, reason: 'already-improved' };
+  }
+  const neighbors = mapNeighbors(state.map, coord);
+  if (neighbors.some(neighbor => state.map.tiles[hexKey(neighbor)]?.improvement === 'fort')) return { ok: false, reason: 'adjacent-fort' };
+
+  const cityCount = Object.values(state.cities).filter(city => city.owner === ownerId).length;
+  const fortCount = Object.values(state.map.tiles).filter(candidate => candidate.owner === ownerId && candidate.improvement === 'fort').length;
+  const isFrontier = neighbors.some(neighbor => {
+    const neighborTile = state.map.tiles[hexKey(neighbor)];
+    return neighborTile !== undefined && neighborTile.owner !== ownerId;
+  });
+  const cap = cityCount + Math.floor(cityCount / 3);
+  if (fortCount >= cap || (fortCount >= cityCount && !isFrontier)) return { ok: false, reason: 'empire-cap' };
+  return { ok: true, isFrontier };
+}
+
+export interface FortificationDefense {
+  multiplier: number;
+  label?: string;
+}
+
+/** One deterministic, viewer-scoped frontier target for an AI Worker. */
+export function findFortificationCandidate(state: GameState, ownerId: string): { coord: HexCoord } | null {
+  const completedTechs = state.civilizations[ownerId]?.techState.completed ?? [];
+  if (!completedTechs.includes('fortresses')) return null;
+  const visibleTiles = state.civilizations[ownerId]?.visibility.tiles ?? {};
+  const threats = Object.values(state.units).filter(unit => {
+    if (unit.owner === ownerId || unit.transportId || UNIT_DEFINITIONS[unit.type]?.strength <= 0) return false;
+    const diplomacy = state.civilizations[ownerId]?.diplomacy;
+    if (unit.owner !== 'barbarian' && (!diplomacy || !isAtWar(diplomacy, unit.owner))) return false;
+    return visibleTiles[hexKey(unit.position)] === 'visible';
+  });
+  if (threats.length === 0) return null;
+  const candidates = Object.values(state.map.tiles)
+    .filter(tile => {
+      const placement = getFortificationPlacement(state, ownerId, tile.coord);
+      return placement.ok && placement.isFrontier;
+    })
+    .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)));
+  for (const candidate of candidates) {
+    const threatened = threats.some(threat => (state.map.wrapsHorizontally
+      ? wrappedHexDistance(candidate.coord, threat.position, state.map.width)
+      : hexDistance(candidate.coord, threat.position)) <= 2);
+    if (threatened) return { coord: { ...candidate.coord } };
+  }
+  return null;
+}
+
+export function resolveFortificationDefense(
+  state: Pick<GameState, 'map' | 'civilizations'>,
+  defender: Unit,
+  attacker: Unit,
+): FortificationDefense {
+  const tile = state.map.tiles[hexKey(defender.position)];
+  const defenderDefinition = UNIT_DEFINITIONS[defender.type];
+  if (!tile || tile.improvement !== 'fort' || tile.improvementTurnsLeft > 0 || tile.owner !== defender.owner
+    || defender.transportId || defenderDefinition.domain === 'naval' || defenderDefinition.domain === 'air' || defenderDefinition.strength <= 0) return { multiplier: 1 };
+  const tier = getFortificationTier(state.civilizations[defender.owner]?.techState.completed ?? []);
+  const penetration = UNIT_DEFINITIONS[attacker.type]?.fortificationPenetration ?? 1;
+  const multiplier = 1 + (tier.multiplier - 1) * penetration;
+  const penetrated = penetration !== 1;
+  return { multiplier, label: `${tier.label} +${Math.round((tier.multiplier - 1) * 100)}%${penetrated ? ` (${Math.round((1 - penetration) * 100)}% penetrated)` : ''}` };
+}

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -1,5 +1,6 @@
 import type {
   BuildableImprovementType,
+  GameState,
   HexTile,
   ImprovementType,
   ResourceType,
@@ -9,6 +10,7 @@ import type {
 } from '@/core/types';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
 import { TECH_TREE } from '@/systems/tech-definitions';
+import { getFortificationPlacement } from '@/systems/fortification-system';
 
 // Improvements that only make sense on tiles with a specific resource.
 // Derived from RESOURCE_DEFINITIONS at module load — avoids re-scanning on every call.
@@ -37,6 +39,8 @@ export interface WorkerActionEligibilityOptions {
   knownResource?: ResourceType | null;
   /** Needed only for `restore_land` eligibility (devastatedUntilTurn > currentTurn). */
   currentTurn?: number;
+  /** Supplies the empire-wide Fort cap and adjacency legality for action lists. */
+  state?: Pick<GameState, 'map' | 'cities'>;
 }
 
 export type WorkerActionBlockerReason =
@@ -150,6 +154,13 @@ export const IMPROVEMENT_DEFINITIONS: Record<BuildableImprovementType, Improveme
     preservesTerrain: true,
     resourceMode: 'resource-only',
   },
+  fort: {
+    type: 'fort', name: 'Fort', buildTurns: 5,
+    validTerrains: ['grassland', 'plains', 'desert', 'forest', 'jungle', 'hills', 'tundra', 'snow', 'swamp', 'volcanic'],
+    requiresRiver: false, requiredTech: 'fortresses',
+    yieldBonus: { food: 0, production: 0, gold: 0, science: 0 },
+    preservesTerrain: true, resourceMode: 'generic',
+  },
 };
 
 export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
@@ -162,6 +173,7 @@ export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
   camp: IMPROVEMENT_DEFINITIONS.camp.buildTurns,
   quarry: IMPROVEMENT_DEFINITIONS.quarry.buildTurns,
   oil_well: IMPROVEMENT_DEFINITIONS.oil_well.buildTurns,
+  fort: IMPROVEMENT_DEFINITIONS.fort.buildTurns,
   resource_outpost: 0,  // set by Expedition unit, not by Worker
   none: 0,
 };
@@ -215,6 +227,10 @@ export function canBuildImprovement(
   if (!definition.validTerrains.includes(tile.terrain)) return false;
   if (definition.requiresRiver && !tile.hasRiver) return false;
   if (definition.requiredTech && !completedTechs.includes(definition.requiredTech)) return false;
+  if (type === 'fort' && options.state
+    && !getFortificationPlacement(options.state, ownerId ?? tile.owner ?? '', tile.coord, {
+      allowReplacement: options.allowReplacement,
+    }).ok) return false;
   if (definition.resourceMode === 'resource-only') {
     return hasMatchingKnownResource(tile, type, completedTechs, options);
   }
@@ -337,6 +353,7 @@ export function formatImprovementYieldLabel(type: ImprovementType): string {
 export function getWorkerActionLabel(action: ImprovementWorkerActionType): string {
   if (action === 'drain_swamp') return 'Drain Swamp (20% worker risk)';
   if (action === 'restore_land') return 'Restore Land';
+  if (action === 'fort') return 'Build Fort — protect a friendly land unit (5 turns, +10%; Citadel +20%)';
   const yieldLabel = formatImprovementYieldLabel(action);
   return `Build ${getImprovementDisplayName(action)}${yieldLabel ? ` ${yieldLabel}` : ''}`;
 }

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -270,6 +270,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     canBuildImprovements: false, productionCost: 125,
     attackProfile: { kind: 'bombard', range: 2, targets: ['unit', 'city'] },
     cargoSize: 3,
+    fortificationPenetration: 0.5,
     cityAssaultMultiplier: 1.25,
   },
   ballista: {
@@ -292,6 +293,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     canBuildImprovements: false, productionCost: 190,
     domain: 'land',
     attackProfile: { kind: 'bombard', range: 2, targets: ['unit', 'city'] },
+    fortificationPenetration: 0.5,
   },
   rocket_artillery: {
     type: 'rocket_artillery', name: 'Rocket Artillery', movementPoints: 2,
@@ -300,6 +302,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     domain: 'land',
     attackProfile: { kind: 'bombard', range: 3, targets: ['unit', 'city'] },
     splash: { damageFraction: 0.25, maxTargets: 2, label: 'Damages up to two nearby visible enemy soldiers' },
+    fortificationPenetration: 0.5,
   },
   grenadier: {
     type: 'grenadier', name: 'Grenadier', movementPoints: 2,
@@ -307,6 +310,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     canBuildImprovements: false, productionCost: 130,
     domain: 'land',
     attackProfile: { kind: 'bombard', range: 1, targets: ['unit', 'city'] },
+    fortificationPenetration: 0.5,
   },
   marine: {
     type: 'marine', name: 'Marine', movementPoints: 2,

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -18,6 +18,7 @@ import {
 } from './improvement-system';
 import { getRoadBlockerReason, getRoadBuildTurns } from './road-system';
 import { getActiveNationalProjectsForCiv } from './national-project-system';
+import { getFortificationPlacement } from './fortification-system';
 
 export const DEFAULT_WORKER_CHARGES = 2;
 export const MAX_WORKER_CHARGES = 5;
@@ -131,6 +132,12 @@ export function applyWorkerAction(
 
   const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
   const isCityTile = isCityCenterTile(state, unit.position);
+
+  if (action === 'fort' && !getFortificationPlacement(state, unit.owner, unit.position, {
+    allowReplacement: options.allowReplacement,
+  }).ok) {
+    return { ok: false, state, reason: 'invalid-action', events: [] };
+  }
 
   if (action === 'build_road') {
     const roadReason = getRoadBlockerReason(tile, completedTechs, unit.owner, isCityTile);

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -39,6 +39,7 @@ import { getAirBaseCapacity, getAirBaseRoster } from '@/systems/air-operations-s
 import type { AirBaseRef } from '@/core/types';
 import { canPillageTile } from '@/systems/pillage-system';
 import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
+import { getFortificationPlacement } from '@/systems/fortification-system';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -480,7 +481,7 @@ export function renderSelectedUnitInfo(
       const unitTileKey = hexKey(unit.position);
       const isCityTile = Object.values(state.cities).some(city => hexKey(city.position) === unitTileKey);
       const knownResource = tile ? getKnownTileResourceForWorkerAction(tile, completedTechs) : null;
-      const workerEligibilityOptions = { isCityTile, knownResource, currentTurn: state.turn };
+      const workerEligibilityOptions = { isCityTile, knownResource, currentTurn: state.turn, state };
       const workerActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, workerEligibilityOptions);
       if (knownResource) {
         const rd = RESOURCE_DEFINITIONS.find(r => r.id === knownResource);
@@ -517,6 +518,27 @@ export function renderSelectedUnitInfo(
           }
         }
         actionsDiv.appendChild(makeButton(label, color, () => callbacks.onWorkerAction!(action)));
+      }
+
+      if (tile && completedTechs.includes('fortresses') && !workerActions.includes('fort')) {
+        const placement = getFortificationPlacement(state, unit.owner, unit.position);
+        if (!placement.ok) {
+          const reason = placement.reason === 'adjacent-fort'
+            ? 'adjacent Fort'
+            : placement.reason === 'empire-cap'
+              ? 'Fort limit reached'
+              : placement.reason === 'city-center'
+                ? 'city center'
+                : placement.reason === 'outside-territory'
+                  ? 'outside your territory'
+                  : 'invalid terrain';
+          const fortButton = makeButton(`Build Fort — ${reason}`, '#64748b');
+          fortButton.disabled = true;
+          fortButton.style.opacity = '0.5';
+          fortButton.style.cursor = 'not-allowed';
+          fortButton.title = 'Forts cannot be adjacent and are limited by your city count.';
+          actionsDiv.appendChild(fortButton);
+        }
       }
 
       const roadBlockerReason = getRoadBlockerReason(tile, completedTechs, unit.owner, isCityTile);

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -800,6 +800,35 @@ describe('AI tactical action ranking', () => {
 });
 
 describe('AI road-building', () => {
+  it('offers the same legal Fort action to an AI worker through the canonical action list', () => {
+    const state = makeState('veteran');
+    state.civilizations[AI].techState.completed = ['fortresses'];
+    addCity(state, 'capital', AI, { q: 0, r: 0 });
+    state.map.tiles[hexKey({ q: 1, r: 0 })]!.owner = AI;
+    const worker = addUnit(state, 'fort-worker', 'worker', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: worker.position },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    expect(rankUnitTacticalActions(context(state, plan), worker.id))
+      .toContainEqual(expect.objectContaining({ action: { kind: 'worker-action', unitId: worker.id, action: 'fort' } }));
+  });
+
+  it.each(['explorer', 'standard', 'veteran'] as const)('moves an AI worker to the same visible threatened Fort frontier on %s', difficulty => {
+    const state = makeState(difficulty);
+    state.civilizations[AI].techState.completed = ['fortresses'];
+    addCity(state, 'capital', AI, { q: 0, r: 0 });
+    state.map.tiles[hexKey({ q: 2, r: 0 })]!.owner = AI;
+    const worker = addUnit(state, 'fort-worker', 'worker', AI, { q: 1, r: 0 });
+    addUnit(state, 'threat', 'warrior', HUMAN, { q: 3, r: 0 });
+    const plan = makePlan({ kind: 'region', id: 'frontier', anchor: { q: 2, r: 0 } }, [worker.id], { objective: 'expand', requiredRoles: {} });
+
+    expect(chooseUnitTacticalAction(context(state, plan), worker.id))
+      .toMatchObject({ kind: 'move', unitId: worker.id, destination: { q: 2, r: 0 } });
+  });
+
   it('queues build_road for an idle worker standing on the road-building target tile', () => {
     const state = makeState('veteran');
     state.civilizations[AI].techState.completed = ['road-building'];

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -467,6 +467,10 @@ describe('IMPROVEMENT_ICONS', () => {
     expect(IMPROVEMENT_ICONS['quarry']).toBe('⚒️');
   });
 
+  it('has a Fort inspection icon', () => {
+    expect(IMPROVEMENT_ICONS['fort']).toBe('🏰');
+  });
+
   it('does not have an entry for none', () => {
     expect(IMPROVEMENT_ICONS['none']).toBeUndefined();
   });

--- a/tests/renderer/improvements/improvement-treatment.test.ts
+++ b/tests/renderer/improvements/improvement-treatment.test.ts
@@ -15,6 +15,8 @@ class MockCanvasContext {
   closePath(): void { this.operations.push('closePath'); }
   arc(): void { this.operations.push('arc'); }
   rect(): void { this.operations.push('rect'); }
+  fillRect(): void { this.operations.push('fillRect'); }
+  strokeRect(): void { this.operations.push('strokeRect'); }
   fill(): void { this.operations.push('fill'); }
   stroke(): void { this.operations.push('stroke'); }
 }
@@ -33,6 +35,12 @@ describe('improvement terrain treatments', () => {
     expect(getImprovementTreatmentFamily('farm')).toBe('field-rows');
     expect(getImprovementTreatmentFamily('lumber_camp')).toBe('managed-timber');
     expect(getImprovementTreatmentFamily('farm')).not.toBe(getImprovementTreatmentFamily('lumber_camp'));
+  });
+
+  it('renders Fort as a fortification treatment', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    expect(getImprovementTreatmentFamily('fort')).toBe('fortification');
+    expect(drawImprovementTreatment(ctx, 'fort', 0, 0, 48)).toBe(true);
   });
 
   it('does not claim unknown improvements', () => {

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -4,6 +4,7 @@ import type { City, GameState, Unit } from '@/core/types';
 import {
   CURRENT_SAVE_SCHEMA_VERSION,
   migrateSaveToCurrent,
+  normalizeImprovementValues,
   UnsupportedSaveSchemaVersionError,
 } from '@/storage/save-migrations';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -12,6 +13,27 @@ import { applyUnitUpgradeToState } from '@/systems/unit-upgrade-system';
 import { foundCity } from '@/systems/city-system';
 
 describe('save migrations', () => {
+  it('preserves Fort saves, clamps invalid build timers, and clears unknown improvements idempotently', () => {
+    const savedGame = createNewGame('rome', 'fort-save-normalization', 'small');
+    const [fortKey, invalidKey] = Object.keys(savedGame.map.tiles);
+    savedGame.map.tiles[fortKey] = {
+      ...savedGame.map.tiles[fortKey],
+      improvement: 'fort',
+      improvementTurnsLeft: 99,
+    };
+    savedGame.map.tiles[invalidKey] = {
+      ...savedGame.map.tiles[invalidKey],
+      improvement: 'obsolete-fort' as never,
+      improvementTurnsLeft: 4,
+    };
+
+    const normalized = normalizeImprovementValues(savedGame);
+
+    expect(normalized.map.tiles[fortKey]).toMatchObject({ improvement: 'fort', improvementTurnsLeft: 5 });
+    expect(normalized.map.tiles[invalidKey]).toMatchObject({ improvement: 'none', improvementTurnsLeft: 0 });
+    expect(normalizeImprovementValues(normalized)).toEqual(normalized);
+  });
+
   it.each(['legacy', 'current'] as const)('preserves an upgraded damaged veteran through %s save normalization', schema => {
     const save = createNewGame('rome', `upgrade-${schema}-round-trip`, 'small');
     const civ = save.civilizations.player;

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -409,6 +409,37 @@ describe('fortify defense bonus', () => {
   });
 });
 
+describe('Fortification combat context', () => {
+  it('applies a separate Fortification multiplier supplied by the shared context', () => {
+    const map = generateMap(30, 30, 'fortification-context');
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const defender = createUnit('warrior', 'p2', { q: 11, r: 10 }, mkC());
+    const base = calculateCombatStrengths(attacker, defender, map);
+    const fortified = calculateCombatStrengths(attacker, defender, map, { defenderFortificationMultiplier: 1.1 });
+    expect(fortified.defenderStrength).toBeCloseTo(base.defenderStrength * 1.1, 5);
+  });
+
+  it('uses the defending owner’s Citadel tech and exposes it to the preview, not the current viewer', () => {
+    const state = createNewGame(undefined, 'fort-hot-seat-context', 'small');
+    const attacker = { ...createUnit('warrior', 'player', { q: 4, r: 4 }, mkC()), id: 'attacker' };
+    const defender = { ...createUnit('warrior', 'ai-1', { q: 5, r: 4 }, mkC()), id: 'defender' };
+    state.currentPlayer = 'player';
+    state.units = { attacker, defender };
+    state.civilizations.player.units = [attacker.id];
+    state.civilizations['ai-1'].units = [defender.id];
+    state.civilizations['ai-1'].techState.completed = ['fortification-engineering'];
+    state.map.tiles[hexKey(defender.position)] = {
+      ...state.map.tiles[hexKey(defender.position)]!,
+      owner: 'ai-1', improvement: 'fort', improvementTurnsLeft: 0,
+    };
+
+    const context = buildCombatContextForDefender(state, attacker, defender);
+
+    expect(context.defenderFortificationMultiplier).toBeCloseTo(1.2);
+    expect(context.defenderFortificationFact).toMatchObject({ label: 'Citadel +20%', outcome: 'applied' });
+  });
+});
+
 describe('bombard-kind defense penalty (MR: counter-attack rule fix, #537)', () => {
   let map: GameMap;
 

--- a/tests/systems/fortification-system.test.ts
+++ b/tests/systems/fortification-system.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { findFortificationCandidate, getFortificationPlacement, getFortificationTier, resolveFortificationDefense } from '@/systems/fortification-system';
+import type { GameState, HexTile } from '@/core/types';
+import { getAvailableWorkerActions } from '@/systems/improvement-system';
+
+function tile(q: number, r: number, owner: string | null, improvement: HexTile['improvement'] = 'none'): HexTile {
+  return { coord: { q, r }, terrain: 'plains', elevation: 'lowland', resource: null, improvement, owner, improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+}
+
+function placementState(): GameState {
+  return {
+    map: { width: 8, height: 8, wrapsHorizontally: false, rivers: [], tiles: {
+      '0,0': tile(0, 0, 'owner'), '1,0': tile(1, 0, null), '0,1': tile(0, 1, 'owner'),
+    } },
+    cities: { capital: { id: 'capital', owner: 'owner', position: { q: 0, r: 0 } } },
+  } as unknown as GameState;
+}
+
+describe('getFortificationTier', () => {
+  it('returns Fort until Fortification Engineering is complete', () => {
+    expect(getFortificationTier(['fortresses'])).toEqual({
+      id: 'fort',
+      label: 'Fort',
+      multiplier: 1.1,
+    });
+  });
+
+  it('returns Citadel from Fortification Engineering without changing the saved improvement id', () => {
+    expect(getFortificationTier(['fortresses', 'fortification-engineering'])).toEqual({
+      id: 'citadel',
+      label: 'Citadel',
+      multiplier: 1.2,
+    });
+  });
+});
+
+describe('getFortificationPlacement', () => {
+  it('allows the first Fort on an owned frontier tile', () => {
+    expect(getFortificationPlacement(placementState(), 'owner', { q: 0, r: 1 })).toMatchObject({ ok: true, isFrontier: true });
+  });
+
+  it('rejects a Fort adjacent to another Fort', () => {
+    const state = placementState();
+    state.map.tiles['0,0'] = tile(0, 0, 'owner', 'fort' as HexTile['improvement']);
+    expect(getFortificationPlacement(state, 'owner', { q: 0, r: 1 })).toMatchObject({ ok: false, reason: 'adjacent-fort' });
+  });
+
+  it('allows replacing a normal improvement only when the caller explicitly permits it', () => {
+    const state = placementState();
+    state.map.tiles['0,1'] = tile(0, 1, 'owner', 'farm');
+
+    expect(getFortificationPlacement(state, 'owner', { q: 0, r: 1 })).toMatchObject({ ok: false, reason: 'already-improved' });
+    expect(getFortificationPlacement(state, 'owner', { q: 0, r: 1 }, { allowReplacement: true })).toMatchObject({ ok: true });
+  });
+
+  it('does not treat an off-map edge as a frontier', () => {
+    const state = placementState();
+    state.map.tiles['2,2'] = tile(2, 2, 'owner', 'fort');
+    state.map.tiles['5,5'] = tile(5, 5, 'owner');
+
+    expect(getFortificationPlacement(state, 'owner', { q: 5, r: 5 })).toMatchObject({ ok: false, reason: 'empire-cap' });
+  });
+
+  it('does not advertise a Fort when the supplied map state rejects its cap', () => {
+    const state = placementState();
+    state.map.tiles['2,2'] = tile(2, 2, 'owner', 'fort');
+    state.map.tiles['5,5'] = tile(5, 5, 'owner');
+
+    expect(getAvailableWorkerActions(state.map.tiles['5,5'], ['fortresses'], 'owner', { state }))
+      .not.toContain('fort');
+  });
+});
+
+describe('resolveFortificationDefense', () => {
+  it('gives a friendly land combat unit the Fort multiplier', () => {
+    const state = placementState();
+    state.map.tiles['0,1'] = tile(0, 1, 'owner', 'fort');
+    state.civilizations = { owner: { techState: { completed: ['fortresses'] } } } as unknown as GameState['civilizations'];
+    const defender = { owner: 'owner', type: 'warrior', position: { q: 0, r: 1 }, transportId: undefined } as GameState['units'][string];
+    const attacker = { owner: 'enemy', type: 'warrior', position: { q: 1, r: 1 } } as GameState['units'][string];
+    expect(resolveFortificationDefense(state, defender, attacker)).toMatchObject({ multiplier: 1.1, label: 'Fort +10%' });
+  });
+
+  it('uses Citadel and halves only its improvement layer for approved siege', () => {
+    const state = placementState();
+    state.map.tiles['0,1'] = tile(0, 1, 'owner', 'fort');
+    state.civilizations = { owner: { techState: { completed: ['fortification-engineering'] } } } as unknown as GameState['civilizations'];
+    const defender = { owner: 'owner', type: 'warrior', position: { q: 0, r: 1 } } as GameState['units'][string];
+    const attacker = { owner: 'enemy', type: 'trebuchet', position: { q: 1, r: 1 } } as GameState['units'][string];
+    expect(resolveFortificationDefense(state, defender, attacker)).toMatchObject({ multiplier: 1.1, label: 'Citadel +20% (50% penetrated)' });
+  });
+
+  it.each(['trebuchet', 'grenadier', 'artillery', 'rocket_artillery'] as const)('keeps exactly half the Citadel layer against %s', type => {
+    const state = placementState();
+    state.map.tiles['0,1'] = tile(0, 1, 'owner', 'fort');
+    state.civilizations = { owner: { techState: { completed: ['fortification-engineering'] } } } as unknown as GameState['civilizations'];
+    const defender = { owner: 'owner', type: 'warrior', position: { q: 0, r: 1 } } as GameState['units'][string];
+    const attacker = { owner: 'enemy', type, position: { q: 1, r: 1 } } as GameState['units'][string];
+
+    expect(resolveFortificationDefense(state, defender, attacker).multiplier).toBeCloseTo(1.1);
+  });
+
+  it.each([
+    { improvementTurnsLeft: 1 },
+    { transportId: 'ship' },
+    { type: 'frigate' },
+  ])('gives no Fort defense to an ineligible occupant: %o', overrides => {
+    const state = placementState();
+    state.map.tiles['0,1'] = { ...tile(0, 1, 'owner', 'fort'), improvementTurnsLeft: overrides.improvementTurnsLeft ?? 0 };
+    state.civilizations = { owner: { techState: { completed: ['fortresses'] } } } as unknown as GameState['civilizations'];
+    const defender = { owner: 'owner', type: 'warrior', position: { q: 0, r: 1 }, ...overrides } as GameState['units'][string];
+    const attacker = { owner: 'enemy', type: 'warrior', position: { q: 1, r: 1 } } as GameState['units'][string];
+
+    expect(resolveFortificationDefense(state, defender, attacker).multiplier).toBe(1);
+  });
+});
+
+describe('findFortificationCandidate', () => {
+  it('chooses the first legal frontier tile with a visible hostile approach', () => {
+    const state = placementState();
+    state.map.tiles['1,1'] = tile(1, 1, 'enemy');
+    state.civilizations = {
+      owner: { techState: { completed: ['fortresses'] }, visibility: { tiles: { '1,1': 'visible' } } },
+    } as unknown as GameState['civilizations'];
+    state.units = {
+      enemy: { id: 'enemy', owner: 'barbarian', type: 'warrior', position: { q: 1, r: 1 } },
+    } as unknown as GameState['units'];
+
+    expect(findFortificationCandidate(state, 'owner')).toMatchObject({ coord: { q: 0, r: 1 } });
+  });
+});

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -10,10 +10,20 @@ import {
   getWorkerActionBlockerReason,
   getWorkerActionLabel,
   getWorkerBlockerHints,
+  IMPROVEMENT_DEFINITIONS,
 } from '@/systems/improvement-system';
 import type { HexTile } from '@/core/types';
 
 describe('canBuildImprovement', () => {
+  it('makes a five-turn Fort available only after Fortresses', () => {
+    const tile: HexTile = {
+      coord: { q: 0, r: 0 }, terrain: 'plains', elevation: 'lowland',
+      resource: null, improvement: 'none', owner: 'p1', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    expect(IMPROVEMENT_DEFINITIONS.fort).toMatchObject({ buildTurns: 5, requiredTech: 'fortresses' });
+    expect(canBuildImprovement(tile, 'fort', ['fortresses'], 'p1')).toBe(true);
+    expect(canBuildImprovement(tile, 'fort', [], 'p1')).toBe(false);
+  });
   it('allows farm on grassland', () => {
     const tile: HexTile = {
       coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland',

--- a/tests/systems/improvement-turn-system.test.ts
+++ b/tests/systems/improvement-turn-system.test.ts
@@ -29,4 +29,20 @@ describe('processImprovementTurns', () => {
     expect(next.notificationLog?.player.at(-1)?.message).toBe('Farm completed!');
     expect(completed).toHaveBeenCalledOnce();
   });
+
+  it('delivers Fort completion only to its owner during a hot-seat turn', () => {
+    const state = createNewGame(undefined, 'fort-hot-seat-completion', 'small');
+    const worker = Object.values(state.units)[0]!;
+    const tile = state.map.tiles[hexKey(worker.position)]!;
+    state.currentPlayer = 'player';
+    tile.improvement = 'fort';
+    tile.improvementTurnsLeft = 1;
+    tile.improvementOwner = worker.owner;
+    worker.workerTask = { action: 'fort', coord: { ...tile.coord } };
+
+    const next = processImprovementTurns(state, new EventBus());
+
+    expect(next.notificationLog?.[worker.owner]?.at(-1)?.message).toBe('Fort completed!');
+    expect(next.notificationLog?.player ?? []).toHaveLength(worker.owner === 'player' ? 1 : 0);
+  });
 });

--- a/tests/systems/pillage-system.test.ts
+++ b/tests/systems/pillage-system.test.ts
@@ -66,6 +66,7 @@ describe('pillage-system', () => {
     it('derives gold from IMPROVEMENT_BUILD_TURNS, not a hand-authored table', () => {
       expect(getPillageGoldReward('farm')).toBe(4 * GOLD_PER_PILLAGE_BUILD_TURN);
       expect(getPillageGoldReward('oil_well')).toBe(5 * GOLD_PER_PILLAGE_BUILD_TURN);
+      expect(getPillageGoldReward('fort')).toBe(5 * GOLD_PER_PILLAGE_BUILD_TURN);
     });
 
     it('awards real gold for a pillaged resource outpost, not zero (#541 second-pass review)', () => {

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -123,6 +123,34 @@ function state(overrides: Partial<GameState> = {}): GameState {
 }
 
 describe('worker action system', () => {
+  it('starts a legal five-turn Fort through the canonical Worker mutation', () => {
+    const start = state();
+    start.civilizations.player.techState.completed = ['fortresses'];
+    const result = applyWorkerAction(start, 'worker-1', 'fort');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({ improvement: 'fort', improvementTurnsLeft: 5 });
+  });
+
+  it('rejects a Worker Fort adjacent to an existing Fort', () => {
+    const start = state();
+    start.civilizations.player.techState.completed = ['fortresses'];
+    start.map.tiles['1,0'] = tile({ coord: { q: 1, r: 0 }, improvement: 'fort' });
+    const result = applyWorkerAction(start, 'worker-1', 'fort');
+    expect(result).toMatchObject({ ok: false, reason: 'invalid-action' });
+  });
+
+  it('replaces a normal improvement with a Fort only through the explicit replacement path', () => {
+    const start = state();
+    start.civilizations.player.techState.completed = ['fortresses'];
+    start.map.tiles['0,0'].improvement = 'farm';
+
+    expect(applyWorkerAction(start, 'worker-1', 'fort').ok).toBe(false);
+    const result = applyWorkerAction(start, 'worker-1', 'fort', { allowReplacement: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({ improvement: 'fort', improvementTurnsLeft: 5 });
+  });
   it('treats legacy workers without chargesRemaining as two-charge workers', () => {
     expect(getWorkerChargesRemaining(worker({ chargesRemaining: undefined }))).toBe(2);
   });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -815,6 +815,41 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     expect(buttons).not.toContain('Drain Swamp (20% worker risk)');
   });
 
+  it('surfaces the plain-language Fort action once Fortresses is researched', () => {
+    const state = makeWorkerState({ terrain: 'plains' });
+    state.civilizations.player.techState.completed = ['fortresses'];
+    state.cities = {
+      capital: { id: 'capital', owner: 'player', position: { q: 0, r: 1 } },
+    } as unknown as GameState['cities'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    expect(findButtons(container).map(button => button.textContent))
+      .toContain('Build Fort — protect a friendly land unit (5 turns, +10%; Citadel +20%)');
+  });
+
+  it('explains why a researched Fort is unavailable beside another Fort', () => {
+    const state = makeWorkerState({ terrain: 'plains' });
+    state.civilizations.player.techState.completed = ['fortresses'];
+    state.cities = {
+      capital: { id: 'capital', owner: 'player', position: { q: 0, r: 1 } },
+    } as unknown as GameState['cities'];
+    state.map.tiles['1,0'] = {
+      ...state.map.tiles['0,0'], coord: { q: 1, r: 0 }, improvement: 'fort', improvementOwner: 'player',
+    };
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const blockedFort = findButtons(container).find(button => button.textContent === 'Build Fort — adjacent Fort');
+    expect(blockedFort?.disabled).toBe(true);
+  });
+
   it('shows watermill only on valid river land', () => {
     const state = makeWorkerState({ terrain: 'plains', resource: 'iron', hasRiver: true });
     const container = new MockElement('div');


### PR DESCRIPTION
Closes #690

## Summary

- Adds a Worker-built Fort that upgrades to a technology-derived Citadel, with cap, adjacency, terrain, replacement, and save-safe legality.
- Wires Fort/Citadel combat facts through the shared player, AI, preview, and world combat context; four siege units halve only the Fortification layer.
- Adds AI frontier placement, owner-scoped hot-seat completion delivery, accessible Worker-panel guidance, and a visible map treatment.

## Verification

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test:durable`
- `bash scripts/run-with-mise.sh yarn test:durable:status`
- Focused Fort, Worker, combat, AI, save, renderer, and hot-seat regressions (443 tests).