### PR TITLE
refactor(787): finish the composition root -- phase 10b-g

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,43 +1,78 @@
 /**
- * Sequences the three module-scope statements that used to run
- * unconditionally as an import side effect at the bottom of `main.ts`
- * (#787 phase 10): register the 72-registration presentation layer,
- * register minor-civ notification listeners, then initialize the game
- * session.
+ * The composition root (#787 phase 10b-g). `createAppComposition` constructs
+ * every controller `main.ts` used to build at module scope -- `host`,
+ * `ceremonies`, `diplomacyActions`, `panelActions`, `selectionController`,
+ * `turnFlow`, `playerActions`, `mapInteraction`, `hud`, `campaignEntry`,
+ * `gameSession`, `presentationContext`, `panelRegistry`, and `router` -- and
+ * returns the handful of them `main.ts` still needs a direct reference to
+ * (to build its own remaining hoisted functions and the final `bootstrap()`
+ * call below). `bootstrap()` itself is unchanged: it still sequences
+ * presentation registration, minor-civ notification listeners, and
+ * `gameSession.init()`, now against the `presentationContext`/`gameSession`
+ * this file constructs instead of ones built in `main.ts`.
  *
- * **Deviation from this arc's plan doc, documented per
- * `.claude/rules/spec-fidelity.md`:** the plan's Phase 10 sketch describes
- * `bootstrap()` as the full composition root -- constructing `session`,
- * `selection`, `host`, `ceremonies`, `router`, `panelRegistry`, and every
- * sibling controller itself, reducing `main.ts` to about 15 lines. That is
- * not what this file does. `panelRegistry`'s ~15 entries (and therefore
- * `router`, and therefore everything that depends on `router`) reference
- * roughly 35 panel-opener and handler functions that Phase 10's own "Moves"
- * list never assigned anywhere -- see the newly-added Phase 10b in the plan
- * doc, filed when that gap was discovered during this phase's planning.
- * Moving `panelRegistry`/`router`/`host`/`ceremonies`/etc. construction into
- * this file before those ~35 functions have a real home would require
- * threading all of them through as deps unchanged, which is churn without
- * payoff. `main.ts` keeps constructing all of that today, exactly as it did
- * before this phase, and hands `bootstrap()` only the pieces this phase's
- * three new controllers (`GameSessionController`, `HudController`,
- * `CampaignEntryController`) actually need. Phase 10b is the phase that
- * finishes the composition-root move this file's name promises.
+ * `main.ts` keeps: the true externally-supplied primitives (`canvas`,
+ * `uiLayer`, `renderLoop`, `audio`, `bus`, `session`, `selection`,
+ * `userSettingsStore`, `roundPresentationGate`, `advisorSystem`), the
+ * `notifier` `let` binding itself (read/write via `getNotifier`/`setNotifier`
+ * below), and the Phase-13-scoped functions (`foundCityAction`,
+ * `beginPlayerCityAssault`, `executeAttack`, `executeMinorCivConquest`,
+ * `executeUpgrade`, `maybeShowPendingHoardChoice`, `showNotification`) --
+ * passed in here as deps because every controller below already depends on
+ * them, and moving them too would pull Phase 13's own unmerged scope into
+ * this phase.
+ *
+ * `notifier` deliberately stays a `main.ts`-owned `let`, not a binding this
+ * file owns: `showNotification` (main.ts-local) reads it directly, and
+ * `GameSessionController.init()` publishes it back via `setNotifier`, so it
+ * has to be reachable from both files. `getNotifier`/`setNotifier` replace
+ * the bare-`notifier`-closure pattern the pre-move code used when everything
+ * lived in one module scope.
  */
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { AudioSystem } from '@/audio/audio-system';
 import type { EventBus } from '@/core/event-bus';
