### PR TITLE
feat(barbarians): add typed unit eligibility catalog (#696)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -379,6 +379,39 @@ export type UnitType =
   | 'cyber_unit' | 'stealth_bomber'
   | 'combat_drone' | 'autonomous_frigate' | 'exosuit_infantry' | 'propagandist' | 'drone_controller';
 
+/** Declarative composition slot for ordinary barbarian camps. */
+export type BarbarianRoleSlot = 'frontline' | 'ranged' | 'siege' | 'mobile' | 'specialist' | 'anti-air';
+export type BarbarianRarity = 'common' | 'uncommon' | 'rare';
+export type BarbarianObservationRequirement = 'armor' | 'air';
+export type BarbarianExclusionReason =
+  | 'civilian'
+  | 'naval'
+  | 'air'
+  | 'unique'
+  | 'crisis'
+  | 'strategic-deterrence'
+  | 'unsupported';
+
+/**
+ * Static composition metadata. The barbarian composer will consume this in a
+ * later issue; keeping it data-only here preserves the existing live roster.
+ */
+export type BarbarianEligibility =
+  | {
+      status: 'eligible';
+      eraWindow: { min: number; max?: number };
+      roleSlot: BarbarianRoleSlot;
+      weight: number;
+      rarity: BarbarianRarity;
+      /** Ceiling while a camp remains below the escalation threshold. */
+      maxPerCampBeforeEscalation?: number;
+      /** Absolute ceiling, regardless of camp escalation. */
+      maxPerCamp?: number;
+      requiresObservation?: BarbarianObservationRequirement;
+      excludesUnits?: readonly UnitType[];
+    }
+  | { status: 'excluded'; reason: BarbarianExclusionReason };
+
 export interface UnitAttackProfile {
   kind: 'melee' | 'ranged' | 'siege' | 'bombard';
   range: number;
@@ -422,6 +455,8 @@ export interface UnitDefinition {
   canFoundCity: boolean;
   canBuildImprovements: boolean;
   productionCost: number;
+  /** Ordinary-camp composition metadata; static until the barbarian composer consumes it. */
+  barbarianEligibility: BarbarianEligibility;
   domain?: 'land' | 'naval' | 'air';
   waterAccess?: 'coastal' | 'ocean'; // required whenever domain === 'naval' — see #751
   spyDetectionChance?: number; // 0–1, probability per adjacent spy unit per turn

--- a/src/systems/barbarian-roster.ts
+++ b/src/systems/barbarian-roster.ts
@@ -1,0 +1,65 @@
+import type { BarbarianEligibility, UnitType } from '@/core/types';
+
+const exclude = (reason: Extract<BarbarianEligibility, { status: 'excluded' }>['reason']) =>
+  ({ status: 'excluded' as const, reason });
+
+const eligible = (
+  eraWindow: { min: number; max?: number },
+  roleSlot: Extract<BarbarianEligibility, { status: 'eligible' }>['roleSlot'],
+  rarity: Extract<BarbarianEligibility, { status: 'eligible' }>['rarity'],
+  options: Omit<Extract<BarbarianEligibility, { status: 'eligible' }>, 'status' | 'eraWindow' | 'roleSlot' | 'rarity' | 'weight'> & { weight?: number } = {},
+) => ({ status: 'eligible' as const, eraWindow, roleSlot, rarity, weight: options.weight ?? (rarity === 'common' ? 100 : rarity === 'uncommon' ? 50 : 25), ...options });
+
+/**
+ * Every trainable or special unit has an explicit ordinary-camp classification.
+ * `Record<UnitType, ...>` makes a newly added unit fail compilation until it is
+ * deliberately admitted or excluded.
+ */
+export const BARBARIAN_ELIGIBILITY_BY_UNIT = {
+  settler: exclude('civilian'), worker: exclude('civilian'), scout: exclude('unsupported'), missionary: exclude('civilian'),
+  warrior: eligible({ min: 1, max: 2 }, 'frontline', 'common'),
+  archer: eligible({ min: 1, max: 2 }, 'ranged', 'common'),
+  swordsman: eligible({ min: 3, max: 4 }, 'frontline', 'common'),
+  pikeman: eligible({ min: 5, max: 7 }, 'frontline', 'common'),
+  musketeer: eligible({ min: 5, max: 7 }, 'frontline', 'common'),
+  galley: exclude('naval'), trireme: exclude('naval'),
+  axeman: eligible({ min: 1, max: 2 }, 'frontline', 'common'),
+  spearman: eligible({ min: 3, max: 4 }, 'frontline', 'common'),
+  horseman: exclude('unsupported'),
+  chariot: eligible({ min: 2, max: 4 }, 'mobile', 'common'),
+  cavalry: eligible({ min: 6, max: 8 }, 'mobile', 'common', { excludesUnits: ['cuirassier'] }),
+  armored_car: eligible({ min: 9, max: 11 }, 'mobile', 'common'),
+  knight: exclude('unsupported'),
+  cuirassier: eligible({ min: 6, max: 8 }, 'mobile', 'rare', { excludesUnits: ['cavalry'] }),
+  crossbowman: eligible({ min: 3, max: 7 }, 'ranged', 'common'),
+  catapult: exclude('unsupported'),
+  trebuchet: eligible({ min: 4, max: 6 }, 'siege', 'uncommon', { maxPerCampBeforeEscalation: 1 }),
+  ballista: exclude('unsupported'), cannon: exclude('unsupported'),
+  grenadier: eligible({ min: 8, max: 9 }, 'ranged', 'common'),
+  marine: exclude('unsupported'),
+  rifleman: eligible({ min: 8, max: 11 }, 'frontline', 'common'),
+  ironclad: exclude('naval'), frigate: exclude('naval'), destroyer: exclude('naval'),
+  artillery: exclude('unsupported'), rocket_artillery: exclude('unsupported'),
+  infantry: exclude('unsupported'),
+  mechanized_infantry: eligible({ min: 10 }, 'frontline', 'uncommon'),
+  machine_gunner: eligible({ min: 10 }, 'ranged', 'common'),
+  pre_dreadnought: exclude('naval'), battleship: exclude('naval'), missile_cruiser: exclude('naval'),
+  observation_balloon: exclude('air'), biplane: exclude('air'), wwii_fighter: exclude('air'), jet_fighter: exclude('air'), bomber: exclude('air'), recon_aircraft: exclude('air'),
+  tank: eligible({ min: 10 }, 'frontline', 'common'), main_battle_tank: exclude('unsupported'),
+  anti_tank_gun: eligible({ min: 9 }, 'specialist', 'uncommon', { requiresObservation: 'armor' }),
+  mobile_aa: eligible({ min: 10 }, 'anti-air', 'uncommon', { requiresObservation: 'air', maxPerCamp: 1 }),
+  submarine: exclude('naval'), carrier: exclude('naval'), attack_helicopter: exclude('air'), missile_submarine: exclude('strategic-deterrence'),
+  spy_scout: exclude('unsupported'), spy_informant: exclude('unsupported'), spy_agent: exclude('unsupported'), spy_operative: exclude('unsupported'), spy_hacker: exclude('unsupported'),
+  scout_hound: exclude('crisis'), shadow_warden: exclude('crisis'), war_hound: exclude('crisis'), beast_handler: exclude('unique'), war_elephant: exclude('unique'),
+  caravan: exclude('civilian'), merchant_wagon: exclude('civilian'), freight_convoy: exclude('civilian'),
+  naval_trader: exclude('civilian'), steamship_trader: exclude('civilian'), cargo_freighter: exclude('civilian'), container_ship: exclude('civilian'),
+  air_freighter: exclude('civilian'), jet_freighter: exclude('civilian'), global_air_cargo: exclude('civilian'), expedition: exclude('civilian'),
+  transport: exclude('naval'), carrack: exclude('naval'), galleon: exclude('naval'), steamship: exclude('naval'), troop_transport: exclude('naval'),
+  pirate_galley: exclude('crisis'), pirate_corsair: exclude('crisis'), pirate_frigate: exclude('crisis'), pirate_ironclad: exclude('crisis'), pirate_fast_attack_craft: exclude('crisis'), pirate_mothership: exclude('crisis'),
+  beast_boar: exclude('crisis'), beast_wolf: exclude('crisis'), beast_basilisk: exclude('crisis'), beast_sea_serpent: exclude('crisis'), beast_wurm: exclude('crisis'), beast_roc: exclude('crisis'), beast_hydra: exclude('crisis'), beast_dragon: exclude('crisis'),
+  cyber_unit: exclude('strategic-deterrence'), stealth_bomber: exclude('strategic-deterrence'), combat_drone: exclude('strategic-deterrence'), autonomous_frigate: exclude('strategic-deterrence'), exosuit_infantry: exclude('strategic-deterrence'), propagandist: exclude('strategic-deterrence'), drone_controller: exclude('strategic-deterrence'),
+} satisfies Record<UnitType, BarbarianEligibility>;
+
+export function getBarbarianEligibility(unitType: UnitType): BarbarianEligibility {
+  return BARBARIAN_ELIGIBILITY_BY_UNIT[unitType];
+}

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -11,11 +11,14 @@ import {
 } from './hex-utils';
 import { isRiverBetween } from './river-system';
 import { PIRATE_HULL_DEFINITIONS, type PirateHullType } from './pirate-definitions';
+import { BARBARIAN_ELIGIBILITY_BY_UNIT } from './barbarian-roster';
+
+type UnitDefinitionBase = Omit<UnitDefinition, 'barbarianEligibility'>;
 
 function createPirateUnitDefinition(
   type: PirateHullType,
   attackProfile: UnitDefinition['attackProfile'],
-): UnitDefinition {
+): UnitDefinitionBase {
   const hull = PIRATE_HULL_DEFINITIONS[type];
   return {
     type,
@@ -32,7 +35,7 @@ function createPirateUnitDefinition(
   };
 }
 
-export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
+const UNIT_DEFINITION_BASES: Record<UnitType, UnitDefinitionBase> = {
   settler: {
     type: 'settler', name: 'Settler', movementPoints: 2,
     visionRange: 2, strength: 0, canFoundCity: true,
@@ -637,6 +640,13 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     airOperation: { baseKinds: ['stealth_airbase'], operationalRange: 7, ferryRange: 14, missions: ['strike', 'rebase'], carrierEligible: false },
   },
 };
+
+export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = Object.fromEntries(
+  Object.entries(UNIT_DEFINITION_BASES).map(([type, definition]) => [
+    type,
+    { ...definition, barbarianEligibility: BARBARIAN_ELIGIBILITY_BY_UNIT[type as UnitType] },
+  ]),
+) as Record<UnitType, UnitDefinition>;
 
 const VIKING_MOBILITY_UNITS = new Set<UnitType>(['scout', 'warrior', 'archer', 'swordsman']);
 

--- a/tests/systems/barbarian-roster.test.ts
+++ b/tests/systems/barbarian-roster.test.ts
@@ -1,0 +1,75 @@
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getBarbarianRosterForEra } from '@/systems/barbarian-system';
+import {
+  BARBARIAN_ELIGIBILITY_BY_UNIT,
+  getBarbarianEligibility,
+} from '@/systems/barbarian-roster';
+
+describe('barbarian eligibility catalog', () => {
+  it('classifies every current unit definition so future units fail closed', () => {
+    expect(Object.keys(BARBARIAN_ELIGIBILITY_BY_UNIT).sort())
+      .toEqual(Object.keys(UNIT_DEFINITIONS).sort());
+
+    for (const definition of Object.values(UNIT_DEFINITIONS)) {
+      expect(getBarbarianEligibility(definition.type)).toBe(
+        BARBARIAN_ELIGIBILITY_BY_UNIT[definition.type],
+      );
+      expect(definition.barbarianEligibility).toBe(
+        BARBARIAN_ELIGIBILITY_BY_UNIT[definition.type],
+      );
+    }
+  });
+
+  it('records the approved future camp composition contract declaratively', () => {
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.chariot).toMatchObject({
+      status: 'eligible', eraWindow: { min: 2, max: 4 }, roleSlot: 'mobile', rarity: 'common', weight: 100,
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.trebuchet).toMatchObject({
+      status: 'eligible', eraWindow: { min: 4, max: 6 }, roleSlot: 'siege', maxPerCampBeforeEscalation: 1,
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.cavalry).toMatchObject({
+      status: 'eligible', eraWindow: { min: 6, max: 8 }, roleSlot: 'mobile', rarity: 'common', weight: 100,
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.cuirassier).toMatchObject({
+      status: 'eligible', eraWindow: { min: 6, max: 8 }, roleSlot: 'mobile', rarity: 'rare', excludesUnits: ['cavalry'],
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.armored_car).toMatchObject({
+      status: 'eligible', eraWindow: { min: 9, max: 11 }, roleSlot: 'mobile', rarity: 'common', weight: 100,
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.anti_tank_gun).toMatchObject({
+      status: 'eligible', eraWindow: { min: 9 }, roleSlot: 'specialist', requiresObservation: 'armor',
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.mobile_aa).toMatchObject({
+      status: 'eligible', eraWindow: { min: 10 }, roleSlot: 'anti-air', requiresObservation: 'air', maxPerCamp: 1,
+    });
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT.mechanized_infantry).toMatchObject({
+      status: 'eligible', eraWindow: { min: 10 }, roleSlot: 'frontline', rarity: 'uncommon',
+    });
+  });
+
+  it.each([
+    'beast_handler', 'war_elephant', 'wwii_fighter', 'main_battle_tank',
+    'rocket_artillery', 'battleship', 'missile_cruiser',
+  ] as const)('explicitly excludes %s from ordinary camps', (unitType) => {
+    expect(BARBARIAN_ELIGIBILITY_BY_UNIT[unitType]).toMatchObject({ status: 'excluded' });
+  });
+
+  it('does not change the live era roster before the composer is introduced', () => {
+    expect([1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12].map(era => [
+      era,
+      getBarbarianRosterForEra(era),
+    ])).toEqual([
+      [1, { maxEra: 2, melee: ['warrior', 'axeman'], ranged: ['archer'] }],
+      [2, { maxEra: 2, melee: ['warrior', 'axeman'], ranged: ['archer'] }],
+      [3, { maxEra: 4, melee: ['swordsman', 'spearman'], ranged: ['crossbowman'] }],
+      [4, { maxEra: 4, melee: ['swordsman', 'spearman'], ranged: ['crossbowman'] }],
+      [5, { maxEra: 7, melee: ['pikeman', 'musketeer'], ranged: ['crossbowman'] }],
+      [7, { maxEra: 7, melee: ['pikeman', 'musketeer'], ranged: ['crossbowman'] }],
+      [8, { maxEra: 9, melee: ['rifleman'], ranged: ['grenadier'] }],
+      [9, { maxEra: 9, melee: ['rifleman'], ranged: ['grenadier'] }],
+      [10, { maxEra: 11, melee: ['tank', 'rifleman'], ranged: ['machine_gunner'] }],
+      [11, { maxEra: 11, melee: ['tank', 'rifleman'], ranged: ['machine_gunner'] }],
+      [12, { maxEra: 11, melee: ['tank', 'rifleman'], ranged: ['machine_gunner'] }],
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #696

## Summary

- Adds typed, exhaustive ordinary-camp eligibility metadata directly to every unit definition.
- Records era windows, composition slots, weights, rarity, observation gates, per-camp caps, reciprocal exclusions, and explicit exclusions.
- Keeps the current hardcoded barbarian spawn roster deliberately unchanged until the later composer work consumes this metadata.

## Player impact

No current gameplay, difficulty, UI, sound, save, solo, hot-seat, or AI behavior changes in this metadata-only slice. The catalog supplies the safe, data-driven seam for later composition work.

## Validation

- `bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-system.test.ts tests/systems/barbarian-roster.test.ts tests/systems/barbarian-system.test.ts`
- `scripts/check-src-rule-violations.sh src/core/types.ts src/systems/unit-system.ts src/systems/barbarian-roster.ts`
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test:durable` and `yarn test:durable:status` (passed for `9909cdc8`)

No screenshots: this change has no UI or renderer surface.