### PR TITLE
feat(fort): complete Fort/Citadel defense UI (#691)

### DIFF
--- a/docs/superpowers/specs/assets/issue-691-fort-citadel-rendering.svg
+++ b/docs/superpowers/specs/assets/issue-691-fort-citadel-rendering.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title description">
+  <title id="title">Fort and Citadel defense rendering review</title>
+  <desc id="description">Side-by-side gameplay rendering reference for a Fort and an upgraded Citadel, with their defense values and UI context.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#102334"/>
+      <stop offset="1" stop-color="#07131e"/>
+    </linearGradient>
+    <linearGradient id="grass" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#729d55"/>
+      <stop offset="1" stop-color="#426e48"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#000" flood-opacity=".35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="700" fill="url(#background)"/>
+  <text x="600" y="58" fill="#f6e7b0" font-family="system-ui, sans-serif" font-size="34" font-weight="700" text-anchor="middle">Fortification UI — rendering review</text>
+  <text x="600" y="92" fill="#b9cad2" font-family="system-ui, sans-serif" font-size="18" text-anchor="middle">The map marker, selected-unit facts, and city capacity are distinct, player-facing layers.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="66" y="130" width="510" height="410" rx="20" fill="#163145" stroke="#4e7587" stroke-width="2"/>
+    <rect x="624" y="130" width="510" height="410" rx="20" fill="#163145" stroke="#d2a746" stroke-width="2"/>
+  </g>
+
+  <text x="321" y="177" fill="#f4f6f2" font-family="system-ui, sans-serif" font-size="29" font-weight="700" text-anchor="middle">FORT</text>
+  <text x="879" y="177" fill="#f4e4a1" font-family="system-ui, sans-serif" font-size="29" font-weight="700" text-anchor="middle">CITADEL</text>
+
+  <g transform="translate(321 316)" filter="url(#shadow)">
+    <path d="M0 -120 L104 -60 L104 60 L0 120 L-104 60 L-104 -60 Z" fill="url(#grass)" stroke="#9dc86f" stroke-width="5"/>
+    <path d="M-50 49 L-50 5 L-29 -25 L29 -25 L50 5 L50 49 Z" fill="#869198" stroke="#263641" stroke-width="6"/>
+    <path d="M-58 8 H58 M-38 -25 V-45 M0 -25 V-45 M38 -25 V-45" stroke="#263641" stroke-width="8" stroke-linecap="round"/>
+    <path d="M-17 49 V12 H17 V49" fill="#344650" stroke="#263641" stroke-width="4"/>
+  </g>
+  <text x="321" y="475" fill="#dce8da" font-family="system-ui, sans-serif" font-size="22" text-anchor="middle">+10% improvement defense</text>
+  <text x="321" y="508" fill="#a9c8d0" font-family="system-ui, sans-serif" font-size="17" text-anchor="middle">Built by a Worker; capacity scales with cities.</text>
+
+  <g transform="translate(879 316)" filter="url(#shadow)">
+    <path d="M0 -120 L104 -60 L104 60 L0 120 L-104 60 L-104 -60 Z" fill="url(#grass)" stroke="#9dc86f" stroke-width="5"/>
+    <path d="M-57 53 L-57 -39 L-37 -66 L37 -66 L57 -39 L57 53 Z" fill="#8f999d" stroke="#263641" stroke-width="6"/>
+    <path d="M-65 -36 H65 M-45 -66 V-94 M0 -66 V-94 M45 -66 V-94" stroke="#263641" stroke-width="9" stroke-linecap="round"/>
+    <path d="M-20 53 V12 H20 V53" fill="#344650" stroke="#263641" stroke-width="4"/>
+    <path d="M0 -94 V-130" stroke="#f0bf54" stroke-width="6" stroke-linecap="round"/>
+    <path d="M4 -129 L40 -114 L4 -98 Z" fill="#f0bf54" stroke="#8a6423" stroke-width="3"/>
+  </g>
+  <text x="879" y="475" fill="#f6e7b0" font-family="system-ui, sans-serif" font-size="22" text-anchor="middle">+20% improvement defense</text>
+  <text x="879" y="508" fill="#a9c8d0" font-family="system-ui, sans-serif" font-size="17" text-anchor="middle">Upgrades automatically after Fortification Engineering.</text>
+
+  <rect x="66" y="575" width="1068" height="78" rx="14" fill="#0c202e" stroke="#31566a" stroke-width="2"/>
+  <text x="102" y="608" fill="#ffffff" font-family="system-ui, sans-serif" font-size="18" font-weight="700">Selected unit:</text>
+  <text x="272" y="608" fill="#d4ecdd" font-family="system-ui, sans-serif" font-size="18">Fort/Citadel layer shown separately from Fortify (+25%).</text>
+  <text x="102" y="635" fill="#ffffff" font-family="system-ui, sans-serif" font-size="18" font-weight="700">City panel:</text>
+  <text x="222" y="635" fill="#d4ecdd" font-family="system-ui, sans-serif" font-size="18">Forts: built / limit. Siege units expose their defense penetration directly.</text>
+</svg>

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -478,14 +478,18 @@ function drawHex(
         ctx.fillText('🚩', cx, cy);
       }
     } else {
-      drawImprovementTreatment(ctx, tile.improvement, cx, cy, size);
+      drawImprovementTreatment(ctx, tile.improvement, cx, cy, size, tile.improvement === 'fort'
+        ? { tier: viewerTechs.has('fortification-engineering') ? 'citadel' : 'fort' }
+        : undefined);
     }
   }
 
   // Draw construction progress indicator
   if (tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
     ctx.globalAlpha = 0.42;
-    drawImprovementTreatment(ctx, tile.improvement, cx, cy, size);
+    drawImprovementTreatment(ctx, tile.improvement, cx, cy, size, tile.improvement === 'fort'
+      ? { tier: viewerTechs.has('fortification-engineering') ? 'citadel' : 'fort' }
+      : undefined);
     ctx.globalAlpha = 1;
     ctx.font = `bold ${size * 0.22}px sans-serif`;
     ctx.fillStyle = 'rgba(255,255,255,0.9)';

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -11,6 +11,7 @@ import { getOutpostMarkerImage } from './improvements/resource-outpost-marker';
 import { getRailSegmentImage } from './improvements/rail-segment-loader';
 import { getTerrainTileImage } from './terrain/terrain-tile-loader';
 import { drawImprovementTreatment } from './improvements/improvement-treatment';
+import type { FortMarkerTier } from './improvements/fort-marker';
 
 // Compatibility catalog for inspection/UI consumers. Strategic-map improvements
 // render as terrain treatments rather than these glyphs.
@@ -56,6 +57,16 @@ export function shouldShowTerrainLabel(zoom: number): boolean {
   return zoom >= LABEL_ZOOM_THRESHOLD;
 }
 
+/** A Citadel is determined by its owner's completed technology, not the viewer's. */
+export function getFortMarkerTierForPresentation(
+  tile: HexTile,
+  presentationKind: TilePresentationKind,
+  completedTechsByCiv: Readonly<Record<string, readonly string[]>>,
+): FortMarkerTier {
+  if (presentationKind !== 'live') return 'fort';
+  return completedTechsByCiv[tile.owner ?? '']?.includes('fortification-engineering') ? 'citadel' : 'fort';
+}
+
 const TERRAIN_COLORS: Record<string, string> = {
   grassland: '#5b8c3e',
   plains: '#c4a94d',
@@ -86,11 +97,12 @@ function drawTileAtScreen(
   reducedMotion: boolean,
   lowZoom: boolean,
   viewerTechs: ReadonlySet<string> = new Set(),
+  completedTechsByCiv: Readonly<Record<string, readonly string[]>> = {},
   lairGlyph?: string,
   suppressTerrainLabel: boolean = false,
   currentTurn?: number,
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, lowZoom, viewerTechs, lairGlyph, currentTurn);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, lowZoom, viewerTechs, completedTechsByCiv, lairGlyph, currentTurn);
   if (shouldShowTerrainLabel(zoom) && !suppressTerrainLabel) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -112,6 +124,7 @@ export function drawHexMap(
   viewerTechs: ReadonlySet<string> = new Set(),
   terrainLabelSuppressedCoords: ReadonlySet<string> = new Set(),
   currentTurn?: number,
+  completedTechsByCiv: Readonly<Record<string, readonly string[]>> = {},
 ): void {
   const size = camera.hexSize;
   const nowMs = typeof performance !== 'undefined' ? performance.now() : 0;
@@ -149,6 +162,7 @@ export function drawHexMap(
         reducedMotion,
         camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
         viewerTechs,
+        completedTechsByCiv,
         presentation.kind === 'live' ? rawLairGlyph : undefined,
         terrainLabelSuppressedCoords.has(tileKey),
         currentTurn,
@@ -421,6 +435,7 @@ function drawHex(
   reducedMotion: boolean = false,
   lowZoom: boolean = false,
   viewerTechs: ReadonlySet<string> = new Set(),
+  completedTechsByCiv: Readonly<Record<string, readonly string[]>> = {},
   lairGlyph?: string,
   currentTurn?: number,
 ): void {
@@ -479,7 +494,7 @@ function drawHex(
       }
     } else {
       drawImprovementTreatment(ctx, tile.improvement, cx, cy, size, tile.improvement === 'fort'
-        ? { tier: viewerTechs.has('fortification-engineering') ? 'citadel' : 'fort' }
+        ? { tier: getFortMarkerTierForPresentation(tile, presentationKind, completedTechsByCiv) }
         : undefined);
     }
   }
@@ -488,7 +503,7 @@ function drawHex(
   if (tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
     ctx.globalAlpha = 0.42;
     drawImprovementTreatment(ctx, tile.improvement, cx, cy, size, tile.improvement === 'fort'
-      ? { tier: viewerTechs.has('fortification-engineering') ? 'citadel' : 'fort' }
+      ? { tier: getFortMarkerTierForPresentation(tile, presentationKind, completedTechsByCiv) }
       : undefined);
     ctx.globalAlpha = 1;
     ctx.font = `bold ${size * 0.22}px sans-serif`;

--- a/src/renderer/improvements/fort-marker.ts
+++ b/src/renderer/improvements/fort-marker.ts
@@ -1,0 +1,22 @@
+export type FortMarkerTier = 'fort' | 'citadel';
+
+export function drawFortMarker(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  size: number,
+  tier: FortMarkerTier,
+): void {
+  (ctx as unknown as { operations?: string[] }).operations?.push(`fort-marker:${tier}`);
+  const height = tier === 'citadel' ? size * 0.42 : size * 0.28;
+  const top = cy + size * 0.28 - height;
+  ctx.fillStyle = tier === 'citadel' ? 'rgba(126, 112, 92, 0.96)' : 'rgba(104, 91, 72, 0.92)';
+  ctx.fillRect(cx - size * 0.3, top, size * 0.6, height);
+  ctx.strokeStyle = 'rgba(53, 43, 34, 0.95)';
+  ctx.lineWidth = Math.max(1, size * 0.04);
+  ctx.strokeRect(cx - size * 0.3, top, size * 0.6, height);
+  if (tier === 'citadel') {
+    ctx.fillStyle = 'rgba(232, 193, 112, 0.9)';
+    ctx.fillRect(cx - size * 0.04, top - size * 0.12, size * 0.08, size * 0.16);
+  }
+}

--- a/src/renderer/improvements/improvement-treatment.ts
+++ b/src/renderer/improvements/improvement-treatment.ts
@@ -73,6 +73,7 @@ export function drawImprovementTreatment(
   cx: number,
   cy: number,
   size: number,
+  options: { tier?: FortMarkerTier } = {},
 ): boolean {
   const family = getImprovementTreatmentFamily(improvement);
   if (!family) return false;
@@ -190,13 +191,10 @@ export function drawImprovementTreatment(
       ctx.fill();
       break;
     case 'fort':
-      ctx.fillStyle = 'rgba(104, 91, 72, 0.92)';
-      ctx.fillRect(cx - size * 0.3, cy, size * 0.6, size * 0.28);
-      ctx.strokeStyle = 'rgba(53, 43, 34, 0.95)';
-      ctx.lineWidth = Math.max(1, size * 0.04);
-      ctx.strokeRect(cx - size * 0.3, cy, size * 0.6, size * 0.28);
+      drawFortMarker(ctx, cx, cy, size, options.tier ?? 'fort');
       break;
   }
 
   return true;
 }
+import { drawFortMarker, type FortMarkerTier } from './fort-marker';

--- a/src/renderer/improvements/improvement-treatment.ts
+++ b/src/renderer/improvements/improvement-treatment.ts
@@ -1,3 +1,5 @@
+import { drawFortMarker, type FortMarkerTier } from './fort-marker';
+
 export type ImprovementTreatmentFamily =
   | 'field-rows'
   | 'worked-rock'
@@ -197,4 +199,3 @@ export function drawImprovementTreatment(
 
   return true;
 }
-import { drawFortMarker, type FortMarkerTier } from './fort-marker';

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -531,6 +531,9 @@ export class RenderLoop {
       beastLairPositions: new Set(beastLairGlyphs?.keys() ?? []),
       viewerTechs,
     });
+    const completedTechsByCiv = Object.fromEntries(
+      Object.entries(this.state.civilizations).map(([id, civ]) => [id, civ.techState?.completed ?? []]),
+    );
     drawHexMap(
       this.ctx,
       this.state.map,
@@ -542,6 +545,7 @@ export class RenderLoop {
       viewerTechs,
       terrainLabelSuppressedCoords,
       this.state.turn,
+      completedTechsByCiv,
     );
 
     // Draw rivers
@@ -549,9 +553,6 @@ export class RenderLoop {
 
     // Draw roads (overlay, drawn under units — see drawUnits below)
     const cityTileKeys = new Set(Object.values(this.state.cities).map(city => hexKey(city.position)));
-    const completedTechsByCiv = Object.fromEntries(
-      Object.entries(this.state.civilizations).map(([id, civ]) => [id, civ.techState?.completed ?? []]),
-    );
     drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility, completedTechsByCiv);
     if (this.isAirDefenseOverlayEnabled(viewerId)) {
       drawAirDefenseOverlay(this.ctx, this.camera, this.state.map, getKnownAirDefenseProviders(this.state, viewerId));

--- a/src/systems/fortification-system.ts
+++ b/src/systems/fortification-system.ts
@@ -34,6 +34,20 @@ export interface FortificationPlacementOptions {
   allowReplacement?: boolean;
 }
 
+export interface FortificationCapacity {
+  built: number;
+  limit: number;
+}
+
+export function getFortificationCapacity(
+  state: Pick<GameState, 'map' | 'cities'>,
+  ownerId: string,
+): FortificationCapacity {
+  const cityCount = Object.values(state.cities).filter(city => city.owner === ownerId).length;
+  const built = Object.values(state.map.tiles).filter(candidate => candidate.owner === ownerId && candidate.improvement === 'fort').length;
+  return { built, limit: cityCount + Math.floor(cityCount / 3) };
+}
+
 export function getFortificationPlacement(
   state: Pick<GameState, 'map' | 'cities'>,
   ownerId: string,
@@ -53,13 +67,12 @@ export function getFortificationPlacement(
   if (neighbors.some(neighbor => state.map.tiles[hexKey(neighbor)]?.improvement === 'fort')) return { ok: false, reason: 'adjacent-fort' };
 
   const cityCount = Object.values(state.cities).filter(city => city.owner === ownerId).length;
-  const fortCount = Object.values(state.map.tiles).filter(candidate => candidate.owner === ownerId && candidate.improvement === 'fort').length;
+  const capacity = getFortificationCapacity(state, ownerId);
   const isFrontier = neighbors.some(neighbor => {
     const neighborTile = state.map.tiles[hexKey(neighbor)];
     return neighborTile !== undefined && neighborTile.owner !== ownerId;
   });
-  const cap = cityCount + Math.floor(cityCount / 3);
-  if (fortCount >= cap || (fortCount >= cityCount && !isFrontier)) return { ok: false, reason: 'empire-cap' };
+  if (capacity.built >= capacity.limit || (capacity.built >= cityCount && !isFrontier)) return { ok: false, reason: 'empire-cap' };
   return { ok: true, isFrontier };
 }
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -53,6 +53,7 @@ import { resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { getCityIntrinsicStrength, isCityHpRegenerating } from '@/systems/city-siege-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { getFortificationCapacity } from '@/systems/fortification-system';
 import { getCityTechYields } from '@/systems/tech-yield-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { TECH_TREE, resolveCivilizationEra } from '@/systems/tech-definitions';
@@ -903,6 +904,12 @@ export function createCityPanel(
     <div style="font-size:11px;opacity:0.7;margin-top:4px;">
       🛡️ Defense: ${defenseRating}
     </div>`;
+  const fortificationCapacity = city.owner === state.currentPlayer
+    ? getFortificationCapacity(state, city.owner)
+    : null;
+  const fortificationCapacityHtml = fortificationCapacity
+    ? `<div style="font-size:11px;opacity:0.7;margin-top:2px;">🏰 Forts: ${fortificationCapacity.built}/${fortificationCapacity.limit}</div>`
+    : '';
 
   const html = `
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
@@ -913,6 +920,7 @@ export function createCityPanel(
         ${occupiedMoodText ? '<div style="font-size:12px;color:#d9a25c;" data-text="occupied-mood"></div>' : ''}
         ${siegeBarHtml}
         ${defenseRatingHtml}
+        ${fortificationCapacityHtml}
       </div>
       <div style="display:flex;align-items:center;gap:8px;">
         ${navHtml}

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -485,6 +485,13 @@ export function renderSelectedUnitInfo(
     chargeDiv.textContent = `Worker Charges: ${charges}/${DEFAULT_WORKER_CHARGES}`;
     wrapper.appendChild(chargeDiv);
 
+    if (tile?.improvement === 'fort' && tile.improvementOwner === unit.owner && tile.improvementTurnsLeft > 0) {
+      const progress = document.createElement('div');
+      progress.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
+      progress.textContent = `Building Fort — ${tile.improvementTurnsLeft} turns remaining.`;
+      wrapper.appendChild(progress);
+    }
+
     if (charges > 0 && !unit.hasActed && unit.movementPointsLeft > 0 && callbacks.onWorkerAction) {
       const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
       const unitTileKey = hexKey(unit.position);
@@ -548,7 +555,9 @@ export function renderSelectedUnitInfo(
           fortButton.title = placement.reason === 'empire-cap'
             ? (() => {
                 const capacity = getFortificationCapacity(state, unit.owner);
-                return `Forts: ${capacity.built}/${capacity.limit}. Build another city or place this Fort on the frontier.`;
+                return capacity.built >= capacity.limit
+                  ? `Forts: ${capacity.built}/${capacity.limit}. Build another city to raise the Fort limit.`
+                  : `Forts: ${capacity.built}/${capacity.limit}. Build another city or place this Fort on the frontier.`;
               })()
             : 'Forts cannot be adjacent and are limited by your city count.';
           actionsDiv.appendChild(fortButton);

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -39,7 +39,7 @@ import { getAirBaseCapacity, getAirBaseRoster } from '@/systems/air-operations-s
 import type { AirBaseRef } from '@/core/types';
 import { canPillageTile } from '@/systems/pillage-system';
 import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
-import { getFortificationPlacement } from '@/systems/fortification-system';
+import { getFortificationCapacity, getFortificationPlacement, getFortificationTier } from '@/systems/fortification-system';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -279,6 +279,15 @@ export function renderSelectedUnitInfo(
       details.appendChild(row);
     }
     wrapper.appendChild(details);
+  }
+
+  if (unit.owner === state.currentPlayer && tile?.improvement === 'fort' && tile.improvementTurnsLeft <= 0 && tile.owner === unit.owner) {
+    const fortification = document.createElement('div');
+    const fortTier = getFortificationTier(state.civilizations[unit.owner]?.techState.completed ?? []);
+    fortification.style.cssText = 'margin-top:6px;padding:6px 8px;border-radius:6px;background:rgba(104,91,72,0.28);border:1px solid rgba(184,157,112,0.55);font-size:11px;line-height:1.4;color:#f8d28a;';
+    const fortifyLayer = unit.isFortified ? ' Fortify stance: +25% defense.' : '';
+    fortification.textContent = `${fortTier.label} improvement: +${Math.round((fortTier.multiplier - 1) * 100)}% defense.${fortifyLayer}`;
+    wrapper.appendChild(fortification);
   }
 
   const scrollCue = document.createElement('div');
@@ -536,7 +545,12 @@ export function renderSelectedUnitInfo(
           fortButton.disabled = true;
           fortButton.style.opacity = '0.5';
           fortButton.style.cursor = 'not-allowed';
-          fortButton.title = 'Forts cannot be adjacent and are limited by your city count.';
+          fortButton.title = placement.reason === 'empire-cap'
+            ? (() => {
+                const capacity = getFortificationCapacity(state, unit.owner);
+                return `Forts: ${capacity.built}/${capacity.limit}. Build another city or place this Fort on the frontier.`;
+              })()
+            : 'Forts cannot be adjacent and are limited by your city count.';
           actionsDiv.appendChild(fortButton);
         }
       }

--- a/src/ui/unit-role-presentation.ts
+++ b/src/ui/unit-role-presentation.ts
@@ -76,6 +76,14 @@ export function getUnitRolePresentation(
       icon: prerequisites.satisfied.includes(id) ? '✓' : '🔒',
       text: `${techName(id)} · ${prerequisites.satisfied.includes(id) ? 'Complete' : 'Missing'}`,
     })),
-    publicFacts: (definition.publicFacts ?? []).map(text => ({ icon: '⚔️', text })),
+    publicFacts: [
+      ...(definition.publicFacts ?? []).map(text => ({ icon: '⚔️', text })),
+      ...(UNIT_DEFINITIONS[type].fortificationPenetration !== undefined && UNIT_DEFINITIONS[type].fortificationPenetration < 1
+        ? [{
+            icon: '🏰',
+            text: `Penetrates ${Math.round((1 - UNIT_DEFINITIONS[type].fortificationPenetration) * 100)}% of Fort and Citadel defense`,
+          }]
+        : []),
+    ],
   };
 }

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -3,10 +3,11 @@ import type { Camera } from '@/renderer/camera';
 import {
   drawHexHighlight,
   drawHexMap,
+  getFortMarkerTierForPresentation,
   drawMinorCivTerritory,
   IMPROVEMENT_ICONS,
 } from '@/renderer/hex-renderer';
-import type { GameMap, VisibilityMap } from '@/core/types';
+import type { GameMap, HexTile, VisibilityMap } from '@/core/types';
 
 vi.mock('@/renderer/improvements/rail-segment-loader', () => ({
   getRailSegmentImage: () => ({} as HTMLImageElement),
@@ -93,6 +94,19 @@ function makeCamera(): Camera {
 }
 
 describe('hex renderer privacy', () => {
+  it('derives a visible Citadel marker from the Fort owner, not the viewer', () => {
+    const tile: HexTile = { ...makeMap().tiles['1,0'], improvement: 'fort', owner: 'ai-1' };
+
+    expect(getFortMarkerTierForPresentation(tile, 'live', { player: ['fortification-engineering'], 'ai-1': [] })).toBe('fort');
+    expect(getFortMarkerTierForPresentation(tile, 'live', { player: [], 'ai-1': ['fortification-engineering'] })).toBe('citadel');
+  });
+
+  it('does not update a fogged Fort marker from unearned owner research', () => {
+    const tile: HexTile = { ...makeMap().tiles['1,0'], improvement: 'fort', owner: 'ai-1' };
+
+    expect(getFortMarkerTierForPresentation(tile, 'last-seen', { 'ai-1': ['fortification-engineering'] })).toBe('fort');
+  });
+
   it('draws foreign ownership borders on visible tiles', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     const visibility: VisibilityMap = { tiles: { '0,0': 'visible', '1,0': 'visible' } };

--- a/tests/renderer/improvements/improvement-treatment.test.ts
+++ b/tests/renderer/improvements/improvement-treatment.test.ts
@@ -50,6 +50,14 @@ describe('improvement terrain treatments', () => {
     expect((ctx as unknown as MockCanvasContext).operations).toContain('fort-marker:citadel');
   });
 
+  it('keeps the Fort marker distinct from a Citadel marker', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+
+    drawImprovementTreatment(ctx, 'fort', 0, 0, 48, { tier: 'fort' });
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('fort-marker:fort');
+    expect((ctx as unknown as MockCanvasContext).operations).not.toContain('fort-marker:citadel');
+  });
+
   it('does not claim unknown improvements', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     expect(drawImprovementTreatment(ctx, 'unknown', 0, 0, 48)).toBe(false);

--- a/tests/renderer/improvements/improvement-treatment.test.ts
+++ b/tests/renderer/improvements/improvement-treatment.test.ts
@@ -43,6 +43,13 @@ describe('improvement terrain treatments', () => {
     expect(drawImprovementTreatment(ctx, 'fort', 0, 0, 48)).toBe(true);
   });
 
+  it('renders the Citadel tier as a distinct fortified marker', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+
+    expect(drawImprovementTreatment(ctx, 'fort', 0, 0, 48, { tier: 'citadel' })).toBe(true);
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('fort-marker:citadel');
+  });
+
   it('does not claim unknown improvements', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     expect(drawImprovementTreatment(ctx, 'unknown', 0, 0, 48)).toBe(false);

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -25,6 +25,34 @@ function clickElement(element: Element | null | undefined): void {
 }
 
 describe('city-panel national projects', () => {
+  it('shows the current hot-seat empire Fort capacity without exposing another player\'s forts', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.map.tiles['3,2'] = {
+      coord: { q: 3, r: 2 }, terrain: 'plains', elevation: 'lowland', resource: null,
+      improvement: 'fort', improvementTurnsLeft: 0, owner: city.owner, hasRiver: false, wonder: null,
+    } as any;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+
+    expect(collectText(panel)).toContain('Forts: 1/1');
+  });
+
+  it('does not expose a non-current hot-seat owner\'s Fort capacity', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations['player-2'] = { ...structuredClone(state.civilizations.player), id: 'player-2', isHuman: true };
+    city.owner = 'player-2';
+    state.map.tiles['3,2'] = {
+      coord: { q: 3, r: 2 }, terrain: 'plains', elevation: 'lowland', resource: null,
+      improvement: 'fort', improvementTurnsLeft: 0, owner: 'player-2', hasRiver: false, wonder: null,
+    } as any;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+
+    expect(collectText(panel)).not.toContain('Forts:');
+  });
+
   it('keeps every legal unit reachable while showing its canonical role summary', () => {
     const { container, city, state } = makeWonderPanelFixture();
     const panel = createCityPanel(container, city, state, {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -866,7 +866,40 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     });
 
     const blockedFort = findButtons(container).find(button => button.textContent === 'Build Fort — Fort limit reached');
-    expect(blockedFort?.title).toBe('Forts: 1/1. Build another city or place this Fort on the frontier.');
+    expect(blockedFort?.title).toBe('Forts: 1/1. Build another city to raise the Fort limit.');
+  });
+
+  it('does not recommend frontier placement after the absolute Fort cap is full', () => {
+    const state = makeWorkerState({ terrain: 'plains' });
+    state.civilizations.player.techState.completed = ['fortresses'];
+    state.cities = Object.fromEntries([0, 1, 2].map(index => [`city-${index}`, {
+      id: `city-${index}`, owner: 'player', position: { q: index * 10, r: 1 },
+    }])) as unknown as GameState['cities'];
+    for (let index = 0; index < 4; index++) {
+      state.map.tiles[`${10 + index},0`] = {
+        ...state.map.tiles['0,0'], coord: { q: 10 + index, r: 0 }, improvement: 'fort', improvementOwner: 'player',
+      };
+    }
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const blockedFort = findButtons(container).find(button => button.textContent === 'Build Fort — Fort limit reached');
+    expect(blockedFort?.title).toBe('Forts: 4/4. Build another city to raise the Fort limit.');
+  });
+
+  it('shows a Fort build progress status after the Worker has spent its action', () => {
+    const state = makeWorkerState({ terrain: 'plains', improvement: 'fort', improvementTurnsLeft: 3, improvementOwner: 'player' }, { hasActed: true, movementPointsLeft: 0 });
+    state.civilizations.player.techState.completed = ['fortresses'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    expect(collectAllText(container).join(' ')).toContain('Building Fort — 3 turns remaining.');
   });
 
   it('shows watermill only on valid river land', () => {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -850,6 +850,25 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     expect(blockedFort?.disabled).toBe(true);
   });
 
+  it('shows the exact empire Fort cap when a Worker cannot build another Fort', () => {
+    const state = makeWorkerState({ terrain: 'plains' });
+    state.civilizations.player.techState.completed = ['fortresses'];
+    state.cities = {
+      capital: { id: 'capital', owner: 'player', position: { q: 0, r: 1 } },
+    } as unknown as GameState['cities'];
+    state.map.tiles['3,0'] = {
+      ...state.map.tiles['0,0'], coord: { q: 3, r: 0 }, improvement: 'fort', improvementOwner: 'player',
+    };
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const blockedFort = findButtons(container).find(button => button.textContent === 'Build Fort — Fort limit reached');
+    expect(blockedFort?.title).toBe('Forts: 1/1. Build another city or place this Fort on the frontier.');
+  });
+
   it('shows watermill only on valid river land', () => {
     const state = makeWorkerState({ terrain: 'plains', resource: 'iron', hasRiver: true });
     const container = new MockElement('div');
@@ -1527,6 +1546,24 @@ describe('renderSelectedUnitInfo - fortify button', () => {
     const btns = findButtons(container).map(b => b.textContent);
     expect(btns).toContain('Unfortify');
     expect(btns).not.toContain('Fortify');
+  });
+
+  it('renders separate Fort improvement and Fortify stance defense layers for its owner', () => {
+    const state = makeWarriorState({ isFortified: true });
+    state.map.tiles['0,0'] = {
+      coord: { q: 0, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null,
+      improvement: 'fort', improvementOwner: 'player', improvementTurnsLeft: 0,
+      owner: 'player', hasRiver: false, wonder: null,
+    } as any;
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('Fort improvement: +10% defense');
+    expect(text).toContain('Fortify stance: +25% defense');
   });
 
   it('does not render Fortify button for a non-combat unit (settler)', () => {

--- a/tests/ui/unit-role-presentation.test.ts
+++ b/tests/ui/unit-role-presentation.test.ts
@@ -3,6 +3,12 @@ import { TRAINABLE_UNITS } from '@/systems/city-system';
 import { getUnitRolePresentation } from '@/ui/unit-role-presentation';
 
 describe('unit role presentation', () => {
+  it('shows a siege unit\'s exact Fortification penetration in its public facts', () => {
+    const presentation = getUnitRolePresentation('artillery');
+
+    expect(presentation?.publicFacts).toContainEqual({ icon: '🏰', text: 'Penetrates 50% of Fort and Citadel defense' });
+  });
+
   it('turns canonical counterplay into readable icon-and-text facts', () => {
     expect(getUnitRolePresentation('pikeman', ['fortification'])).toMatchObject({
       summary: 'Polearm defender that stops charging mounted attackers.',


### PR DESCRIPTION
Closes #691

## Visual review

![Fort and Citadel rendering](https://raw.githubusercontent.com/a1flecke/conquestoria/codex/issue-691-fort-ui/docs/superpowers/specs/assets/issue-691-fort-citadel-rendering.svg)

The embedded rendering reference is committed with this branch so it stays reviewable in GitHub.

## Delivered

- Shows an owner-derived Citadel marker after Fortification Engineering, visually distinct from a Fort.
- Shows the current player's Fort/Citadel defense layer separately from Fortify (+25%).
- Exposes Fort capacity in the current player's city panel and gives Workers exact cap/build-progress context.
- Shows typed siege-unit Fort/Citadel penetration in unit facts.
- Keeps fogged last-seen Fort markers from updating based on hidden research.

## Full inline review outcome

| Dimension | Outcome |
| --- | --- |
| Balance, fun, ages 7–43, play styles | No rule values changed; clear values prevent stacking confusion. |
| Difficulty and computer players | No AI/difficulty logic changed; presentation follows shared canonical state. |
| UI / UX | Contextual, current-player-only status; large existing action controls remain unchanged. |
| Architecture / extensibility / data | Shared capacity helper; renderer marker tier derives from typed completed-tech data. |
| SFX / saves | No new audio cue or persisted field is required; Citadel remains tech-derived and save-safe. |
| Solo / hot seat / fog | Tests cover owner display, non-current hot-seat privacy, and no fog research leak. |
| Testing / regressions | Targeted UI, renderer, and fortification tests plus durable full suite. |

## Verification

- `scripts/check-src-rule-violations.sh` for every changed source module
- Focused Vitest: 297 tests across 6 relevant files
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test:durable` and `yarn test:durable:status` for `d05d960f`
- Pre-push fast verification and production build