-import type { GameState } from '@/core/types';
-import type { NotificationSink } from '@/ui/notification-routing';
-import type { GameSessionController } from '@/app/controllers/game-session-controller';
+import type { AdvisorSystem } from '@/ui/advisor-system';
+import type { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import type { GameSession, Notifier, SelectionStore } from '@/app/ports';
+import type { UserSettingsStore } from '@/app/user-settings-store';
+import type { CombatResult, HexCoord, UnitType, CivBonusEffect } from '@/core/types';
+import type { NotificationEntry } from '@/core/notification-log';
+import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
+import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
+import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
+import { createPanelActionsController, type PanelActionsController } from '@/app/controllers/panel-actions-controller';
+import { createPlayerActionController, type PlayerActionController } from '@/app/controllers/player-action-controller';
+import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
+import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
+import { createHudController, type HudController } from '@/app/controllers/hud-controller';
+import { createCampaignEntryController, type CampaignEntryController } from '@/app/controllers/campaign-entry-controller';
+import { createGameSessionController, type GameSessionController } from '@/app/controllers/game-session-controller';
 import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
+import { createPanelHost, type PanelHost } from '@/app/panel-host';
+import { createPanelRouter, type PanelRouter } from '@/app/panel-router';
+import type { PanelContext, PanelRegistry } from '@/app/panel-registry';
+import {
+  getCurrentCiv,
+  getCurrentCivDef,
+  clearUnloadState,
+  prefersReducedMotion,
+  scanBeastSightings,
+  focusNotificationTarget,
+  focusPirateTarget,
+  applyPirateActionResult,
+} from '@/app/cross-cutting-helpers';
 
 export interface AppServices {
   readonly bus: EventBus;
   readonly presentationContext: PresentationContext;
-  readonly getState: () => GameState;
+  readonly getState: () => import('@/core/types').GameState;
   readonly appendToCivLog: NotificationSink;
   readonly gameSession: Pick<GameSessionController, 'init'>;
 }
+
+type NotificationSink = (...args: Parameters<Notifier['deliver']>) => void;
 
 export async function bootstrap(services: AppServices): Promise<void> {
   registerAllPresentation(services.bus, services.presentationContext);
@@ -45,4 +80,480 @@ export async function bootstrap(services: AppServices): Promise<void> {
     appendToCivLog: services.appendToCivLog,
   });
   await services.gameSession.init();
+}
+
+export interface AppCompositionDeps {
+  readonly canvas: HTMLCanvasElement;
+  readonly uiLayer: HTMLDivElement;
+  readonly renderLoop: RenderLoop;
+  readonly audio: AudioSystem;
+  readonly bus: EventBus;
+  readonly roundPresentationGate: RoundPresentationGate;
+  readonly advisorSystem: AdvisorSystem;
+  readonly session: GameSession;
+  readonly selection: SelectionStore;
+  readonly userSettingsStore: UserSettingsStore;
+  readonly getNotifier: () => Notifier;
+  readonly setNotifier: (notifier: Notifier) => void;
+  readonly foundCityAction: () => void;
+  readonly executeUpgrade: (unitId: string, targetType: UnitType) => boolean;
+  readonly executeAttack: (attackerId: string, targetKey: string) => void;
+  readonly executeMinorCivConquest: (unitId: string, target: HexCoord, minorCivId: string, cityId: string) => void;
+  readonly beginPlayerCityAssault: (
+    attackerId: string,
+    cityId: string,
+    attackerBonus?: CivBonusEffect,
+    precedingCombat?: CombatResult,
+    embarkedAssault?: boolean,
+  ) => 'pending' | 'resolved';
+  readonly maybeShowPendingHoardChoice: () => void;
+  readonly showNotification: (
+    message: string,
+    type?: NotificationEntry['type'],
+    target?: NotificationEntry['target'],
+  ) => void;
+}
+
+export interface AppComposition {
+  readonly selectionController: SelectionController;
+  readonly playerActions: PlayerActionController;
+  readonly turnFlow: TurnFlowController;
+  readonly hud: HudController;
+  readonly gameSession: GameSessionController;
+  readonly presentationContext: PresentationContext;
+}
+
+export function createAppComposition(deps: AppCompositionDeps): AppComposition {
+  const {
+    canvas, uiLayer, renderLoop, audio, bus, roundPresentationGate, advisorSystem,
+    session, selection, userSettingsStore, getNotifier, setNotifier,
+    foundCityAction, executeUpgrade, executeAttack, executeMinorCivConquest,
+    beginPlayerCityAssault, maybeShowPendingHoardChoice, showNotification,
+  } = deps;
+
+  /**
+   * Owns the panel DOM layer and the interaction-blocking overlay flag,
+   * replacing `createUiInteractionState()` (#787 phase 5).
+   */
+  const host: PanelHost = createPanelHost(uiLayer);
+
+  /**
+   * `router` and `panelContext` are circular by construction (a panel's
+   * `open(ctx)` reads `ctx.router` to potentially chain-open another panel),
+   * so `panelContext` is built first with `notifier`/`router` behind getters
+   * that resolve to the live bindings once they exist -- the same
+   * deferred-but-eager pattern `notifier` itself already uses in `main.ts`.
+   */
+  let router: PanelRouter;
+  const panelContext: PanelContext = {
+    session,
+    get notifier() { return getNotifier(); },
+    host,
+    selection,
+    get router() { return router; },
+  };
+
+  function setBlockingOverlay(id: string | null): void {
+    host.setBlockingOverlay(id);
+  }
+
+  /**
+   * Owns the wonder-discovery and legendary-completion ceremony queues plus
+   * the move-settle defer flag, replacing three module-scope bindings
+   * (#787 phase 6). Subscribes to `host.onInteractionUnblocked` for the pump
+   * that used to live inside `setBlockingOverlay` above.
+   */
+  const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
+    host,
+    reducedMotion: prefersReducedMotion,
+    requestMapHighlight: (item, reducedMotion) => {
+      renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
+    },
+    playDiscoveryAudio: wonderId => {
+      void audio.playNaturalWonderDiscovery(wonderId);
+    },
+    openAtlas: wonderId => panelActions.openWonderAtlas(wonderId),
+    openCity: cityId => {
+      const city = session.getState().cities[cityId];
+      if (city) panelActions.openCityPanelForCity(city);
+    },
+    openJournal: cityId => {
+      if (session.getState().cities[cityId]) panelActions.openWonderPanelForCityId(cityId);
+    },
+  });
+
+  /**
+   * Owns the diplomacy, minor-civ, and crisis-interaction handlers (#787 phase
+   * 10b-a). `hud` and `selectionController` are wrapped in thin lazily-evaluating
+   * objects, not passed directly -- both are `const`s not assigned until later
+   * in this function (`selectionController` right below this, `hud` further
+   * down), so a direct reference here would capture `undefined` at construction
+   * time. Same deferred-but-eager closure pattern `selectionController` itself
+   * already uses for `updateHUD: () => hud.update()` below. `openDiplomacyPanel`
+   * is `PanelActionsController`'s own function (phase 10b-c), but `panelActions`
+   * is constructed just below `diplomacyActions`, so the same lazy-wrapper
+   * treatment applies here too, not a direct reference.
+   */
+  const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsController({
+    session,
+    bus,
+    renderLoop,
+    uiLayer,
+    showNotification,
+    openDiplomacyPanel: () => panelActions.openDiplomacyPanel(),
+    hud: { update: () => hud.update() },
+    selectionController: { selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts) },
+  });
+
+  /**
+   * Owns every panel opener extracted across #787 phases 10b-b (utility/world-event
+   * panels), 10b-c (unit/network/civ-management panels), and 10b-d (the two
+   * largest panels: `openCityPanelForCity`, `openEspionagePanel`). `hud` and
+   * `selectionController` use the same deferred-but-eager lazy-wrapper pattern
+   * as `diplomacyActions` above, for the same reason (neither is assigned yet
+   * at this point). `diplomacyActions` needs no such wrapper here since it is
+   * constructed just above. `router` DOES need the wrapper -- it is a `let`
+   * not assigned until `createPanelRouter(...)` further down (after
+   * `panelRegistry`, which itself needs this controller's methods) -- same
+   * pattern `turnFlow`'s own `router` dep below already uses. `executeUpgrade`
+   * is a `main.ts`-local Phase-13 function passed in as a dep, so no wrapper
+   * needed for it either. `focusNotificationTarget`/`focusPirateTarget`/
+   * `applyPirateActionResult`/`currentCiv`/`currentCivDef` are inline arrows
+   * calling the pure functions in `src/app/cross-cutting-helpers.ts` (#787
+   * phase 10b-f) -- `getNotifier()` inside those arrows resolves through
+   * `main.ts`'s `notifier` `let`, not assigned until `init()`, same
+   * deferred-but-eager pattern as `router` just below.
+   */
+  const panelActions: PanelActionsController = createPanelActionsController({
+    session,
+    bus,
+    uiLayer,
+    getElementById: id => document.getElementById(id),
+    selection,
+    audio,
+    renderLoop,
+    showNotification,
+    focusNotificationTarget: target => focusNotificationTarget(renderLoop, getNotifier(), session, target),
+    focusPirateTarget: target => focusPirateTarget(renderLoop, getNotifier(), target),
+    applyPirateActionResult: (result, successMessage) => applyPirateActionResult(
+      { session, bus, renderLoop, updateHUD: () => hud.update(), showNotification },
+      result,
+      successMessage,
+    ),
+    currentCiv: () => getCurrentCiv(session),
+    currentCivDef: () => getCurrentCivDef(session),
+    diplomacyActions,
+    executeUpgrade,
+    router: { open: panel => router.open(panel) },
+    hud: { closeDrawer: () => hud.closeDrawer(), update: () => hud.update() },
+    selectionController: {
+      selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts),
+      deselectUnit: () => selectionController.deselectUnit(),
+    },
+  });
+
+  /**
+   * Owns unit selection: `selectUnit`, `deselectUnit`, `selectNextUnit`, and the
+   * animated-move / auto-explore / journey lifecycle around a selected unit
+   * (#787 phase 8c). References `foundCityAction`, a `main.ts`-local Phase-13
+   * function passed in as a dep -- safe to call bare since it's only invoked
+   * during real gameplay, well after this function returns.
+   * `performWorkerAction`/`getUnitTurnFlow`/`restAction`/`ensurePlayerWarState`
+   * are lazy wrappers around `playerActions` (phase 10b-e), constructed after
+   * this controller further down.
+   */
+  const selectionController: SelectionController = createSelectionController({
+    session,
+    selection,
+    renderLoop,
+    bus,
+    uiLayer,
+    host,
+    ceremonies,
+    getInfoPanel: () => document.getElementById('info-panel'),
+    showNotification,
+    updateHUD: () => hud.update(),
+    clearUnloadState: () => clearUnloadState(selection),
+    getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
+    foundCityAction,
+    performWorkerAction: action => playerActions.performWorkerAction(action),
+    performPreach: (unitId, cityId) => playerActions.performPreach(unitId, cityId),
+    restAction: () => playerActions.restAction(),
+    openNetworkIntentPanel: panelActions.openNetworkIntentPanel,
+    openUnitStackPicker: panelActions.openUnitStackPicker,
+    openPirateHeadquartersAssault: panelActions.openPirateHeadquartersAssault,
+    handleEstablishRoute: diplomacyActions.handleEstablishRoute,
+    executeUpgrade,
+    ensurePlayerWarState: targetCivId => playerActions.ensurePlayerWarState(targetCivId),
+    scanBeastSightings: () => scanBeastSightings(session, bus),
+    currentCiv: () => getCurrentCiv(session),
+  });
+
+  /**
+   * Owns turn advancement: `endTurn`, the hot-seat handoff lifecycle, AI-move
+   * replay, difficulty application at handoff, and "entering a viewer's turn"
+   * (#787 phase 9). `router`/`notifier` are wrapped in thin lazily-evaluating
+   * objects, not passed directly -- `router` is a `let` not assigned until
+   * `createPanelRouter(...)` below, and `getNotifier()` resolves through
+   * `main.ts`'s `notifier` `let`, not assigned until `init()` runs. Same
+   * deferred-but-eager pattern as `presentationContext`'s
+   * `get notifier()`/`get router()` getters further down.
+   */
+  const turnFlow: TurnFlowController = createTurnFlowController({
+    session,
+    selection,
+    renderLoop,
+    bus,
+    uiLayer,
+    audio,
+    router: {
+      close: panel => router.close(panel),
+      open: panel => router.open(panel),
+    },
+    roundPresentationGate,
+    ceremonies,
+    notifier: {
+      withHappenedTurn: (turn, fn) => getNotifier().withHappenedTurn(turn, fn),
+    },
+    userSettingsStore,
+    getElementById: id => document.getElementById(id),
+    getNetworkIntentPanel: () => document.querySelector('[aria-label="Network intent"]'),
+    showNotification,
+    updateHUD: () => hud.update(),
+    setBlockingOverlay,
+    currentCiv: () => getCurrentCiv(session),
+    // Lazy wrapper: `playerActions` (10b-e) is constructed after `turnFlow`
+    // (it needs `turnFlow.endTurn` as a direct dep), same deferred-but-eager
+    // reverse forward-reference as `selectionController`'s dep above.
+    getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
+    deselectUnit: selectionController.deselectUnit,
+    selectNextUnit: selectionController.selectNextUnit,
+    scanBeastSightings: () => scanBeastSightings(session, bus),
+    maybeShowPendingHoardChoice,
+    checkAdvisors: () => advisorSystem.check(session.getState()),
+    // `campaignEntry` is declared after `turnFlow` (it needs `turnFlow` itself
+    // as a dep) -- same deferred-but-eager forward reference `router`/`notifier`
+    // already use elsewhere in this function; safe because this closure is not
+    // invoked until real gameplay.
+    showGameModeSelection: () => campaignEntry.showGameModeSelection(),
+    reloadPage: () => window.location.reload(),
+    openCityPanelForCity: panelActions.openCityPanelForCity,
+  });
+
+  /**
+   * Owns the player-unit-action functions `getUnitTurnFlow`, `performWorkerAction`,
+   * `performPreach`, `ensurePlayerWarState`, `restAction`, and
+   * `showEspionageCaptureChoice` (#787 phase 10b-e -- a partial `PlayerActionController`;
+   * Phase 13, not yet merged, will extend this same file with a different
+   * function group in the same domain). Constructed after both `selectionController`
+   * and `turnFlow` so it can take direct references to both -- see the lazy
+   * wrappers those two use above for the reverse direction of this same
+   * three-way forward reference. `getNotifier()` still resolves through
+   * `main.ts`'s `notifier` `let`, not assigned until `init()` runs.
+   */
+  const playerActions: PlayerActionController = createPlayerActionController({
+    session,
+    bus,
+    uiLayer,
+    selection,
+    selectionController,
+    turnFlow,
+    hud: { update: () => hud.update() },
+    renderLoop,
+    showNotification,
+    setBlockingOverlay,
+    currentCiv: () => getCurrentCiv(session),
+    notifier: { choice: (message, actions) => getNotifier().choice(message, actions) },
+  });
+
+  /**
+   * Owns the two map-input entry points, `handleHexTap` and
+   * `handleHexLongPress` (#787 phase 8d). References `main.ts`-local Phase-13
+   * functions (`executeAttack`, `executeMinorCivConquest`, `beginPlayerCityAssault`)
+   * passed in as deps -- safe to call bare since none of them run until real
+   * gameplay. `openCityPanelForCity` is a `panelActions` method (10b-d), not a
+   * hoisted function, but `mapInteraction` is constructed after `panelActions`
+   * so a direct reference still works with no wrapper needed.
+   */
+  const mapInteraction: MapInteractionController = createMapInteractionController({
+    session,
+    selection,
+    selectionController,
+    renderLoop,
+    audio,
+    bus,
+    uiLayer,
+    getElementById: id => document.getElementById(id),
+    showNotification,
+    updateHUD: () => hud.update(),
+    clearUnloadState: () => clearUnloadState(selection),
+    currentCiv: () => getCurrentCiv(session),
+    openPirateWaters: panelActions.openPirateWaters,
+    openUnitStackPicker: panelActions.openUnitStackPicker,
+    openCityPanelForCity: panelActions.openCityPanelForCity,
+    openWonderAtlas: panelActions.openWonderAtlas,
+    executeAttack,
+    executeMinorCivConquest,
+    beginPlayerCityAssault,
+    finalizePendingCityCaptureChoice: turnFlow.finalizePendingCityCaptureChoice,
+  });
+
+  /**
+   * Owns the HUD readout, the treasury drawer, the anti-aircraft-overlay
+   * toggle button, and the map viewport bottom inset (#787 phase 10).
+   */
+  const hud: HudController = createHudController({
+    session,
+    renderLoop,
+    canvas,
+    router: { open: panel => router.open(panel) },
+    getElementById: id => document.getElementById(id),
+    getDrawerMountRoot: () => document.getElementById('game-shell') ?? document.body,
+  });
+
+  // The two refreshes `session.commit()` performs on every state publication.
+  // Registered once, here, rather than repeated as a three-statement discipline
+  // at each write site. Renderer first, matching the order the manual pairs used.
+  // Moved here from module scope alongside `hud`'s own construction (#787
+  // phase 10b-g) -- `hud` didn't exist yet at `main.ts`'s old subscribe site.
+  session.subscribe(next => renderLoop.setGameState(next));
+  session.subscribe(() => hud.update());
+
+  /**
+   * Owns campaign entry: the start/save panel, mode selection, and
+   * `enterCampaign` (#787 phase 10). `startGame` is a forward reference to
+   * `gameSession` (declared `let` just below and assigned immediately after)
+   * -- the same deferred-but-eager pattern `router`/`notifier` already use,
+   * needed because `gameSession` itself depends on `campaignEntry`.
+   */
+  let gameSession: GameSessionController;
+  const campaignEntry: CampaignEntryController = createCampaignEntryController({
+    session,
+    uiLayer,
+    audio,
+    bus,
+    roundPresentationGate,
+    host,
+    turnFlow,
+    userSettingsStore,
+    getElementById: id => document.getElementById(id),
+    showNotification,
+    startGame: () => gameSession.startGame(),
+    reloadPage: () => window.location.reload(),
+  });
+
+  /**
+   * Owns app startup: `init`, `createUI`, `startGame`, and the
+   * `inputInitialized` construct-once guard (#787 phase 10).
+   */
+  gameSession = createGameSessionController({
+    session,
+    selection,
+    renderLoop,
+    audio,
+    bus,
+    canvas,
+    uiLayer,
+    documentRef: document,
+    host,
+    router: {
+      toggle: panel => router.toggle(panel),
+      open: panel => router.open(panel),
+      close: panel => router.close(panel),
+      closeGroup: group => router.closeGroup(group),
+      isOpen: panel => router.isOpen(panel),
+    },
+    roundPresentationGate,
+    advisorSystem,
+    userSettingsStore,
+    turnFlow,
+    mapInteraction,
+    selectionController,
+    hud,
+    campaignEntry,
+    getElementById: id => document.getElementById(id),
+    showNotification,
+    foundCityAction,
+    maybeShowPendingHoardChoice,
+    setNotifier,
+    focusNotificationTarget: target => focusNotificationTarget(renderLoop, getNotifier(), session, target),
+  });
+
+  /**
+   * Shared deps for the domain presentation registrars replacing 72
+   * module-scope `bus.on(...)` registrations (#787 phase 7). `notifier`/`router`
+   * resolve through getters -- the same deferred-but-eager pattern
+   * `panelContext` above already uses -- since both are only assigned once
+   * `init()` runs.
+   */
+  const presentationContext: PresentationContext = {
+    session,
+    get notifier() { return getNotifier(); },
+    get router() { return router; },
+    ceremonies,
+    selection,
+    requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
+    applyCombatVisual: result => renderLoop.applyCombatVisual(result),
+    showEspionageCaptureChoice: (spyId, spyOwner) => playerActions.showEspionageCaptureChoice(spyId, spyOwner),
+    uiLayer,
+    maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
+    isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
+    resetAdvisorMessage: id => advisorSystem.resetMessage(id),
+    checkAdvisors: () => advisorSystem.check(session.getState()),
+    showNotification: (message, type, target) => showNotification(message, type, target),
+  };
+
+  /**
+   * Replaces `togglePanel`'s 288-line `else if` chain (#787 phase 5). Panels
+   * that require a specific target -- a city id, a hex coord -- have no
+   * parameterless "open the current one" call, so their `open` throws; they
+   * still need a registry entry so `closeGroup`/`isOpen`/`close` (all
+   * DOM-derived off `domId`) behave correctly when a 'main' or 'transient'
+   * sweep runs. `openCityPanelForCity`'s and `openWonderPanelForCityId`'s real
+   * entry points both now live in `PanelActionsController` (10b-c, 10b-d).
+   * The territory-inspection panel has no such entry point of
+   * its own -- it opens only as a side effect of `mapInteraction.handleHexLongPress`
+   * (#787 phase 8d), which is not itself in this registry.
+   */
+  const panelRegistry = {
+    council: { domId: 'council-panel', group: 'main', open: () => panelActions.openCouncilPanel() },
+    tech: { domId: 'tech-panel', group: 'main', open: () => panelActions.openTechPanel() },
+    city: {
+      domId: 'city-panel',
+      group: 'main',
+      open: () => {
+        throw new Error("'city' is parameterized -- call panelActions.openCityPanelForCity(city) directly, not router.open('city').");
+      },
+    },
+    espionage: { domId: 'espionage-panel', group: 'main', open: () => panelActions.openEspionagePanel() },
+    diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => panelActions.openDiplomacyPanel() },
+    marketplace: { domId: 'marketplace-panel', group: 'main', open: () => panelActions.openMarketplacePanel() },
+    network: { domId: 'network-panel', group: 'transient', open: () => panelActions.openNetworkPanel() },
+    wonder: {
+      domId: 'wonder-panel',
+      group: 'transient',
+      open: () => {
+        throw new Error("'wonder' is parameterized -- call panelActions.openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
+      },
+    },
+    'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => panelActions.openWonderAtlas() },
+    bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => panelActions.openBestiary() },
+    'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => panelActions.openPirateWaters() },
+    'notification-log': { domId: 'notification-log', group: 'transient', open: () => panelActions.openNotificationLog() },
+    'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => panelActions.openCityOverviewPanel() },
+    'territory-inspection': {
+      domId: 'territory-inspection-panel',
+      group: 'transient',
+      open: () => {
+        throw new Error(
+          "'territory-inspection' opens only via mapInteraction.handleHexLongPress(coord) (#787 phase 8d) -- not router.open('territory-inspection').",
+        );
+      },
+    },
+    'pacing-debug': { domId: 'pacing-debug-panel', group: 'transient', open: () => panelActions.openPacingDebugPanel() },
+  } satisfies PanelRegistry;
+
+  router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });
+
+  return { selectionController, playerActions, turnFlow, hud, gameSession, presentationContext };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,38 +40,15 @@ import type { NotificationCityAction, NotificationEntry } from '@/core/notificat
 import { createUserSettingsStore } from '@/app/user-settings-store';
 import type { Notifier } from '@/app/ports';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
