### PR TITLE
feat(coastal): complete Coastal Battery defense (#692)

### DIFF
--- a/docs/superpowers/plans/2026-08-14-issue-692-coastal-battery.md
+++ b/docs/superpowers/plans/2026-08-14-issue-692-coastal-battery.md
@@ -49,6 +49,15 @@
 - Repeat on a second Battery city and verify independent state.
 - Switch `currentPlayer` between two human owners and assert delivery stays with the city owner.
 
+## Approved execution expansion — real player and major-AI naval bombardment
+
+The #692 parity audit found that naval units advertise city targets, but the player and major-AI executors only resolve unit combat/capture. The user explicitly approved completing this now so Coastal Battery is never a player-reachable partial feature.
+
+- Introduce one shared naval-bombardment mutation for human and major-AI warships. It validates a visible hostile city target through existing targeting rules, uses `round(attacker strength × current-health fraction × 0.40)` as bounded raw siege damage, resolves the existing naval-defense formula, applies Battery counterfire from the resulting `hpLost`, and consumes the ship's action.
+- Naval bombardment cannot capture, sack, or destroy a city; it leaves an otherwise lethal city at 1 HP for a land capture. This preserves #522's explicit single-exchange land-capture contract and prevents an offshore unit from bypassing occupation/capture choice.
+- Add one recipient-explicit `city:naval-bombarded` event. Presentation uses it only to notify the city owner; the actor's ordinary local feedback stays in the existing action flow. The Battery event remains distinct.
+- Add an AI `bombard-city` tactical action. It can target only a visible hostile city with no hostile unit occupying the city tile, uses the same shared mutation, and scores from legal observed state. It must not derive target information from hidden cities or units.
+
 ### Task 1: Add the buildable, coastal-gated content entry
 
 **Files:**

--- a/docs/superpowers/plans/2026-08-14-issue-692-coastal-battery.md
+++ b/docs/superpowers/plans/2026-08-14-issue-692-coastal-battery.md
@@ -1,0 +1,361 @@
+# Coastal Battery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver #692’s Naval Armor-gated Coastal Battery with naval-only city defense and once-per-city-per-turn deterministic counterfire.
+
+**Architecture:** Put build eligibility in the existing `BUILDINGS`/`getAvailableBuildings` path, put the +8 fact in `getCityDefenseBreakdown`, and put the stateful retaliation in a new pure `coastal-defense-system`. Call the resolver only after shared city-siege damage is known, persist its city-local turn marker, and deliver a recipient-explicit event through the existing presentation boundary.
+
+**Tech Stack:** TypeScript, Vitest, Canvas/DOM city panel, serializable `GameState`, event bus, Vite.
+
+---
+
+## File map
+
+- `src/core/types.ts`: City turn marker and recipient-safe Battery event payload.
+- `src/systems/city-system.ts`: building definition; existing coastal eligibility and production dequeue path consume it without an ID branch.
+- `src/systems/tech-definitions-eras8.ts`: Naval Armor unlock registration.
+- `src/systems/combat-system.ts`: named +8 naval defense fact.
+- `src/systems/coastal-defense-system.ts`: pure eligibility, damage calculation, immutable state application, and event payload.
+- `src/core/turn-manager.ts`, `src/systems/pirate-system.ts`, `src/systems/city-capture-system.ts`: mutation callers pass actual `CitySiegeResult.hpLost` to the shared resolver.
+- `src/storage/save-migrations.ts`: additive, idempotent city-marker normalization.
+- `src/presentation/register-raider-presentation.ts`: owner-recipient event delivery.
+- Tests mirror each changed module; city panel and AI catalog tests prove the player-facing and computer-player paths.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Coastal city, Naval Armor complete | Open Build | Coastal Battery is listed at 170 production with its exact naval-only rule. |
+| Inland city, Naval Armor complete | Open Build | Coastal Battery is absent; it cannot enter the queue. |
+| Battery city, first damaging naval siege this turn | Resolve attack | City takes mitigated damage; attacker takes `min(12, round(hpLost * .20))`; owner receives one Battery notice. |
+| Same city, second naval siege this turn | Resolve attack | No second Battery damage or notice. |
+| Different Battery city or next global turn | Resolve first naval siege | That city’s Battery can fire once. |
+| Land/air attack, or naval zero-damage/block | Resolve attack | No Battery defense part outside naval and no retaliation marker/event. |
+
+## Misleading UI Risks
+
+- “Naval defense +8” must not appear as general city defense; its displayed label includes “against naval attacks”.
+- A player must not see a buildable Battery in a landlocked city; use the existing `coastalRequired` eligibility and production-dequeue guard.
+- A notification must not suggest every naval hit retaliates; say “first naval hit this turn”.
+- The city panel remains the complete build catalog; do not hide other unlocked military buildings while surfacing Battery.
+
+## Interaction Replay Checklist
+
+- Open a Naval Armor coastal city and find Battery in Build.
+- Build Battery, rerender the still-open city panel, and assert its name/rule text appears immediately.
+- Reopen an inland city and assert Battery is unavailable.
+- Resolve first naval hit, repeat the hit in the same turn, then advance a turn and hit again.
+- Repeat on a second Battery city and verify independent state.
+- Switch `currentPlayer` between two human owners and assert delivery stays with the city owner.
+
+### Task 1: Add the buildable, coastal-gated content entry
+
+**Files:**
+- Modify: `src/systems/city-system.ts: BUILDINGS military section`
+- Modify: `src/systems/tech-definitions-eras8.ts: naval-armor`
+- Test: `tests/systems/city-system.test.ts`
+- Test: `tests/systems/tech-unlocks-consistency.test.ts`
+
+- [ ] **Step 1: Write failing catalog tests.**
+
+```ts
+expect(getAvailableBuildings(coastalCity, ['naval-armor'], coastalMap))
+  .toContainEqual(expect.objectContaining({ id: 'coastal_battery', productionCost: 170 }));
+expect(getAvailableBuildings(inlandCity, ['naval-armor'], inlandMap)
+  .map(building => building.id)).not.toContain('coastal_battery');
+```
+
+- [ ] **Step 2: Run the focused tests and confirm Battery is absent.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/city-system.test.ts tests/systems/tech-unlocks-consistency.test.ts`
+
+Expected: failing assertion because `coastal_battery` is not yet defined/unlocked.
+
+- [ ] **Step 3: Add the typed definition and tech registration.**
+
+```ts
+coastal_battery: {
+  id: 'coastal_battery', name: 'Coastal Battery', category: 'military',
+  yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 170,
+  description: 'Naval defense +8. First naval hit each turn returns 20% damage (max 12).',
+  techRequired: 'naval-armor', coastalRequired: true,
+},
+// Naval Armor: unlocksBuildings: ['coastal_battery']
+```
+
+- [ ] **Step 4: Add a production-queue regression.**
+
+```ts
+const result = processCity(inlandCityQueuedWithBattery, ownerCiv, inlandMap, options);
+expect(result.droppedProductionItems).toContainEqual({
+  itemId: 'coastal_battery', itemKind: 'building', reason: 'coastal-access-lost',
+});
+```
+
+- [ ] **Step 5: Run focused tests and commit.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/city-system.test.ts tests/systems/tech-unlocks-consistency.test.ts`
+
+Expected: PASS.
+
+Commit: `git commit -am "feat(coastal): add Battery production entry"`
+
+### Task 2: Make the +8 defense fact naval-only and preview-visible
+
+**Files:**
+- Modify: `src/systems/combat-system.ts: getCityDefenseBreakdown`
+- Test: `tests/systems/city-defense.test.ts`
+- Test: `tests/systems/city-siege-system.test.ts`
+- Test: `tests/ui/combat-preview.test.ts`
+
+- [ ] **Step 1: Write failing naval/land/air breakdown tests.**
+
+```ts
+expect(getCityDefenseBreakdown({ cityBuildings: ['coastal_battery'], defenderCompletedTechs: [], attackerDomain: 'naval' }))
+  .toMatchObject({ flatBonus: 8, parts: [expect.objectContaining({ source: 'coastal_battery' })] });
+expect(getCityDefenseBreakdown({ cityBuildings: ['coastal_battery'], defenderCompletedTechs: [], attackerDomain: 'land' }).flatBonus).toBe(0);
+expect(getCityDefenseBreakdown({ cityBuildings: ['coastal_battery'], defenderCompletedTechs: [], attackerDomain: 'air' }).flatBonus).toBe(0);
+```
+
+- [ ] **Step 2: Run them and confirm the Battery fact is missing.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/city-defense.test.ts tests/systems/city-siege-system.test.ts tests/ui/combat-preview.test.ts`
+
+Expected: FAIL on the naval flat-defense assertion.
+
+- [ ] **Step 3: Add one named naval-domain part.**
+
+```ts
+if (input.attackerDomain === 'naval' && input.cityBuildings.includes('coastal_battery')) {
+  flatBonus += 8;
+  parts.push({ source: 'coastal_battery', label: 'Coastal Battery +8 vs naval', kind: 'flat', value: 8 });
+}
+```
+
+- [ ] **Step 4: Assert the live city intrinsic strength and combat preview both retain that named part.**
+
+```ts
+expect(getCityIntrinsicStrength(cityWithBattery, owner, 'naval'))
+  .toBeCloseTo(getCityIntrinsicStrength(cityWithoutBattery, owner, 'naval') + 8, 5);
+expect(renderedPreviewText).toContain('Coastal Battery +8 vs naval');
+```
+
+- [ ] **Step 5: Run focused tests and commit.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/city-defense.test.ts tests/systems/city-siege-system.test.ts tests/ui/combat-preview.test.ts`
+
+Expected: PASS.
+
+Commit: `git commit -am "feat(coastal): apply naval-only city defense"`
+
+### Task 3: Implement deterministic, persisted Battery counterfire
+
+**Files:**
+- Modify: `src/core/types.ts: City and GameEventMap`
+- Create: `src/systems/coastal-defense-system.ts`
+- Modify: `src/storage/save-migrations.ts: CURRENT_SAVE_SCHEMA_VERSION, migration map, normalization chain`
+- Test: `tests/systems/coastal-defense-system.test.ts`
+- Test: `tests/storage/save-migrations-v13.test.ts`
+
+- [ ] **Step 1: Write failing resolver tests.**
+
+```ts
+const fired = resolveCoastalBatteryCounterfire(state, {
+  cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'pirate',
+});
+expect(fired.damage).toBe(8);
+expect(fired.state.cities.port.coastalBatteryCounterfireTurn).toBe(state.turn);
+expect(fired.event).toMatchObject({ recipientCivId: state.cities.port.owner, source: 'pirate' });
+
+expect(resolveCoastalBatteryCounterfire(fired.state, { ...input, cityDamage: 60 }).damage).toBe(0);
+expect(resolveCoastalBatteryCounterfire(state, { ...input, attackerDomain: 'land' }).damage).toBe(0);
+expect(resolveCoastalBatteryCounterfire(state, { ...input, cityDamage: 0 }).damage).toBe(0);
+```
+
+- [ ] **Step 2: Run the new test and confirm it fails because the module does not exist.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/coastal-defense-system.test.ts`
+
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 3: Define the serializable state and pure resolver.**
+
+```ts
+export type CoastalBatterySource = 'player' | 'ai' | 'barbarian' | 'pirate';
+export interface CoastalBatteryCounterfireEvent {
+  cityId: string; attackerUnitId: string; recipientCivId: string;
+  source: CoastalBatterySource; damage: number; attackerDied: boolean;
+}
+export function resolveCoastalBatteryCounterfire(
+  state: GameState, input: CoastalBatteryCounterfireInput,
+): CoastalBatteryCounterfireResult {
+  // return unchanged state/no event unless Battery, naval, positive CitySiegeResult.hpLost,
+  // live attacker, and city.coastalBatteryCounterfireTurn !== state.turn.
+  // apply min(12, Math.round(input.cityDamage * 0.2)) immutably, then record the turn.
+}
+```
+
+- [ ] **Step 4: Add schema-13 migration and additive normalization.**
+
+```ts
+function normalizeCoastalBatteryCounterfireTurns(state: GameState): GameState {
+  // retain only finite integer city markers; omit any malformed marker without changing valid ones.
+}
+// CURRENT_SAVE_SCHEMA_VERSION = 13; SAVE_MIGRATIONS[13] = normalizeCoastalBatteryCounterfireTurns
+// also call the normalizer after every migration for current-schema malformed saves.
+```
+
+- [ ] **Step 5: Add save tests.**
+
+```ts
+expect(migrateSaveToCurrent(legacyWithoutMarker).cities.port.coastalBatteryCounterfireTurn).toBeUndefined();
+expect(migrateSaveToCurrent(malformedMarker).cities.port.coastalBatteryCounterfireTurn).toBeUndefined();
+expect(migrateSaveToCurrent(midTurnMarker).cities.port.coastalBatteryCounterfireTurn).toBe(42);
+expect(migrateSaveToCurrent(migrateSaveToCurrent(midTurnMarker))).toEqual(migrateSaveToCurrent(midTurnMarker));
+```
+
+- [ ] **Step 6: Run system/storage tests and commit.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/coastal-defense-system.test.ts tests/storage/save-migrations-v13.test.ts tests/storage/save-migrations.test.ts`
+
+Expected: PASS.
+
+Commit: `git commit -am "feat(coastal): add bounded Battery counterfire"`
+
+### Task 4: Wire all actual naval siege mutation paths and owner-safe presentation
+
+**Files:**
+- Modify: `src/systems/pirate-system.ts: completed-round naval siege`
+- Modify: `src/core/turn-manager.ts: any naval city siege order path`
+- Modify: `src/systems/city-capture-system.ts: city-assault path when attacker domain is naval`
+- Modify: `src/presentation/register-raider-presentation.ts`
+- Test: `tests/systems/pirate-system.test.ts`
+- Test: `tests/core/turn-manager.test.ts`
+- Test: `tests/systems/city-capture-system.test.ts`
+- Test: `tests/presentation/register-raider-presentation.test.ts`
+
+- [ ] **Step 1: Write integration tests that spy on the new event.**
+
+```ts
+bus.on('city:coastal-battery-fired', onBattery);
+processPiratesForCompletedRound(batterySiegeState, bus);
+expect(onBattery).toHaveBeenCalledWith(expect.objectContaining({ source: 'pirate', recipientCivId: 'player' }));
+expect(attackerAfter.health).toBe(attackerBefore.health - Math.min(12, Math.round(cityHpLost * .2)));
+```
+
+- [ ] **Step 2: Add parity/negative cases before wiring.**
+
+```ts
+expect(secondSameTurnEvent).not.toHaveBeenCalled();
+expect(landSiegeBatteryEvent).not.toHaveBeenCalled();
+expect(airSiegeBatteryEvent).not.toHaveBeenCalled();
+expect(barbarianAndMajorAiEventSources).toEqual(expect.arrayContaining(['barbarian', 'ai']));
+```
+
+- [ ] **Step 3: Run tests and confirm the Battery event is absent.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/pirate-system.test.ts tests/core/turn-manager.test.ts tests/systems/city-capture-system.test.ts tests/presentation/register-raider-presentation.test.ts`
+
+Expected: FAIL because callers do not yet invoke the resolver.
+
+- [ ] **Step 4: Wire immediately after `resolveCitySiegeDamage` and before applying its outcome.**
+
+```ts
+const siege = resolveCitySiegeDamage(input);
+const battery = resolveCoastalBatteryCounterfire(nextState, {
+  cityId, attackerUnitId, attackerDomain: 'naval', cityDamage: siege.hpLost, source,
+});
+nextState = battery.state;
+nextState = applyCitySiegeOutcome(nextState, cityId, siege);
+if (battery.event) bus.emit('city:coastal-battery-fired', battery.event);
+```
+
+This ordering lets an eligible Battery fire from the pre-destruction city snapshot using the exact resolved `hpLost`; the outcome application then preserves the recorded marker if the city survives and naturally removes it if the city is destroyed. Never call this for land/air orders or from existing `city:counter-fire`; preserve existing walls behavior unchanged.
+
+- [ ] **Step 5: Deliver only to the explicit owner recipient.**
+
+```ts
+bus.on('city:coastal-battery-fired', ({ cityId, recipientCivId, damage, attackerDied }) => {
+  if (!ctx.session.getState().civilizations[recipientCivId]?.isHuman) return;
+  ctx.notifier.deliver(recipientCivId, batteryMessage(cityId, damage, attackerDied), attackerDied ? 'success' : 'info');
+});
+```
+
+- [ ] **Step 6: Run integration tests and commit.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/pirate-system.test.ts tests/core/turn-manager.test.ts tests/systems/city-capture-system.test.ts tests/presentation/register-raider-presentation.test.ts`
+
+Expected: PASS.
+
+Commit: `git commit -am "feat(coastal): wire city Battery retaliation"`
+
+### Task 5: Prove player UI, AI catalog, difficulty, and hot-seat behavior
+
+**Files:**
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/ai/ai-production.test.ts`
+- Test: `tests/presentation/register-raider-presentation.test.ts`
+- Test: `tests/simulation/ai-playability-fixture.ts` if the existing coastal scenario can host a Battery assertion
+
+- [ ] **Step 1: Add rendered-DOM city-panel tests.**
+
+```ts
+expect(collectText(createCityPanel(container, coastalCity, state, callbacks)))
+  .toContain('Naval defense +8. First naval hit each turn returns 20% damage (max 12).');
+expect(collectText(createCityPanel(inlandContainer, inlandCity, state, callbacks)))
+  .not.toContain('Coastal Battery');
+```
+
+- [ ] **Step 2: Add generic AI-candidate coverage.**
+
+```ts
+expect(generateProductionCandidates(coastalAiState, aiId, coastalCity.id, demands)
+  .map(candidate => candidate.itemId)).toContain('coastal_battery');
+expect(generateProductionCandidates(inlandAiState, aiId, inlandCity.id, demands)
+  .map(candidate => candidate.itemId)).not.toContain('coastal_battery');
+```
+
+- [ ] **Step 3: Add difficulty and hot-seat regressions.**
+
+```ts
+for (const challenge of ['explorer', 'standard', 'veteran'] as const) {
+  expect(resolveCoastalBatteryCounterfire(fixture(challenge), input).damage).toBe(8);
+}
+expect(deliver).toHaveBeenCalledWith(city.owner, expect.stringContaining('Coastal Battery'), expect.any(String));
+expect(deliver).not.toHaveBeenCalledWith(otherHumanId, expect.anything(), expect.anything());
+```
+
+- [ ] **Step 4: Run focused UI/AI/presentation tests and commit.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts tests/ai/ai-production.test.ts tests/presentation/register-raider-presentation.test.ts`
+
+Expected: PASS.
+
+Commit: `git commit -am "test(coastal): cover UI AI and hot-seat parity"`
+
+### Task 6: Final review and verification
+
+**Files:** Review all changed files and `docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md`.
+
+- [ ] **Step 1: Run source-rule checks and focused suite.**
+
+Run: `scripts/check-src-rule-violations.sh src/core/types.ts src/systems/city-system.ts src/systems/combat-system.ts src/systems/coastal-defense-system.ts src/storage/save-migrations.ts src/systems/pirate-system.ts src/core/turn-manager.ts src/systems/city-capture-system.ts src/presentation/register-raider-presentation.ts`
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/coastal-defense-system.test.ts tests/systems/city-system.test.ts tests/systems/city-defense.test.ts tests/systems/city-siege-system.test.ts tests/storage/save-migrations-v13.test.ts tests/systems/pirate-system.test.ts tests/core/turn-manager.test.ts tests/systems/city-capture-system.test.ts tests/ui/city-panel.test.ts tests/ai/ai-production.test.ts tests/presentation/register-raider-presentation.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Rebase and review drift before PR.**
+
+Run: `git fetch origin`, then `git rebase origin/main`, then inspect `git diff --check`, `git diff --stat origin/main...HEAD`, `git diff --stat`, and the full committed/uncommitted diff.
+
+- [ ] **Step 3: Run release verification.**
+
+Run separately: `./scripts/run-with-mise.sh yarn build`, `./scripts/run-with-mise.sh yarn test:durable`, and `./scripts/run-with-mise.sh yarn test:durable:status`.
+
+Expected: build exit 0 and durable evidence bound to the rebased `HEAD`.
+
+- [ ] **Step 4: Perform the requested inline review before opening the draft MR.**
+
+Confirm balance cap, 7–43 clarity, coastal/non-coastal play styles, difficulty parity, AI non-omniscience, UI truth, architecture, data/save idempotence, no new SFX, solo/hot-seat recipient safety, and actor-path regressions. Fix every actionable finding before publishing.

--- a/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
@@ -9,7 +9,7 @@ Add a Naval Armor-era Coastal Battery that gives a city a narrow, intelligible a
 - **Gate:** Naval Armor and a coastal city. The shared city-aware eligibility helper rejects inland cities so players and AI never spend production on an inert naval defense.
 - **Cost:** 170 production.
 - **Defense:** +8 flat city defense only when the attacker is naval.
-- **Counterfire:** The first naval attack that deals damage to each Battery city during a turn takes `min(12, round(actual city damage × 0.20))` retaliation. “Actual city damage” is `CitySiegeResult.hpLost`, captured before a sack or destruction removes the city.
+- **Counterfire:** The first naval attack that deals damage to each Battery city during a turn consumes its reaction and takes `min(12, round(actual city damage × 0.20))` retaliation. A 1–2 HP hit rounds to zero damage but still consumes that turn's reaction. “Actual city damage” is `CitySiegeResult.hpLost`, captured before a sack or destruction removes the city.
 - **Exclusions:** No land or air defense, no land or air counterfire, and no recursive counterfire.
 - **Parity:** The same rule applies to human, major-AI, barbarian, and pirate naval attackers. Explorer, Standard, and Veteran have the same rule values and legality.
 

--- a/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
@@ -1,0 +1,65 @@
+# Coastal Battery design (#692)
+
+## Purpose
+
+Add a Naval Armor-era Coastal Battery that gives a city a narrow, intelligible answer to naval siege pressure without changing land or air combat.
+
+## Gameplay contract
+
+- **Gate:** Naval Armor.
+- **Cost:** 170 production.
+- **Defense:** +8 flat city defense only when the attacker is naval.
+- **Counterfire:** The first naval attack that deals damage to each Battery city during a turn takes `min(12, round(actual city damage × 0.20))` retaliation.
+- **Exclusions:** No land or air defense, no land or air counterfire, and no recursive counterfire.
+- **Parity:** The same rule applies to human, major-AI, barbarian, and pirate naval attackers. Explorer, Standard, and Veteran have the same rule values and legality.
+
+The building is a defensive coastal specialization, not a universal city-defense upgrade. It remains useful to island, trade, naval, and defensive play styles while neither taxing nor invalidating land-first expansion.
+
+## Architecture
+
+`getCityDefenseBreakdown` remains the sole source of truth for the +8 naval-only defense fact, so live resolution and combat preview agree. It will read the ordinary city building list and add one named flat defense part only for the naval domain.
+
+A new `coastal-defense-system` owns Battery counterfire. Its input is the current state, city id, attacking unit id, attacker domain, actual city HP damage, and source actor. It checks the building, naval domain, positive damage, and an optional city-scoped turn marker. When eligible it applies deterministic capped damage to the attacker, records the current turn on that city, and emits a recipient-safe event from the mutation path. It does not call a combat resolver, so retaliation cannot trigger itself.
+
+This deliberately stays separate from `getCityCounterFireDamage`. The older walls counterfire is random, requires an ungarrisoned city, and is not once-per-turn; combining the two would hide different rules behind one misleading name and make future tuning unsafe.
+
+## State and saves
+
+Each city may carry `coastalBatteryCounterfireTurn?: number`. It is a serializable, optional marker:
+
+- absent in legacy saves means the Battery has not fired this turn;
+- a malformed/non-finite marker normalizes to absent;
+- current saves preserve the marker so a mid-turn reload cannot fire twice;
+- no save-schema reservation is made until the current save format is re-audited during implementation.
+
+The marker is city-local. A Battery on another city is still eligible in the same turn.
+
+## Player truth and privacy
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Naval Armor complete; coastal city lacks Battery | Open Build catalog | Coastal Battery is reachable with its cost and plain naval-only explanation. |
+| Battery city is hit by a naval attacker | First damaging naval hit this turn | The naval attacker loses the displayed 20%-capped retaliation; the city owner receives the event. |
+| Same Battery city is hit again this turn | Second damaging naval hit | No second Battery retaliation. |
+| Battery city is attacked by land or air | Any hit | No Battery +8 or retaliation is applied. |
+| Two human players share a device | Turn handoff | Only the owning human receives the Battery event; no preview, notification, animation, or audio reveals it to another viewer. |
+
+The city panel shows icon plus text, never color or sound alone: “Naval defense +8. First naval hit each turn returns 20% damage (max 12).” This keeps the mechanic understandable for younger/casual players while giving optimizing players the exact values.
+
+## AI and presentation
+
+Coastal Battery enters the existing generic building eligibility and AI production candidate paths. AI may only score its own eligible coastal cities and observed pressure; it cannot inspect hidden enemy units or routes. No new difficulty exception is introduced.
+
+This mechanics delivery adds no audio. The event and visible combat result are the required accessible feedback, while #718 owns fortification audio polish. The existing notification delivery system must target the city owner explicitly.
+
+## Verification matrix
+
+- building gate, exact cost, city-panel description, and full catalog reachability;
+- +8 only for naval attackers, with land/air negative tests;
+- first damaging naval hit, same-turn second hit, next-turn reset, and independent city markers;
+- 20% calculation uses actual mitigated city damage, capped at 12, and cannot recurse;
+- player/AI/barbarian/pirate paths share the resolver and preserve unit/civilization cleanup;
+- Explorer/Standard/Veteran rule parity;
+- legacy, malformed, current, and mid-turn save/load normalization;
+- solo recipient feedback and two-human hot-seat isolation;
+- deterministic balance fixtures for an intended naval attacker, comparable land attacker, and a non-Battery city.

--- a/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-692-coastal-battery-design.md
@@ -6,10 +6,10 @@ Add a Naval Armor-era Coastal Battery that gives a city a narrow, intelligible a
 
 ## Gameplay contract
 
-- **Gate:** Naval Armor.
+- **Gate:** Naval Armor and a coastal city. The shared city-aware eligibility helper rejects inland cities so players and AI never spend production on an inert naval defense.
 - **Cost:** 170 production.
 - **Defense:** +8 flat city defense only when the attacker is naval.
-- **Counterfire:** The first naval attack that deals damage to each Battery city during a turn takes `min(12, round(actual city damage × 0.20))` retaliation.
+- **Counterfire:** The first naval attack that deals damage to each Battery city during a turn takes `min(12, round(actual city damage × 0.20))` retaliation. “Actual city damage” is `CitySiegeResult.hpLost`, captured before a sack or destruction removes the city.
 - **Exclusions:** No land or air defense, no land or air counterfire, and no recursive counterfire.
 - **Parity:** The same rule applies to human, major-AI, barbarian, and pirate naval attackers. Explorer, Standard, and Veteran have the same rule values and legality.
 
@@ -19,7 +19,7 @@ The building is a defensive coastal specialization, not a universal city-defense
 
 `getCityDefenseBreakdown` remains the sole source of truth for the +8 naval-only defense fact, so live resolution and combat preview agree. It will read the ordinary city building list and add one named flat defense part only for the naval domain.
 
-A new `coastal-defense-system` owns Battery counterfire. Its input is the current state, city id, attacking unit id, attacker domain, actual city HP damage, and source actor. It checks the building, naval domain, positive damage, and an optional city-scoped turn marker. When eligible it applies deterministic capped damage to the attacker, records the current turn on that city, and emits a recipient-safe event from the mutation path. It does not call a combat resolver, so retaliation cannot trigger itself.
+A new `coastal-defense-system` owns Battery counterfire. Its input is the current state, city id, attacking unit id, attacker domain, actual city HP damage, and source actor. It checks the building, naval domain, positive damage, and an optional city-scoped turn marker. When eligible it applies deterministic capped damage to the attacker, records the current turn on that city, and emits a mutation-owned event containing `recipientCivId: city.owner` plus the actor source. It does not call a combat resolver, so retaliation cannot trigger itself. Presentation delivers only to `recipientCivId`; it never reads `currentPlayer` to infer the recipient.
 
 This deliberately stays separate from `getCityCounterFireDamage`. The older walls counterfire is random, requires an ungarrisoned city, and is not once-per-turn; combining the two would hide different rules behind one misleading name and make future tuning unsafe.
 
@@ -28,7 +28,7 @@ This deliberately stays separate from `getCityCounterFireDamage`. The older wall
 Each city may carry `coastalBatteryCounterfireTurn?: number`. It is a serializable, optional marker:
 
 - absent in legacy saves means the Battery has not fired this turn;
-- a malformed/non-finite marker normalizes to absent;
+- a malformed, non-finite, or non-integer marker normalizes to absent;
 - current saves preserve the marker so a mid-turn reload cannot fire twice;
 - no save-schema reservation is made until the current save format is re-audited during implementation.
 
@@ -48,17 +48,17 @@ The city panel shows icon plus text, never color or sound alone: “Naval defens
 
 ## AI and presentation
 
-Coastal Battery enters the existing generic building eligibility and AI production candidate paths. AI may only score its own eligible coastal cities and observed pressure; it cannot inspect hidden enemy units or routes. No new difficulty exception is introduced.
+Coastal Battery enters the existing generic building eligibility and AI production candidate paths through the same coastal-city eligibility helper used by city production completion. AI may only score its own eligible coastal cities and observed pressure; it cannot inspect hidden enemy units or routes. No new difficulty exception is introduced.
 
 This mechanics delivery adds no audio. The event and visible combat result are the required accessible feedback, while #718 owns fortification audio polish. The existing notification delivery system must target the city owner explicitly.
 
 ## Verification matrix
 
-- building gate, exact cost, city-panel description, and full catalog reachability;
+- Naval Armor plus coastal-city gate, exact cost, city-panel description, and full catalog reachability, with an inland-city negative test;
 - +8 only for naval attackers, with land/air negative tests;
 - first damaging naval hit, same-turn second hit, next-turn reset, and independent city markers;
 - 20% calculation uses actual mitigated city damage, capped at 12, and cannot recurse;
-- player/AI/barbarian/pirate paths share the resolver and preserve unit/civilization cleanup;
+- player/AI/barbarian/pirate paths share the resolver, preserve unit/civilization cleanup, and emit the explicit city-owner recipient;
 - Explorer/Standard/Veteran rule parity;
 - legacy, malformed, current, and mid-turn save/load normalization;
 - solo recipient feedback and two-human hot-seat isolation;

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -18,6 +18,7 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { resolveCombatEra } from '@/systems/era-resolution';
+import { resolveNavalCityBombardment } from '@/systems/naval-city-bombardment-system';
 import {
   beginMajorCityAssault,
   canUnitOccupyCity,
@@ -371,6 +372,18 @@ function executeAction(
         succeeded: attack.state !== state,
         followUps: attack.followUps,
       };
+    }
+    case 'bombard-city': {
+      const bombardment = resolveNavalCityBombardment(state, {
+        attackerUnitId: action.unitId,
+        cityId: action.cityId,
+        source: 'ai',
+      });
+      if (bombardment.ok) {
+        if (bombardment.cityEvent) bus.emit('city:naval-bombarded', bombardment.cityEvent);
+        if (bombardment.batteryEvent) bus.emit('city:coastal-battery-fired', bombardment.batteryEvent);
+      }
+      return { state: bombardment.ok ? bombardment.state : state, succeeded: bombardment.ok, followUps: [] };
     }
     case 'embarked-attack': {
       const attack = executeEmbarkedAttack(state, action, civId, bus);

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -70,9 +70,11 @@ import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
 import { isAIHostileOwner } from './ai-hostility';
 import { getLegalRebaseDestinations, resolveAirStrike, resolveReconMission, rebaseAircraft, startIntercept } from '@/systems/air-operations-system';
 import { resolveCombatEra } from '@/systems/era-resolution';
+import { resolveNavalCityBombardment } from '@/systems/naval-city-bombardment-system';
 
 export type AITacticalAction =
   | { kind: 'attack'; unitId: string; targetUnitId: string }
+  | { kind: 'bombard-city'; unitId: string; cityId: string }
   | { kind: 'embarked-attack'; unitId: string; targetUnitId: string }
   | { kind: 'air-strike'; unitId: string; target: HexCoord }
   | { kind: 'air-recon'; unitId: string; target: HexCoord }
@@ -131,6 +133,8 @@ function actionId(action: AITacticalAction): string {
   switch (action.kind) {
     case 'attack':
       return `attack:${action.unitId}:${action.targetUnitId}`;
+    case 'bombard-city':
+      return `bombard-city:${action.unitId}:${action.cityId}`;
     case 'embarked-attack':
       return `embarked-attack:${action.unitId}:${action.targetUnitId}`;
     case 'air-strike':
@@ -315,7 +319,18 @@ function rankAttacks(
     viewerId: context.actorId,
     requireVisibility: true,
   })) {
-    if (target.result.targetType !== 'unit') continue;
+    if (target.result.targetType === 'city') {
+      const city = context.state.cities[target.result.cityId];
+      if (
+        city
+        && UNIT_DEFINITIONS[unit.type].domain === 'naval'
+        && isAIHostileOwner(context.state, context.actorId, city.owner)
+      ) {
+        attacks.push(ranked({ kind: 'bombard-city', unitId: unit.id, cityId: city.id },
+          560 + Math.max(0, 100 - (city.hp ?? 100))));
+      }
+      continue;
+    }
     const defender = context.state.units[target.result.targetUnitId];
     if (!defender) continue;
     if (!isAIHostileOwner(context.state, context.actorId, defender.owner)) {
@@ -831,6 +846,14 @@ function applyPredictedAction(
         resolveCombatEra(next, unit, defender),
       );
       return applyCombatOutcomeToState(next, result, seed).state;
+    }
+    case 'bombard-city': {
+      const result = resolveNavalCityBombardment(next, {
+        attackerUnitId: action.unitId,
+        cityId: action.cityId,
+        source: 'ai',
+      });
+      return result.ok ? result.state : next;
     }
     case 'embarked-attack': {
       const defender = next.units[action.targetUnitId];

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -82,6 +82,7 @@ import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender, getAmphibiousAssaultMultiplier } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { resolveNavalCityBombardment } from '@/systems/naval-city-bombardment-system';
 import { applyCombatOutcomeToState, getCaptureNotificationLabel } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { resolveCombatEra } from '@/systems/era-resolution';
@@ -561,10 +562,38 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     // hasActed guard: enforce "no action remaining" at the execution layer, not just
     // the highlight layer (getAttackTargets). Prevents double-action if executeAttack
     // is ever called outside the normal tap → highlight → confirm flow.
-    if (!initialAttacker || initialAttacker.hasActed || !legality.ok || legality.targetType !== 'unit') {
+    if (!initialAttacker || initialAttacker.hasActed || !legality.ok) {
       deps.showNotification('That target is no longer attackable.', 'warning');
       const currentlySelected = deps.selection.getSelectedUnitId();
       if (currentlySelected) deps.selectionController.selectUnit(currentlySelected);
+      return;
+    }
+
+    if (!amphibiousAssault && legality.targetType === 'city') {
+      const city = deps.session.getState().cities[legality.cityId];
+      if (!city) return;
+      ensurePlayerWarState(city.owner);
+      const bombardment = resolveNavalCityBombardment(deps.session.getState(), {
+        attackerUnitId: initialAttacker.id,
+        cityId: city.id,
+        source: 'player',
+      });
+      if (!bombardment.ok) {
+        deps.showNotification('That city cannot be bombarded by this unit.', 'warning');
+        return;
+      }
+      deps.session.setStateWithoutRefresh(bombardment.state);
+      if (bombardment.cityEvent) deps.bus.emit('city:naval-bombarded', bombardment.cityEvent);
+      if (bombardment.batteryEvent) deps.bus.emit('city:coastal-battery-fired', bombardment.batteryEvent);
+      deps.renderLoop.setGameState(deps.session.getState());
+      deps.hud.update();
+      deps.selectionController.refreshSelectedUnitAfterCombat();
+      deps.selectionController.selectNextUnit();
+      return;
+    }
+
+    if (legality.targetType !== 'unit') {
+      deps.showNotification('That target is no longer attackable.', 'warning');
       return;
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -558,6 +558,8 @@ export interface City {
   hp?: number;               // city hit points for pirate siege (default 100)
   concessionImmunityUntilTurn?: number; // uprising concession: no new unrest until this turn
   resilienceBonusUntilTurn?: number;    // catastrophe recovery: +1 food +1 production until this turn
+  /** Global turn when this city's Coastal Battery last returned naval siege damage. */
+  coastalBatteryCounterfireTurn?: number;
 }
 
 // --- Economy ---
@@ -1926,6 +1928,10 @@ export interface GameEvents {
   'pirate:city-destroyed': { cityId: string; ownerId: string; factionId: string };
   'city:sacked': { cityId: string; source: 'barbarian' | 'pirate'; goldLost: number };
   'city:counter-fire': { cityId: string; attackerUnitId: string; source: 'barbarian' | 'pirate'; damage: number; attackerDied: boolean };
+  'city:coastal-battery-fired': {
+    cityId: string; attackerUnitId: string; recipientCivId: string;
+    source: 'player' | 'ai' | 'barbarian' | 'pirate'; damage: number; attackerDied: boolean;
+  };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1932,6 +1932,9 @@ export interface GameEvents {
     cityId: string; attackerUnitId: string; recipientCivId: string;
     source: 'player' | 'ai' | 'barbarian' | 'pirate'; damage: number; attackerDied: boolean;
   };
+  'city:naval-bombarded': {
+    cityId: string; recipientCivId: string; source: 'player' | 'ai'; hpLost: number;
+  };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -12,6 +12,7 @@ import {
   type LandUnitWaterRecovery,
 } from '@/systems/unit-water-recovery';
 import { getEmbarkedAssaultTargets } from '@/systems/transport-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 
 export interface SelectedUnitHighlightResult {
   movementRange: HexCoord[];
@@ -126,7 +127,8 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
   const attackTargets = unit.transportId
     ? getEmbarkedAssaultTargets(state, unitId, { viewerId: state.currentPlayer })
     : getAttackTargets(state, unit, { viewerId: state.currentPlayer })
-      .filter(target => target.result.targetType === 'unit');
+      .filter(target => target.result.targetType === 'unit'
+        || (target.result.targetType === 'city' && UNIT_DEFINITIONS[unit.type].domain === 'naval'));
   const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));
   const nonCombatMovementRange = movementRange
     .filter(coord => !attackKeys.has(hexKey(coord)));

--- a/src/presentation/register-raider-presentation.ts
+++ b/src/presentation/register-raider-presentation.ts
@@ -59,6 +59,23 @@ export const registerRaiderPresentation: PresentationRegistrar = (bus, ctx) => {
         : `${city.name}'s walls fought back, damaging a ${raiderLabel} (−${damage} HP)!`;
       ctx.notifier.deliver(city.owner, message, attackerDied ? 'success' : 'info');
     }),
+    bus.on('city:coastal-battery-fired', ({ cityId, recipientCivId, source, damage, attackerDied }) => {
+      const state = ctx.session.getState();
+      if (!state.civilizations[recipientCivId]?.isHuman) return;
+      const cityName = state.cities[cityId]?.name ?? 'A coastal city';
+      const attackerLabel = source === 'pirate' ? 'pirate ship' : 'naval attacker';
+      const message = attackerDied
+        ? `${cityName}'s Coastal Battery destroyed a ${attackerLabel}!`
+        : `${cityName}'s Coastal Battery returned fire on a ${attackerLabel} (−${damage} HP; first naval hit this turn).`;
+      ctx.notifier.deliver(recipientCivId, message, attackerDied ? 'success' : 'info');
+    }),
+    bus.on('city:naval-bombarded', ({ cityId, recipientCivId, source, hpLost }) => {
+      const state = ctx.session.getState();
+      if (!state.civilizations[recipientCivId]?.isHuman) return;
+      const cityName = state.cities[cityId]?.name ?? 'A coastal city';
+      const attacker = source === 'ai' ? 'an enemy fleet' : 'a naval bombardment';
+      ctx.notifier.deliver(recipientCivId, `${cityName} took ${hpLost} damage from ${attacker}.`, 'warning');
+    }),
     // Pirate-faction naval siege (#522) mirror of the barbarian handler above.
     bus.on('pirate:city-destroyed', ({ cityId, ownerId }) => {
       const state = ctx.session.getState();

--- a/src/renderer/sprites/buildings.tsx
+++ b/src/renderer/sprites/buildings.tsx
@@ -1336,6 +1336,32 @@ export function StarFortSprite({ palette, svgOnly = false }: BuildingSpriteProps
   );
 }
 
+/** Coastal gun emplacement: low sea wall, two traversing guns, and a signal mast. */
+export function CoastalBatterySprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Coastal Battery" category="military" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <path d="M30,122 Q58,100 96,108 Q134,100 162,122 L158,140 H34 Z"
+        fill={P.stone.mid} stroke={P.ink.line} strokeWidth="1.4" />
+      <path d="M36,123 H156" stroke={P.stone.light} strokeWidth="5" opacity="0.75" />
+      <path d="M44,136 Q72,128 96,136 Q124,128 150,136" fill="none" stroke={P.ground.water} strokeWidth="4" opacity="0.8" />
+      {[68, 124].map(x => (
+        <g key={x}>
+          <ellipse cx={x} cy="112" rx="18" ry="8" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1" />
+          <circle cx={x} cy="108" r="7" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+          <rect x={x - 3} y="70" width="7" height="38" rx="2" fill={P.metal.iron}
+            stroke={P.ink.line} strokeWidth="1" transform={`rotate(${x === 68 ? -24 : 24} ${x} 108)`} />
+          <circle cx={x} cy="108" r="2" fill={P.metal.gold} />
+        </g>
+      )).join('')}
+      <path d="M96,102 V48" stroke={P.wood.dark} strokeWidth="3" />
+      <path d="M98,50 L124,58 L98,70 Z" fill={palette.bright} stroke={P.ink.line} strokeWidth="1" />
+      <path d="M44,96 L52,82 L60,96 M132,96 L140,82 L148,96" fill={P.stone.light} stroke={P.ink.line} strokeWidth="1" />
+      <Banner x={42} y={48} palette={palette} scale={0.72} />
+    </BuildingFrame>
+  );
+}
+
 // TODO(art): Replace with a military academy: parade ground archway, colonnaded hall, officers' crest above entrance, stacked muskets flanking doors.
 export function MilitaryAcademySprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
   const merlonsLeft = [28, 36, 44].map(x => <rect x={x} y={52} width="6" height="10" rx="1" fill={P.stone.mid} />).join('');

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -35,6 +35,7 @@ import {
   IronFoundrySprite, WarAcademySprite, MasonryWorksSprite, SiegeWorkshopSprite,
   CaravanseraiSprite, BankSprite, StockExchangeSprite,
   NaturalHistoryMuseumSprite, SurgeryGuildSprite, ConcertHallSprite, StarFortSprite,
+  CoastalBatterySprite,
   MilitaryAcademySprite, GrandCipherBureauSprite, ColonialAdministrationSprite,
   FactorySprite, SteelMillSprite, FieldHospitalSprite, PrintShopSprite, CensusOfficeSprite,
   NationalRailwaySprite, GrandArsenalSprite, PeoplesUniversitySprite,
@@ -454,6 +455,7 @@ export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = 
   surgery_guild:          SurgeryGuildSprite,
   concert_hall:           ConcertHallSprite,
   star_fort:              StarFortSprite,
+  coastal_battery:        CoastalBatterySprite,
   // Era 7 regular buildings
   factory:                FactorySprite,
   steel_mill:             SteelMillSprite,

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -16,7 +16,7 @@ import { syncTransportCargoPositions } from '@/systems/transport-system';
 import { IMPROVEMENT_BUILD_TURNS } from '@/systems/improvement-system';
 import type { ImprovementType } from '@/core/types';
 
-export const CURRENT_SAVE_SCHEMA_VERSION = 12;
+export const CURRENT_SAVE_SCHEMA_VERSION = 13;
 
 export type SaveMigration = (state: GameState) => GameState;
 
@@ -717,6 +717,7 @@ export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   10: migrateRetimedCavalry,
   11: migrateRetimedKnight,
   12: migrateLegacyMainFixups,
+  13: normalizeCoastalBatteryCounterfireTurns,
 };
 
 function readSchemaVersion(raw: Record<string, unknown>): number {
@@ -749,6 +750,20 @@ export function normalizeImprovementValues(state: GameState): GameState {
   return changed ? { ...state, map: { ...state.map, tiles: nextTiles } } : state;
 }
 
+/** Retains valid per-city Battery turn markers while removing malformed save data. */
+export function normalizeCoastalBatteryCounterfireTurns(state: GameState): GameState {
+  let changed = false;
+  const cities = { ...state.cities };
+  for (const [cityId, city] of Object.entries(state.cities)) {
+    const marker = city.coastalBatteryCounterfireTurn;
+    if (marker === undefined || (Number.isFinite(marker) && Number.isInteger(marker))) continue;
+    const { coastalBatteryCounterfireTurn: _invalidMarker, ...normalizedCity } = city;
+    cities[cityId] = normalizedCity;
+    changed = true;
+  }
+  return changed ? { ...state, cities } : state;
+}
+
 export function migrateSaveToCurrent(raw: unknown): GameState {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new TypeError('Save data must be an object.');
@@ -773,5 +788,7 @@ export function migrateSaveToCurrent(raw: unknown): GameState {
   const techGrace = normalizeLegacyTechGrace(manufacturing);
   const crises = normalizeCrisisArchetypes(techGrace);
   const religions = withReligionDefaults(crises);
-  return normalizeImprovementValues(normalizeRetimedBiplaneQueues(normalizeCityFaithConversionProgress(religions)));
+  return normalizeImprovementValues(normalizeCoastalBatteryCounterfireTurns(
+    normalizeRetimedBiplaneQueues(normalizeCityFaithConversionProgress(religions)),
+  ));
 }

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -148,6 +148,8 @@ export interface CitySiegeInput {
   // A civ is only ever ended by another civ's conquest. Optional/defaults false so
   // existing direct-construction call sites keep their current destroy behavior.
   isOwnersLastCity?: boolean;
+  /** Offshore bombardment reduces a city to one HP; only land capture can change ownership. */
+  preventDestruction?: boolean;
   era: number;
   challenge: OpponentChallenge;
 }
@@ -187,6 +189,10 @@ export function resolveCitySiegeDamage(input: CitySiegeInput): CitySiegeResult {
 
   if (newHp > 0) {
     return { hpLost: currentHp - newHp, newHp, outcome: 'damaged', goldLost: 0 };
+  }
+
+  if (input.preventDestruction) {
+    return { hpLost: currentHp - 1, newHp: 1, outcome: 'damaged', goldLost: 0 };
   }
 
   const destructionEra = OPPONENT_CHALLENGE_PROFILES[input.challenge].citySiegeDestructionEra;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -629,6 +629,12 @@ export const BUILDINGS: Record<string, Building> = {
     description: 'Industrial exhibition center. +2 gold, +1 science per turn.',
     techRequired: 'engineering-exhibition',
   },
+  coastal_battery: {
+    id: 'coastal_battery', name: 'Coastal Battery', category: 'military',
+    yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 170,
+    description: 'Naval defense +8. First naval hit each turn returns 20% damage (max 12).',
+    techRequired: 'naval-armor', coastalRequired: true,
+  },
 
   /* === ERA 9 REGULAR BUILDINGS === */
   oil_refinery: {
@@ -1617,6 +1623,7 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   sanatorium:           '🏥',
   power_station:        '⚡',
   exhibition_hall:      '🏛️',
+  coastal_battery:      '💥',
   // era 8 units
   machine_gunner:  '🔫',
   pre_dreadnought: '🚢',

--- a/src/systems/coastal-defense-system.ts
+++ b/src/systems/coastal-defense-system.ts
@@ -44,14 +44,16 @@ export function resolveCoastalBatteryCounterfire(
     || city.coastalBatteryCounterfireTurn === state.turn
   ) return noCounterfire(state);
 
-  const damage = Math.min(12, Math.round(input.cityDamage * 0.2));
-  if (damage <= 0) return noCounterfire(state);
-
-  const attackerDied = attacker.health <= damage;
   const cities = {
     ...state.cities,
     [city.id]: { ...city, coastalBatteryCounterfireTurn: state.turn },
   };
+  const damage = Math.min(12, Math.round(input.cityDamage * 0.2));
+  // A 1–2 HP first hit rounds to zero retaliation, but it is still the first
+  // damaging hit and must consume this turn's single Battery reaction.
+  if (damage <= 0) return { state: { ...state, cities }, damage: 0 };
+
+  const attackerDied = attacker.health <= damage;
   const units = { ...state.units };
   if (attackerDied) {
     delete units[attacker.id];

--- a/src/systems/coastal-defense-system.ts
+++ b/src/systems/coastal-defense-system.ts
@@ -1,0 +1,85 @@
+import type { GameState } from '@/core/types';
+
+export type CoastalBatterySource = 'player' | 'ai' | 'barbarian' | 'pirate';
+
+export interface CoastalBatteryCounterfireInput {
+  cityId: string;
+  attackerUnitId: string;
+  attackerDomain: 'land' | 'naval' | 'air';
+  /** The resolved CitySiegeResult.hpLost, never raw pre-mitigation damage. */
+  cityDamage: number;
+  source: CoastalBatterySource;
+}
+
+export interface CoastalBatteryCounterfireEvent {
+  cityId: string;
+  attackerUnitId: string;
+  recipientCivId: string;
+  source: CoastalBatterySource;
+  damage: number;
+  attackerDied: boolean;
+}
+
+export interface CoastalBatteryCounterfireResult {
+  state: GameState;
+  damage: number;
+  event?: CoastalBatteryCounterfireEvent;
+}
+
+const noCounterfire = (state: GameState): CoastalBatteryCounterfireResult => ({ state, damage: 0 });
+
+/** Applies the once-per-city, per-global-turn Coastal Battery reaction after a naval city siege. */
+export function resolveCoastalBatteryCounterfire(
+  state: GameState,
+  input: CoastalBatteryCounterfireInput,
+): CoastalBatteryCounterfireResult {
+  const city = state.cities[input.cityId];
+  const attacker = state.units[input.attackerUnitId];
+  if (
+    !city
+    || !attacker
+    || !city.buildings.includes('coastal_battery')
+    || input.attackerDomain !== 'naval'
+    || input.cityDamage <= 0
+    || city.coastalBatteryCounterfireTurn === state.turn
+  ) return noCounterfire(state);
+
+  const damage = Math.min(12, Math.round(input.cityDamage * 0.2));
+  if (damage <= 0) return noCounterfire(state);
+
+  const attackerDied = attacker.health <= damage;
+  const cities = {
+    ...state.cities,
+    [city.id]: { ...city, coastalBatteryCounterfireTurn: state.turn },
+  };
+  const units = { ...state.units };
+  if (attackerDied) {
+    delete units[attacker.id];
+  } else {
+    units[attacker.id] = { ...attacker, health: attacker.health - damage };
+  }
+
+  const owner = state.civilizations?.[attacker.owner];
+  const civilizations = attackerDied && owner
+    ? {
+      ...state.civilizations,
+      [attacker.owner]: { ...owner, units: owner.units.filter(unitId => unitId !== attacker.id) },
+    }
+    : state.civilizations;
+  const nextState = attackerDied && owner
+    ? { ...state, cities, units, civilizations }
+    : { ...state, cities, units };
+
+  return {
+    state: nextState,
+    damage,
+    event: {
+      cityId: city.id,
+      attackerUnitId: attacker.id,
+      recipientCivId: city.owner,
+      source: input.source,
+      damage,
+      attackerDied,
+    },
+  };
+}

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -136,6 +136,11 @@ export function getCityDefenseBreakdown(input: CityDefenseInput): CityDefenseBre
     parts.push({ source: 'torpedo-warfare', label: 'Torpedo Warfare +5', kind: 'flat', value: 5 });
   }
 
+  if (input.attackerDomain === 'naval' && input.cityBuildings.includes('coastal_battery')) {
+    flatBonus += 8;
+    parts.push({ source: 'coastal_battery', label: 'Coastal Battery +8 vs naval', kind: 'flat', value: 8 });
+  }
+
   return { multiplier, flatBonus, parts };
 }
 

--- a/src/systems/naval-city-bombardment-system.ts
+++ b/src/systems/naval-city-bombardment-system.ts
@@ -1,0 +1,94 @@
+import type { GameState, Unit } from '@/core/types';
+import { resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { resolveCoastalBatteryCounterfire, type CoastalBatteryCounterfireEvent } from '@/systems/coastal-defense-system';
+import { applyCitySiegeOutcome, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+import { resolveCivilizationEra } from '@/systems/tech-definitions';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type NavalCityBombardmentSource = 'player' | 'ai';
+
+export interface NavalCityBombardmentInput {
+  attackerUnitId: string;
+  cityId: string;
+  source: NavalCityBombardmentSource;
+}
+
+export interface NavalCityBombardmentEvent {
+  cityId: string;
+  recipientCivId: string;
+  source: NavalCityBombardmentSource;
+  hpLost: number;
+}
+
+export type NavalCityBombardmentResult =
+  | { ok: true; state: GameState; cityEvent?: NavalCityBombardmentEvent; batteryEvent?: CoastalBatteryCounterfireEvent }
+  | { ok: false; state: GameState; reason: string };
+
+function consumeAttackAction(state: GameState, attacker: Unit): GameState {
+  const current = state.units[attacker.id];
+  if (!current) return state;
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [attacker.id]: { ...current, hasActed: true, movementPointsLeft: 0 },
+    },
+  };
+}
+
+/**
+ * Resolves a non-capturing naval siege against a hostile city. This is the single
+ * mutation seam shared by player input and major-AI tactics; pirates retain their
+ * separate blockade cadence but use the same defense and Battery helpers.
+ */
+export function resolveNavalCityBombardment(
+  state: GameState,
+  input: NavalCityBombardmentInput,
+): NavalCityBombardmentResult {
+  const attacker = state.units[input.attackerUnitId];
+  const city = state.cities[input.cityId];
+  if (!attacker || !city) return { ok: false, state, reason: 'missing-attacker-or-city' };
+  if (UNIT_DEFINITIONS[attacker.type].domain !== 'naval') {
+    return { ok: false, state, reason: 'non-naval-attacker' };
+  }
+
+  const legality = canUnitAttackTarget(state, attacker, city.position, { requireVisibility: false });
+  if (!legality.ok || legality.targetType !== 'city' || legality.cityId !== city.id) {
+    return { ok: false, state, reason: legality.ok ? 'invalid-city-target' : legality.reason };
+  }
+
+  const ownerCiv = state.civilizations[city.owner];
+  if (!ownerCiv) return { ok: false, state, reason: 'missing-city-owner' };
+
+  const rawDamage = Math.max(1, Math.round(UNIT_DEFINITIONS[attacker.type].strength * (attacker.health / 100) * 0.4));
+  const siege = resolveCitySiegeDamage({
+    city,
+    ownerCiv,
+    rawDamage,
+    attackerDomain: 'naval',
+    hasGarrison: getCityGarrisonUnit(state.units, city) !== undefined,
+    isOwnersLastCity: ownerCiv.cities.length <= 1,
+    preventDestruction: true,
+    era: resolveCivilizationEra(ownerCiv.techState.completed),
+    challenge: resolveChallengeForCiv(state, city.owner),
+  });
+  const battery = resolveCoastalBatteryCounterfire(state, {
+    cityId: city.id,
+    attackerUnitId: attacker.id,
+    attackerDomain: 'naval',
+    cityDamage: siege.hpLost,
+    source: input.source,
+  });
+  const afterSiege = applyCitySiegeOutcome(battery.state, city.id, siege);
+  const nextState = consumeAttackAction(afterSiege, attacker);
+
+  return {
+    ok: true,
+    state: nextState,
+    cityEvent: siege.hpLost > 0
+      ? { cityId: city.id, recipientCivId: city.owner, source: input.source, hpLost: siege.hpLost }
+      : undefined,
+    batteryEvent: battery.event,
+  };
+}

--- a/src/systems/naval-city-bombardment-system.ts
+++ b/src/systems/naval-city-bombardment-system.ts
@@ -1,6 +1,6 @@
 import type { GameState, Unit } from '@/core/types';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
-import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { canUnitAttackTarget, type AttackTargetFailure } from '@/systems/attack-targeting';
 import { resolveCoastalBatteryCounterfire, type CoastalBatteryCounterfireEvent } from '@/systems/coastal-defense-system';
 import { applyCitySiegeOutcome, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 import { resolveCivilizationEra } from '@/systems/tech-definitions';
@@ -21,9 +21,16 @@ export interface NavalCityBombardmentEvent {
   hpLost: number;
 }
 
+export type NavalCityBombardmentFailure =
+  | 'missing-attacker-or-city'
+  | 'missing-city-owner'
+  | 'non-naval-attacker'
+  | 'invalid-city-target'
+  | AttackTargetFailure;
+
 export type NavalCityBombardmentResult =
   | { ok: true; state: GameState; cityEvent?: NavalCityBombardmentEvent; batteryEvent?: CoastalBatteryCounterfireEvent }
-  | { ok: false; state: GameState; reason: string };
+  | { ok: false; state: GameState; reason: NavalCityBombardmentFailure };
 
 function consumeAttackAction(state: GameState, attacker: Unit): GameState {
   const current = state.units[attacker.id];

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -11,6 +11,7 @@ import { applyCombatOutcomeToState } from './combat-reward-system';
 import { deterministicCombatSeed, resolveCombat } from './combat-system';
 import { buildCombatContextForDefender } from './combat-context';
 import { applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
+import { resolveCoastalBatteryCounterfire } from './coastal-defense-system';
 import type { PirateEconomyModifiers } from './economy-system';
 import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
 import {
@@ -830,7 +831,27 @@ export function processPiratesForCompletedRound(
       era: resolveCivilizationEra(ownerCiv.techState.completed),
       challenge: resolveChallengeForCiv(nextState, city.owner),
     });
+    const batteryTarget = (nextState.pirates?.factions[siege.factionId]?.shipIds ?? [])
+      .map(id => nextState.units[id])
+      .filter((unit): unit is Unit => Boolean(unit))
+      .sort((left, right) => {
+        const distance = nextState.map.wrapsHorizontally
+          ? (unit: Unit) => wrappedHexDistance(unit.position, city.position, nextState.map.width)
+          : (unit: Unit) => hexDistance(unit.position, city.position);
+        return distance(left) - distance(right) || left.id.localeCompare(right.id);
+      })[0];
+    const battery = batteryTarget
+      ? resolveCoastalBatteryCounterfire(nextState, {
+        cityId: city.id,
+        attackerUnitId: batteryTarget.id,
+        attackerDomain: 'naval',
+        cityDamage: result.hpLost,
+        source: 'pirate',
+      })
+      : undefined;
+    if (battery) nextState = battery.state;
     nextState = applyCitySiegeOutcome(nextState, siege.cityId, result);
+    if (battery?.event) bus.emit('city:coastal-battery-fired', battery.event);
 
     // One-time "under siege" alert ONLY on the transition from full HP into damage —
     // the notification de-dup key is per-turn, so pushing this every damaging round

--- a/src/systems/tech-definitions-eras8.ts
+++ b/src/systems/tech-definitions-eras8.ts
@@ -90,7 +90,7 @@ const ERA_8_TECHS: Tech[] = [
   { id: 'naval-armor', name: 'Naval Armor', track: 'maritime', cost: 250,
     prerequisites: ['ironclad-warships', 'steam-navigation'],
     unlocks: ['Naval units +5 strength; armored warships dominate coastal waters'],
-    unlocksUnits: ['pre_dreadnought'], era: 8 },
+    unlocksUnits: ['pre_dreadnought'], unlocksBuildings: ['coastal_battery'], era: 8 },
   { id: 'torpedo-warfare', name: 'Torpedo Warfare', track: 'maritime', cost: 90,
     prerequisites: ['steam-navigation'],
     unlocks: ['Naval ranged units +8 strength; coastal cities gain +5 defense bonus against naval assault'], era: 8 },

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -109,6 +109,20 @@ function makePlan(
   };
 }
 
+describe('naval city bombardment', () => {
+  it('offers a visible hostile city to an eligible warship without treating it as a capture', () => {
+    const state = makeState();
+    const ship = addUnit(state, 'ship', 'frigate', AI, { q: 2, r: 2 }, { movementPointsLeft: 3 });
+    const city = addCity(state, 'target-city', HUMAN, { q: 3, r: 2 });
+    const plan = makePlan({ kind: 'city', id: city.id, lastKnownPosition: city.position }, [ship.id]);
+
+    expect(rankUnitTacticalActions({ state, actorId: AI, plan, assignedUnitIds: [ship.id] }, ship.id)
+      .some(candidate => candidate.action.kind === 'bombard-city'
+        && candidate.action.unitId === ship.id
+        && candidate.action.cityId === city.id)).toBe(true);
+  });
+});
+
 function context(
   state: GameState,
   plan: AIStrategicPlan,

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -33,6 +33,24 @@ describe('selected-unit-highlights', () => {
     });
   });
 
+  it('highlights a visible hostile city for a naval bombardment, but not for a land unit', () => {
+    const state = createNewGame(undefined, 'naval-city-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      ship: { ...createUnit('frigate', 'player', { q: 1, r: 1 }, mkC()), id: 'ship', movementPointsLeft: 3 },
+      soldier: { ...createUnit('warrior', 'player', { q: 1, r: 2 }, mkC()), id: 'soldier', movementPointsLeft: 2 },
+    };
+    state.civilizations.player.units = ['ship', 'soldier'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations.player.visibility.tiles = { '1,1': 'visible', '1,2': 'visible', '2,1': 'visible' };
+    const city = foundCity('ai-1', { q: 2, r: 1 }, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+
+    expect(buildSelectedUnitHighlights(state, 'ship').highlights).toContainEqual({ coord: { q: 2, r: 1 }, type: 'attack' });
+    expect(buildSelectedUnitHighlights(state, 'soldier').highlights).not.toContainEqual({ coord: { q: 2, r: 1 }, type: 'attack' });
+  });
+
   it('marks visible ZOC terminal destinations with a non-attack movement highlight', () => {
     const state = createNewGame(undefined, 'zoc-highlight', 'small');
     state.currentPlayer = 'player';

--- a/tests/presentation/register-raider-presentation.test.ts
+++ b/tests/presentation/register-raider-presentation.test.ts
@@ -123,6 +123,24 @@ describe('raider presentation', () => {
     expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('ship'), 'info');
   });
 
+  it('delivers Coastal Battery feedback to its explicit hot-seat owner, not the currently rendered city owner', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: {
+        cities: { 'city-a': city({ owner: 'p2', name: 'Other Rome' }) } as never,
+        civilizations: { p1: humanCiv(), p2: humanCiv() } as never,
+      },
+    });
+
+    registerRaiderPresentation(bus, ctx);
+    bus.emit('city:coastal-battery-fired', {
+      cityId: 'city-a', attackerUnitId: 'unit-1', recipientCivId: 'p1', source: 'pirate', damage: 5, attackerDied: false,
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('p1', expect.stringContaining('Coastal Battery'), 'info');
+    expect(ctx.deliver).not.toHaveBeenCalledWith('p2', expect.anything(), expect.anything());
+  });
+
   it('announces a barbarian sacking, distinct from destruction', () => {
     const bus = new EventBus();
     const ctx = makePresentationContext({

--- a/tests/storage/save-migrations-v13.test.ts
+++ b/tests/storage/save-migrations-v13.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { CURRENT_SAVE_SCHEMA_VERSION, migrateSaveToCurrent } from '@/storage/save-migrations';
+
+function saveAtSchema(version: number) {
+  const save = createNewGame('rome', `coastal-battery-schema-${version}`, 'small');
+  save.saveSchemaVersion = version;
+  return save;
+}
+
+describe('save migration 13 — Coastal Battery counterfire marker', () => {
+  it('adds no marker to legacy cities and preserves a valid mid-turn marker', () => {
+    const legacy = saveAtSchema(12);
+    const legacyCity = Object.values(legacy.cities)[0]!;
+    delete legacyCity.coastalBatteryCounterfireTurn;
+
+    const migratedLegacy = migrateSaveToCurrent(legacy);
+    expect(migratedLegacy.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(migratedLegacy.cities[legacyCity.id]!.coastalBatteryCounterfireTurn).toBeUndefined();
+
+    const midTurn = saveAtSchema(12);
+    const midTurnCity = Object.values(midTurn.cities)[0]!;
+    midTurnCity.coastalBatteryCounterfireTurn = 42;
+    const migratedMidTurn = migrateSaveToCurrent(midTurn);
+    expect(migratedMidTurn.cities[midTurnCity.id]!.coastalBatteryCounterfireTurn).toBe(42);
+    expect(migrateSaveToCurrent(migratedMidTurn)).toEqual(migratedMidTurn);
+  });
+
+  it('removes malformed markers even from a save already at the current schema', () => {
+    const malformed = saveAtSchema(CURRENT_SAVE_SCHEMA_VERSION);
+    const city = Object.values(malformed.cities)[0]!;
+    city.coastalBatteryCounterfireTurn = Number.NaN;
+
+    const migrated = migrateSaveToCurrent(malformed);
+    expect(migrated.cities[city.id]!.coastalBatteryCounterfireTurn).toBeUndefined();
+    expect(migrateSaveToCurrent(migrated)).toEqual(migrated);
+  });
+});

--- a/tests/systems/city-defense.test.ts
+++ b/tests/systems/city-defense.test.ts
@@ -97,6 +97,23 @@ describe('getCityDefenseBreakdown', () => {
     expect(vsLand.flatBonus).toBe(0);
   });
 
+  it('Coastal Battery grants a named +8 flat defense only against naval attackers', () => {
+    const vsNaval = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['coastal_battery'], attackerDomain: 'naval' }),
+    );
+    expect(vsNaval.flatBonus).toBe(8);
+    expect(vsNaval.parts).toContainEqual({
+      source: 'coastal_battery', label: 'Coastal Battery +8 vs naval', kind: 'flat', value: 8,
+    });
+
+    expect(getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['coastal_battery'], attackerDomain: 'land' }),
+    ).flatBonus).toBe(0);
+    expect(getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['coastal_battery'], attackerDomain: 'air' }),
+    ).flatBonus).toBe(0);
+  });
+
   it('stacks walls + star_fort + fortification-engineering + professional-army in documented order', () => {
     const breakdown = getCityDefenseBreakdown(
       baseCityDefenseInput({

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -320,6 +320,34 @@ describe('getAvailableBuildings', () => {
     expect(available.find(b => b.id === 'dock')).toBeDefined();
   });
 
+  it('offers Coastal Battery only to a coastal Naval Armor city', () => {
+    const tile = (q: number, r: number, terrain: 'plains' | 'coast') => ({
+      coord: { q, r }, terrain, elevation: 'lowland', resource: null, improvement: 'none',
+      owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    });
+    const map = {
+      width: 20, height: 20, wrapsHorizontally: false, rivers: [],
+      tiles: {
+        [hexKey({ q: 5, r: 5 })]: tile(5, 5, 'plains'),
+        [hexKey({ q: 6, r: 5 })]: tile(6, 5, 'coast'),
+        [hexKey({ q: 15, r: 15 })]: tile(15, 15, 'plains'),
+      },
+    } as GameMap;
+    const cityAt = (position: HexCoord) => ({
+      id: hexKey(position), name: 'Test', owner: 'p1', position, population: 1,
+      food: 0, foodNeeded: 15, buildings: [], productionQueue: [], productionProgress: 0,
+      ownedTiles: [position], workedTiles: [], focus: 'balanced', grid: [], gridSize: 1,
+      hp: 100, maturity: 'core',
+    } as unknown as City);
+    const coastalCity = cityAt({ q: 5, r: 5 });
+    const inlandCity = cityAt({ q: 15, r: 15 });
+
+    expect(getAvailableBuildings(coastalCity, ['naval-armor'], map))
+      .toContainEqual(expect.objectContaining({ id: 'coastal_battery', productionCost: 170 }));
+    expect(getAvailableBuildings(inlandCity, ['naval-armor'], map).map(building => building.id))
+      .not.toContain('coastal_battery');
+  });
+
   it('excludes dock from coastal city without fishing tech', () => {
     const map = generateMap(30, 30, 'coastal-test');
     const waterTile = Object.values(map.tiles).find(t => t.terrain === 'ocean' || t.terrain === 'coast')!;

--- a/tests/systems/coastal-defense-system.test.ts
+++ b/tests/systems/coastal-defense-system.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState } from '@/core/types';
+import { resolveCoastalBatteryCounterfire } from '@/systems/coastal-defense-system';
+
+function makeState(): GameState {
+  return {
+    turn: 42,
+    cities: {
+      port: {
+        id: 'port', name: 'Port', owner: 'player', position: { q: 0, r: 0 },
+        population: 1, food: 0, foodNeeded: 15, buildings: ['coastal_battery'],
+        productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [],
+        focus: 'balanced', maturity: 'core', unrestLevel: 0, unrestTurns: 0,
+        spyUnrestBonus: 0,
+      },
+    },
+    units: {
+      ship: {
+        id: 'ship', type: 'pirate_frigate', owner: 'pirates', position: { q: 1, r: 0 },
+        movementPointsLeft: 0, health: 100, experience: 0, hasMoved: true, hasActed: true,
+        isResting: false,
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('resolveCoastalBatteryCounterfire', () => {
+  it('returns twenty percent of the first damaging naval siege, marks only that city, and identifies its owner', () => {
+    const state = makeState();
+    const result = resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'pirate',
+    });
+
+    expect(result.damage).toBe(8);
+    expect(result.state).not.toBe(state);
+    expect(result.state.units.ship.health).toBe(92);
+    expect(result.state.cities.port.coastalBatteryCounterfireTurn).toBe(42);
+    expect(result.event).toEqual({
+      cityId: 'port', attackerUnitId: 'ship', recipientCivId: 'player', source: 'pirate', damage: 8, attackerDied: false,
+    });
+    expect(state.units.ship.health).toBe(100);
+    expect(state.cities.port.coastalBatteryCounterfireTurn).toBeUndefined();
+  });
+
+  it('caps damage, never fires twice in a turn, and rejects non-naval or zero-damage sieges', () => {
+    const state = makeState();
+    const first = resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 100, source: 'ai',
+    });
+    expect(first.damage).toBe(12);
+    expect(resolveCoastalBatteryCounterfire(first.state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 100, source: 'ai',
+    }).event).toBeUndefined();
+    expect(resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'land', cityDamage: 100, source: 'barbarian',
+    }).event).toBeUndefined();
+    expect(resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 0, source: 'player',
+    }).event).toBeUndefined();
+  });
+});

--- a/tests/systems/coastal-defense-system.test.ts
+++ b/tests/systems/coastal-defense-system.test.ts
@@ -58,4 +58,35 @@ describe('resolveCoastalBatteryCounterfire', () => {
       cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 0, source: 'player',
     }).event).toBeUndefined();
   });
+
+  it('consumes the first damaging hit even when the rounded retaliation is zero', () => {
+    const state = makeState();
+    const first = resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 1, source: 'ai',
+    });
+
+    expect(first.damage).toBe(0);
+    expect(first.event).toBeUndefined();
+    expect(first.state.cities.port.coastalBatteryCounterfireTurn).toBe(state.turn);
+    expect(resolveCoastalBatteryCounterfire(first.state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'ai',
+    }).damage).toBe(0);
+  });
+
+  it('tracks each Battery city independently and resets on the next global turn', () => {
+    const state = makeState();
+    state.cities.secondPort = { ...state.cities.port, id: 'secondPort', position: { q: 3, r: 0 } };
+    const firstPort = resolveCoastalBatteryCounterfire(state, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'pirate',
+    });
+    const secondPort = resolveCoastalBatteryCounterfire(firstPort.state, {
+      cityId: 'secondPort', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'pirate',
+    });
+    expect(secondPort.damage).toBe(8);
+
+    const nextTurn = resolveCoastalBatteryCounterfire({ ...firstPort.state, turn: state.turn + 1 }, {
+      cityId: 'port', attackerUnitId: 'ship', attackerDomain: 'naval', cityDamage: 40, source: 'pirate',
+    });
+    expect(nextTurn.damage).toBe(8);
+  });
 });

