### PR TITLE
feat(defense): add reinforced concrete bunker (#693)

### DIFF
--- a/docs/superpowers/plans/2026-08-14-issue-693-bunker.md
+++ b/docs/superpowers/plans/2026-08-14-issue-693-bunker.md
@@ -1,0 +1,52 @@
+# Bunker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver #693's Walls-gated Bunker as a clear modern defensive choice with non-stacking Star Fort supersession.
+
+**Architecture:** Keep city-defense facts in the canonical typed defense breakdown and pass a narrow bombardment context through the shared siege resolver. City production, UI previews, AI, player action, and non-human siege callers read the same facts; no actor-specific defense branch is permitted.
+
+**Tech Stack:** TypeScript, Vitest, Canvas/DOM city panels, serializable GameState.
+
+---
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Walls + Reinforced Concrete | Open Build | Bunker is listed at 175 with its exact defense/supersession text. |
+| Reinforced Concrete without Walls | Open Build | Bunker is absent and an invalid queued Bunker is dropped. |
+| Bunker replaces Star Fort's contribution | Open defense preview | Bunker +8 appears and Star Fort is labeled superseded. |
+| Bunker city suffers naval/air bombardment | Resolve hit | HP loss reflects 15% mitigation; adjacent land attacks do not. |
+
+## Tasks
+
+### Task 1: Typed content and catalog gate
+
+**Files:** `src/systems/city-system.ts`, `src/systems/tech-definitions-eras*.ts`, `tests/systems/city-system.test.ts`
+
+- [ ] Add failing tests for Reinforced Concrete + Walls availability, 175 cost, and the no-Walls negative case.
+- [ ] Add the minimal typed Bunker building data and technology unlock; use the existing prerequisite and queue validation helpers.
+- [ ] Run the mirrored city-system tests.
+
+### Task 2: Canonical supersession and bombardment mitigation
+
+**Files:** `src/systems/combat-system.ts`, `src/systems/city-siege-system.ts`, `tests/systems/city-defense.test.ts`, `tests/systems/city-siege-system.test.ts`
+
+- [ ] Add failing tests proving Bunker replaces Star Fort +5, adds +8, mitigates naval/air siege damage by 15%, and leaves adjacent land damage unchanged.
+- [ ] Add typed defense parts and one shared siege context option; preserve named preview/history parts.
+- [ ] Run focused defense and siege tests.
+
+### Task 3: Complete player, AI, presentation, and sprite wiring
+
+**Files:** `src/ui/**`, `src/ai/**`, `src/renderer/sprites/**`, matching tests.
+
+- [ ] Add failing rendered-DOM and generic AI candidate tests for complete Bunker reachability and immediate panel refresh.
+- [ ] Add a catalog sprite fallback and recipient-safe presentation only where an existing shared event needs a Bunker fact.
+- [ ] Verify player and major-AI calls reach the same city-siege resolver, including solo and two-human hot-seat coverage.
+
+### Task 4: Audit and delivery
+
+- [ ] Inspect `origin/main...HEAD` and uncommitted diffs against the design.
+- [ ] Run source-rule checks, focused tests, build, and durable suite.
+- [ ] Rebase on current `origin/main`, rerun exact-HEAD verification, push, and open the MR.

--- a/docs/superpowers/specs/2026-08-14-issue-693-bunker-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-693-bunker-design.md
@@ -1,0 +1,54 @@
+# Bunker design (#693)
+
+## Contract
+
+Reinforced Concrete unlocks the 175-production Bunker for cities that already
+have Walls. It supersedes Star Fort's +5 city-defense contribution rather than
+stacking with it, adds +8 flat city defense, and reduces ranged naval or air
+bombardment damage by 15%. Adjacent land assaults do not receive this
+mitigation.
+
+The building is a deliberate modern defensive choice: coastal, air-exposed,
+and turtle play gain a reliable answer, while mobile, expansionist, and
+combined-arms players retain the land-assault counterplay. Explorer, Standard,
+and Veteran use the same content and combat rules.
+
+## Architecture
+
+City defense remains typed data owned by `getCityDefenseBreakdown`; it reports
+every active and superseded defense part for previews and history. A small
+typed city-siege option identifies bombardment, so the existing resolver
+applies Bunker's 15% mitigation after the shared defense calculation without
+inventing a separate player/AI mutation path. Player attacks, major AI,
+pirates, and air operations all consume that system result.
+
+The city build catalog supplies the Walls prerequisite, preserves full catalog
+reachability, and names the supersession plainly. AI receives Bunker through
+the generic eligible-building catalog; no hidden-state query or building-ID
+priority branch is added. The building uses a catalog sprite fallback and no
+new sound: its result remains visible in preview and city text, so sound is
+not required for accessibility or hot-seat privacy.
+
+## Player truth table
+
+| Before | Action | Immediate result |
+| --- | --- | --- |
+| Reinforced Concrete, Walls | Open city build catalog | Bunker is visible at 175 production with its plain rule text. |
+| Reinforced Concrete, no Walls | Open catalog | Bunker is unavailable and cannot remain queued. |
+| Walls, Star Fort, Bunker | Inspect defense preview | Bunker +8 is shown; Star Fort is shown as superseded, not stacked. |
+| Bunker city under naval/air bombardment | Resolve attack | Mitigated city damage is 15% lower; preview/history use the same fact. |
+| Bunker city under adjacent land assault | Resolve attack | No Bunker bombardment mitigation is applied. |
+| Two human hot-seat players | Opponent attack/handoff | Feedback is explicitly recipient-scoped and reveals no hidden action to another player. |
+
+## Verification
+
+- Building gate, cost, full city-catalog reachability, and immediate panel
+  refresh after selection.
+- Defense breakdown verifies Star Fort supersession, Bunker +8, naval/air
+  bombardment mitigation, and adjacent-land negative behavior.
+- Player and major-AI actions use the shared result; generic AI production sees
+  each eligible building without rival hidden state.
+- Current, legacy, malformed, and mid-turn saves remain valid with no new
+  persisted state beyond the ordinary building id.
+- Deterministic balance cases compare Walls/Star Fort/Bunker against a naval
+  bombardment, air strike, adjacent land attacker, and a non-fortified city.

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -455,6 +455,7 @@ export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = 
   surgery_guild:          SurgeryGuildSprite,
   concert_hall:           ConcertHallSprite,
   star_fort:              StarFortSprite,
+  bunker:                 StarFortSprite,
   coastal_battery:        CoastalBatterySprite,
   // Era 7 regular buildings
   factory:                FactorySprite,

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -183,7 +183,9 @@ export function resolveCitySiegeDamage(input: CitySiegeInput): CitySiegeResult {
   });
   const mitigatedDamage = Math.max(
     0,
-    Math.round(input.rawDamage / breakdown.multiplier) - breakdown.flatBonus,
+    Math.round(
+      (input.rawDamage * breakdown.bombardmentDamageMultiplier) / breakdown.multiplier,
+    ) - breakdown.flatBonus,
   );
   const newHp = Math.max(0, currentHp - mitigatedDamage);
 

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -482,6 +482,12 @@ export const BUILDINGS: Record<string, Building> = {
     description: 'Angled bastion fortress. +3 production. City walls gain +5 garrison defense.',
     techRequired: 'fortification-engineering',
   },
