### PR TITLE
feat(787): extract PlayerActionController part 1 -- unit-action group (phase 10b-e)

### DIFF
--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -1,0 +1,370 @@
+/**
+ * Owns the player-unit-action functions extracted from `main.ts` in #787
+ * phase 10b-e: `getUnitTurnFlow`, `performWorkerAction`, `performPreach`,
+ * `ensurePlayerWarState`, `restAction`, `showEspionageCaptureChoice`
+ * (~274 lines pre-move).
+ *
+ * This is a partial `PlayerActionController` -- Phase 13 (PR #800, not yet
+ * merged as of this writing) covers a *different* six-function group in the
+ * same domain (`executeAttack`, `foundCityAction`, `executeUpgrade`,
+ * `beginPlayerCityAssault`, `executeMinorCivConquest`,
+ * `finalizePendingCityCaptureChoice`) and is expected to extend this same
+ * file with those functions once it lands, per the plan doc's explicit
+ * fallback: "if Phase 13 has not yet been implemented when 10b-e starts,
+ * add these functions to Phase 13's own Moves list instead of creating a
+ * second controller." Those six functions stay in `main.ts` for now and are
+ * NOT touched by this phase.
+ *
+ * Construction-order circularity: `getUnitTurnFlow`'s body needs
+ * `turnFlow.endTurn` and `selectionController`'s unit-selection methods;
+ * conversely `selectionController` and `turnFlow` both take
+ * `getUnitTurnFlow` (and `selectionController` also takes
+ * `performWorkerAction`/`performPreach`/`restAction`/`ensurePlayerWarState`)
+ * as their own construction deps. `main.ts` resolves this the same way it
+ * resolves every other three-way forward reference in this file: this
+ * controller is constructed *after* both `selectionController` and
+ * `turnFlow`, taking direct references to both; `selectionController`'s and
+ * `turnFlow`'s own construction use lazy wrappers (`{ getUnitTurnFlow: () =>
+ * playerActions.getUnitTurnFlow(), ... }`) for the functions that moved here,
+ * the same deferred-but-eager pattern `router`/`notifier`/`campaignEntry`
+ * already use elsewhere in `main.ts`.
+ *
+ * `notifier` is threaded through as a lazy wrapper too -- it's a `let` not
+ * assigned until `init()` runs, well after every module-scope controller
+ * construction, same as `turnFlow`'s own `notifier` dep.
+ *
+ * `setBlockingOverlay` and `currentCiv` are cross-cutting helpers (phase
+ * 10b-f's domain) still living in `main.ts` -- threaded through as deps
+ * until that phase gives them a real home.
+ *
+ * Everything this file calls that is a pure `@/systems/*`, `@/ui/*` helper
+ * is imported directly, matching the precedent set by every prior controller
+ * in this arc.
+ */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { EventBus } from '@/core/event-bus';
+import type { GameSession, SelectionStore, Notifier } from '@/app/ports';
+import type { HudController } from '@/app/controllers/hud-controller';
+import type { SelectionController } from '@/app/controllers/selection-controller';
+import type { TurnFlowController } from '@/app/controllers/turn-flow-controller';
+import type { Civilization, WorkerActionType } from '@/core/types';
+import type { UnitTurnFlow } from '@/ui/unit-turn-flow';
+import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
+import { removeRouteForUnit } from '@/systems/trade-system';
+import { applyWorkerAction } from '@/systems/worker-action-system';
+import { preach } from '@/systems/religion-system';
+import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
+import { UNIT_DEFINITIONS, canHeal, restUnit, createUnit } from '@/systems/unit-system';
+import { isMajorCivOwner } from '@/core/owner-kind';
+import { declareWar, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
+import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
+import { getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation } from '@/systems/espionage-system';
+import { getCapitalCity } from '@/systems/capital-system';
+
+export interface PlayerActionController {
+  getUnitTurnFlow(): UnitTurnFlow;
+  performWorkerAction(action: WorkerActionType): void;
+  performPreach(unitId: string, cityId: string): void;
+  ensurePlayerWarState(targetCivId: string): void;
+  restAction(): void;
+  showEspionageCaptureChoice(spyId: string, spyOwner: string): void;
+}
+
+/** The narrow slice of `RenderLoop` this controller needs. */
+export type PlayerActionRenderer = Pick<RenderLoop, 'setGameState'> & { readonly camera: Pick<RenderLoop['camera'], 'centerOn'> };
+
+export interface PlayerActionControllerDeps {
+  readonly session: GameSession;
+  readonly bus: EventBus;
+  readonly uiLayer: HTMLDivElement;
+  readonly selection: Pick<SelectionStore, 'getSelectedUnitId'>;
+  readonly selectionController: Pick<SelectionController, 'selectUnit' | 'deselectUnit' | 'selectNextUnit' | 'refreshCurrentPlayerVisibility'>;
+  /** Lazy wrapper not needed here -- constructed after `turnFlow` in `main.ts`. */
+  readonly turnFlow: Pick<TurnFlowController, 'endTurn'>;
+  readonly hud: Pick<HudController, 'update'>;
+  readonly renderLoop: PlayerActionRenderer;
+  readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
+  readonly setBlockingOverlay: (id: string | null) => void;
+  readonly currentCiv: () => Civilization;
+  /**
+   * Lazy wrapper, not a direct reference -- `notifier` is a `let` not
+   * assigned until `init()` runs, well after this controller is constructed.
+   */
+  readonly notifier: Pick<Notifier, 'choice'>;
+}
+
+export function createPlayerActionController(deps: PlayerActionControllerDeps): PlayerActionController {
+  function getUnitTurnFlow(): UnitTurnFlow {
+    return createUnitTurnFlow({
+      uiLayer: deps.uiLayer,
+      getState: () => deps.session.getState(),
+      setState: nextState => { deps.session.setStateWithoutRefresh(nextState); },
+      getSelectedUnitId: () => deps.selection.getSelectedUnitId(),
+      selectUnit: deps.selectionController.selectUnit,
+      deselectUnit: deps.selectionController.deselectUnit,
+      selectNextUnit: deps.selectionController.selectNextUnit,
+      centerOn: coord => deps.renderLoop.camera.centerOn(coord),
+      refreshVisibility: deps.selectionController.refreshCurrentPlayerVisibility,
+      setRenderState: state => deps.renderLoop.setGameState(state),
+      updateHUD: () => deps.hud.update(),
+      showNotification: deps.showNotification,
+      setBlockingOverlay: deps.setBlockingOverlay,
+      endTurn: options => { void deps.turnFlow.endTurn(options); },
+      onUnitDisbanded: (state, unitId, routeId) =>
+        removeRouteForUnit(state, unitId, deps.bus, 'unit-disbanded', routeId),
+    });
+  }
+
+  function performWorkerAction(action: WorkerActionType): void {
+    const selectedUnitId = deps.selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+
+    const result = applyWorkerAction(deps.session.getState(), selectedUnitId, action);
+    if (!result.ok) return;
+
+    deps.session.setStateWithoutRefresh(result.state);
+    for (const event of result.events) {
+      if (event.type === 'improvement:started') {
+        deps.bus.emit('improvement:started', event.payload);
+      } else if (event.type === 'road:started') {
+        deps.bus.emit('road:started', event.payload);
+      } else {
+        deps.bus.emit('unit:destroyed', event.payload);
+      }
+    }
+
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+
+    if (result.workerConsumed || result.workerLost || !deps.session.getState().units[selectedUnitId]) {
+      deps.selectionController.deselectUnit();
+    } else {
+      deps.selectionController.selectUnit(selectedUnitId);
+    }
+
+    deps.showNotification(result.message, result.workerLost ? 'warning' : 'info');
+  }
+
+  // #592 MR5: preach action. Mirrors performWorkerAction's state-apply + rerender pattern,
+  // but adds a non-destructive confirmation dialog when the missionary is consumed on its
+  // last charge -- the deletion has already happened inside preach() by this point, so the
+  // dialog is an acknowledgment, not a gate (hideCancel: true, no undo possible).
+  function performPreach(unitId: string, cityId: string): void {
+    const unit = deps.session.getState().units[unitId];
+    const cityName = deps.session.getState().cities[cityId]?.name ?? cityId;
+    const result = preach(deps.session.getState(), unitId, cityId, deps.bus);
+    if (!result.ok) return;
+
+    deps.session.commit(result.state);
+
+    const message = result.converted
+      ? `${cityName} has converted to your faith!`
+      : `You preached in ${cityName}.`;
+
+    if (result.unitConsumed) {
+      deps.selectionController.deselectUnit();
+      deps.setBlockingOverlay('unit-delete-confirmation');
+      createUnitDeleteConfirmationPanel(deps.uiLayer, {
+        unitName: unit ? UNIT_DEFINITIONS[unit.type].name : 'Missionary',
+        title: 'Missionary Used Up',
+        bodyText: `${message} That was its last charge, so the missionary is gone.`,
+        confirmLabel: 'OK',
+        hideCancel: true,
+        tone: 'neutral',
+        onConfirm: () => {
+          deps.uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
+          deps.setBlockingOverlay(null);
+        },
+        onCancel: () => {
+          deps.uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
+          deps.setBlockingOverlay(null);
+        },
+      });
+    } else {
+      deps.selectionController.selectUnit(unitId);
+      deps.showNotification(message, result.converted ? 'success' : 'info');
+    }
+  }
+
+  function ensurePlayerWarState(targetCivId: string): void {
+    const targetCiv = deps.session.getState().civilizations[targetCivId];
+    if (!targetCiv || !isMajorCivOwner(targetCivId)) return;
+
+    const cp = deps.session.getState().currentPlayer;
+    const alreadyAtWar = deps.currentCiv().diplomacy?.atWarWith.includes(targetCivId) ?? false;
+    if (alreadyAtWar) return;
+
+    deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivId, deps.session.getState().turn);
+    targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, deps.session.getState().turn);
+    deps.bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
+    deps.session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(deps.session.getState(), cp, targetCivId, deps.bus));
+  }
+
+  function restAction(): void {
+    const selectedUnitId = deps.selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+    const unit = deps.session.getState().units[selectedUnitId];
+    if (!unit || !canHeal(unit)) return;
+
+    deps.session.getState().units[selectedUnitId] = restUnit(unit);
+    deps.showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
+    deps.selectionController.deselectUnit();
+    deps.renderLoop.setGameState(deps.session.getState());
+  }
+
+  function showEspionageCaptureChoice(spyId: string, spyOwner: string): void {
+    const captorEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+    const spy = deps.session.getState().espionage?.[spyOwner]?.spies[spyId];
+    if (!captorEsp || !spy) return;
+    const spyOwnerName = deps.session.getState().civilizations[spyOwner]?.name ?? spyOwner;
+
+    // D1: always reveal true identity to captor regardless of disguise
+    const captureMessage = `You have captured ${spy.name}, a ${spy.unitType} belonging to ${spyOwnerName}.`;
+
+    // infiltrated spies are inside the city (distance 0); otherwise use boundary penalty
+    const distanceToCity = spy.infiltrationCityId ? 0 : 1;
+    const relPenalty = getSpyCaptureRelationshipPenalty(distanceToCity);
+
+    deps.notifier.choice(captureMessage, [
+      {
+        label: `Expel (${relPenalty} relations)`,
+        onClick: () => {
+          const updatedOwnerEsp = expelSpy(deps.session.getState().espionage![spyOwner], spyId, 15);
+          const capital = getCapitalCity(deps.session.getState(), spyOwner);
+          if (capital) {
+            const newUnit = createUnit(spy.unitType, spyOwner, capital.position, deps.session.getState().idCounters);
+            deps.session.setStateWithoutRefresh({
+              ...deps.session.getState(),
+              units: { ...deps.session.getState().units, [newUnit.id]: newUnit },
+              civilizations: {
+                ...deps.session.getState().civilizations,
+                [spyOwner]: {
+                  ...deps.session.getState().civilizations[spyOwner],
+                  units: [...deps.session.getState().civilizations[spyOwner].units, newUnit.id],
+                },
+              },
+            });
+            const { [spyId]: _old, ...rest } = updatedOwnerEsp.spies;
+            deps.session.setStateWithoutRefresh({
+              ...deps.session.getState(),
+              espionage: {
+                ...deps.session.getState().espionage,
+                [spyOwner]: {
+                  ...updatedOwnerEsp,
+                  spies: { ...rest, [newUnit.id]: { ...updatedOwnerEsp.spies[spyId]!, id: newUnit.id } },
+                },
+              },
+            });
+          } else {
+            deps.session.setStateWithoutRefresh({ ...deps.session.getState(), espionage: { ...deps.session.getState().espionage, [spyOwner]: updatedOwnerEsp } });
+          }
+          // Bilateral: captor's view of spy owner AND spy owner's view of captor
+          const captorId = deps.session.getState().currentPlayer;
+          deps.session.setStateWithoutRefresh({
+            ...deps.session.getState(),
+            civilizations: {
+              ...deps.session.getState().civilizations,
+              [captorId]: {
+                ...deps.session.getState().civilizations[captorId],
+                diplomacy: modifyRelationship(
+                  deps.session.getState().civilizations[captorId].diplomacy, spyOwner, relPenalty,
+                ),
+              },
+              [spyOwner]: {
+                ...deps.session.getState().civilizations[spyOwner],
+                diplomacy: modifyRelationship(
+                  deps.session.getState().civilizations[spyOwner].diplomacy, captorId, relPenalty,
+                ),
+              },
+            },
+          });
+          deps.showNotification(`${spy.name} expelled. Will return to their capital after 15 turns.`, 'info');
+          deps.renderLoop.setGameState(deps.session.getState());
+        },
+      },
+      {
+        label: 'Execute',
+        danger: true,
+        onClick: () => {
+          // Second in-panel confirmation -- no window.confirm on mobile
+          deps.notifier.choice(
+            `Execute ${spy.name}? This cannot be undone and will severely damage relations with ${spyOwnerName}.`,
+            [
+              {
+                label: 'Cancel',
+                onClick: () => showEspionageCaptureChoice(spyId, spyOwner),
+              },
+              {
+                label: 'Confirm Execute',
+                danger: true,
+                onClick: () => {
+                  const captorId = deps.session.getState().currentPlayer;
+                  deps.session.setStateWithoutRefresh({
+                    ...deps.session.getState(),
+                    espionage: {
+                      ...deps.session.getState().espionage,
+                      [spyOwner]: executeSpy(deps.session.getState().espionage![spyOwner], spyId),
+                    },
+                    // Bilateral: captor's view AND spy owner's view
+                    civilizations: {
+                      ...deps.session.getState().civilizations,
+                      [captorId]: {
+                        ...deps.session.getState().civilizations[captorId],
+                        diplomacy: modifyRelationship(
+                          deps.session.getState().civilizations[captorId].diplomacy, spyOwner, relPenalty * 2,
+                        ),
+                      },
+                      [spyOwner]: {
+                        ...deps.session.getState().civilizations[spyOwner],
+                        diplomacy: modifyRelationship(
+                          deps.session.getState().civilizations[spyOwner].diplomacy, captorId, relPenalty * 2,
+                        ),
+                      },
+                    },
+                  });
+                  deps.bus.emit('espionage:spy-executed', {
+                    executingCivId: captorId, spyOwner, spyId, spyName: spy.name,
+                  });
+                  deps.showNotification(`${spy.name} has been executed.`, 'warning');
+                  deps.renderLoop.setGameState(deps.session.getState());
+                },
+              },
+            ],
+          );
+        },
+      },
+      {
+        label: 'Interrogate (4 turns)',
+        onClick: () => {
+          const ownerEsp = deps.session.getState().espionage![spyOwner];
+          deps.session.setStateWithoutRefresh({
+            ...deps.session.getState(),
+            espionage: {
+              ...deps.session.getState().espionage,
+              [deps.session.getState().currentPlayer]: startInterrogation(captorEsp, spyId, spyOwner),
+              // Set spy status to 'interrogated' on the spy owner's record
+              [spyOwner]: {
+                ...ownerEsp,
+                spies: {
+                  ...ownerEsp.spies,
+                  [spyId]: { ...ownerEsp.spies[spyId]!, status: 'interrogated' as const },
+                },
+              },
+            },
+          });
+          deps.showNotification(`${spy.name} is being interrogated. Check the Intel panel for results.`, 'info');
+          deps.renderLoop.setGameState(deps.session.getState());
+        },
+      },
+    ]);
+  }
+
+  return {
+    getUnitTurnFlow,
+    performWorkerAction,
+    performPreach,
+    ensurePlayerWarState,
+    restAction,
+    showEspionageCaptureChoice,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import { EventBus } from '@/core/event-bus';
 import { RenderLoop } from '@/renderer/render-loop';
 import { hexKey, parseHexKey } from '@/systems/hex-utils';
-import { moveUnit, getMovementCost, UNIT_DEFINITIONS, restUnit, canHeal, createUnit } from '@/systems/unit-system';
-import { isMajorCivOwner } from '@/core/owner-kind';
+import { moveUnit, getMovementCost } from '@/systems/unit-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
@@ -11,10 +10,7 @@ import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
-import { applyWorkerAction } from '@/systems/worker-action-system';
 import { resolveCombatEra } from '@/systems/era-resolution';
-import { preach } from '@/systems/religion-system';
-import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
 import { getVisibility } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast } from '@/systems/beast-system';