--- a/tests/systems/naval-city-bombardment-system.test.ts
+++ b/tests/systems/naval-city-bombardment-system.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState } from '@/core/types';
+import { resolveNavalCityBombardment } from '@/systems/naval-city-bombardment-system';
+
+function makeState(): GameState {
+  return {
+    turn: 30,
+    map: { width: 8, height: 8, wrapsHorizontally: false, tiles: {} },
+    cities: {
+      port: {
+        id: 'port', name: 'Port', owner: 'player', position: { q: 0, r: 0 },
+        population: 4, food: 0, foodNeeded: 15, buildings: ['coastal_battery'],
+        productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [], focus: 'balanced',
+        maturity: 'city', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0, hp: 100,
+      },
+    },
+    units: {
+      cruiser: {
+        id: 'cruiser', type: 'missile_cruiser', owner: 'ai-1', position: { q: 1, r: 0 },
+        movementPointsLeft: 4, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+      },
+    },
+    civilizations: {
+      player: { id: 'player', cities: ['port'], units: [], gold: 100, techState: { completed: [] } },
+      'ai-1': {
+        id: 'ai-1', cities: [], units: ['cruiser'], gold: 100, techState: { completed: [] },
+        diplomacy: { atWarWith: ['player'] },
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('resolveNavalCityBombardment', () => {
+  it('uses the naval defense result for Battery counterfire, consumes the ship, and leaves the city capturable', () => {
+    const result = resolveNavalCityBombardment(makeState(), {
+      attackerUnitId: 'cruiser', cityId: 'port', source: 'ai',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.cities.port.hp).toBe(80);
+    expect(result.state.units.cruiser.health).toBe(96);
+    expect(result.state.units.cruiser.hasActed).toBe(true);
+    expect(result.state.units.cruiser.movementPointsLeft).toBe(0);
+    expect(result.batteryEvent).toMatchObject({ recipientCivId: 'player', damage: 4, source: 'ai' });
+    expect(result.cityEvent).toEqual({ cityId: 'port', recipientCivId: 'player', source: 'ai', hpLost: 20 });
+  });
+
+  it('cannot destroy a city from offshore and does not let a second same-turn bombardment re-fire its Battery', () => {
+    const nearDeath = makeState();
+    nearDeath.cities.port.hp = 3;
+    const first = resolveNavalCityBombardment(nearDeath, {
+      attackerUnitId: 'cruiser', cityId: 'port', source: 'player',
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    expect(first.state.cities.port.hp).toBe(1);
+
+    const again = resolveNavalCityBombardment(
+      {
+        ...first.state,
+        units: {
+          ...first.state.units,
+          cruiser: { ...first.state.units.cruiser, hasActed: false, movementPointsLeft: 4 },
+        },
+      },
+      { attackerUnitId: 'cruiser', cityId: 'port', source: 'player' },
+    );
+    expect(again.ok).toBe(true);
+    if (!again.ok) return;
+    expect(again.batteryEvent).toBeUndefined();
+  });
+});

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -633,6 +633,28 @@ describe('pirate naval siege (#522)', () => {
     expect(result.state.units['ship-a']?.health ?? 0).toBe(shipBefore);
   });
 
+  it('fires Coastal Battery once from actual naval HP loss and emits an owner-safe Battery event', () => {
+    const state = siegeReadyState(100);
+    state.cities.port = { ...state.cities.port!, buildings: ['coastal_battery'] };
+    state.pirates!.factions['pirate-1']!.maritimeStage = 5;
+    const bus = new EventBus();
+    const onBattery = vi.fn();
+    bus.on('city:coastal-battery-fired', onBattery);
+
+    const result = processPiratesForCompletedRound(state, bus);
+    const event = onBattery.mock.calls[0]?.[0];
+    const hpLost = 100 - (result.state.cities.port!.hp ?? 100);
+
+    expect(event).toMatchObject({ cityId: 'port', recipientCivId: 'player', source: 'pirate' });
+    expect(event.damage).toBe(Math.min(12, Math.round(hpLost * 0.2)));
+    expect(result.state.cities.port!.coastalBatteryCounterfireTurn).toBe(state.turn);
+    expect(result.state.units['ship-a']!.health).toBe(100 - event.damage);
+
+    const repeated = processPiratesForCompletedRound(result.state, bus);
+    expect(onBattery).toHaveBeenCalledTimes(1);
+    expect(repeated.state.units['ship-a']!.health).toBe(result.state.units['ship-a']!.health);
+  });
+
   it('emits city:counter-fire so the player gets feedback that their walls fought back (#522)', () => {
     const state = siegeReadyState(100);
     state.cities.port = { ...state.cities.port!, buildings: ['walls'], population: 20 };

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -5,7 +5,7 @@ import { SESSION_SHOWN_TIPS } from '@/ui/advisor-system';
 import { createUnit } from '@/systems/unit-system';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
-import { hexKey } from '@/systems/hex-utils';
+import { hexKey, hexNeighbors } from '@/systems/hex-utils';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { createMarketplaceState } from '@/systems/trade-system';
 import { collectText, makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
@@ -25,6 +25,28 @@ function clickElement(element: Element | null | undefined): void {
 }
 
 describe('city-panel national projects', () => {
+  it('renders Coastal Battery and its naval-only rule only for a researched coastal city', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('naval-armor');
+    const coast = hexNeighbors(city.position)[0]!;
+    state.map.tiles[hexKey(coast)] = {
+      coord: coast, terrain: 'coast', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: city.owner, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    } as never;
+
+    const coastalPanel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    expect(coastalPanel.querySelector('[data-item-id="coastal_battery"]')).toBeTruthy();
+    expect(collectText(coastalPanel)).toContain('Naval defense +8. First naval hit each turn returns 20% damage (max 12).');
+
+    state.map.tiles[hexKey(coast)] = { ...state.map.tiles[hexKey(coast)]!, terrain: 'plains' };
+    const inlandPanel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    expect(inlandPanel.querySelector('[data-item-id="coastal_battery"]')).toBeNull();
+  });
+
   it('shows the current hot-seat empire Fort capacity without exposing another player\'s forts', () => {
     const { container, city, state } = makeWonderPanelFixture();
     state.map.tiles['3,2'] = {


### PR DESCRIPTION
Closes #692

## Summary

- Adds the Coastal Battery as a save-safe coastal-only city building with visible city-panel availability and dedicated sprite art.
- Applies naval-only flat city defense and one bounded counterfire reaction per city per turn, including pirate sieges.
- Completes the player and major-AI naval loop: visible hostile city bombardment shares one canonical mutation, respects defenses and garrisons, consumes the ship action, never captures or destroys from offshore, and emits hot-seat-safe recipient events.
- Adds regression coverage for saves, production eligibility, pirate pressure, player targeting, AI decisions, presentation routing, naval resolution, and sprite catalog coverage.

## Validation

- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test:durable` — 484 files passed; 7,864 tests passed; 3 skipped
- Focused system/UI/AI/presentation/sprite tests and source-rule checks

Rebased cleanly onto current `origin/main` before push.