+  bunker: {
+    id: 'bunker', name: 'Bunker', category: 'military',
+    yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 175,
+    description: 'Reinforced shelter. +8 city defense; naval and air bombardment deal 15% less damage. Supersedes Star Fort.',
+    techRequired: 'reinforced-concrete', requiresBuildings: ['walls'],
+  },
 
   // ERA 7 REGULAR BUILDINGS — costs calibrated to era-7 production rate of ~15/turn
   // infrastructure band [8,13]: 120–195; power-spike band [9,14]: 135–210
@@ -1599,6 +1605,7 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   surgery_guild:        '⚕️',
   concert_hall:         '🎻',
   star_fort:            '⭐',
+  bunker:               '🛡️',
   // era 7 regular buildings
   factory:              '🏭',
   steel_mill:           '⚙️',

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -97,6 +97,8 @@ export interface CityDefensePart {
 export interface CityDefenseBreakdown {
   multiplier: number;
   flatBonus: number;
+  /** Damage multiplier applied only by the city-siege bombardment resolver. */
+  bombardmentDamageMultiplier: number;
   parts: CityDefensePart[];
 }
 
@@ -105,15 +107,30 @@ export function getCityDefenseBreakdown(input: CityDefenseInput): CityDefenseBre
   const parts: CityDefensePart[] = [];
   let multiplier = 1;
   let flatBonus = 0;
+  let bombardmentDamageMultiplier = 1;
 
   if (hasWalls) {
     multiplier *= 1.25;
     parts.push({ source: 'walls', label: 'Walls ×1.25', kind: 'mult', value: 1.25 });
   }
 
+  const hasBunker = hasWalls && input.cityBuildings.includes('bunker');
   if (hasWalls && input.cityBuildings.includes('star_fort')) {
-    flatBonus += 5;
-    parts.push({ source: 'star_fort', label: 'Star Fort +5', kind: 'flat', value: 5 });
+    if (hasBunker) {
+      parts.push({ source: 'star_fort', label: 'Star Fort superseded by Bunker', kind: 'flat', value: 0 });
+    } else {
+      flatBonus += 5;
+      parts.push({ source: 'star_fort', label: 'Star Fort +5', kind: 'flat', value: 5 });
+    }
+  }
+
+  if (hasBunker) {
+    flatBonus += 8;
+    parts.push({ source: 'bunker', label: 'Bunker +8', kind: 'flat', value: 8 });
+    if (input.attackerDomain === 'naval' || input.attackerDomain === 'air') {
+      bombardmentDamageMultiplier = 0.85;
+      parts.push({ source: 'bunker', label: 'Bunker bombardment −15%', kind: 'mult', value: 0.85 });
+    }
   }
 
   if (hasWalls && input.defenderCompletedTechs.includes('fortification-engineering')) {
@@ -141,7 +158,7 @@ export function getCityDefenseBreakdown(input: CityDefenseInput): CityDefenseBre
     parts.push({ source: 'coastal_battery', label: 'Coastal Battery +8 vs naval', kind: 'flat', value: 8 });
   }
 
-  return { multiplier, flatBonus, parts };
+  return { multiplier, flatBonus, bombardmentDamageMultiplier, parts };
 }
 
 export interface UnitModifierBreakdown {

--- a/src/systems/tech-definitions-eras8.ts
+++ b/src/systems/tech-definitions-eras8.ts
@@ -108,7 +108,8 @@ const ERA_8_TECHS: Tech[] = [
   // CONSTRUCTION (2)
   { id: 'reinforced-concrete', name: 'Reinforced Concrete', track: 'construction', cost: 250,
     prerequisites: ['urban-planning', 'structural-engineering'],
-    unlocks: ['+2 production in cities with 4 or more buildings; iron-reinforced concrete enables taller urban structures'], era: 8 },
+    unlocks: ['+2 production in cities with 4 or more buildings; iron-reinforced concrete enables taller urban structures'],
+    unlocksBuildings: ['bunker'], era: 8 },
   { id: 'sanitation-networks', name: 'Sanitation Networks', track: 'construction', cost: 240,
     prerequisites: ['iron-bridges', 'urban-planning'],
     unlocks: ['+1 food all cities; municipal water and sewage systems transform urban health'], era: 8 },

--- a/tests/ai/ai-production.test.ts
+++ b/tests/ai/ai-production.test.ts
@@ -451,6 +451,23 @@ describe('AI strategic production', () => {
     }
   });
 