@@ -28,9 +24,8 @@ import { AdvisorSystem } from '@/ui/advisor-system';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { PirateActionResult } from '@/systems/pirate-actions';
 import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
-import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
 import { resolveCivDefinition } from '@/systems/civ-registry';
-import { declareWar, makePeace, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
+import { makePeace } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
 import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
@@ -41,13 +36,12 @@ import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupa
 import { beginPlayerCityAssaultChoice, shouldPromptForPlayerCityCapture } from '@/input/city-assault-flow';
 import { canUnitOccupyCity } from '@/systems/city-capture-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
-import { getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation, isSpyUnitType } from '@/systems/espionage-system';
+import { isSpyUnitType } from '@/systems/espionage-system';
 import { applyUnitUpgradeToState } from '@/systems/unit-upgrade-system';
 import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
-import { getCapitalCity } from '@/systems/capital-system';
-import type { CombatResult, GameState, HexCoord, UnitType, CivBonusEffect, WorkerActionType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, UnitType, CivBonusEffect } from '@/core/types';
 import { appendNotification, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
 import type { NotificationSink } from '@/ui/notification-routing';
 import { createUserSettingsStore } from '@/app/user-settings-store';
@@ -57,6 +51,7 @@ import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/contr
 import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
 import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
 import { createPanelActionsController, type PanelActionsController } from '@/app/controllers/panel-actions-controller';
+import { createPlayerActionController, type PlayerActionController } from '@/app/controllers/player-action-controller';
 import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
 import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
 import { createHudController, type HudController } from '@/app/controllers/hud-controller';
@@ -66,7 +61,6 @@ import { bootstrap } from '@/app/bootstrap';
 import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
-import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import type { GameSession } from '@/app/ports';
 import { createGameSession } from '@/app/game-session';
@@ -197,11 +191,14 @@ const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
 /**
  * Owns unit selection: `selectUnit`, `deselectUnit`, `selectNextUnit`, and the
  * animated-move / auto-explore / journey lifecycle around a selected unit
- * (#787 phase 8c). References several functions defined later in this file
- * (`foundCityAction`, `performWorkerAction`, `getUnitTurnFlow`, etc.) --
- * safe because they are hoisted function declarations and none of them run
- * until real gameplay, well after module evaluation finishes. The same
+ * (#787 phase 8c). References `foundCityAction`, a function defined later in
+ * this file -- safe because it's a hoisted function declaration that doesn't
+ * run until real gameplay, well after module evaluation finishes. The same
  * deferred-but-eager pattern `notifier` and `router` already use.
+ * `performWorkerAction`/`getUnitTurnFlow`/`restAction`/`ensurePlayerWarState`
+ * moved into `PlayerActionController` (phase 10b-e) and are threaded through
+ * as lazy wrappers instead, per that controller's own construction comment
+ * further down.
  */
 /**
  * Owns the diplomacy, minor-civ, and crisis-interaction handlers (#787 phase
@@ -264,6 +261,15 @@ const panelActions: PanelActionsController = createPanelActionsController({
   },
 });
 
+/**
+ * `getUnitTurnFlow`/`performWorkerAction`/`performPreach`/`restAction`/
+ * `ensurePlayerWarState` are wrapped in thin lazily-evaluating closures, not
+ * passed directly -- `playerActions` (#787 phase 10b-e) is constructed after
+ * `selectionController` (it needs `selectionController` itself as a direct
+ * dep, resolving the reverse forward-reference), so a direct reference here
+ * would capture `undefined` at construction time. Same deferred-but-eager
+ * pattern this file already uses for `router`/`notifier`/`campaignEntry`.
+ */
 const selectionController: SelectionController = createSelectionController({
   session,
   selection,
@@ -276,17 +282,17 @@ const selectionController: SelectionController = createSelectionController({
   showNotification,
   updateHUD: () => hud.update(),
   clearUnloadState,
-  getUnitTurnFlow,
+  getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
   foundCityAction,
-  performWorkerAction,
-  performPreach,
-  restAction,
+  performWorkerAction: action => playerActions.performWorkerAction(action),
+  performPreach: (unitId, cityId) => playerActions.performPreach(unitId, cityId),
+  restAction: () => playerActions.restAction(),
   openNetworkIntentPanel: panelActions.openNetworkIntentPanel,
   openUnitStackPicker: panelActions.openUnitStackPicker,
   openPirateHeadquartersAssault: panelActions.openPirateHeadquartersAssault,
   handleEstablishRoute: diplomacyActions.handleEstablishRoute,
   executeUpgrade,
-  ensurePlayerWarState,
+  ensurePlayerWarState: targetCivId => playerActions.ensurePlayerWarState(targetCivId),
   scanBeastSightings,
   currentCiv,
 });
@@ -324,7 +330,10 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   updateHUD: () => hud.update(),
   setBlockingOverlay,
   currentCiv,
-  getUnitTurnFlow,
+  // Lazy wrapper: `playerActions` (10b-e) is constructed after `turnFlow`
+  // (it needs `turnFlow.endTurn` as a direct dep), same deferred-but-eager
+  // reverse forward-reference as `selectionController`'s dep above.
+  getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
   deselectUnit: selectionController.deselectUnit,
   selectNextUnit: selectionController.selectNextUnit,
   scanBeastSightings,
@@ -337,6 +346,32 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   showGameModeSelection: () => campaignEntry.showGameModeSelection(),
   reloadPage: () => window.location.reload(),
   openCityPanelForCity: panelActions.openCityPanelForCity,
+});
+
+/**
+ * Owns the player-unit-action functions `getUnitTurnFlow`, `performWorkerAction`,
+ * `performPreach`, `ensurePlayerWarState`, `restAction`, and
+ * `showEspionageCaptureChoice` (#787 phase 10b-e -- a partial `PlayerActionController`;
+ * Phase 13, not yet merged, will extend this same file with a different
+ * function group in the same domain). Constructed after both `selectionController`
+ * and `turnFlow` so it can take direct references to both -- see the lazy
+ * wrappers those two use above for the reverse direction of this same
+ * three-way forward reference. `notifier` still needs its own lazy wrapper
+ * here since it is a `let` not assigned until `init()` runs.
+ */
+const playerActions: PlayerActionController = createPlayerActionController({
+  session,
+  bus,
+  uiLayer,
+  selection,
+  selectionController,
+  turnFlow,
+  hud: { update: () => hud.update() },
+  renderLoop,
+  showNotification,
+  setBlockingOverlay,
+  currentCiv,
+  notifier: { choice: (message, actions) => notifier.choice(message, actions) },
 });
 
 /**
@@ -461,7 +496,7 @@ const presentationContext: PresentationContext = {
   selection,
   requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
   applyCombatVisual: result => renderLoop.applyCombatVisual(result),
-  showEspionageCaptureChoice: (spyId, spyOwner) => showEspionageCaptureChoice(spyId, spyOwner),
+  showEspionageCaptureChoice: (spyId, spyOwner) => playerActions.showEspionageCaptureChoice(spyId, spyOwner),
   uiLayer,
   maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
   isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
@@ -665,27 +700,6 @@ const panelRegistry = {
 
 router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });
 
-function getUnitTurnFlow() {
-  return createUnitTurnFlow({
-    uiLayer,
-    getState: () => session.getState(),
-    setState: nextState => { session.setStateWithoutRefresh(nextState); },
-    getSelectedUnitId: () => selection.getSelectedUnitId(),
-    selectUnit: selectionController.selectUnit,
-    deselectUnit: selectionController.deselectUnit,
-    selectNextUnit: selectionController.selectNextUnit,
-    centerOn: coord => renderLoop.camera.centerOn(coord),
-    refreshVisibility: selectionController.refreshCurrentPlayerVisibility,
-    setRenderState: state => renderLoop.setGameState(state),
-    updateHUD: () => hud.update(),
-    showNotification,
-    setBlockingOverlay,
-    endTurn: options => { void turnFlow.endTurn(options); },
-    onUnitDisbanded: (state, unitId, routeId) =>
-      removeRouteForUnit(state, unitId, bus, 'unit-disbanded', routeId),
-  });
-}
-
 function foundCityAction(): void {
   const selectedUnitId = selection.getSelectedUnitId();
   if (!selectedUnitId) return;
@@ -725,91 +739,6 @@ function foundCityAction(): void {
   hud.update();
 }
 
-function performWorkerAction(action: WorkerActionType): void {
-  const selectedUnitId = selection.getSelectedUnitId();
-  if (!selectedUnitId) return;
-
-  const result = applyWorkerAction(session.getState(), selectedUnitId, action);
-  if (!result.ok) return;
-
-  session.setStateWithoutRefresh(result.state);
-  for (const event of result.events) {
-    if (event.type === 'improvement:started') {
-      bus.emit('improvement:started', event.payload);
-    } else if (event.type === 'road:started') {
-      bus.emit('road:started', event.payload);
-    } else {
-      bus.emit('unit:destroyed', event.payload);
-    }
-  }
-
-  renderLoop.setGameState(session.getState());
-  hud.update();
-
-  if (result.workerConsumed || result.workerLost || !session.getState().units[selectedUnitId]) {
-    selectionController.deselectUnit();
-  } else {
-    selectionController.selectUnit(selectedUnitId);
-  }
-
-  showNotification(result.message, result.workerLost ? 'warning' : 'info');
-}
-
-// #592 MR5: preach action. Mirrors performWorkerAction's state-apply + rerender pattern,
-// but adds a non-destructive confirmation dialog when the missionary is consumed on its
-// last charge — the deletion has already happened inside preach() by this point, so the
-// dialog is an acknowledgment, not a gate (hideCancel: true, no undo possible).
-function performPreach(unitId: string, cityId: string): void {
-  const unit = session.getState().units[unitId];
-  const cityName = session.getState().cities[cityId]?.name ?? cityId;
-  const result = preach(session.getState(), unitId, cityId, bus);
-  if (!result.ok) return;
-
-  session.commit(result.state);
-
-  const message = result.converted
-    ? `${cityName} has converted to your faith!`
-    : `You preached in ${cityName}.`;
-
-  if (result.unitConsumed) {
-    selectionController.deselectUnit();
-    setBlockingOverlay('unit-delete-confirmation');
-    createUnitDeleteConfirmationPanel(uiLayer, {
-      unitName: unit ? UNIT_DEFINITIONS[unit.type].name : 'Missionary',
-      title: 'Missionary Used Up',
-      bodyText: `${message} That was its last charge, so the missionary is gone.`,
-      confirmLabel: 'OK',
-      hideCancel: true,
-      tone: 'neutral',
-      onConfirm: () => {
-        uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
-        setBlockingOverlay(null);
-      },
-      onCancel: () => {
-        uiLayer.querySelector('#unit-delete-confirmation-panel')?.remove();
-        setBlockingOverlay(null);
-      },
-    });
-  } else {
-    selectionController.selectUnit(unitId);
-    showNotification(message, result.converted ? 'success' : 'info');
-  }
-}
-
-function ensurePlayerWarState(targetCivId: string): void {
-  const targetCiv = session.getState().civilizations[targetCivId];
-  if (!targetCiv || !isMajorCivOwner(targetCivId)) return;
-
-  const cp = session.getState().currentPlayer;
-  const alreadyAtWar = currentCiv().diplomacy?.atWarWith.includes(targetCivId) ?? false;
-  if (alreadyAtWar) return;
-
-  currentCiv().diplomacy = declareWar(currentCiv().diplomacy, targetCivId, session.getState().turn);
-  targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, session.getState().turn);
-  bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
-  session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(session.getState(), cp, targetCivId, bus));
-}
-
 function beginPlayerCityAssault(
   attackerId: string,
   cityId: string,
@@ -822,7 +751,7 @@ function beginPlayerCityAssault(
   const attacker = session.getState().units[attackerId];
   if (!attacker || !canUnitOccupyCity(attacker)) return 'resolved';
 
-  ensurePlayerWarState(city.owner);
+  playerActions.ensurePlayerWarState(city.owner);
   let attackerMultiplier: number | undefined;
   if (embarkedAssault) {
     const legality = getEmbarkedAssaultTarget(session.getState(), attackerId, city.position, { viewerId: session.getState().currentPlayer });
@@ -905,7 +834,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
     attacker = detached.attacker;
   }
 
-  ensurePlayerWarState(defender.owner);
+  playerActions.ensurePlayerWarState(defender.owner);
 
   const seed = deterministicCombatSeed(session.getState().gameId, session.getState().turn, attacker.id, defender.id);
   const attackerBonus = currentCivDef()?.bonusEffect;
@@ -1025,165 +954,6 @@ function executeAttack(attackerId: string, targetKey: string): void {
   hud.update();
   selectionController.refreshSelectedUnitAfterCombat();
   renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectionController.selectNextUnit());
-}
-
-function restAction(): void {
-  const selectedUnitId = selection.getSelectedUnitId();
-  if (!selectedUnitId) return;
-  const unit = session.getState().units[selectedUnitId];
-  if (!unit || !canHeal(unit)) return;
-
-  session.getState().units[selectedUnitId] = restUnit(unit);
-  showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
-  selectionController.deselectUnit();
-  renderLoop.setGameState(session.getState());
-}
-
-function showEspionageCaptureChoice(spyId: string, spyOwner: string): void {
-  const captorEsp = session.getState().espionage?.[session.getState().currentPlayer];
-  const spy = session.getState().espionage?.[spyOwner]?.spies[spyId];
-  if (!captorEsp || !spy) return;
-  const spyOwnerName = session.getState().civilizations[spyOwner]?.name ?? spyOwner;
-
-  // D1: always reveal true identity to captor regardless of disguise
-  const captureMessage = `You have captured ${spy.name}, a ${spy.unitType} belonging to ${spyOwnerName}.`;
-
-  // infiltrated spies are inside the city (distance 0); otherwise use boundary penalty
-  const distanceToCity = spy.infiltrationCityId ? 0 : 1;
-  const relPenalty = getSpyCaptureRelationshipPenalty(distanceToCity);
-
-  notifier.choice(captureMessage, [
-    {
-      label: `Expel (${relPenalty} relations)`,
-      onClick: () => {
-        const updatedOwnerEsp = expelSpy(session.getState().espionage![spyOwner], spyId, 15);
-        const capital = getCapitalCity(session.getState(), spyOwner);
-        if (capital) {
-          const newUnit = createUnit(spy.unitType, spyOwner, capital.position, session.getState().idCounters);
-          session.setStateWithoutRefresh({
-            ...session.getState(),
-            units: { ...session.getState().units, [newUnit.id]: newUnit },
-            civilizations: {
-              ...session.getState().civilizations,
-              [spyOwner]: {
-                ...session.getState().civilizations[spyOwner],
-                units: [...session.getState().civilizations[spyOwner].units, newUnit.id],
-              },
-            },
-          });
-          const { [spyId]: _old, ...rest } = updatedOwnerEsp.spies;
-          session.setStateWithoutRefresh({
-            ...session.getState(),
-            espionage: {
-              ...session.getState().espionage,
-              [spyOwner]: {
-                ...updatedOwnerEsp,
-                spies: { ...rest, [newUnit.id]: { ...updatedOwnerEsp.spies[spyId]!, id: newUnit.id } },
-              },
-            },
-          });
-        } else {
-          session.setStateWithoutRefresh({ ...session.getState(), espionage: { ...session.getState().espionage, [spyOwner]: updatedOwnerEsp } });
-        }
-        // Bilateral: captor's view of spy owner AND spy owner's view of captor
-        const captorId = session.getState().currentPlayer;
-        session.setStateWithoutRefresh({
-          ...session.getState(),
-          civilizations: {
-            ...session.getState().civilizations,
-            [captorId]: {
-              ...session.getState().civilizations[captorId],
-              diplomacy: modifyRelationship(
-                session.getState().civilizations[captorId].diplomacy, spyOwner, relPenalty,
-              ),
-            },
-            [spyOwner]: {
-              ...session.getState().civilizations[spyOwner],
-              diplomacy: modifyRelationship(
-                session.getState().civilizations[spyOwner].diplomacy, captorId, relPenalty,
-              ),
-            },
-          },
-        });
-        showNotification(`${spy.name} expelled. Will return to their capital after 15 turns.`, 'info');
-        renderLoop.setGameState(session.getState());
-      },
-    },
-    {
-      label: 'Execute',
-      danger: true,
-      onClick: () => {
-        // Second in-panel confirmation — no window.confirm on mobile
-        notifier.choice(
-          `Execute ${spy.name}? This cannot be undone and will severely damage relations with ${spyOwnerName}.`,
-          [
-            {
-              label: 'Cancel',
-              onClick: () => showEspionageCaptureChoice(spyId, spyOwner),
-            },
-            {
-              label: 'Confirm Execute',
-              danger: true,
-              onClick: () => {
-                const captorId = session.getState().currentPlayer;
-                session.setStateWithoutRefresh({
-                  ...session.getState(),
-                  espionage: {
-                    ...session.getState().espionage,
-                    [spyOwner]: executeSpy(session.getState().espionage![spyOwner], spyId),
-                  },
-                  // Bilateral: captor's view AND spy owner's view
-                  civilizations: {
-                    ...session.getState().civilizations,
-                    [captorId]: {
-                      ...session.getState().civilizations[captorId],
-                      diplomacy: modifyRelationship(
-                        session.getState().civilizations[captorId].diplomacy, spyOwner, relPenalty * 2,
-                      ),
-                    },
-                    [spyOwner]: {
-                      ...session.getState().civilizations[spyOwner],
-                      diplomacy: modifyRelationship(
-                        session.getState().civilizations[spyOwner].diplomacy, captorId, relPenalty * 2,
-                      ),
-                    },
-                  },
-                });
-                bus.emit('espionage:spy-executed', {
-                  executingCivId: captorId, spyOwner, spyId, spyName: spy.name,
-                });
-                showNotification(`${spy.name} has been executed.`, 'warning');
-                renderLoop.setGameState(session.getState());
-              },
-            },
-          ],
-        );
-      },
-    },
-    {
-      label: 'Interrogate (4 turns)',
-      onClick: () => {
-        const ownerEsp = session.getState().espionage![spyOwner];
-        session.setStateWithoutRefresh({
-          ...session.getState(),
-          espionage: {
-            ...session.getState().espionage,
-            [session.getState().currentPlayer]: startInterrogation(captorEsp, spyId, spyOwner),
-            // Set spy status to 'interrogated' on the spy owner's record
-            [spyOwner]: {
-              ...ownerEsp,
-              spies: {
-                ...ownerEsp.spies,
-                [spyId]: { ...ownerEsp.spies[spyId]!, status: 'interrogated' as const },
-              },
-            },
-          },
-        });
-        showNotification(`${spy.name} is being interrogated. Check the Intel panel for results.`, 'info');
-        renderLoop.setGameState(session.getState());
-      },
-    },
-  ]);
 }
 
 // --- Bootstrap ---

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { createGameSession } from '@/app/game-session';
+import { createUnit } from '@/systems/unit-system';
+import { createEspionageCivState } from '@/systems/espionage-system';
+import { foundReligion } from '@/systems/religion-system';
+import { hexKey } from '@/systems/hex-utils';
+import { makeReligionFixture } from '../../systems/helpers/religion-fixture';
+import type { GameState, HexCoord, Spy } from '@/core/types';
+import {
+  createPlayerActionController,
+  type PlayerActionControllerDeps,
+} from '@/app/controllers/player-action-controller';
+
+vi.mock('@/ui/unit-turn-flow', () => ({ createUnitTurnFlow: vi.fn(() => ({ mocked: 'unit-turn-flow' })) }));
+
+import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
+
+function mockedCallArg<T = unknown>(mockFn: unknown, callIndex: number, argIndex: number): T {
+  return (mockFn as ReturnType<typeof vi.fn>).mock.calls[callIndex][argIndex] as T;
+}
+
+function makeFixture(seed = 'player-action-controller'): { state: GameState; aiCivId: string } {
+  const state = createNewGame(undefined, seed, 'small');
+  state.currentPlayer = 'player';
+  const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+  return { state, aiCivId };
+}
+
+function placeUnit(state: GameState, type: Parameters<typeof createUnit>[0], unitId: string, position: HexCoord, overrides: Partial<GameState['units'][string]> = {}): void {
+  const idCounters = { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 };
+  state.units[unitId] = { ...createUnit(type, 'player', position, idCounters), id: unitId, ...overrides };
+  state.civilizations.player.units.push(unitId);
+}
+
+function makeCity(id: string, overrides: Partial<NonNullable<GameState['cities'][string]>> = {}): NonNullable<GameState['cities'][string]> {
+  return {
+    id, name: `City ${id}`, owner: 'player', position: { q: 0, r: 0 },
+    population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+function placeSpy(state: GameState, civId: string, spyId: string, overrides: Partial<Spy> = {}): void {
+  const spy: Spy = {
+    id: spyId, owner: civId, name: `Agent ${spyId}`, unitType: 'spy_scout',
+    targetCivId: null, targetCityId: null, position: null,
+    status: 'idle', experience: 0, currentMission: null,
+    cooldownTurns: 0, promotion: undefined, promotionAvailable: false,
+    feedsFalseIntel: false,
+    ...overrides,
+  };
+  const existing = state.espionage?.[civId] ?? createEspionageCivState();
+  state.espionage = { ...state.espionage, [civId]: { ...existing, spies: { ...existing.spies, [spyId]: spy } } };
+}
+
+function makeDeps(state: GameState, overrides: Partial<PlayerActionControllerDeps> = {}) {
+  return {
+    session: createGameSession(state),
+    bus: new EventBus(),
+    uiLayer: document.createElement('div'),
+    selection: { getSelectedUnitId: vi.fn(() => null) },
+    selectionController: {
+      selectUnit: vi.fn(), deselectUnit: vi.fn(), selectNextUnit: vi.fn(), refreshCurrentPlayerVisibility: vi.fn(),
+    },
+    turnFlow: { endTurn: vi.fn(() => Promise.resolve()) },
+    hud: { update: vi.fn() },
+    renderLoop: { camera: { centerOn: vi.fn() }, setGameState: vi.fn() },
+    showNotification: vi.fn(),
+    setBlockingOverlay: vi.fn(),
+    currentCiv: vi.fn(() => state.civilizations[state.currentPlayer]),
+    notifier: { choice: vi.fn() },
+    ...overrides,
+  };
+}
+
+function build(state: GameState, overrides: Partial<PlayerActionControllerDeps> = {}) {
+  const deps = makeDeps(state, overrides);
+  const controller = createPlayerActionController(deps);
+  return { deps, controller };
+}
+
+describe('PlayerActionController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getUnitTurnFlow', () => {
+    it('routes every callback through the real injected deps instead of stale local references', () => {
+      const { state } = makeFixture('unit-turn-flow');
+      const { deps, controller } = build(state);
+
+      controller.getUnitTurnFlow();
+
+      expect(createUnitTurnFlow).toHaveBeenCalledTimes(1);
+      const flowDeps = mockedCallArg<{
+        selectUnit: (unitId: string) => void;
+        deselectUnit: () => void;
+        selectNextUnit: () => void;
+        centerOn: (coord: HexCoord) => void;
+        refreshVisibility: () => void;
+        endTurn: (options: { allowUnmovedUnits?: boolean }) => void;
+        onUnitDisbanded: (state: GameState, unitId: string, routeId: string) => GameState;
+      }>(createUnitTurnFlow, 0, 0);
+
+      flowDeps.selectUnit('unit-1');
+      expect(deps.selectionController.selectUnit).toHaveBeenCalledWith('unit-1');
+      flowDeps.deselectUnit();
+      expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
+      flowDeps.selectNextUnit();
+      expect(deps.selectionController.selectNextUnit).toHaveBeenCalledTimes(1);
+      flowDeps.refreshVisibility();
+      expect(deps.selectionController.refreshCurrentPlayerVisibility).toHaveBeenCalledTimes(1);
+      flowDeps.centerOn({ q: 2, r: 2 });
+      expect(deps.renderLoop.camera.centerOn).toHaveBeenCalledWith({ q: 2, r: 2 });
+      flowDeps.endTurn({ allowUnmovedUnits: true });
+      expect(deps.turnFlow.endTurn).toHaveBeenCalledWith({ allowUnmovedUnits: true });
+
+      // onUnitDisbanded delegates to the real removeRouteForUnit -- a unit with no
+      // committed route is a real no-op (state returned unchanged), not a stub.
+      const result = flowDeps.onUnitDisbanded(deps.session.getState(), 'no-such-unit', 'route-1');
+      expect(result).toStrictEqual(deps.session.getState());
+    });
+  });
+
+  describe('performWorkerAction', () => {
+    it('does nothing when no unit is selected', () => {
+      const { state } = makeFixture('worker-action-none-selected');
+      const { deps, controller } = build(state);
+
+      controller.performWorkerAction('farm');
+
+      expect(deps.showNotification).not.toHaveBeenCalled();
+      expect(deps.renderLoop.setGameState).not.toHaveBeenCalled();
+    });
+
+    it('applies a real worker action, refreshes the renderer, and reselects the unit', () => {
+      const { state } = makeFixture('worker-action-farm');
+      state.map.tiles['0,0'] = {
+        coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null,
+        improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+      };
+      placeUnit(state, 'worker', 'worker-1', { q: 0, r: 0 });
+      const { deps, controller } = build(state, { selection: { getSelectedUnitId: vi.fn(() => 'worker-1') } });
+
+      controller.performWorkerAction('farm');
+
+      expect(deps.session.getState().map.tiles['0,0'].improvement === 'farm'
+        || deps.session.getState().map.tiles['0,0'].improvementTurnsLeft > 0).toBe(true);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.any(String), expect.any(String));
+    });
+  });
+
+  describe('performPreach', () => {
+    it('does nothing when the real preach guard rejects the attempt (not a missionary)', () => {
+      const { state } = makeFixture('preach-invalid');
+      state.cities['test-city'] = makeCity('test-city');
+      placeUnit(state, 'warrior', 'warrior-1', { q: 0, r: 0 });
+      const { deps, controller } = build(state);
+
+      controller.performPreach('warrior-1', 'test-city');
+
+      expect(deps.selectionController.selectUnit).not.toHaveBeenCalled();
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('commits a real successful conversion, reselects the missionary, and notifies (not consumed)', () => {
+      const { state: baseState, civId, templeCity, otherCity } = makeReligionFixture();
+      const bus = new EventBus();
+      let state = foundReligion(baseState, civId, templeCity, bus);
+      // Discover the target city so the real `hasDiscoveredCity` guard passes.
+      state = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          [civId]: {
+            ...state.civilizations[civId],
+            visibility: { tiles: { [hexKey(state.cities[otherCity].position)]: 'visible' } },
+          },
+        },
+      };
+      const missionary = createUnit('missionary', civId, state.cities[otherCity].position, state.idCounters);
+      missionary.chargesRemaining = 2;
+      state.units[missionary.id] = missionary;
+      state.civilizations[civId].units.push(missionary.id);
+      state.currentPlayer = civId;
+
+      const { deps, controller } = build(state, { bus });
+
+      controller.performPreach(missionary.id, otherCity);
+
+      const updated = deps.session.getState();
+      expect(updated.cityFaith?.[otherCity]?.religionId).toBe(`religion-${civId}`);
+      expect(deps.selectionController.selectUnit).toHaveBeenCalledWith(missionary.id);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('preached'), 'info');
+      expect(deps.setBlockingOverlay).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ensurePlayerWarState', () => {
+    it('declares war bilaterally against a major civ not already at war', () => {
+      const { state, aiCivId } = makeFixture('war-state-declare');
+      const { deps, controller } = build(state);
+
+      controller.ensurePlayerWarState(aiCivId);
+
+      const updated = deps.session.getState();
+      expect(updated.civilizations.player.diplomacy.atWarWith).toContain(aiCivId);
+      expect(updated.civilizations[aiCivId].diplomacy.atWarWith).toContain('player');
+    });
+
+    it('does nothing when the two civs are already at war (no duplicate atWarWith entries)', () => {
+      const { state, aiCivId } = makeFixture('war-state-already-at-war');
+      state.civilizations.player.diplomacy.atWarWith = [aiCivId];
+      state.civilizations[aiCivId].diplomacy.atWarWith = ['player'];
+      const { deps, controller } = build(state);
+
+      controller.ensurePlayerWarState(aiCivId);
+
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toEqual([aiCivId]);
+    });
+
+    it('does nothing for a non-major-civ target (e.g. a minor civ or barbarian id)', () => {
+      const { state } = makeFixture('war-state-non-major');
+      const { deps, controller } = build(state);
+
+      controller.ensurePlayerWarState('barbarians');
+
+      expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toEqual([]);
+    });
+  });
+
+  describe('restAction', () => {
+    it('does nothing when no unit is selected', () => {
+      const { deps, controller } = build(makeFixture('rest-none-selected').state);
+
+      controller.restAction();
+
+      expect(deps.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the selected unit is already at full health', () => {
+      const { state } = makeFixture('rest-full-health');
+      placeUnit(state, 'warrior', 'warrior-1', { q: 0, r: 0 }, { health: 100 });
+      const { deps, controller } = build(state, { selection: { getSelectedUnitId: vi.fn(() => 'warrior-1') } });
+
+      controller.restAction();
+
+      expect(deps.showNotification).not.toHaveBeenCalled();
+      expect(deps.session.getState().units['warrior-1'].isResting).toBeFalsy();
+    });
+
+    it('rests a real damaged unit, heals via restUnit, and deselects', () => {
+      const { state } = makeFixture('rest-damaged');
+      placeUnit(state, 'warrior', 'warrior-1', { q: 0, r: 0 }, { health: 50 });
+      const { deps, controller } = build(state, { selection: { getSelectedUnitId: vi.fn(() => 'warrior-1') } });
+
+      controller.restAction();
+
+      expect(deps.session.getState().units['warrior-1'].isResting).toBe(true);
+      expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('heal'), 'info');
+    });
+  });
+
+  describe('showEspionageCaptureChoice', () => {
+    it('does nothing when the target spy does not exist', () => {
+      const { state, aiCivId } = makeFixture('espionage-choice-missing-spy');
+      const { deps, controller } = build(state);
+
+      controller.showEspionageCaptureChoice('no-such-spy', aiCivId);
+
+      expect(deps.notifier.choice).not.toHaveBeenCalled();
+    });
+
+    it('presents Expel/Execute/Interrogate and expels a real spy to a real capital on Expel', () => {
+      const { state, aiCivId } = makeFixture('espionage-choice-expel');
+      state.cities['capital-city'] = makeCity('capital-city', { owner: aiCivId });
+      state.civilizations[aiCivId].cities = ['capital-city'];
+      placeSpy(state, 'player', 'captor-esp-seed'); // ensures espionage.player exists as captor
+      placeSpy(state, aiCivId, 'spy-1', { status: 'stationed', unitType: 'spy_scout' });
+      const { deps, controller } = build(state);
+
+      controller.showEspionageCaptureChoice('spy-1', aiCivId);
+
+      expect(deps.notifier.choice).toHaveBeenCalledTimes(1);
+      const actions = mockedCallArg<Array<{ label: string; onClick: () => void }>>(deps.notifier.choice, 0, 1);
+      expect(actions.map(a => a.label)).toEqual([
+        expect.stringContaining('Expel'), 'Execute', 'Interrogate (4 turns)',
+      ]);
+
+      actions[0].onClick();
+
+      const updated = deps.session.getState();
+      expect(updated.espionage![aiCivId].spies['spy-1']).toBeUndefined();
+      const expelledSpy = Object.values(updated.espionage![aiCivId].spies).find(spy => spy.name === 'Agent spy-1');
+      expect(expelledSpy).toBeDefined();
+      expect(updated.units[expelledSpy!.id].position).toEqual(state.cities['capital-city'].position);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('expelled'), 'info');
+    });
+  });
+});

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -32,7 +32,9 @@ describe('player combat wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const executeAttack = main.slice(
       main.indexOf('function executeAttack('),
-      main.indexOf('function restAction('),
+      // #787 phase 10b-e: restAction moved into PlayerActionController;
+      // executeAttack is now the last function declaration in main.ts.
+      main.indexOf('// --- Bootstrap ---'),
     );
 
     expect(executeAttack).toContain(
@@ -44,7 +46,9 @@ describe('player combat wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const executeAttack = main.slice(
       main.indexOf('function executeAttack('),
-      main.indexOf('function restAction('),
+      // #787 phase 10b-e: restAction moved into PlayerActionController;
+      // executeAttack is now the last function declaration in main.ts.
+      main.indexOf('// --- Bootstrap ---'),
     );
     const stateRefresh = executeAttack.indexOf('renderLoop.setGameState(session.getState());');
     const panelRefresh = executeAttack.indexOf('refreshSelectedUnitAfterCombat();');
@@ -59,7 +63,9 @@ describe('player combat wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const executeAttack = main.slice(
       main.indexOf('function executeAttack('),
-      main.indexOf('function restAction('),
+      // #787 phase 10b-e: restAction moved into PlayerActionController;
+      // executeAttack is now the last function declaration in main.ts.
+      main.indexOf('// --- Bootstrap ---'),
     );
     const cityCaptureBranch = executeAttack.slice(
       executeAttack.indexOf('const assaultStatus = beginPlayerCityAssault('),
@@ -135,7 +141,9 @@ describe('shared city founding wiring', () => {
     );
     const playerFlow = main.slice(
       main.indexOf('function foundCityAction(): void'),
-      main.indexOf('function performWorkerAction('),
+      // #787 phase 10b-e: performWorkerAction moved into PlayerActionController;
+      // beginPlayerCityAssault is what now immediately follows foundCityAction.
+      main.indexOf('function beginPlayerCityAssault('),
     );
 
     expect(playerFlow).toContain(
@@ -153,9 +161,9 @@ describe('shared unit upgrade wiring', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const handler = main.slice(
       main.indexOf('function executeUpgrade('),
-      // #787 phase 10b-d: openCityPanelForCity moved into PanelActionsController;
-      // getUnitTurnFlow is what now immediately follows executeUpgrade.
-      main.indexOf('function getUnitTurnFlow('),
+      // #787 phase 10b-e: getUnitTurnFlow moved into PlayerActionController;
+      // foundCityAction is what now immediately follows executeUpgrade.
+      main.indexOf('function foundCityAction('),
     );
 
     expect(handler).toContain('applyUnitUpgradeToState(');
@@ -305,16 +313,11 @@ describe('selection controller wiring (#787 phase 8c)', () => {
     }
   });
 
-  it('routes the unit-turn-flow deps through the controller instead of stale local references', () => {
-    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const getUnitTurnFlow = main.slice(
-      main.indexOf('function getUnitTurnFlow('),
-      main.indexOf('function foundCityAction('),
-    );
-
-    expect(getUnitTurnFlow).toContain('selectUnit: selectionController.selectUnit,');
-    expect(getUnitTurnFlow).toContain('deselectUnit: selectionController.deselectUnit,');
-    expect(getUnitTurnFlow).toContain('selectNextUnit: selectionController.selectNextUnit,');
-    expect(getUnitTurnFlow).toContain('refreshVisibility: selectionController.refreshCurrentPlayerVisibility,');
-  });
+  // The former 'routes the unit-turn-flow deps through the controller instead of
+  // stale local references' grep test lived here. #787 phase 10b-e moved
+  // `getUnitTurnFlow` out of `main.ts` into `PlayerActionController` -- the same
+  // routing is now proven behaviorally in
+  // `tests/app/controllers/player-action-controller.test.ts` ('getUnitTurnFlow'
+  // describe block), which exercises the returned `UnitTurnFlow`'s callbacks
+  // against real injected `selectionController` mocks instead of grepping source text.
 });


### PR DESCRIPTION
## Summary

Part of the composition-root decomposition arc ([#787](https://github.com/a1flecke/conquestoria/issues/787)), continuing Phase 10b's sub-phase split (10b-a through 10b-g, see [PR #807](https://github.com/a1flecke/conquestoria/pull/807), still unmerged docs-only). Builds on merged Phase 10b-d ([PR #812](https://github.com/a1flecke/conquestoria/pull/812)).

Extracts a new `PlayerActionController` with the unit-action group: `getUnitTurnFlow`, `performWorkerAction`, `performPreach`, `ensurePlayerWarState`, `restAction`, `showEspionageCaptureChoice` (~274 lines pre-move). Each was moved verbatim out of `main.ts` with mechanical dep-substitution only — no behavior changes.

**This is a partial `PlayerActionController`.** Phase 13 ([PR #800](https://github.com/a1flecke/conquestoria/pull/800), plan write-up not yet merged) covers a *different* six-function group in the same domain (`executeAttack`, `foundCityAction`, `executeUpgrade`, `beginPlayerCityAssault`, `executeMinorCivConquest`, `finalizePendingCityCaptureChoice`) and is expected to extend this same file once it lands, per the plan doc's own explicit fallback for this ordering. Those six functions are untouched by this PR.

**`main.ts`: 1202 → 972 lines** (net line count reflects ~274 lines of function bodies removed offset by construction-block growth from lazy wrappers, documented below).

## The interesting part: a genuine three-way construction-order circularity

`selectionController` and `turnFlow` both already took `getUnitTurnFlow` (and `selectionController` also took `performWorkerAction`/`performPreach`/`restAction`/`ensurePlayerWarState`) as bare hoisted-function-reference deps before this move. Once those functions became methods on a new `playerActions` controller, `playerActions` itself needs `selectionController`'s selection methods and `turnFlow.endTurn` — a genuine three-way forward reference, not resolvable by hoisting alone.

Resolved the same way this file resolves every other forward reference in this arc: `playerActions` is constructed *after* both `selectionController` and `turnFlow` (direct references to both, no wrapper needed on that side). `selectionController`'s and `turnFlow`'s own construction use lazy wrapper closures for the functions that moved here (`getUnitTurnFlow: () => playerActions.getUnitTurnFlow()`, etc.) — the identical deferred-but-eager pattern already established for `router`/`notifier`/`campaignEntry` elsewhere in this file. `notifier` itself also needs its own lazy wrapper inside `playerActions`'s construction, since it's a `let` not assigned until `init()` runs.

## Verification

- **Exhaustive call-count parity audit**: 13 markers compared against pre-move `main.ts` — zero real drift. The two non-zero deltas (`hud.update(` +1, `notifier.choice(` +1) were hand-verified as exactly the two new legitimate lazy-wrapper lines this phase adds, not stray misses.
- **Dead-import hygiene**: baseline (13 pre-existing unrelated dead imports) re-confirmed unchanged. 19 imports that became genuinely dead in `main.ts` after the move were removed (`UNIT_DEFINITIONS`, `WorkerActionType`, `applyOpportunisticWarPenaltyIfCrisisStruck`, `applyWorkerAction`, `canHeal`, `createUnit`, `createUnitDeleteConfirmationPanel`, `createUnitTurnFlow`, `declareWar`, `executeSpy`, `expelSpy`, `getCapitalCity`, `getSpyCaptureRelationshipPenalty`, `isMajorCivOwner`, `modifyRelationship`, `preach`, `resolveOpponentKind`, `restUnit`, `startInterrogation`). The new controller file itself has zero dead imports.
- **`tests/main.integration.test.ts` cleanup**: retired one grep-based structural test (`routes the unit-turn-flow deps...`) whose target function no longer exists in `main.ts` — its real behavior now has proper coverage in `player-action-controller.test.ts`'s `getUnitTurnFlow` describe block. Updated four other slice-boundary markers that used moved functions as end-of-region anchors.
- 13 new tests in `tests/app/controllers/player-action-controller.test.ts`, real system-state fixtures throughout: real `applyWorkerAction` (farm improvement), real `preach`/`foundReligion` conversion (reusing the shared `religion-fixture` helper), real bilateral `declareWar`, real `restUnit`, and a real `expelSpy`/`getCapitalCity` capture-choice flow — only `@/ui/unit-turn-flow`'s `createUnitTurnFlow` factory is mocked.
- Full suite green: 480 files / 7814 tests, `yarn build` clean, `yarn test:web-smoke` 8/8.
- **Full review across all requested dimensions performed before opening this PR**: confirmed via grep that no AI code path touches any of the 6 moved functions (all player-only); confirmed zero hardcoded `'player'` strings (hot-seat safe, `state.currentPlayer` used exclusively); confirmed zero `as any`/`as never`/`as unknown as` casts; confirmed every injected dep's `Pick<...>` narrowing matches its real usage exactly (`renderLoop`, `selectionController`, `turnFlow`, `hud`, `notifier` all checked field-by-field); confirmed no SFX regression (none of the 6 functions called `SFX.*` before or after); no save-schema changes. Fetched and rebased onto `origin/main` (an unrelated Citadels feature had merged in the interim) and re-ran the full verification suite clean before pushing.

## Test plan

- [x] `yarn build`
- [x] `yarn test` (full suite, 480 files / 7814 tests)
- [x] `yarn test:web-smoke` (8/8)
- [x] Manual diff review of `main.ts` changes (pure removal + rewiring, no leftover artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)