### PR TITLE
refactor(787): extract cross-cutting helpers into a pure module (phase 10b-f)

### DIFF
--- a/src/app/cross-cutting-helpers.ts
+++ b/src/app/cross-cutting-helpers.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure, explicit-parameter versions of the cross-cutting helpers that used to
+ * live as `main.ts`-local `function`/`const` declarations (#787 phase 10b-f).
+ *
+ * These 8 (of the 12 helpers the plan doc's inventory names) were the ones
+ * where extracting the real logic into an importable, testable module was a
+ * clean win: each is either a one-line pure read (`getCurrentCiv`,
+ * `getCurrentCivDef`, `clearUnloadState`, `prefersReducedMotion`) or a
+ * function whose every dependency (`session`, `bus`, `renderLoop`,
+ * `notifier`) is already explicit and passable as a plain argument
+ * (`scanBeastSightings`, `focusNotificationTarget`, `focusPirateTarget`,
+ * `notifyPlayer`, `applyPirateActionResult`).
+ *
+ * `main.ts` still owns *wiring* these into each controller's construction --
+ * every controller's own `Deps` interface is intentionally untouched by this
+ * phase (e.g. `focusNotificationTarget: (target) => void` stays exactly that
+ * shape on `PanelActionsController`/`GameSessionController`). `main.ts` just
+ * rewires the *value* it passes for that dep from a bare hoisted-function
+ * reference to an inline arrow calling the pure function here, e.g.
+ * `focusNotificationTarget: target => focusNotificationTarget(renderLoop,
+ * notifier, session, target)`. This keeps the phase's blast radius to
+ * `main.ts` + this one new file, instead of also touching every one of
+ * 10b-a-10b-e's already-shipped controller files.
+ *
+ * Three of the twelve inventoried helpers are deliberately NOT here, with
+ * reasons recorded at their remaining `main.ts` call site instead of ported
+ * reflexively:
+ * - `setBlockingOverlay` stays a 3-line `main.ts` wrapper around
+ *   `host.setBlockingOverlay` -- it is already minimal, and extracting it
+ *   would only trade a thin function for a `host` dep newly threaded into
+ *   two controllers, for no net simplification.
+ * - `showNotification` stays a thin `main.ts` wrapper delegating to
+ *   `notifyPlayer` below -- its own consumer list is large (every controller
+ *   plus most remaining `main.ts`-local functions), so keeping one hoisted
+ *   name letting every consumer's `Deps` interface stay untouched was judged
+ *   safer than widening ~8 call sites to take `notifier` directly for a
+ *   function whose logic is otherwise already fully extracted.
+ * - `maybeShowPendingHoardChoice` stays a `main.ts`-local function -- it is
+ *   self-recursive (its own `onChoice` callback calls itself) and closes
+ *   over `hud.update()`, `uiLayer`, `session`, and `bus` together; splitting
+ *   the recursion out into an explicit-callback pure function did not read
+ *   as a real simplification for its one meaningful shape.
+ * - `appendToCivLog` (a `const`, not a `function`) had exactly one consumer
+ *   (the `bootstrap({...})` call) and was inlined directly there instead of
+ *   moved here at all.
+ */
+import type { GameSession, SelectionStore, Notifier } from '@/app/ports';
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { EventBus } from '@/core/event-bus';
+import type { Civilization, CivDefinition } from '@/core/types';
+import type { NotificationEntry } from '@/core/notification-log';
+import type { PirateFocusTarget } from '@/systems/pirate-presentation';
+import type { PirateActionResult } from '@/systems/pirate-actions';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { appendNotification } from '@/core/notification-log';
+import { getVisibility } from '@/systems/fog-of-war';
+import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
+import { isBeastConcealedFrom } from '@/systems/beast-system';
+import { recordBeastSightings } from '@/systems/beast-presentation';
+import { hexKey } from '@/systems/hex-utils';
+
+export function getCurrentCiv(session: GameSession): Civilization {
+  return session.getState().civilizations[session.getState().currentPlayer];
+}
+
+export function getCurrentCivDef(session: GameSession): CivDefinition | undefined {
+  return resolveCivDefinition(session.getState(), getCurrentCiv(session).civType ?? '');
+}
+
+/**
+ * Deliberately narrower than `selection.setPendingIntent({ kind: 'none' })`:
+ * call sites fire on selection and movement changes that must not cancel a
+ * pending air mission, journey, or city-capture choice.
+ */
+export function clearUnloadState(selection: Pick<SelectionStore, 'getPendingIntent' | 'setPendingIntent'>): void {
+  if (selection.getPendingIntent().kind === 'unload') {
+    selection.setPendingIntent({ kind: 'none' });
+  }
+}
+
+export function prefersReducedMotion(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function scanBeastSightings(session: GameSession, bus: EventBus): void {
+  const visTiles = getCurrentCiv(session)?.visibility?.tiles;
+  if (!visTiles) return;
+  const viewerUnits = Object.values(session.getState().units).filter(
+    u => u.owner === session.getState().currentPlayer && !u.transportId,
+  );
+  const visibleKeys = new Set(
+    Object.entries(visTiles).filter(([, v]) => v === 'visible').map(([k]) => k),
+  );
+  // A beast concealed in its habitat cannot be sighted even if the tile is visible
+  for (const unit of Object.values(session.getState().units)) {
+    if (isBeastConcealedFrom(unit, session.getState().map, viewerUnits)) {
+      visibleKeys.delete(hexKey(unit.position));
+    }
+  }
+  const sightingResult = recordBeastSightings(session.getState(), session.getState().currentPlayer, visibleKeys);
+  session.setStateWithoutRefresh(sightingResult.state);
+  for (const beastId of sightingResult.newSightings) {
+    bus.emit('beast:sighted', { beastId, civId: session.getState().currentPlayer });
+  }
+}
+
+export function focusNotificationTarget(
+  renderLoop: { readonly camera: Pick<RenderLoop['camera'], 'centerOn'> },
+  notifier: Pick<Notifier, 'toast'>,
+  session: GameSession,
+  target: NotificationEntry['target'],
+): void {
+  if (!target) return;
+  renderLoop.camera.centerOn(target.coord);
+  const visibility = getCurrentCiv(session).visibility;
+  const isCurrentlyVisible = visibility ? getVisibility(visibility, target.coord) === 'visible' : false;
+  notifier.toast(formatNotificationTargetFocusMessage(target, isCurrentlyVisible), 'info');
+}
+
+export function focusPirateTarget(
+  renderLoop: { readonly camera: Pick<RenderLoop['camera'], 'centerOn'> },
+  notifier: Pick<Notifier, 'toast'>,
+  target: PirateFocusTarget,
+): void {
+  const coord = target.kind === 'region' ? target.center : target.coord;
+  renderLoop.camera.centerOn(coord);
+  notifier.toast(target.label, 'info');
+}
+
+/** `showNotification`'s extracted body -- see the module docblock for why `showNotification` itself stays a thin `main.ts` wrapper around this. */
+export function notifyPlayer(
+  notifier: Pick<Notifier, 'toast'>,
+  session: GameSession,
+  message: string,
+  type: NotificationEntry['type'] = 'info',
+  target?: NotificationEntry['target'],
+): void {
+  notifier.toast(message, type, target);
+  if (session.getState()) {
+    appendNotification(session.getState(), session.getState().currentPlayer, {
+      message,
+      type,
+      turn: session.getState().turn,
+      target,
+    });
+  }
+}
+
+export interface ApplyPirateActionResultDeps {
+  readonly session: GameSession;
+  readonly bus: EventBus;
+  readonly renderLoop: Pick<RenderLoop, 'setGameState'>;
+  readonly updateHUD: () => void;
+  readonly showNotification: (message: string, type?: NotificationEntry['type']) => void;
+}
+
+export function applyPirateActionResult(
+  deps: ApplyPirateActionResultDeps,
+  result: PirateActionResult,
+  successMessage: string,
+): void {
+  if (!result.success) {
+    deps.showNotification(result.reason ?? 'That pirate action is no longer available.', 'warning');
+    return;
+  }
+  deps.session.setStateWithoutRefresh(result.state);
+  for (const event of result.events) {
+    if (event.type === 'tribute-paid') {
+      deps.bus.emit('pirate:audio-cue', { cue: 'tribute', factionId: event.factionId, viewerIds: [event.civId] });
+    } else if (event.type === 'contract-accepted') {
+      deps.bus.emit('pirate:audio-cue', { cue: 'contract-accepted', factionId: event.factionId, viewerIds: [event.employerId] });
+    }
+  }
+  deps.renderLoop.setGameState(deps.session.getState());
+  deps.updateHUD();
+  deps.showNotification(successMessage, 'success');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,20 +11,14 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { resolveCombatEra } from '@/systems/era-resolution';
-import { getVisibility } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
-import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast } from '@/systems/beast-system';
+import { recordBeastSlain, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast } from '@/systems/beast-system';
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
-import { recordBeastSightings } from '@/systems/beast-presentation';
 import { loadSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX } from '@/audio/sfx';
 import { AdvisorSystem } from '@/ui/advisor-system';
-import type { PirateFocusTarget } from '@/systems/pirate-presentation';
-import type { PirateActionResult } from '@/systems/pirate-actions';
-import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
-import { resolveCivDefinition } from '@/systems/civ-registry';
 import { makePeace } from '@/systems/diplomacy-system';
 import { visitVillage } from '@/systems/village-system';
 import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
@@ -42,8 +36,7 @@ import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import { getEmbarkedAssaultTarget, detachCargoForEmbarkedAssault } from '@/systems/transport-system';
 import { createSelectionStore } from '@/app/selection-store';
 import type { CombatResult, GameState, HexCoord, UnitType, CivBonusEffect } from '@/core/types';
-import { appendNotification, type NotificationCityAction, type NotificationEntry } from '@/core/notification-log';
-import type { NotificationSink } from '@/ui/notification-routing';
+import type { NotificationCityAction, NotificationEntry } from '@/core/notification-log';
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
@@ -68,6 +61,17 @@ import { createPanelHost, type PanelHost } from '@/app/panel-host';
 import { createPanelRouter, type PanelRouter } from '@/app/panel-router';
 import type { PanelContext, PanelRegistry } from '@/app/panel-registry';
 import { installGlobalShortcuts } from '@/app/global-shortcuts';
+import {
+  getCurrentCiv,
+  getCurrentCivDef,
+  clearUnloadState,
+  prefersReducedMotion,
+  scanBeastSightings,
+  focusNotificationTarget,
+  focusPirateTarget,
+  notifyPlayer,
+  applyPirateActionResult,
+} from '@/app/cross-cutting-helpers';
 
 // --- App State ---
 /**
@@ -99,22 +103,6 @@ const userSettingsStore = createUserSettingsStore({ load: loadSettings });
  */
 let notifier: Notifier;
 
-/**
- * Cancels a pending unload, and only a pending unload.
- *
- * Deliberately narrower than `selection.setPendingIntent({ kind: 'none' })`:
- * the call sites below fire on selection and movement changes that must not
- * cancel a pending air mission, journey, or city-capture choice.
- */
-function clearUnloadState(): void {
-  if (selection.getPendingIntent().kind === 'unload') {
-    selection.setPendingIntent({ kind: 'none' });
-  }
-}
-
-function currentCivDef() {
-  return resolveCivDefinition(session.getState(), currentCiv().civType ?? '');
-}
 const bus = new EventBus();
 const audioCtx = new AudioContext();
 const audio = new AudioSystem(audioCtx);
@@ -156,11 +144,6 @@ session.subscribe(() => hud.update());
 
 function setBlockingOverlay(id: string | null): void {
   host.setBlockingOverlay(id);
-}
-
-function prefersReducedMotion(): boolean {
-  return typeof window.matchMedia === 'function'
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 /**
@@ -234,8 +217,12 @@ const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsContr
  * wrapper -- it is a `let` not assigned until `createPanelRouter(...)` much
  * later in module evaluation (after `panelRegistry`, which itself needs this
  * controller's methods) -- same pattern `turnFlow`'s own `router` dep below
- * already uses. `executeUpgrade` and `currentCivDef` are plain hoisted
- * function declarations (like `currentCiv`), so no wrapper needed for them.
+ * already uses. `executeUpgrade` is a plain hoisted function declaration, so
+ * no wrapper needed for it. `focusNotificationTarget`/`focusPirateTarget`/
+ * `applyPirateActionResult`/`currentCiv`/`currentCivDef` are inline arrows
+ * calling the pure functions in `src/app/cross-cutting-helpers.ts` (#787
+ * phase 10b-f) -- `notifier` inside those arrows is a `let` not assigned
+ * until `init()`, same deferred-but-eager pattern as `router` just below.
  */
 const panelActions: PanelActionsController = createPanelActionsController({
   session,
@@ -246,11 +233,15 @@ const panelActions: PanelActionsController = createPanelActionsController({
   audio,
   renderLoop,
   showNotification,
-  focusNotificationTarget,
-  focusPirateTarget,
-  applyPirateActionResult,
-  currentCiv,
-  currentCivDef,
+  focusNotificationTarget: target => focusNotificationTarget(renderLoop, notifier, session, target),
+  focusPirateTarget: target => focusPirateTarget(renderLoop, notifier, target),
+  applyPirateActionResult: (result, successMessage) => applyPirateActionResult(
+    { session, bus, renderLoop, updateHUD: () => hud.update(), showNotification },
+    result,
+    successMessage,
+  ),
+  currentCiv: () => getCurrentCiv(session),
+  currentCivDef: () => getCurrentCivDef(session),
   diplomacyActions,
   executeUpgrade,
   router: { open: panel => router.open(panel) },
@@ -281,7 +272,7 @@ const selectionController: SelectionController = createSelectionController({
   getInfoPanel: () => document.getElementById('info-panel'),
   showNotification,
   updateHUD: () => hud.update(),
-  clearUnloadState,
+  clearUnloadState: () => clearUnloadState(selection),
   getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
   foundCityAction,
   performWorkerAction: action => playerActions.performWorkerAction(action),
@@ -293,8 +284,8 @@ const selectionController: SelectionController = createSelectionController({
   handleEstablishRoute: diplomacyActions.handleEstablishRoute,
   executeUpgrade,
   ensurePlayerWarState: targetCivId => playerActions.ensurePlayerWarState(targetCivId),
-  scanBeastSightings,
-  currentCiv,
+  scanBeastSightings: () => scanBeastSightings(session, bus),
+  currentCiv: () => getCurrentCiv(session),
 });
 
 /**
@@ -329,14 +320,14 @@ const turnFlow: TurnFlowController = createTurnFlowController({
   showNotification,
   updateHUD: () => hud.update(),
   setBlockingOverlay,
-  currentCiv,
+  currentCiv: () => getCurrentCiv(session),
   // Lazy wrapper: `playerActions` (10b-e) is constructed after `turnFlow`
   // (it needs `turnFlow.endTurn` as a direct dep), same deferred-but-eager
   // reverse forward-reference as `selectionController`'s dep above.
   getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
   deselectUnit: selectionController.deselectUnit,
   selectNextUnit: selectionController.selectNextUnit,
-  scanBeastSightings,
+  scanBeastSightings: () => scanBeastSightings(session, bus),
   maybeShowPendingHoardChoice,
   checkAdvisors: () => advisorSystem.check(session.getState()),
   // `campaignEntry` is declared after `turnFlow` (it needs `turnFlow` itself
@@ -370,7 +361,7 @@ const playerActions: PlayerActionController = createPlayerActionController({
   renderLoop,
   showNotification,
   setBlockingOverlay,
-  currentCiv,
+  currentCiv: () => getCurrentCiv(session),
   notifier: { choice: (message, actions) => notifier.choice(message, actions) },
 });
 
@@ -396,8 +387,8 @@ const mapInteraction: MapInteractionController = createMapInteractionController(
   getElementById: id => document.getElementById(id),
   showNotification,
   updateHUD: () => hud.update(),
-  clearUnloadState,
-  currentCiv,
+  clearUnloadState: () => clearUnloadState(selection),
+  currentCiv: () => getCurrentCiv(session),
   openPirateWaters: panelActions.openPirateWaters,
   openUnitStackPicker: panelActions.openUnitStackPicker,
   openCityPanelForCity: panelActions.openCityPanelForCity,
@@ -478,7 +469,7 @@ gameSession = createGameSessionController({
   foundCityAction,
   maybeShowPendingHoardChoice,
   setNotifier: n => { notifier = n; },
-  focusNotificationTarget,
+  focusNotificationTarget: target => focusNotificationTarget(renderLoop, notifier, session, target),
 });
 
 /**
@@ -511,28 +502,6 @@ const presentationContext: PresentationContext = {
 // it can depend on the real `Notifier`/`PanelRouter` ports instead of
 // reaching into module-scope closures directly (#787 phase 5).
 
-function scanBeastSightings(): void {
-  const visTiles = currentCiv()?.visibility?.tiles;
-  if (!visTiles) return;
-  const viewerUnits = Object.values(session.getState().units).filter(
-    u => u.owner === session.getState().currentPlayer && !u.transportId,
-  );
-  const visibleKeys = new Set(
-    Object.entries(visTiles).filter(([, v]) => v === 'visible').map(([k]) => k),
-  );
-  // A beast concealed in its habitat cannot be sighted even if the tile is visible
-  for (const unit of Object.values(session.getState().units)) {
-    if (isBeastConcealedFrom(unit, session.getState().map, viewerUnits)) {
-      visibleKeys.delete(hexKey(unit.position));
-    }
-  }
-  const sightingResult = recordBeastSightings(session.getState(), session.getState().currentPlayer, visibleKeys);
-  session.setStateWithoutRefresh(sightingResult.state);
-  for (const beastId of sightingResult.newSightings) {
-    bus.emit('beast:sighted', { beastId, civId: session.getState().currentPlayer });
-  }
-}
-
 function maybeShowPendingHoardChoice(): void {
   const pending = (session.getState().beasts?.pendingHoardChoices ?? [])
     .find(p => p.civId === session.getState().currentPlayer);
@@ -547,74 +516,24 @@ function maybeShowPendingHoardChoice(): void {
   });
 }
 
-// --- Game Logic ---
-function currentCiv() {
-  return session.getState().civilizations[session.getState().currentPlayer];
-}
-
-
 // --- Notifications ---
 // The toast queue, the choice modal, and the delivery contract below all live
 // in notifier (created in init(), see src/ui/notification-center.ts) (#787
 // phase 4). `notifier.toast` is the pure DOM enqueue (no log side effect) --
-// exactly today's enqueueToast, which is why focusNotificationTarget and
-// focusPirateTarget call it directly instead of showNotification below.
+// exactly today's enqueueToast, which is why the extracted `focusNotificationTarget`/
+// `focusPirateTarget` helpers (#787 phase 10b-f, src/app/cross-cutting-helpers.ts)
+// call it directly instead of going through `showNotification` below.
 
+// Thin wrapper (not extracted, see cross-cutting-helpers.ts's module docblock
+// for why): delegates to the pure `notifyPlayer`, but stays a hoisted
+// `main.ts` function so its ~8 controller consumers' `showNotification` dep
+// keeps working as a bare reference, unchanged by this phase.
 function showNotification(
   message: string,
   type: NotificationEntry['type'] = 'info',
   target?: NotificationEntry['target'],
 ): void {
-  notifier.toast(message, type, target);
-  if (session.getState()) {
-    appendNotification(session.getState(), session.getState().currentPlayer, {
-      message,
-      type,
-      turn: session.getState().turn,
-      target,
-    });
-  }
-}
-
-// The single delivery contract for game-consequence notifications (#551):
-// logs to the recipient civ always, toasts only when that civ is the active
-// unsuppressed viewer, and queues to pendingEvents (hot seat only) otherwise
-// -- the turn-handoff summary drains that queue. All existing router call
-// sites keep using this name unchanged. Thunked (not `= notifier.deliver`)
-// because `notifier` is not assigned until init() runs, after every one of
-// these module-scope const/function declarations.
-const appendToCivLog: NotificationSink = (...args) => notifier.deliver(...args);
-
-function focusNotificationTarget(target: NotificationEntry['target']): void {
-  if (!target) return;
-  renderLoop.camera.centerOn(target.coord);
-  const visibility = currentCiv().visibility;
-  const isCurrentlyVisible = visibility ? getVisibility(visibility, target.coord) === 'visible' : false;
-  notifier.toast(formatNotificationTargetFocusMessage(target, isCurrentlyVisible), 'info');
-}
-
-function focusPirateTarget(target: PirateFocusTarget): void {
-  const coord = target.kind === 'region' ? target.center : target.coord;
-  renderLoop.camera.centerOn(coord);
-  notifier.toast(target.label, 'info');
-}
-
-function applyPirateActionResult(result: PirateActionResult, successMessage: string): void {
-  if (!result.success) {
-    showNotification(result.reason ?? 'That pirate action is no longer available.', 'warning');
-    return;
-  }
-  session.setStateWithoutRefresh(result.state);
-  for (const event of result.events) {
-    if (event.type === 'tribute-paid') {
-      bus.emit('pirate:audio-cue', { cue: 'tribute', factionId: event.factionId, viewerIds: [event.civId] });
-    } else if (event.type === 'contract-accepted') {
-      bus.emit('pirate:audio-cue', { cue: 'contract-accepted', factionId: event.factionId, viewerIds: [event.employerId] });
-    }
-  }
-  renderLoop.setGameState(session.getState());
-  hud.update();
-  showNotification(successMessage, 'success');
+  notifyPlayer(notifier, session, message, type, target);
 }
 
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
@@ -837,7 +756,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
   playerActions.ensurePlayerWarState(defender.owner);
 
   const seed = deterministicCombatSeed(session.getState().gameId, session.getState().turn, attacker.id, defender.id);
-  const attackerBonus = currentCivDef()?.bonusEffect;
+  const attackerBonus = getCurrentCivDef(session)?.bonusEffect;
   // Capture defender position before combat (defender may be removed from state after)
   const defenderPosition = { ...defender.position };
   // Capture route IDs before combat (units may be removed from state after)
@@ -967,6 +886,10 @@ void bootstrap({
   bus,
   presentationContext,
   getState: () => session.getState(),
-  appendToCivLog,
+  // Thunked, not `notifier.deliver` directly -- `notifier` is not assigned
+  // until init() runs, after this module-scope call (#787 phase 10b-f,
+  // formerly the separate `appendToCivLog` const, inlined at its one
+  // consumer).
+  appendToCivLog: (...args) => notifier.deliver(...args),
   gameSession,
 });

--- a/tests/app/cross-cutting-helpers.test.ts
+++ b/tests/app/cross-cutting-helpers.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { createGameSession } from '@/app/game-session';
+import { hexKey } from '@/systems/hex-utils';
+import type { GameState, Unit } from '@/core/types';
+import {
+  getCurrentCiv,
+  getCurrentCivDef,
+  clearUnloadState,
+  prefersReducedMotion,
+  scanBeastSightings,
+  focusNotificationTarget,
+  focusPirateTarget,
+  notifyPlayer,
+  applyPirateActionResult,
+} from '@/app/cross-cutting-helpers';
+
+function makeFixture(seed = 'cross-cutting-helpers'): GameState {
+  const state = createNewGame(undefined, seed, 'small');
+  state.currentPlayer = 'player';
+  return state;
+}
+
+function stateWithLair(): GameState {
+  const state = createNewGame('rome', 'cross-cutting-beast-seed', 'small');
+  state.currentPlayer = 'player';
+  state.beasts = {
+    mode: 'wild',
+    lairs: {
+      'lair-giant_boar': {
+        id: 'lair-giant_boar', beastId: 'giant_boar', position: { q: 10, r: 10 },
+        status: 'awake', strength: 0, unitIds: ['beast-1'],
+      },
+    },
+    sightingsByCiv: {},
+  };
+  state.units['beast-1'] = {
+    id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 },
+    movementPointsLeft: 2, health: 100, experience: 0,
+    hasMoved: false, hasActed: false, isResting: false,
+  } as Unit;
+  return state;
+}
+
+describe('getCurrentCiv', () => {
+  it('reads the civ for state.currentPlayer, not a hardcoded id', () => {
+    const state = makeFixture();
+    const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+    state.currentPlayer = aiCivId;
+    const session = createGameSession(state);
+
+    expect(getCurrentCiv(session)).toBe(state.civilizations[aiCivId]);
+  });
+});
+
+describe('getCurrentCivDef', () => {
+  it('returns undefined for a civType with no matching definition', () => {
+    const state = makeFixture();
+    state.civilizations.player.civType = 'generic';
+    const session = createGameSession(state);
+
+    expect(getCurrentCivDef(session)).toBeUndefined();
+  });
+
+  it('resolves a real civ definition (with bonusEffect) for a known civType', () => {
+    const state = makeFixture();
+    state.civilizations.player.civType = 'egypt';
+    const session = createGameSession(state);
+
+    const def = getCurrentCivDef(session);
+    expect(def?.id).toBe('egypt');
+    expect(def?.bonusEffect).toBeDefined();
+  });
+});
+
+describe('clearUnloadState', () => {
+  it('clears a pending unload intent', () => {
+    const setPendingIntent = vi.fn();
+    const selection = {
+      getPendingIntent: vi.fn(() => ({
+        kind: 'unload' as const, transportId: 'transport-1', cargoUnitId: 'cargo-1', range: [],
+      })),
+      setPendingIntent,
+    };
+
+    clearUnloadState(selection);
+
+    expect(setPendingIntent).toHaveBeenCalledWith({ kind: 'none' });
+  });
+
+  it('leaves a non-unload pending intent untouched (e.g. air mission, journey, city-capture choice)', () => {
+    const setPendingIntent = vi.fn();
+    const selection = {
+      getPendingIntent: vi.fn(() => ({ kind: 'air-mission' as const, unitId: 'unit-1', mission: 'strike' as const })),
+      setPendingIntent,
+    };
+
+    clearUnloadState(selection);
+
+    expect(setPendingIntent).not.toHaveBeenCalled();
+  });
+});
+
+describe('prefersReducedMotion', () => {
+  it('returns true when matchMedia reports the reduced-motion query matches', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: true }),
+    });
+
+    expect(prefersReducedMotion()).toBe(true);
+  });
+
+  it('returns false when matchMedia reports no match', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+describe('scanBeastSightings', () => {
+  it('does nothing when the current civ has no visibility tiles yet', () => {
+    const state = stateWithLair();
+    const session = createGameSession(state);
+    const bus = new EventBus();
+    const emit = vi.spyOn(bus, 'emit');
+
+    scanBeastSightings(session, bus);
+
+    expect(session.getState().beasts!.sightingsByCiv.player ?? []).toEqual([]);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('records a real new sighting and emits beast:sighted when the beast tile is visible', () => {
+    const state = stateWithLair();
+    state.civilizations.player.visibility = { tiles: { [hexKey({ q: 10, r: 10 })]: 'visible' } };
+    const session = createGameSession(state);
+    const bus = new EventBus();
+    const emit = vi.spyOn(bus, 'emit');
+
+    scanBeastSightings(session, bus);
+
+    expect(session.getState().beasts!.sightingsByCiv.player).toEqual(['giant_boar']);
+    expect(emit).toHaveBeenCalledWith('beast:sighted', { beastId: 'giant_boar', civId: 'player' });
+  });
+
+  it('does not re-emit for a beast already recorded as sighted (steady-state scan)', () => {
+    const state = stateWithLair();
+    state.civilizations.player.visibility = { tiles: { [hexKey({ q: 10, r: 10 })]: 'visible' } };
+    state.beasts!.sightingsByCiv.player = ['giant_boar'];
+    const session = createGameSession(state);
+    const bus = new EventBus();
+    const emit = vi.spyOn(bus, 'emit');
+
+    scanBeastSightings(session, bus);
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+describe('focusNotificationTarget', () => {
+  it('does nothing when there is no target', () => {
+    const state = makeFixture();
+    const session = createGameSession(state);
+    const renderLoop = { camera: { centerOn: vi.fn() } };
+    const notifier = { toast: vi.fn() };
+
+    focusNotificationTarget(renderLoop, notifier, session, undefined);
+
+    expect(renderLoop.camera.centerOn).not.toHaveBeenCalled();
+    expect(notifier.toast).not.toHaveBeenCalled();
+  });
+
+  it('centers the camera and reports a currently-visible target as focused', () => {
+    const state = makeFixture();
+    const coord = { q: 3, r: 4 };
+    state.civilizations.player.visibility = { tiles: { [hexKey(coord)]: 'visible' } };
+    const session = createGameSession(state);
+    const renderLoop = { camera: { centerOn: vi.fn() } };
+    const notifier = { toast: vi.fn() };
+    const target = { kind: 'map' as const, coord, label: 'Ancient Ruins' };
+
+    focusNotificationTarget(renderLoop, notifier, session, target);
+
+    expect(renderLoop.camera.centerOn).toHaveBeenCalledWith(coord);
+    expect(notifier.toast).toHaveBeenCalledWith('Focused Ancient Ruins.', 'info');
+  });
+
+  it('reports a no-longer-visible target as last spotted here', () => {
+    const state = makeFixture();
+    const coord = { q: 3, r: 4 };
+    const session = createGameSession(state);
+    const renderLoop = { camera: { centerOn: vi.fn() } };
+    const notifier = { toast: vi.fn() };
+    const target = { kind: 'map' as const, coord, label: 'Ancient Ruins' };
+
+    focusNotificationTarget(renderLoop, notifier, session, target);
+
+    expect(notifier.toast).toHaveBeenCalledWith('Ancient Ruins was last spotted here.', 'info');
+  });
+});
+
+describe('focusPirateTarget', () => {
+  it('centers on a headquarters target coord', () => {
+    const renderLoop = { camera: { centerOn: vi.fn() } };
+    const notifier = { toast: vi.fn() };
+    const coord = { q: 5, r: 5 };
+
+    focusPirateTarget(renderLoop, notifier, { kind: 'headquarters', coord, current: true, label: 'Pirate Cove' });
+
+    expect(renderLoop.camera.centerOn).toHaveBeenCalledWith(coord);
+    expect(notifier.toast).toHaveBeenCalledWith('Pirate Cove', 'info');
+  });
+
+  it('centers on a region target center, not a coord field', () => {
+    const renderLoop = { camera: { centerOn: vi.fn() } };
+    const notifier = { toast: vi.fn() };
+    const center = { q: 7, r: 8 };
+
+    focusPirateTarget(renderLoop, notifier, { kind: 'region', center, radius: 2, label: 'Contested Waters' });
+
+    expect(renderLoop.camera.centerOn).toHaveBeenCalledWith(center);
+    expect(notifier.toast).toHaveBeenCalledWith('Contested Waters', 'info');
+  });
+});
+
+describe('notifyPlayer', () => {
+  it('toasts and appends a persistent log entry for the current player', () => {
+    const state = makeFixture();
+    const session = createGameSession(state);
+    const notifier = { toast: vi.fn() };
+
+    notifyPlayer(notifier, session, 'Something happened', 'warning');
+
+    expect(notifier.toast).toHaveBeenCalledWith('Something happened', 'warning', undefined);
+    const log = session.getState().notificationLog!.player;
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ message: 'Something happened', type: 'warning', turn: state.turn });
+  });
+
+  it('defaults to type info and threads a target through to both the toast and the log', () => {
+    const state = makeFixture();
+    const session = createGameSession(state);
+    const notifier = { toast: vi.fn() };
+    const target = { kind: 'map' as const, coord: { q: 1, r: 1 }, label: 'Somewhere' };
+
+    notifyPlayer(notifier, session, 'Default type', undefined, target);
+
+    expect(notifier.toast).toHaveBeenCalledWith('Default type', 'info', target);
+    expect(session.getState().notificationLog!.player[0]).toMatchObject({ type: 'info', target });
+  });
+});
+
+describe('applyPirateActionResult', () => {
+  function makeDeps(state: GameState) {
+    return {
+      session: createGameSession(state),
+      bus: new EventBus(),
+      renderLoop: { setGameState: vi.fn() },
+      updateHUD: vi.fn(),
+      showNotification: vi.fn(),
+    };
+  }
+
+  it('shows the failure reason and does not touch state on failure', () => {
+    const state = makeFixture();
+    const deps = makeDeps(state);
+
+    applyPirateActionResult(deps, { success: false, state, reason: 'Not enough gold.', events: [] }, 'Should not show');
+
+    expect(deps.showNotification).toHaveBeenCalledWith('Not enough gold.', 'warning');
+    expect(deps.renderLoop.setGameState).not.toHaveBeenCalled();
+    expect(deps.updateHUD).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a generic failure message when reason is null', () => {
+    const state = makeFixture();
+    const deps = makeDeps(state);
+
+    applyPirateActionResult(deps, { success: false, state, reason: null, events: [] }, 'Should not show');
+
+    expect(deps.showNotification).toHaveBeenCalledWith('That pirate action is no longer available.', 'warning');
+  });
+
+  it('commits the new state, refreshes renderer/HUD, and emits a tribute audio cue on success', () => {
+    const state = makeFixture();
+    const deps = makeDeps(state);
+    const nextState = { ...state, turn: state.turn + 1 };
+    const emit = vi.spyOn(deps.bus, 'emit');
+
+    applyPirateActionResult(deps, {
+      success: true,
+      state: nextState,
+      reason: null,
+      events: [{ type: 'tribute-paid', factionId: 'faction-1', civId: 'player', cost: 50 }],
+    }, 'Pirate tribute paid.');
+
+    expect(deps.session.getState()).toBe(nextState);
+    expect(deps.renderLoop.setGameState).toHaveBeenCalledWith(nextState);
+    expect(deps.updateHUD).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('pirate:audio-cue', { cue: 'tribute', factionId: 'faction-1', viewerIds: ['player'] });
+    expect(deps.showNotification).toHaveBeenCalledWith('Pirate tribute paid.', 'success');
+  });
+
+  it('emits a contract-accepted audio cue for the employer, not the target', () => {
+    const state = makeFixture();
+    const deps = makeDeps(state);
+    const emit = vi.spyOn(deps.bus, 'emit');
+
+    applyPirateActionResult(deps, {
+      success: true,
+      state,
+      reason: null,
+      events: [{ type: 'contract-accepted', factionId: 'faction-1', employerId: 'player', targetId: 'ai-1', cost: 100 }],
+    }, 'Pirate flotilla hired.');
+
+    expect(emit).toHaveBeenCalledWith('pirate:audio-cue', { cue: 'contract-accepted', factionId: 'faction-1', viewerIds: ['player'] });
+  });
+});


### PR DESCRIPTION
## Summary

Part of the #787 composition-root decomposition arc — phase 10b-f. Extracts 8 of the 12 cross-cutting `main.ts`-local helpers named in the plan doc's inventory (`currentCiv` → `getCurrentCiv`, `currentCivDef` → `getCurrentCivDef`, `clearUnloadState`, `prefersReducedMotion`, `scanBeastSightings`, `focusNotificationTarget`, `focusPirateTarget`, `applyPirateActionResult`) into a new pure module, `src/app/cross-cutting-helpers.ts`. `showNotification`'s body is also extracted as `notifyPlayer`, though `showNotification` itself stays a thin `main.ts` wrapper (see below).

- Each extracted helper takes its dependencies (`session`, `bus`, `renderLoop`, `notifier`, `selection`) as explicit parameters instead of closing over module-scope bindings, matching the pattern the plan doc anticipated for this phase.
- **Every existing controller's `Deps` interface is untouched.** `main.ts` only rewires the *value* it passes for each dep — from a bare hoisted-function reference to an inline arrow calling the new pure function (e.g. `currentCiv: () => getCurrentCiv(session)`). This kept the blast radius to `main.ts` + one new file, instead of also touching all six already-shipped 10b-a…10b-e controller files.
- Net effect: `main.ts` shrinks by 77 lines (-129/+52).

### Deliberate non-extractions (documented in the new module's docblock)

Four of the twelve inventoried helpers stay in `main.ts`, each with a recorded reason:
- `setBlockingOverlay` — already a 3-line wrapper around `host.setBlockingOverlay`; extracting it would only trade the wrapper for a `host` dep threaded into two more controllers.
- `showNotification` — stays a thin wrapper delegating to the new `notifyPlayer`; its consumer list (every controller + most remaining `main.ts` functions) made widening every call site to take `notifier` directly a worse trade than keeping one hoisted name.
- `maybeShowPendingHoardChoice` — self-recursive, tightly coupled to `hud`/`uiLayer`/`session`/`bus` together; didn't read as a real simplification.
- `appendToCivLog` — had exactly one consumer (the `bootstrap({...})` call) and was inlined there instead of modularized.

## Verification

- `yarn build` (full `tsc` type-check via Vite) passes clean.
- New `tests/app/cross-cutting-helpers.test.ts`: 21 tests directly exercising the extracted pure functions with real system state (real `GameSession`, real beast-sighting/notification-log/pirate-event logic), not mocks of the logic under test.
- Exhaustive diff review against a pre-phase snapshot of `main.ts` confirms every deleted function body's logic was preserved verbatim in the new module, and every construction call site was correctly rewired.
- Dead-import hygiene check: removed 9 imports that became unused once their sole consumer function moved out of `main.ts` (`resolveCivDefinition`, `getVisibility`, `formatNotificationTargetFocusMessage`, `isBeastConcealedFrom`, `recordBeastSightings`, `appendNotification`, `NotificationSink`, `PirateFocusTarget`, `PirateActionResult`); the pre-existing frozen baseline of 13 unrelated dead imports is unchanged.
- Local pre-push gate (`yarn test:fast` + `yarn build`) passed clean on push: 481/481 test files, 7835/7838 tests (3 skipped by design), 0 failures.
- A full non-fast `yarn test` run earlier in the session hit 5-6 test-file timeouts; each was individually re-run in isolation and passed (`civ-registry.test.ts`, `religion-notification-routing.test.ts`, `pirate-behavior.test.ts`), or is a pre-existing slow-tier file already documented as contention-sensitive on this shared dev machine (`tech-panel.test.ts`, `pacing-production-budget.test.ts`, `world-pressure-fairness.test.ts`) — none reference any file this PR touches.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` (fast tier, via pre-push gate) passes: 481/481 files, 0 failures
- [x] New unit tests for every extracted function in `cross-cutting-helpers.ts`
- [x] Manual diff review confirming zero behavioral drift from the pre-phase snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)