+  it('offers Bunker to an AI city with Walls and Reinforced Concrete through the shared building catalog', () => {
+    const state = setupState(['reinforced-concrete']);
+    state.cities['city-a'].buildings = ['walls'];
+
+    const candidates = generateAIProductionCandidates(
+      state,
+      'ai-1',
+      'city-a',
+      [],
+      aggressive,
+    );
+
+    expect(candidates).toContainEqual(expect.objectContaining({
+      itemId: 'bunker', kind: 'building', productionTurns: expect.any(Number),
+    }));
+  });
+
   it('counts empire-wide national-project yields in economy scoring', () => {
     const state = setupState(['gathering']);
     state.era = 1;

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -120,6 +120,17 @@ describe('save migrations', () => {
     expect(migrateSaveToCurrent(loaded)).toEqual(loaded);
   });
 
+  it('#693 Bunker infrastructure is definition data and survives save normalization unchanged', () => {
+    const savedGame = createNewGame('rome', 'bunker-save-compatibility', 'small');
+    const cityId = Object.keys(savedGame.cities)[0]!;
+    savedGame.cities[cityId]!.buildings = ['walls', 'star_fort', 'bunker'];
+    const loaded = migrateSaveToCurrent(structuredClone(savedGame));
+
+    expect(loaded.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(loaded.cities[cityId]!.buildings).toEqual(['walls', 'star_fort', 'bunker']);
+    expect(migrateSaveToCurrent(loaded)).toEqual(loaded);
+  });
+
   it('#678 preserves a legacy Biplane queue by retiming it to the legal fighter successor', () => {
     const savedGame = createNewGame('rome', 'retimed-biplane-queue', 'small');
     const source = Object.values(savedGame.units)[0]!;

--- a/tests/systems/city-defense.test.ts
+++ b/tests/systems/city-defense.test.ts
@@ -53,6 +53,37 @@ describe('getCityDefenseBreakdown', () => {
     expect(breakdown.flatBonus).toBe(0);
   });
 
+  it('Bunker supersedes Star Fort, adds +8 with Walls, and limits bombardment only', () => {
+    const naval = getCityDefenseBreakdown(
+      baseCityDefenseInput({
+        cityBuildings: ['walls', 'star_fort', 'bunker'],
+        attackerDomain: 'naval',
+      }),
+    );
+    const air = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['walls', 'bunker'], attackerDomain: 'air' }),
+    );
+    const land = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['walls', 'bunker'], attackerDomain: 'land' }),
+    );
+
+    expect(naval.flatBonus).toBe(8);
+    expect(naval.bombardmentDamageMultiplier).toBeCloseTo(0.85);
+    expect(air.bombardmentDamageMultiplier).toBeCloseTo(0.85);
+    expect(land.bombardmentDamageMultiplier).toBe(1);
+    expect(naval.parts).toContainEqual({
+      source: 'star_fort', label: 'Star Fort superseded by Bunker', kind: 'flat', value: 0,
+    });
+  });
+
+  it('Bunker WITHOUT Walls contributes no defense or bombardment mitigation (negative test)', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['bunker'], attackerDomain: 'naval' }),
+    );
+    expect(breakdown.flatBonus).toBe(0);
+    expect(breakdown.bombardmentDamageMultiplier).toBe(1);
+  });
+
   it('fortification-engineering adds +5 flat defense when walls are present', () => {
     const breakdown = getCityDefenseBreakdown(
       baseCityDefenseInput({

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -79,6 +79,31 @@ describe('resolveCitySiegeDamage (#522)', () => {
     expect(fortifiedResult.hpLost).toBeLessThan(baseResult.hpLost);
   });
 
+  it('Bunker replaces Star Fort defense and mitigates naval and air bombardment, not land assaults', () => {
+    const makeBunkerCity = () => makeCityAndCiv({
+      hp: 50, buildings: ['walls', 'star_fort', 'bunker'],
+    });
+    const { city: navalCity, ownerCiv: navalCiv } = makeBunkerCity();
+    const { city: airCity, ownerCiv: airCiv } = makeBunkerCity();
+    const { city: landCity, ownerCiv: landCiv } = makeBunkerCity();
+
+    const naval = resolveCitySiegeDamage({
+      city: navalCity, ownerCiv: navalCiv, rawDamage: 30, attackerDomain: 'naval', hasGarrison: false, era: 1, challenge: 'standard',
+    });
+    const air = resolveCitySiegeDamage({
+      city: airCity, ownerCiv: airCiv, rawDamage: 30, attackerDomain: 'air', hasGarrison: false, era: 1, challenge: 'standard',
+    });
+    const land = resolveCitySiegeDamage({
+      city: landCity, ownerCiv: landCiv, rawDamage: 30, attackerDomain: 'land', hasGarrison: false, era: 1, challenge: 'standard',
+    });
+
+    // +8: round(30 / 1.25) - 8 = 16. Bombardment also receives 15% mitigation:
+    // round((30 * 0.85) / 1.25) - 8 = 12. Star Fort must not stack to +13.
+    expect(naval.hpLost).toBe(12);
+    expect(air.hpLost).toBe(12);
+    expect(land.hpLost).toBe(16);
+  });
+
   it('applies Torpedo Warfare\'s flat bonus only against a naval attacker, not a land attacker', () => {
     const { city: navalCity, ownerCiv: navalCivBase } = makeCityAndCiv({ hp: 50, buildings: ['walls'] });
     const { city: navalCityNoTech, ownerCiv: navalCivNoTech } = makeCityAndCiv({ hp: 50, buildings: ['walls'] });

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -348,6 +348,17 @@ describe('getAvailableBuildings', () => {
       .not.toContain('coastal_battery');
   });
 
+  it('offers Bunker only after Reinforced Concrete and Walls', () => {
+    const map = generateMap(20, 20, 'bunker-gate');
+    const city = foundCity('p1', { q: 5, r: 5 }, map, mkC());
+
+    expect(getAvailableBuildings(city, ['reinforced-concrete'], map).map(building => building.id))
+      .not.toContain('bunker');
+    city.buildings = ['walls'];
+    expect(getAvailableBuildings(city, ['reinforced-concrete'], map))
+      .toContainEqual(expect.objectContaining({ id: 'bunker', productionCost: 175 }));
+  });
+
   it('excludes dock from coastal city without fishing tech', () => {
     const map = generateMap(30, 30, 'coastal-test');
     const waterTile = Object.values(map.tiles).find(t => t.terrain === 'ocean' || t.terrain === 'coast')!;

--- a/tests/systems/pacing-reference-economy.test.ts
+++ b/tests/systems/pacing-reference-economy.test.ts
@@ -24,8 +24,11 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   // #441: Security Bureau now enters the bounded loadout at era 13 through its era-10 gate.
   // That crosses the reference fixture's four-buildings-per-population threshold, adding one
   // worked tile and therefore one science.
+  // #693: Bunker makes Walls a forced prerequisite of an Era-8 defensive upgrade. The bounded
+  // fixture intentionally retains forced prerequisite chains; at eras 10, 11, and 13 that
+  // crosses its four-buildings-per-population threshold and adds one worked-tile science.
   const expectedBoundedByEra: Record<number, number> = {
-    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 35, 8: 50, 9: 68, 10: 75, 11: 103, 12: 113, 13: 114,
+    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 35, 8: 50, 9: 68, 10: 76, 11: 104, 12: 113, 13: 115,
   };
   const expectedMaximalByEra: Record<number, number> = {
     1: 2, 2: 6, 3: 8, 4: 9, 5: 13, 6: 34, 7: 48, 8: 79, 9: 118, 10: 135, 11: 170, 12: 198, 13: 236,

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -25,6 +25,29 @@ function clickElement(element: Element | null | undefined): void {
 }
 
 describe('city-panel national projects', () => {
+  it('renders Bunker only after Reinforced Concrete and Walls, with its full defensive rule', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('reinforced-concrete');
+    city.buildings.push('walls');
+
+    const unlockedPanel = createCityPanel(container, city, state, {
+      onBuild: (cityId, itemId) => {
+        state.cities[cityId]!.productionQueue = [itemId];
+      }, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    expect(unlockedPanel.querySelector('[data-item-id="bunker"]')).toBeTruthy();
+    expect(collectText(unlockedPanel)).toContain('Reinforced shelter. +8 city defense; naval and air bombardment deal 15% less damage. Supersedes Star Fort.');
+
+    clickElement(unlockedPanel.querySelector('[data-item-id="bunker"]'));
+    expect(collectText(container)).toContain('Producing: 🛡️ Bunker');
+
+    city.buildings = [];
+    const gatedPanel = createCityPanel(container, city, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    expect(gatedPanel.querySelector('[data-item-id="bunker"]')).toBeNull();
+  });
+
   it('renders Coastal Battery and its naval-only rule only for a researched coastal city', () => {
     const { container, city, state } = makeWonderPanelFixture();
     state.civilizations.player.techState.completed.push('naval-armor');

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -36,6 +36,7 @@ describe('formatCombatPreviewDetails', () => {
       cityDefense: {
         multiplier: 1.25,
         flatBonus: 0,
+        bombardmentDamageMultiplier: 1,
         parts: [{ source: 'walls', label: 'Walls ×1.25', kind: 'mult', value: 1.25 }],
       },
     });


### PR DESCRIPTION
Closes #693

## Summary

- Adds the 175-production, Walls-gated Bunker to Reinforced Concrete and makes it visible in the city catalog with plain-language defense and supersession text.
- Centralizes Bunker defense in the typed city-defense breakdown: +8 flat defense supersedes Star Fort +5, and only naval/air city bombardment receives the 15% damage mitigation.
- Covers generic AI production, player panel refresh, sprite fallback, save round-trip, naval/air/land parity, and the bounded pacing reference consequence of the Walls prerequisite.

## Verification

- `yarn test --run` focused #693 suite: 586 passed
- `yarn build`
- `yarn test:durable`: 484 files passed, 7,877 tests passed, 3 skipped
- `scripts/check-src-rule-violations.sh` for changed source files

## Review

Completed the requested inline review across gameplay balance, accessibility, play styles and difficulty, AI, UI/UX, architecture/types, extensibility/data, SFX, saves, solo/hot-seat parity, and regressions. The review fixes are included in this MR.