### PR TITLE
fix(787): flush renderer on hoard-choice and minor-civ war state (phase 14a)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -143,9 +143,13 @@ export function createAppComposition(deps: AppCompositionDeps): AppComposition {
     const preview = getHoardChoicePreview(session.getState(), pending.lairId);
     const lair = session.getState().beasts!.lairs[pending.lairId];
     createBeastHoardPanel(uiLayer, preview, choice => {
-      session.setStateWithoutRefresh(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
+      // #787 phase 14: was setStateWithoutRefresh + a manual hud.update() --
+      // that skipped renderLoop.setGameState, so the 'trophy' choice's
+      // lair.status: 'claimed' (rendered as a different map icon, see
+      // hex-renderer.ts) never reached the canvas until an unrelated commit
+      // elsewhere happened to push it. commit() refreshes both.
+      session.commit(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
       bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
-      hud.update();
       maybeShowPendingHoardChoice();
     });
   }

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -143,13 +143,15 @@ export function createAppComposition(deps: AppCompositionDeps): AppComposition {
     const preview = getHoardChoicePreview(session.getState(), pending.lairId);
     const lair = session.getState().beasts!.lairs[pending.lairId];
     createBeastHoardPanel(uiLayer, preview, choice => {
-      // #787 phase 14: was setStateWithoutRefresh + a manual hud.update() --
-      // that skipped renderLoop.setGameState, so the 'trophy' choice's
-      // lair.status: 'claimed' (rendered as a different map icon, see
-      // hex-renderer.ts) never reached the canvas until an unrelated commit
-      // elsewhere happened to push it. commit() refreshes both.
-      session.commit(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
+      // #787 phase 14: audited -- setStateWithoutRefresh here is correct, not
+      // a bug. hex-renderer.ts's lair glyph treats 'slain' and 'claimed'
+      // identically (both draw 🏆), so the 'trophy' choice has no canvas
+      // effect; the 'gold'/'lore' choices' effects (civ.gold, tech name/rate)
+      // are already covered by the explicit hud.update() below. No renderer-
+      // or HUD-visible field goes stale here.
+      session.setStateWithoutRefresh(applyHoardChoice(session.getState(), pending.lairId, pending.civId, choice));
       bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
+      hud.update();
       maybeShowPendingHoardChoice();
     });
   }

--- a/src/app/controllers/map-interaction-controller.ts
+++ b/src/app/controllers/map-interaction-controller.ts
@@ -632,6 +632,16 @@ export function createMapInteractionController(deps: MapInteractionControllerDep
             if (!war.ok) return;
             session.setStateWithoutRefresh(war.state);
             emitMinorCivQuestTransitions(bus, war.transitions, session.getState());
+            // #787 phase 14: this used to rely entirely on
+            // executeMinorCivConquest below to flush the renderer/HUD -- but
+            // that function returns early with no refresh at all when the
+            // follow-up move fails, leaving a real declared war unrendered
+            // until an unrelated commit happened elsewhere. Explicit refresh
+            // here (matching every sibling case in this switch) makes the war
+            // declaration itself visible regardless of what the conquest
+            // attempt does next.
+            renderLoop.setGameState(session.getState());
+            deps.updateHUD();
             deps.executeMinorCivConquest(selectedId, coord, intent.minorCivId, intent.cityId);
           },
           onCancel: () => selectionController.selectUnit(selectedId),

--- a/src/app/controllers/map-interaction-controller.ts
+++ b/src/app/controllers/map-interaction-controller.ts
@@ -635,11 +635,14 @@ export function createMapInteractionController(deps: MapInteractionControllerDep
             // #787 phase 14: this used to rely entirely on
             // executeMinorCivConquest below to flush the renderer/HUD -- but
             // that function returns early with no refresh at all when the
-            // follow-up move fails, leaving a real declared war unrendered
-            // until an unrelated commit happened elsewhere. Explicit refresh
-            // here (matching every sibling case in this switch) makes the war
-            // declaration itself visible regardless of what the conquest
-            // attempt does next.
+            // follow-up move fails. A declared war has a real, if narrow,
+            // HUD-visible effect: economy-system.ts excludes trade-route gold
+            // from any partner you're at war with, so a civ with an active
+            // trade route to this minor civ needs its gold-per-turn
+            // recalculated immediately, not whenever some later unrelated
+            // commit happens to flush it. Explicit refresh here (matching
+            // every sibling case in this switch) also keeps this case
+            // consistent regardless of what the conquest attempt does next.
             renderLoop.setGameState(session.getState());
             deps.updateHUD();
             deps.executeMinorCivConquest(selectedId, coord, intent.minorCivId, intent.cityId);

--- a/src/app/controllers/map-interaction-controller.ts
+++ b/src/app/controllers/map-interaction-controller.ts
@@ -635,14 +635,19 @@ export function createMapInteractionController(deps: MapInteractionControllerDep
             // #787 phase 14: this used to rely entirely on
             // executeMinorCivConquest below to flush the renderer/HUD -- but
             // that function returns early with no refresh at all when the
-            // follow-up move fails. A declared war has a real, if narrow,
-            // HUD-visible effect: economy-system.ts excludes trade-route gold
-            // from any partner you're at war with, so a civ with an active
-            // trade route to this minor civ needs its gold-per-turn
-            // recalculated immediately, not whenever some later unrelated
-            // commit happens to flush it. Explicit refresh here (matching
-            // every sibling case in this switch) also keeps this case
-            // consistent regardless of what the conquest attempt does next.
+            // follow-up move fails. A declared war has a real, immediate
+            // canvas effect: unit-map-presentation.ts's chooseLead reads
+            // viewerDiplomacy.atWarWith every render() frame from the
+            // renderer's own cached state to decide whether a foreign unit
+            // stack picks its "lead" sprite by combat-defender strength
+            // (selectDefenderForAttack) or by plain id sort -- and the city
+            // the player just tapped to declare this war is on-screen right
+            // now, typically with a garrison stack. Without this refresh that
+            // stack keeps rendering its pre-war (non-hostile) lead unit until
+            // some later unrelated commit happens to flush it. Explicit
+            // refresh here (matching every sibling case in this switch) also
+            // keeps this case consistent regardless of what the conquest
+            // attempt does next.
             renderLoop.setGameState(session.getState());
             deps.updateHUD();
             deps.executeMinorCivConquest(selectedId, coord, intent.minorCivId, intent.cityId);

--- a/tests/app/bootstrap.test.ts
+++ b/tests/app/bootstrap.test.ts
@@ -101,6 +101,9 @@ function makeCompositionDeps(overrides: Partial<AppCompositionDeps> = {}): AppCo
     applyDeliveryVisual: vi.fn(),
     applyCombatVisual: vi.fn(),
     animations: { add: vi.fn() },
+    isAirDefenseOverlayEnabled: vi.fn().mockReturnValue(false),
+    toggleAirDefenseOverlay: vi.fn().mockReturnValue(false),
+    resizeCanvas: vi.fn(),
   } as unknown as RenderLoop;
   const audio = {
     playNaturalWonderDiscovery: vi.fn().mockResolvedValue(undefined),
@@ -190,5 +193,44 @@ describe('createAppComposition', () => {
 
     expect(() => deps.session.commit(deps.session.getState())).not.toThrow();
     expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('maybeShowPendingHoardChoice refreshes the renderer, not just the HUD, when a choice is made', () => {
+    // #787 phase 14: this used to call session.setStateWithoutRefresh(...)
+    // and only manually call hud.update() -- skipping renderLoop.setGameState.
+    // The 'trophy' choice mutates lair.status to 'claimed', which
+    // hex-renderer.ts renders as a different icon (🏆 vs 🐾) -- a real
+    // stale-render bug, since only a later unrelated commit() elsewhere would
+    // ever push the claimed status to the canvas.
+    const deps = makeCompositionDeps();
+    let state = deps.session.getState();
+    state = {
+      ...state,
+      beasts: {
+        mode: 'wild',
+        lairs: {
+          'lair-1': {
+            id: 'lair-1', beastId: 'dire_wolf', position: { q: 10, r: 10 },
+            status: 'slain', strength: 0, unitIds: [], slainBy: state.currentPlayer,
+          },
+        },
+        sightingsByCiv: {},
+        pendingHoardChoices: [{ lairId: 'lair-1', civId: state.currentPlayer }],
+      },
+    };
+    deps.session.commit(state);
+    const setGameStateSpy = vi.mocked(deps.renderLoop.setGameState);
+    setGameStateSpy.mockClear();
+
+    const composition = createAppComposition(deps);
+    composition.presentationContext.maybeShowPendingHoardChoice();
+
+    const trophyButton = deps.uiLayer.querySelector<HTMLButtonElement>('[data-choice="trophy"]');
+    expect(trophyButton).not.toBeNull();
+    trophyButton!.click();
+
+    expect(setGameStateSpy).toHaveBeenCalled();
+    const pushedState = setGameStateSpy.mock.calls.at(-1)![0];
+    expect(pushedState.beasts!.lairs['lair-1'].status).toBe('claimed');
   });
 });

--- a/tests/app/bootstrap.test.ts
+++ b/tests/app/bootstrap.test.ts
@@ -194,43 +194,4 @@ describe('createAppComposition', () => {
     expect(() => deps.session.commit(deps.session.getState())).not.toThrow();
     expect(updateSpy).toHaveBeenCalled();
   });
-
-  it('maybeShowPendingHoardChoice refreshes the renderer, not just the HUD, when a choice is made', () => {
-    // #787 phase 14: this used to call session.setStateWithoutRefresh(...)
-    // and only manually call hud.update() -- skipping renderLoop.setGameState.
-    // The 'trophy' choice mutates lair.status to 'claimed', which
-    // hex-renderer.ts renders as a different icon (🏆 vs 🐾) -- a real
-    // stale-render bug, since only a later unrelated commit() elsewhere would
-    // ever push the claimed status to the canvas.
-    const deps = makeCompositionDeps();
-    let state = deps.session.getState();
-    state = {
-      ...state,
-      beasts: {
-        mode: 'wild',
-        lairs: {
-          'lair-1': {
-            id: 'lair-1', beastId: 'dire_wolf', position: { q: 10, r: 10 },
-            status: 'slain', strength: 0, unitIds: [], slainBy: state.currentPlayer,
-          },
-        },
-        sightingsByCiv: {},
-        pendingHoardChoices: [{ lairId: 'lair-1', civId: state.currentPlayer }],
-      },
-    };
-    deps.session.commit(state);
-    const setGameStateSpy = vi.mocked(deps.renderLoop.setGameState);
-    setGameStateSpy.mockClear();
-
-    const composition = createAppComposition(deps);
-    composition.presentationContext.maybeShowPendingHoardChoice();
-
-    const trophyButton = deps.uiLayer.querySelector<HTMLButtonElement>('[data-choice="trophy"]');
-    expect(trophyButton).not.toBeNull();
-    trophyButton!.click();
-
-    expect(setGameStateSpy).toHaveBeenCalled();
-    const pushedState = setGameStateSpy.mock.calls.at(-1)![0];
-    expect(pushedState.beasts!.lairs['lair-1'].status).toBe('claimed');
-  });
 });

--- a/tests/app/controllers/map-interaction-controller.test.ts
+++ b/tests/app/controllers/map-interaction-controller.test.ts
@@ -283,9 +283,11 @@ describe('MapInteractionController', () => {
       // minor-civilization conquest after failed movement" proves that path calls
       // neither renderLoop.setGameState nor hud.update when the follow-up move fails
       // -- so a declared war could sit unrefreshed until an unrelated commit happened.
-      // Concretely: economy-system.ts excludes trade-route gold from any civ you're
-      // at war with, so a civ with an active route to this minor civ needs its
-      // gold-per-turn (shown on the HUD) recalculated immediately.
+      // Concretely: unit-map-presentation.ts's chooseLead reads atWarWith every
+      // render() frame from the renderer's own cached state to pick a foreign unit
+      // stack's "lead" sprite (defender-strength order once hostile, plain id sort
+      // otherwise) -- the city just tapped to declare this war is on-screen right now
+      // and typically has a garrison stack that needs this refresh immediately.
       const state = makeFixture();
       document.body.innerHTML = '<div id="info-panel"></div>';
       const mcId = Object.keys(state.minorCivs)[0]!;

--- a/tests/app/controllers/map-interaction-controller.test.ts
+++ b/tests/app/controllers/map-interaction-controller.test.ts
@@ -282,7 +282,10 @@ describe('MapInteractionController', () => {
       // afterward. player-action-controller.test.ts's "does not resolve
       // minor-civilization conquest after failed movement" proves that path calls
       // neither renderLoop.setGameState nor hud.update when the follow-up move fails
-      // -- so a declared war could sit unrendered until an unrelated commit happened.
+      // -- so a declared war could sit unrefreshed until an unrelated commit happened.
+      // Concretely: economy-system.ts excludes trade-route gold from any civ you're
+      // at war with, so a civ with an active route to this minor civ needs its
+      // gold-per-turn (shown on the HUD) recalculated immediately.
       const state = makeFixture();
       document.body.innerHTML = '<div id="info-panel"></div>';
       const mcId = Object.keys(state.minorCivs)[0]!;

--- a/tests/app/controllers/map-interaction-controller.test.ts
+++ b/tests/app/controllers/map-interaction-controller.test.ts
@@ -275,6 +275,42 @@ describe('MapInteractionController', () => {
       cancelBtn!.click();
       expect(selection.getSelectedUnitId()).toBeNull();
     });
+
+    it('confirming a minor-civ war declaration refreshes the renderer even if the follow-up conquest attempt never does (#787 phase 14)', () => {
+      // Regression guard: this case used to call session.setStateWithoutRefresh(war.state)
+      // and rely entirely on deps.executeMinorCivConquest to flush the renderer/HUD
+      // afterward. player-action-controller.test.ts's "does not resolve
+      // minor-civilization conquest after failed movement" proves that path calls
+      // neither renderLoop.setGameState nor hud.update when the follow-up move fails
+      // -- so a declared war could sit unrendered until an unrelated commit happened.
+      const state = makeFixture();
+      document.body.innerHTML = '<div id="info-panel"></div>';
+      const mcId = Object.keys(state.minorCivs)[0]!;
+      const cityId = state.minorCivs[mcId].cityId;
+      state.cities[cityId] = { ...state.cities[cityId], position: { q: 1, r: 0 } };
+      placePlayerUnit(state, 'u1', { position: { q: 0, r: 0 } });
+      state.civilizations.player.diplomacy.atWarWith = state.civilizations.player.diplomacy.atWarWith.filter(id => id !== mcId);
+      makeVisible(state, { q: 0, r: 0 });
+      makeVisible(state, { q: 1, r: 0 });
+      // Simulate the follow-up move failing silently, same as the real
+      // executeMinorCivConquest does on a blocked/failed move: it just returns.
+      const { deps, session } = baseDeps(state, { executeMinorCivConquest: vi.fn() });
+      const controller = createMapInteractionController(deps);
+      deps.selectionController.selectUnit('u1');
+
+      controller.handleHexTap({ q: 1, r: 0 });
+
+      const confirmBtn = Array.from(deps.uiLayer.querySelectorAll('button')).find(b => b.textContent === 'Continue');
+      expect(confirmBtn).toBeDefined();
+      vi.mocked(deps.renderLoop.setGameState).mockClear();
+
+      confirmBtn!.click();
+
+      expect(session.getState().civilizations.player.diplomacy.atWarWith).toContain(mcId);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      const pushedState = vi.mocked(deps.renderLoop.setGameState).mock.calls.at(-1)![0];
+      expect(pushedState.civilizations.player.diplomacy.atWarWith).toContain(mcId);
+    });
   });
 
   describe('handleHexLongPress', () => {


### PR DESCRIPTION
## Summary

Phase 14a of #787: first sub-phase of the `setStateWithoutRefresh` debt audit across the controller layer (Phase 14). Audits the 5 sites in `bootstrap.ts`, `cross-cutting-helpers.ts`, and `map-interaction-controller.ts`.

Phase 14 is comparable in size to the entire Phase 10b sub-arc (65 real call sites across 10 files). Splitting into lettered sub-phases the same way, landing them incrementally.

**Updated twice after requested final self-reviews** — see "Self-review corrections" below. Net result: **1 real bug fixed**.

## The real bug: `map-interaction-controller.ts`'s `confirm-war-minor-civ` case

Set war state via `setStateWithoutRefresh` and relied entirely on the following `executeMinorCivConquest` call to flush the renderer/HUD — but that function returns early with **zero** refresh when the follow-up move fails (proven by an existing `player-action-controller.test.ts` case: "does not resolve minor-civilization conquest after failed movement" asserts `hud.update` is never called on that path).

Verified concrete consequence (see "Self-review corrections" for how I got here): `unit-map-presentation.ts`'s `chooseLead` reads `viewerDiplomacy.atWarWith` every `render()` frame from the renderer's own cached state, to decide whether a foreign unit stack's "lead" sprite is chosen by combat-defender strength (once hostile) or plain id sort (otherwise). `buildUnitMapPresentations` calls this for every co-located unit group on every visible hex, every frame. The city the player just tapped to declare this war is on-screen right now and typically has a garrison stack — exactly the case this misrenders without the fix. Added explicit `renderLoop.setGameState`/`updateHUD` calls, matching every sibling case in the same switch.

## Self-review corrections (two rounds)

Two separate requested final-review passes each caught a factual error in this PR's own justification for its changes — both are worth recording precisely, since they're a good example of why "it compiles and the test passes" isn't the same as "the stated reason is true."

**Round 1** — caught that `bootstrap.ts`'s `maybeShowPendingHoardChoice` fix had no real bug behind it: I'd claimed the `'trophy'` choice's `lair.status: 'claimed'` produced a different map icon than `'slain'`. It doesn't — `hex-renderer.ts` renders both identically (🏆). The `'gold'`/`'lore'` choices' effects were already covered by the pre-existing `hud.update()` call. Reverted that site back to `setStateWithoutRefresh` + `hud.update()`, and removed the regression test that had been passing while guarding nothing real.

**Round 2** — caught that my *replacement* justification for the `map-interaction-controller.ts` fix (kept from round 1) was **also** wrong: I'd claimed a civ with an active trade route to the minor civ needed its HUD gold-per-turn recalculated because "`economy-system.ts` excludes trade-route gold from any partner you're at war with." Traced it precisely this time: that `isAtWar` check is gated behind `!state.civilizations[partnerCivId]` first, and minor civs live in `state.minorCivs`, never `state.civilizations` — so the check is unreachable for a minor-civ partner. The function that actually computes HUD gold-per-turn from routes (`processTradeRouteIncome`) doesn't check war status at all. Routes to a civ you're at war with are only removed by `scrubStaleForeignRoutes`, called exclusively from `turn-manager.ts` at end-of-turn — not synchronously when war is declared. So the trade-route claim was false. The fix itself is still correct, just for the different, now-verified `chooseLead`/unit-stack-rendering reason described above.

## Sites audited with no change needed

- `bootstrap.ts`'s `maybeShowPendingHoardChoice` (see round 1 above).
- `cross-cutting-helpers.ts`'s `scanBeastSightings`: `sightingsByCiv` is only read by the bestiary panel, which fetches fresh state on open; no renderer/HUD surface depends on immediate refresh.
- `cross-cutting-helpers.ts`'s `applyPirateActionResult` and `map-interaction-controller.ts`'s `confirm-war-city`: both already manually call `renderLoop.setGameState` + `updateHUD` right after the no-refresh write, so no staleness exists.

## Bonus finding from the original review pass

Completing the `renderLoop` test mock (`isAirDefenseOverlayEnabled`, `toggleAirDefenseOverlay`, `resizeCanvas`) exposed a **pre-existing masked bug** in `bootstrap.test.ts`'s *other* test: the "session HUD subscription" test's `hud.update()` was throwing a real `TypeError` every run, silently swallowed by `GameSession.publish()`'s per-subscriber try/catch (the intentional "one failing subscriber doesn't strand others" behavior from Phase 2). The test's own `toHaveBeenCalled()` assertion only checks invocation, not completion, so it passed despite `hud.update()` never actually finishing. Confirmed by toggling the mock addition off/on. This mock completion is kept, since it's an independently real fix.

## Test plan

- [x] The real fix has a regression test proven to fail before the fix and pass after (manually reverted the fix locally, confirmed the test fails, restored, confirmed it passes).
- [x] `yarn build` — green
- [x] `yarn test` (full suite) — 484 files / 7898 passed / 3 skipped
- [x] `yarn test tests/app/determinism-guard.test.ts` — green
- [x] `yarn test:ai-playability` — green (this phase changes commit/refresh timing, which is exactly what this guard exists to catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)