-import { createCeremonyCoordinator, type CeremonyCoordinator } from '@/app/controllers/ceremony-coordinator';
-import { createSelectionController, type SelectionController } from '@/app/controllers/selection-controller';
-import { createDiplomacyActionsController, type DiplomacyActionsController } from '@/app/controllers/diplomacy-actions-controller';
-import { createPanelActionsController, type PanelActionsController } from '@/app/controllers/panel-actions-controller';
-import { createPlayerActionController, type PlayerActionController } from '@/app/controllers/player-action-controller';
-import { createMapInteractionController, type MapInteractionController } from '@/app/controllers/map-interaction-controller';
-import { createTurnFlowController, type TurnFlowController } from '@/app/controllers/turn-flow-controller';
-import { createHudController, type HudController } from '@/app/controllers/hud-controller';
-import { createCampaignEntryController, type CampaignEntryController } from '@/app/controllers/campaign-entry-controller';
-import { createGameSessionController, type GameSessionController } from '@/app/controllers/game-session-controller';
-import { bootstrap } from '@/app/bootstrap';
-import { registerAllPresentation, type PresentationContext } from '@/presentation/register-all';
+import { bootstrap, createAppComposition, type AppComposition } from '@/app/bootstrap';
+import { registerAllPresentation } from '@/presentation/register-all';
 import { removeRouteForUnit, createMarketplaceState } from '@/systems/trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import type { GameSession } from '@/app/ports';
 import { createGameSession } from '@/app/game-session';
-import { createPanelHost, type PanelHost } from '@/app/panel-host';
-import { createPanelRouter, type PanelRouter } from '@/app/panel-router';
-import type { PanelContext, PanelRegistry } from '@/app/panel-registry';
 import { installGlobalShortcuts } from '@/app/global-shortcuts';
-import {
-  getCurrentCiv,
-  getCurrentCivDef,
-  clearUnloadState,
-  prefersReducedMotion,
-  scanBeastSightings,
-  focusNotificationTarget,
-  focusPirateTarget,
-  notifyPlayer,
-  applyPirateActionResult,
-} from '@/app/cross-cutting-helpers';
+import { getCurrentCivDef, notifyPlayer } from '@/app/cross-cutting-helpers';
 
 // --- App State ---
 /**
@@ -95,11 +72,13 @@ const userSettingsStore = createUserSettingsStore({ load: loadSettings });
  *
  * Constructed in `GameSessionController.init()`, once `createUI()` has
  * created the `#notifications` element `NotificationCenterDeps.layer`
- * needs, then published back here via `setNotifier` (#787 phase 10).
- * Every function below that reads `notifier` is only ever invoked during
- * real gameplay, well after `init()` completes -- the same
- * deferred-but-eager pattern `session` and `selection` already use for
- * their own module-scope bindings.
+ * needs, then published back here via `setNotifier` (#787 phase 10),
+ * threaded through `createAppComposition`'s `setNotifier` dep (#787 phase
+ * 10b-g, since `GameSessionController` now lives in `bootstrap.ts`). Every
+ * function below that reads `notifier` is only ever invoked during real
+ * gameplay, well after `init()` completes -- the same deferred-but-eager
+ * pattern `session` and `selection` already use for their own module-scope
+ * bindings.
  */
 let notifier: Notifier;
 
@@ -114,408 +93,6 @@ const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
 
-/**
- * Owns the panel DOM layer and the interaction-blocking overlay flag,
- * replacing `createUiInteractionState()` (#787 phase 5).
- */
-const host: PanelHost = createPanelHost(uiLayer);
-
-/**
- * `router` and `panelContext` are circular by construction (a panel's
- * `open(ctx)` reads `ctx.router` to potentially chain-open another panel),
- * so `panelContext` is built first with `notifier`/`router` behind getters
- * that resolve to the live module-scope bindings once they exist -- the
- * same deferred-but-eager pattern `notifier` itself already uses.
- */
-let router: PanelRouter;
-const panelContext: PanelContext = {
-  session,
-  get notifier() { return notifier; },
-  host,
-  selection,
-  get router() { return router; },
-};
-
-// The two refreshes `session.commit()` performs on every state publication.
-// Registered once, here, rather than repeated as a three-statement discipline
-// at each write site. Renderer first, matching the order the manual pairs used.
-session.subscribe(next => renderLoop.setGameState(next));
-session.subscribe(() => hud.update());
-
-function setBlockingOverlay(id: string | null): void {
-  host.setBlockingOverlay(id);
-}
-
-/**
- * Owns the wonder-discovery and legendary-completion ceremony queues plus
- * the move-settle defer flag, replacing three module-scope bindings
- * (#787 phase 6). Subscribes to `host.onInteractionUnblocked` for the pump
- * that used to live inside `setBlockingOverlay` above.
- */
-const ceremonies: CeremonyCoordinator = createCeremonyCoordinator({
-  host,
-  reducedMotion: prefersReducedMotion,
-  requestMapHighlight: (item, reducedMotion) => {
-    renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
-  },
-  playDiscoveryAudio: wonderId => {
-    void audio.playNaturalWonderDiscovery(wonderId);
-  },
-  openAtlas: wonderId => panelActions.openWonderAtlas(wonderId),
-  openCity: cityId => {
-    const city = session.getState().cities[cityId];
-    if (city) panelActions.openCityPanelForCity(city);
-  },
-  openJournal: cityId => {
-    if (session.getState().cities[cityId]) panelActions.openWonderPanelForCityId(cityId);
-  },
-});
-
-/**
- * Owns unit selection: `selectUnit`, `deselectUnit`, `selectNextUnit`, and the
- * animated-move / auto-explore / journey lifecycle around a selected unit
- * (#787 phase 8c). References `foundCityAction`, a function defined later in
- * this file -- safe because it's a hoisted function declaration that doesn't
- * run until real gameplay, well after module evaluation finishes. The same
- * deferred-but-eager pattern `notifier` and `router` already use.
- * `performWorkerAction`/`getUnitTurnFlow`/`restAction`/`ensurePlayerWarState`
- * moved into `PlayerActionController` (phase 10b-e) and are threaded through
- * as lazy wrappers instead, per that controller's own construction comment
- * further down.
- */
-/**
- * Owns the diplomacy, minor-civ, and crisis-interaction handlers (#787 phase
- * 10b-a). `hud` and `selectionController` are wrapped in thin lazily-evaluating
- * objects, not passed directly -- both are `const`s not assigned until later
- * in module evaluation (`selectionController` right below this, `hud` further
- * down), so a direct reference here would capture `undefined` at construction
- * time. Same deferred-but-eager closure pattern `selectionController` itself
- * already uses for `updateHUD: () => hud.update()` below. `openDiplomacyPanel`
- * is now `PanelActionsController`'s own function (phase 10b-c), but `panelActions`
- * is constructed just below `diplomacyActions`, so the same lazy-wrapper
- * treatment applies here too, not a direct reference.
- */
-const diplomacyActions: DiplomacyActionsController = createDiplomacyActionsController({
-  session,
-  bus,
-  renderLoop,
-  uiLayer,
-  showNotification,
-  openDiplomacyPanel: () => panelActions.openDiplomacyPanel(),
-  hud: { update: () => hud.update() },
-  selectionController: { selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts) },
-});
-
-/**
- * Owns every panel opener extracted across #787 phases 10b-b (utility/world-event
- * panels), 10b-c (unit/network/civ-management panels), and 10b-d (the two
- * largest panels: `openCityPanelForCity`, `openEspionagePanel`). `hud` and
- * `selectionController` use the same deferred-but-eager lazy-wrapper pattern
- * as `diplomacyActions` above, for the same reason (neither is assigned yet
- * at this point in module evaluation). `diplomacyActions` needs no such
- * wrapper here since it is constructed just above. `router` DOES need the
- * wrapper -- it is a `let` not assigned until `createPanelRouter(...)` much
- * later in module evaluation (after `panelRegistry`, which itself needs this
- * controller's methods) -- same pattern `turnFlow`'s own `router` dep below
- * already uses. `executeUpgrade` is a plain hoisted function declaration, so
- * no wrapper needed for it. `focusNotificationTarget`/`focusPirateTarget`/
- * `applyPirateActionResult`/`currentCiv`/`currentCivDef` are inline arrows
- * calling the pure functions in `src/app/cross-cutting-helpers.ts` (#787
- * phase 10b-f) -- `notifier` inside those arrows is a `let` not assigned
- * until `init()`, same deferred-but-eager pattern as `router` just below.
- */
-const panelActions: PanelActionsController = createPanelActionsController({
-  session,
-  bus,
-  uiLayer,
-  getElementById: id => document.getElementById(id),
-  selection,
-  audio,
-  renderLoop,
-  showNotification,
-  focusNotificationTarget: target => focusNotificationTarget(renderLoop, notifier, session, target),
-  focusPirateTarget: target => focusPirateTarget(renderLoop, notifier, target),
-  applyPirateActionResult: (result, successMessage) => applyPirateActionResult(
-    { session, bus, renderLoop, updateHUD: () => hud.update(), showNotification },
-    result,
-    successMessage,
-  ),
-  currentCiv: () => getCurrentCiv(session),
-  currentCivDef: () => getCurrentCivDef(session),
-  diplomacyActions,
-  executeUpgrade,
-  router: { open: panel => router.open(panel) },
-  hud: { closeDrawer: () => hud.closeDrawer(), update: () => hud.update() },
-  selectionController: {
-    selectUnit: (unitId, opts) => selectionController.selectUnit(unitId, opts),
-    deselectUnit: () => selectionController.deselectUnit(),
-  },
-});
-
-/**
- * `getUnitTurnFlow`/`performWorkerAction`/`performPreach`/`restAction`/
- * `ensurePlayerWarState` are wrapped in thin lazily-evaluating closures, not
- * passed directly -- `playerActions` (#787 phase 10b-e) is constructed after
- * `selectionController` (it needs `selectionController` itself as a direct
- * dep, resolving the reverse forward-reference), so a direct reference here
- * would capture `undefined` at construction time. Same deferred-but-eager
- * pattern this file already uses for `router`/`notifier`/`campaignEntry`.
- */
-const selectionController: SelectionController = createSelectionController({
-  session,
-  selection,
-  renderLoop,
-  bus,
-  uiLayer,
-  host,
-  ceremonies,
-  getInfoPanel: () => document.getElementById('info-panel'),
-  showNotification,
-  updateHUD: () => hud.update(),
-  clearUnloadState: () => clearUnloadState(selection),
-  getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
-  foundCityAction,
-  performWorkerAction: action => playerActions.performWorkerAction(action),
-  performPreach: (unitId, cityId) => playerActions.performPreach(unitId, cityId),
-  restAction: () => playerActions.restAction(),
-  openNetworkIntentPanel: panelActions.openNetworkIntentPanel,
-  openUnitStackPicker: panelActions.openUnitStackPicker,
-  openPirateHeadquartersAssault: panelActions.openPirateHeadquartersAssault,
-  handleEstablishRoute: diplomacyActions.handleEstablishRoute,
-  executeUpgrade,
-  ensurePlayerWarState: targetCivId => playerActions.ensurePlayerWarState(targetCivId),
-  scanBeastSightings: () => scanBeastSightings(session, bus),
-  currentCiv: () => getCurrentCiv(session),
-});
-
-/**
- * Owns turn advancement: `endTurn`, the hot-seat handoff lifecycle, AI-move
- * replay, difficulty application at handoff, and "entering a viewer's turn"
- * (#787 phase 9). `router`/`notifier` are wrapped in thin lazily-evaluating
- * objects, not passed directly -- both are `let`s not assigned until later
- * in module evaluation (`router` at `createPanelRouter(...)` below,
- * `notifier` inside `init()`), so a direct reference here would capture
- * `undefined`. Same deferred-but-eager pattern as `presentationContext`'s
- * `get notifier()`/`get router()` getters further down.
- */
-const turnFlow: TurnFlowController = createTurnFlowController({
-  session,
-  selection,
-  renderLoop,
-  bus,
-  uiLayer,
-  audio,
-  router: {
-    close: panel => router.close(panel),
-    open: panel => router.open(panel),
-  },
-  roundPresentationGate,
-  ceremonies,
-  notifier: {
-    withHappenedTurn: (turn, fn) => notifier.withHappenedTurn(turn, fn),
-  },
-  userSettingsStore,
-  getElementById: id => document.getElementById(id),
-  getNetworkIntentPanel: () => document.querySelector('[aria-label="Network intent"]'),
-  showNotification,
-  updateHUD: () => hud.update(),
-  setBlockingOverlay,
-  currentCiv: () => getCurrentCiv(session),
-  // Lazy wrapper: `playerActions` (10b-e) is constructed after `turnFlow`
-  // (it needs `turnFlow.endTurn` as a direct dep), same deferred-but-eager
-  // reverse forward-reference as `selectionController`'s dep above.
-  getUnitTurnFlow: () => playerActions.getUnitTurnFlow(),
-  deselectUnit: selectionController.deselectUnit,
-  selectNextUnit: selectionController.selectNextUnit,
-  scanBeastSightings: () => scanBeastSightings(session, bus),
-  maybeShowPendingHoardChoice,
-  checkAdvisors: () => advisorSystem.check(session.getState()),
-  // `campaignEntry` is declared after `turnFlow` (it needs `turnFlow` itself
-  // as a dep) -- same deferred-but-eager forward reference `router`/`notifier`
-  // already use elsewhere in this file; safe because this closure is not
-  // invoked until real gameplay.
-  showGameModeSelection: () => campaignEntry.showGameModeSelection(),
-  reloadPage: () => window.location.reload(),
-  openCityPanelForCity: panelActions.openCityPanelForCity,
-});
-
-/**
- * Owns the player-unit-action functions `getUnitTurnFlow`, `performWorkerAction`,
- * `performPreach`, `ensurePlayerWarState`, `restAction`, and
- * `showEspionageCaptureChoice` (#787 phase 10b-e -- a partial `PlayerActionController`;
- * Phase 13, not yet merged, will extend this same file with a different
- * function group in the same domain). Constructed after both `selectionController`
- * and `turnFlow` so it can take direct references to both -- see the lazy
- * wrappers those two use above for the reverse direction of this same
- * three-way forward reference. `notifier` still needs its own lazy wrapper
- * here since it is a `let` not assigned until `init()` runs.
- */
-const playerActions: PlayerActionController = createPlayerActionController({
-  session,
-  bus,
-  uiLayer,
-  selection,
-  selectionController,
-  turnFlow,
-  hud: { update: () => hud.update() },
-  renderLoop,
-  showNotification,
-  setBlockingOverlay,
-  currentCiv: () => getCurrentCiv(session),
-  notifier: { choice: (message, actions) => notifier.choice(message, actions) },
-});
-
-/**
- * Owns the two map-input entry points, `handleHexTap` and
- * `handleHexLongPress` (#787 phase 8d). References several functions
- * defined later in this file (`executeAttack`, `executeMinorCivConquest`,
- * etc.) -- safe because they are hoisted function declarations and none of
- * them run until real gameplay, well after module evaluation finishes. The
- * same deferred-but-eager pattern `selectionController` above already uses.
- * `openCityPanelForCity` is a `panelActions` method now (10b-d), not a
- * hoisted function, but `mapInteraction` is constructed after `panelActions`
- * so a direct reference still works with no wrapper needed.
- */
-const mapInteraction: MapInteractionController = createMapInteractionController({
-  session,
-  selection,
-  selectionController,
-  renderLoop,
-  audio,
-  bus,
-  uiLayer,
-  getElementById: id => document.getElementById(id),
-  showNotification,
-  updateHUD: () => hud.update(),
-  clearUnloadState: () => clearUnloadState(selection),
-  currentCiv: () => getCurrentCiv(session),
-  openPirateWaters: panelActions.openPirateWaters,
-  openUnitStackPicker: panelActions.openUnitStackPicker,
-  openCityPanelForCity: panelActions.openCityPanelForCity,
-  openWonderAtlas: panelActions.openWonderAtlas,
-  executeAttack,
-  executeMinorCivConquest,
-  beginPlayerCityAssault,
-  finalizePendingCityCaptureChoice: turnFlow.finalizePendingCityCaptureChoice,
-});
-
-/**
- * Owns the HUD readout, the treasury drawer, the anti-aircraft-overlay
- * toggle button, and the map viewport bottom inset (#787 phase 10).
- */
-const hud: HudController = createHudController({
-  session,
-  renderLoop,
-  canvas,
-  router: { open: panel => router.open(panel) },
-  getElementById: id => document.getElementById(id),
-  getDrawerMountRoot: () => document.getElementById('game-shell') ?? document.body,
-});
-
-/**
- * Owns campaign entry: the start/save panel, mode selection, and
- * `enterCampaign` (#787 phase 10). `startGame` is a forward reference to
- * `gameSession` (declared `let` just below and assigned immediately after)
- * -- the same deferred-but-eager pattern `router`/`notifier` already use,
- * needed because `gameSession` itself depends on `campaignEntry`.
- */
-let gameSession: GameSessionController;
-const campaignEntry: CampaignEntryController = createCampaignEntryController({
-  session,
-  uiLayer,
-  audio,
-  bus,
-  roundPresentationGate,
-  host,
-  turnFlow,
-  userSettingsStore,
-  getElementById: id => document.getElementById(id),
-  showNotification,
-  startGame: () => gameSession.startGame(),
-  reloadPage: () => window.location.reload(),
-});
-
-/**
- * Owns app startup: `init`, `createUI`, `startGame`, and the
- * `inputInitialized` construct-once guard (#787 phase 10).
- */
-gameSession = createGameSessionController({
-  session,
-  selection,
-  renderLoop,
-  audio,
-  bus,
-  canvas,
-  uiLayer,
-  documentRef: document,
-  host,
-  router: {
-    toggle: panel => router.toggle(panel),
-    open: panel => router.open(panel),
-    close: panel => router.close(panel),
-    closeGroup: group => router.closeGroup(group),
-    isOpen: panel => router.isOpen(panel),
-  },
-  roundPresentationGate,
-  advisorSystem,
-  userSettingsStore,
-  turnFlow,
-  mapInteraction,
-  selectionController,
-  hud,
-  campaignEntry,
-  getElementById: id => document.getElementById(id),
-  showNotification,
-  foundCityAction,
-  maybeShowPendingHoardChoice,
-  setNotifier: n => { notifier = n; },
-  focusNotificationTarget: target => focusNotificationTarget(renderLoop, notifier, session, target),
-});
-
-/**
- * Shared deps for the domain presentation registrars replacing 72
- * module-scope `bus.on(...)` registrations (#787 phase 7). `notifier`/`router`
- * resolve through getters -- the same deferred-but-eager pattern
- * `panelContext` above already uses -- since both are only assigned once
- * `init()` runs.
- */
-const presentationContext: PresentationContext = {
-  session,
-  get notifier() { return notifier; },
-  get router() { return router; },
-  ceremonies,
-  selection,
-  requestDeliveryVisual: unitId => renderLoop.applyDeliveryVisual(unitId),
-  applyCombatVisual: result => renderLoop.applyCombatVisual(result),
-  showEspionageCaptureChoice: (spyId, spyOwner) => playerActions.showEspionageCaptureChoice(spyId, spyOwner),
-  uiLayer,
-  maybeShowPendingHoardChoice: () => maybeShowPendingHoardChoice(),
-  isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
-  resetAdvisorMessage: id => advisorSystem.resetMessage(id),
-  checkAdvisors: () => advisorSystem.check(session.getState()),
-  showNotification: (message, type, target) => showNotification(message, type, target),
-};
-
-// Escape-cancels-journey and backtick-toggles-pacing-debug used to live in a
-// module-scope `window.addEventListener('keydown', ...)` here. Moved to
-// `installGlobalShortcuts` (called from `init()`, once `notifier` exists) so
-// it can depend on the real `Notifier`/`PanelRouter` ports instead of
-// reaching into module-scope closures directly (#787 phase 5).
-
-function maybeShowPendingHoardChoice(): void {
-  const pending = (session.getState().beasts?.pendingHoardChoices ?? [])
-    .find(p => p.civId === session.getState().currentPlayer);
-  if (!pending) return;
-  const preview = getHoardChoicePreview(session.getState(), pending.lairId);
-  const lair = session.getState().beasts!.lairs[pending.lairId];
-  createBeastHoardPanel(uiLayer, preview, choice => {
-    session.setStateWithoutRefresh(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
-    bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
-    hud.update();
-    maybeShowPendingHoardChoice();
-  });
-}
-
 // --- Notifications ---
 // The toast queue, the choice modal, and the delivery contract below all live
 // in notifier (created in init(), see src/ui/notification-center.ts) (#787
@@ -526,7 +103,7 @@ function maybeShowPendingHoardChoice(): void {
 
 // Thin wrapper (not extracted, see cross-cutting-helpers.ts's module docblock
 // for why): delegates to the pure `notifyPlayer`, but stays a hoisted
-// `main.ts` function so its ~8 controller consumers' `showNotification` dep
+// `main.ts` function so its controller consumers' `showNotification` dep
 // keeps working as a bare reference, unchanged by this phase.
 function showNotification(
   message: string,
@@ -536,9 +113,23 @@ function showNotification(
   notifyPlayer(notifier, session, message, type, target);
 }
 
+function maybeShowPendingHoardChoice(): void {
+  const pending = (session.getState().beasts?.pendingHoardChoices ?? [])
+    .find(p => p.civId === session.getState().currentPlayer);
+  if (!pending) return;
+  const preview = getHoardChoicePreview(session.getState(), pending.lairId);
+  const lair = session.getState().beasts!.lairs[pending.lairId];
+  createBeastHoardPanel(uiLayer, preview, choice => {
+    session.setStateWithoutRefresh(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
+    bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
+    composition.hud.update();
+    maybeShowPendingHoardChoice();
+  });
+}
+
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = session.getState().cities[cityId]?.name ?? 'City-State';
-  const movement = selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(session.getState(), unitId, target, {
+  const movement = composition.selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(session.getState(), unitId, target, {
     actor: 'player',
     civId: session.getState().currentPlayer,
     bus,
@@ -554,7 +145,7 @@ function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: s
   showNotification(`${cityName} has been conquered!`, 'success');
   SFX.tap();
   renderLoop.setGameState(session.getState());
-  hud.update();
+  composition.hud.update();
 }
 
 function executeUpgrade(
@@ -566,58 +157,6 @@ function executeUpgrade(
   session.commit(result.state);
   return true;
 }
-
-/**
- * Replaces `togglePanel`'s 288-line `else if` chain (#787 phase 5). Panels
- * that require a specific target -- a city id, a hex coord -- have no
- * parameterless "open the current one" call, so their `open` throws; they
- * still need a registry entry so `closeGroup`/`isOpen`/`close` (all
- * DOM-derived off `domId`) behave correctly when a 'main' or 'transient'
- * sweep runs. `openCityPanelForCity`'s and `openWonderPanelForCityId`'s real
- * entry points both now live in `PanelActionsController` (10b-c, 10b-d).
- * The territory-inspection panel has no such entry point of
- * its own -- it opens only as a side effect of `mapInteraction.handleHexLongPress`
- * (#787 phase 8d), which is not itself in this registry.
- */
-const panelRegistry = {
-  council: { domId: 'council-panel', group: 'main', open: () => panelActions.openCouncilPanel() },
-  tech: { domId: 'tech-panel', group: 'main', open: () => panelActions.openTechPanel() },
-  city: {
-    domId: 'city-panel',
-    group: 'main',
-    open: () => {
-      throw new Error("'city' is parameterized -- call panelActions.openCityPanelForCity(city) directly, not router.open('city').");
-    },
-  },
-  espionage: { domId: 'espionage-panel', group: 'main', open: () => panelActions.openEspionagePanel() },
-  diplomacy: { domId: 'diplomacy-panel', group: 'main', open: () => panelActions.openDiplomacyPanel() },
-  marketplace: { domId: 'marketplace-panel', group: 'main', open: () => panelActions.openMarketplacePanel() },
-  network: { domId: 'network-panel', group: 'transient', open: () => panelActions.openNetworkPanel() },
-  wonder: {
-    domId: 'wonder-panel',
-    group: 'transient',
-    open: () => {
-      throw new Error("'wonder' is parameterized -- call panelActions.openWonderPanelForCityId(cityId) directly, not router.open('wonder').");
-    },
-  },
-  'wonder-atlas': { domId: 'wonder-codex-panel', group: 'transient', open: () => panelActions.openWonderAtlas() },
-  bestiary: { domId: 'bestiary-panel', group: 'transient', open: () => panelActions.openBestiary() },
-  'pirate-waters': { domId: 'pirate-waters-panel', group: 'transient', open: () => panelActions.openPirateWaters() },
-  'notification-log': { domId: 'notification-log', group: 'transient', open: () => panelActions.openNotificationLog() },
-  'city-overview': { domId: 'city-overview-panel', group: 'main', open: () => panelActions.openCityOverviewPanel() },
-  'territory-inspection': {
-    domId: 'territory-inspection-panel',
-    group: 'transient',
-    open: () => {
-      throw new Error(
-        "'territory-inspection' opens only via mapInteraction.handleHexLongPress(coord) (#787 phase 8d) -- not router.open('territory-inspection').",
-      );
-    },
-  },
-  'pacing-debug': { domId: 'pacing-debug-panel', group: 'transient', open: () => panelActions.openPacingDebugPanel() },
-} satisfies PanelRegistry;
-
-router = createPanelRouter({ host, registry: panelRegistry, context: panelContext });
 
 function foundCityAction(): void {
   const selectedUnitId = selection.getSelectedUnitId();
@@ -643,7 +182,7 @@ function foundCityAction(): void {
   }
   session.setStateWithoutRefresh(result.state);
 
-  selectionController.deselectUnit();
+  composition.selectionController.deselectUnit();
   const foundedCity = session.getState().cities[result.cityId];
   showNotification(`${foundedCity.name} has been founded!`, 'success');
   SFX.foundCity();
@@ -655,7 +194,7 @@ function foundCityAction(): void {
   }
 
   renderLoop.setGameState(session.getState());
-  hud.update();
+  composition.hud.update();
 }
 
 function beginPlayerCityAssault(
@@ -670,7 +209,7 @@ function beginPlayerCityAssault(
   const attacker = session.getState().units[attackerId];
   if (!attacker || !canUnitOccupyCity(attacker)) return 'resolved';
 
-  playerActions.ensurePlayerWarState(city.owner);
+  composition.playerActions.ensurePlayerWarState(city.owner);
   let attackerMultiplier: number | undefined;
   if (embarkedAssault) {
     const legality = getEmbarkedAssaultTarget(session.getState(), attackerId, city.position, { viewerId: session.getState().currentPlayer });
@@ -701,13 +240,13 @@ function beginPlayerCityAssault(
       'warning',
     );
     renderLoop.setGameState(session.getState());
-    hud.update();
+    composition.hud.update();
     return 'resolved';
   }
 
   selection.setPendingIntent({ kind: 'city-capture', choice: begun.pending });
   if (!shouldPromptForPlayerCityCapture(city)) {
-    turnFlow.finalizePendingCityCaptureChoice('raze', attackerBonus);
+    composition.turnFlow.finalizePendingCityCaptureChoice('raze', attackerBonus);
     return 'resolved';
   }
 
@@ -715,8 +254,8 @@ function beginPlayerCityAssault(
     cityName: city.name,
     occupiedPopulation: begun.pending.occupiedPopulation,
     razeGold: begun.pending.razeGold,
-    onOccupy: () => turnFlow.finalizePendingCityCaptureChoice('occupy', attackerBonus),
-    onRaze: () => turnFlow.finalizePendingCityCaptureChoice('raze', attackerBonus),
+    onOccupy: () => composition.turnFlow.finalizePendingCityCaptureChoice('occupy', attackerBonus),
+    onRaze: () => composition.turnFlow.finalizePendingCityCaptureChoice('raze', attackerBonus),
   });
   return 'pending';
 }
@@ -734,7 +273,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
   if (!initialAttacker || initialAttacker.hasActed || !legality.ok || legality.targetType !== 'unit') {
     showNotification('That target is no longer attackable.', 'warning');
     const currentlySelected = selection.getSelectedUnitId();
-    if (currentlySelected) selectionController.selectUnit(currentlySelected);
+    if (currentlySelected) composition.selectionController.selectUnit(currentlySelected);
     return;
   }
 
@@ -753,7 +292,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
     attacker = detached.attacker;
   }
 
-  playerActions.ensurePlayerWarState(defender.owner);
+  composition.playerActions.ensurePlayerWarState(defender.owner);
 
   const seed = deterministicCombatSeed(session.getState().gameId, session.getState().turn, attacker.id, defender.id);
   const attackerBonus = getCurrentCivDef(session)?.bonusEffect;
@@ -854,10 +393,10 @@ function executeAttack(attackerId: string, targetKey: string): void {
           );
           SFX.combat();
           renderLoop.setGameState(session.getState());
-          hud.update();
-          selectionController.refreshSelectedUnitAfterCombat();
+          composition.hud.update();
+          composition.selectionController.refreshSelectedUnitAfterCombat();
           if (assaultStatus === 'resolved') {
-            setTimeout(() => selectionController.selectNextUnit(), 400);
+            setTimeout(() => composition.selectionController.selectNextUnit(), 400);
           }
           return;
         }
@@ -870,26 +409,63 @@ function executeAttack(attackerId: string, targetKey: string): void {
   // `attacker` was captured before applyCombatOutcomeToState — safe even if attacker was destroyed
   SFX.combat();
   renderLoop.setGameState(session.getState());
-  hud.update();
-  selectionController.refreshSelectedUnitAfterCombat();
-  renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectionController.selectNextUnit());
+  composition.hud.update();
+  composition.selectionController.refreshSelectedUnitAfterCombat();
+  renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => composition.selectionController.selectNextUnit());
 }
+
+/**
+ * Constructs every controller `main.ts` used to build at module scope --
+ * `host`, `ceremonies`, `diplomacyActions`, `panelActions`,
+ * `selectionController`, `turnFlow`, `playerActions`, `mapInteraction`,
+ * `hud`, `campaignEntry`, `gameSession`, `presentationContext`,
+ * `panelRegistry`, and `router` -- moved into `bootstrap.ts` as the
+ * composition root (#787 phase 10b-g). The Phase-13-scoped functions above
+ * are hoisted `function` declarations, so passing them here bare is safe --
+ * they aren't invoked until real gameplay, well after this call returns and
+ * `composition` is assigned. The reverse reference (those functions reading
+ * `composition.selectionController`/`composition.hud`/etc.) is the same
+ * deferred-but-eager pattern, now spanning the `main.ts`/`bootstrap.ts`
+ * boundary instead of positions within one file.
+ */
+const composition: AppComposition = createAppComposition({
+  canvas,
+  uiLayer,
+  renderLoop,
+  audio,
+  bus,
+  roundPresentationGate,
+  advisorSystem,
+  session,
+  selection,
+  userSettingsStore,
+  getNotifier: () => notifier,
+  setNotifier: n => { notifier = n; },
+  foundCityAction,
+  executeUpgrade,
+  executeAttack,
+  executeMinorCivConquest,
+  beginPlayerCityAssault,
+  maybeShowPendingHoardChoice,
+  showNotification,
+});
 
 // --- Bootstrap ---
 // registerAllPresentation/registerMinorCivNotificationListeners used to run
 // as bare module-scope statements here, immediately followed by a bare
 // init() call. bootstrap() (#787 phase 10) sequences the same three steps
-// explicitly instead of as an import side effect -- see src/app/bootstrap.ts
-// for why it does not yet also construct session/selection/host/ceremonies/
-// router/panelRegistry (Phase 10b).
+// explicitly instead of as an import side effect -- see src/app/bootstrap.ts,
+// which now also constructs session/selection/host/ceremonies/router/
+// panelRegistry via createAppComposition above (#787 phase 10b-g finished
+// the composition-root move Phase 10's own docblock had deferred).
 void bootstrap({
   bus,
-  presentationContext,
+  presentationContext: composition.presentationContext,
   getState: () => session.getState(),
   // Thunked, not `notifier.deliver` directly -- `notifier` is not assigned
   // until init() runs, after this module-scope call (#787 phase 10b-f,
   // formerly the separate `appendToCivLog` const, inlined at its one
   // consumer).
   appendToCivLog: (...args) => notifier.deliver(...args),
-  gameSession,
+  gameSession: composition.gameSession,
 });

--- a/tests/app/bootstrap.test.ts
+++ b/tests/app/bootstrap.test.ts
@@ -3,7 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import * as registerAllModule from '@/presentation/register-all';
 import * as minorCivListenersModule from '@/ui/minor-civ-notification-listeners';
-import { bootstrap, type AppServices } from '@/app/bootstrap';
+import { bootstrap, createAppComposition, type AppServices, type AppCompositionDeps } from '@/app/bootstrap';
+import type { RenderLoop } from '@/renderer/render-loop';
+import type { AudioSystem } from '@/audio/audio-system';
+import type { Notifier } from '@/app/ports';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { AdvisorSystem } from '@/ui/advisor-system';
+import { createGameSession } from '@/app/game-session';
+import { createNewGame } from '@/core/game-state';
+import { createSelectionStore } from '@/app/selection-store';
+import { createUserSettingsStore } from '@/app/user-settings-store';
 
 vi.mock('@/presentation/register-all', async () => {
   const actual = await vi.importActual<typeof registerAllModule>('@/presentation/register-all');
@@ -64,5 +73,113 @@ describe('bootstrap', () => {
     releaseInit();
     await bootstrapPromise;
     expect(resolved).toBe(true);
+  });
+});
+
+// #787 phase 10b-g: createAppComposition is the composition root's
+// construction-order-heavy half -- every controller main.ts used to build at
+// module scope now lives here. The highest-risk regression class for a move
+// like this is a wrong lazy-wrapper-vs-direct-reference call (a runtime
+// `undefined` crash on first real interaction, not a type error, since most
+// of these deps are same-shaped functions TypeScript can't distinguish by
+// timing) -- these tests cover the one part of that risk a smoke test can
+// exercise without a full playable game: that construction itself succeeds,
+// returns every controller the rest of the app depends on, and that the
+// `notifier` plumbing (the one piece of code this phase actually changed,
+// not just relocated -- `getNotifier()`/`setNotifier` replace the bare
+// `notifier` closure the pre-move code used inside one module scope) really
+// does resolve through the live binding at call time rather than capturing
+// `undefined` at construction time.
+function makeCompositionDeps(overrides: Partial<AppCompositionDeps> = {}): AppCompositionDeps {
+  document.body.innerHTML = '<canvas id="game-canvas"></canvas><div id="ui-layer"></div>';
+  const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+  const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
+  const bus = new EventBus();
+  const renderLoop = {
+    setGameState: vi.fn(),
+    requestWonderDiscoveryHighlight: vi.fn(),
+    applyDeliveryVisual: vi.fn(),
+    applyCombatVisual: vi.fn(),
+    animations: { add: vi.fn() },
+  } as unknown as RenderLoop;
+  const audio = {
+    playNaturalWonderDiscovery: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AudioSystem;
+  let notifier: Notifier | undefined;
+
+  return {
+    canvas,
+    uiLayer,
+    renderLoop,
+    audio,
+    bus,
+    roundPresentationGate: new RoundPresentationGate(),
+    advisorSystem: new AdvisorSystem(bus),
+    session: createGameSession(createNewGame(undefined, 'bootstrap-composition-test', 'small')),
+    selection: createSelectionStore(),
+    userSettingsStore: createUserSettingsStore({ load: async () => undefined }),
+    getNotifier: () => notifier as Notifier,
+    setNotifier: n => { notifier = n; },
+    foundCityAction: vi.fn(),
+    executeUpgrade: vi.fn(() => true),
+    executeAttack: vi.fn(),
+    executeMinorCivConquest: vi.fn(),
+    beginPlayerCityAssault: vi.fn((): 'pending' | 'resolved' => 'resolved'),
+    maybeShowPendingHoardChoice: vi.fn(),
+    showNotification: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeFakeNotifier(): Notifier {
+  return {
+    toast: vi.fn(),
+    deliver: vi.fn(),
+    choice: vi.fn(),
+    withHappenedTurn: (_turn, fn) => fn(),
+  };
+}
+
+describe('createAppComposition', () => {
+  it('constructs every controller without throwing', () => {
+    expect(() => createAppComposition(makeCompositionDeps())).not.toThrow();
+  });
+
+  it('returns every controller the rest of the app depends on', () => {
+    const composition = createAppComposition(makeCompositionDeps());
+
+    expect(composition.selectionController).toBeDefined();
+    expect(composition.playerActions).toBeDefined();
+    expect(composition.turnFlow).toBeDefined();
+    expect(composition.hud).toBeDefined();
+    expect(composition.gameSession).toBeDefined();
+    expect(composition.presentationContext).toBeDefined();
+  });
+
+  it('resolves notifier through getNotifier at call time, not at construction time', () => {
+    const deps = makeCompositionDeps();
+    const composition = createAppComposition(deps);
+
+    // Not assigned yet -- mirrors real startup, where GameSessionController.init()
+    // publishes the real Notifier well after every controller above is built.
+    expect(composition.presentationContext.notifier).toBeUndefined();
+
+    const fakeNotifier = makeFakeNotifier();
+    deps.setNotifier(fakeNotifier);
+
+    expect(composition.presentationContext.notifier).toBe(fakeNotifier);
+  });
+
+  it('updating the session HUD subscription does not throw before or after hud construction', () => {
+    // Regression guard for the #787 phase 10b-g relocation of
+    // `session.subscribe(() => hud.update())` from main.ts's old (pre-`hud`)
+    // subscribe site to right after `hud` is constructed in this file --
+    // asserts a state commit actually reaches the returned `hud` instance.
+    const deps = makeCompositionDeps();
+    const composition = createAppComposition(deps);
+    const updateSpy = vi.spyOn(composition.hud, 'update');
+
+    expect(() => deps.session.commit(deps.session.getState())).not.toThrow();
+    expect(updateSpy).toHaveBeenCalled();
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -219,8 +219,10 @@ describe('shared city assault wiring', () => {
       main.indexOf('function executeUpgrade('),
     );
 
+    // #787 phase 10b-g: selectionController now lives behind `composition`,
+    // constructed by createAppComposition in src/app/bootstrap.ts.
     expect(minorCaptureFlow).toContain(
-      'const movement = selectionController.executeAnimatedUnitMove(',
+      'const movement = composition.selectionController.executeAnimatedUnitMove(',
     );
     expect(minorCaptureFlow).toMatch(/if \(!movement\.ok\) return;/);
   });
@@ -268,8 +270,11 @@ describe('map interaction controller wiring (#787 phase 8d)', () => {
 
   it('constructs MapInteractionController', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    // #787 phase 10b-g: this construction moved from main.ts's module scope
+    // into createAppComposition (src/app/bootstrap.ts), the composition root.
+    const bootstrapSrc = readFileSync(resolve(PROJECT_ROOT, 'src/app/bootstrap.ts'), 'utf8');
 
-    expect(main).toContain('createMapInteractionController(');
+    expect(bootstrapSrc).toContain('createMapInteractionController(');
 
     // These four used to be local `function` declarations in main.ts;
     // map-interaction-controller.test.ts now owns their behavioral coverage.
@@ -281,6 +286,7 @@ describe('map interaction controller wiring (#787 phase 8d)', () => {
     ];
     for (const declaration of movedFunctionDeclarations) {
       expect(main).not.toContain(declaration);
+      expect(bootstrapSrc).not.toContain(declaration);
     }
   });
 
@@ -294,8 +300,11 @@ describe('map interaction controller wiring (#787 phase 8d)', () => {
 describe('selection controller wiring (#787 phase 8c)', () => {
   it('constructs SelectionController and no longer defines the eleven functions it now owns', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    // #787 phase 10b-g: this construction moved from main.ts's module scope
+    // into createAppComposition (src/app/bootstrap.ts), the composition root.
+    const bootstrapSrc = readFileSync(resolve(PROJECT_ROOT, 'src/app/bootstrap.ts'), 'utf8');
 
-    expect(main).toContain('createSelectionController(');
+    expect(bootstrapSrc).toContain('createSelectionController(');
 
     // Each of these used to be a local `function` declaration in main.ts;
     // selection-controller.test.ts now owns their behavioral coverage.
@@ -310,6 +319,7 @@ describe('selection controller wiring (#787 phase 8c)', () => {
     ];
     for (const declaration of movedFunctionDeclarations) {
       expect(main).not.toContain(declaration);
+      expect(bootstrapSrc).not.toContain(declaration);
     }
   });
 


### PR DESCRIPTION
## Summary

Finishes the composition-root move that Phase 10's `bootstrap.ts` docblock deferred: `host`, `panelContext`, `ceremonies`, `diplomacyActions`, `panelActions`, `selectionController`, `turnFlow`, `playerActions`, `mapInteraction`, `hud`, `campaignEntry`, `gameSession`, `presentationContext`, `panelRegistry`, and `router` construction all move out of `main.ts`'s module scope into a new `createAppComposition` factory in `src/app/bootstrap.ts`.

- `main.ts`: 895 → 471 lines.
- `bootstrap.ts`: 48 → 559 lines.

`main.ts` now keeps only:
- the true externally-supplied primitives (`canvas`, `uiLayer`, `renderLoop`, `audio`, `bus`, `session`, `selection`, `userSettingsStore`, `roundPresentationGate`, `advisorSystem`)
- the `notifier` `let` (still main.ts-owned since `showNotification` reads it directly; threaded into `bootstrap.ts` via `getNotifier`/`setNotifier` deps instead of a bare closure, since it now crosses a file boundary)
- the Phase-13-scoped functions (`foundCityAction`, `beginPlayerCityAssault`, `executeAttack`, `executeMinorCivConquest`, `executeUpgrade`, `maybeShowPendingHoardChoice`, `showNotification`), which now read the returned `AppComposition` object instead of bare module-scope bindings for `hud`/`selectionController`/`turnFlow`/`playerActions`

**Technique:** verbatim-move + parity audit. Every lazy-wrapper-vs-direct-reference decision from the original construction order (documented at each call site) is preserved unchanged -- I did not re-derive any of it, only relocated it and swapped the bare `notifier` closure for an explicit getter/setter pair. Confirmed via `yarn build` (tsc catches missed/misordered references as type errors) and a grep-based sweep of the pre-move snapshot for every raw invocation of everything that moved, confirming each has exactly one call site and it's correctly rewired through `composition.*`.

## Test changes

`tests/main.integration.test.ts` had 3 source-grep assertions that hardcoded `main.ts` as the construction site for `createSelectionController(`/`createMapInteractionController(`, and one that expected a bare `selectionController.` reference inside `executeMinorCivConquest`. Updated to check `bootstrap.ts` for the construction calls and `composition.selectionController.` for the reference -- no behavioral coverage was lost, these are structural/architecture-boundary checks and the equivalent runtime behavior is already covered by each controller's own test suite (as the existing comments in that file note).

## Deviations from the plan doc

None beyond what Phase 10's own docblock already documented (that Phase 10b would finish this move). The plan's original Phase 10 sketch showed `main.ts` shrinking to ~15 lines with `bootstrap()` itself doing all construction; per `.claude/rules/spec-fidelity.md` I did not blindly implement that stale sketch -- current code already deviated from it (documented in the pre-existing `bootstrap.ts` docblock), so I kept `bootstrap()` (the async init-sequencing function) separate from the new `createAppComposition` (the sync construction factory), added additively rather than folding them together, since they're different responsibilities and this keeps the diff minimal and easy to parity-audit.

Also dropped the now-fully-dead `type PresentationContext` import from `main.ts` (its only usage, `presentationContext`'s own type annotation, moved with the construction) -- not a dedicated cleanup pass, just a direct consequence of this move. Left the pre-existing ~13-14 unrelated dead imports (`moveUnit`, `getMovementCost`, `canUnitAttackBeast`, etc., plus `registerAllPresentation`/`registerMinorCivNotificationListeners`/`installGlobalShortcuts`, all already dead pre-move since their real call sites already live elsewhere) untouched, per the arc's "not this arc's problem to fix" baseline policy.

## Test plan

- [x] `yarn build` (tsc + vite) -- green
- [x] `yarn test` (full unabridged suite via `test:durable`) -- 481 files, 7846 passed, 3 skipped, 0 failed
- [x] `yarn test:web-smoke` (Playwright) -- 8/8 passed, run because this phase touches panel routing and campaign-adjacent wiring
- [x] Inline review pass (architecture/testing/implementation-correctness dimensions; gameplay/balance/UI/AI/SFX/save-migration dimensions are N/A -- pure internal wiring relocation, no player-visible behavior change)
- [x] Phase 11 boundary-test sanity check: zero `bus.on(`, zero `window.addEventListener(` in `main.ts`; one remaining `let notifier` and 471 lines are both expected until Phase 13 (separate, unstarted, tracked by #800) also lands

## Follow-up

Per issue #787, will post a status comment there once this merges and check off phase 10b-g in the tracking issue's body. If 10b-g is the last item in the Phase 10b checklist, will note Phase 11 is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)