### PR TITLE
feat(barbarians): compose deterministic camp forces (#697)

### DIFF
--- a/src/systems/barbarian-force-composer.ts
+++ b/src/systems/barbarian-force-composer.ts
@@ -1,0 +1,130 @@
+import type {
+  BarbarianEligibility,
+  BarbarianObservationRequirement,
+  UnitType,
+} from '@/core/types';
+import { seededLcg, weightedPick } from './seeded-lcg';
+import { BARBARIAN_ELIGIBILITY_BY_UNIT } from './barbarian-roster';
+
+type EligibleBarbarianUnit = Extract<BarbarianEligibility, { status: 'eligible' }>;
+
+export interface BarbarianForceCompositionContext {
+  era: number;
+  /** Upper bound. The composer may underfill rather than violate a role cap. */
+  forceSize: number;
+  escalated: boolean;
+  seed: number;
+  /** Coarse camp-local facts; persistence and collection arrive in #698. */
+  observedThreats?: readonly BarbarianObservationRequirement[];
+}
+
+interface Candidate {
+  unitType: UnitType;
+  eligibility: EligibleBarbarianUnit;
+}
+
+const FRONTLINE_MINIMUM = 0.4;
+const FRONTLINE_MAXIMUM = 0.6;
+const RANGED_AND_SIEGE_MAXIMUM = 0.3;
+const MOBILE_MAXIMUM = 0.4;
+const SPECIALIST_MAXIMUM = 0.25;
+
+function normalizeEra(era: number): number {
+  return Number.isFinite(era) ? Math.max(1, Math.floor(era)) : 1;
+}
+
+function normalizeForceSize(forceSize: number): number {
+  return Number.isFinite(forceSize) ? Math.max(0, Math.floor(forceSize)) : 0;
+}
+
+function candidateForContext(
+  unitType: UnitType,
+  context: BarbarianForceCompositionContext,
+): Candidate | null {
+  const eligibility = BARBARIAN_ELIGIBILITY_BY_UNIT[unitType];
+  if (eligibility.status !== 'eligible') return null;
+  if (context.era < eligibility.eraWindow.min
+    || context.era > (eligibility.eraWindow.max ?? Infinity)) return null;
+  if (eligibility.requiresObservation
+    && context.observedThreats?.includes(eligibility.requiresObservation) !== true) return null;
+  return { unitType, eligibility };
+}
+
+function candidatesFor(context: BarbarianForceCompositionContext): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (const unitType of Object.keys(BARBARIAN_ELIGIBILITY_BY_UNIT) as UnitType[]) {
+    const candidate = candidateForContext(unitType, context);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates.sort((left, right) => left.unitType.localeCompare(right.unitType));
+}
+
+function countRole(force: readonly Candidate[], role: EligibleBarbarianUnit['roleSlot']): number {
+  return force.filter(candidate => candidate.eligibility.roleSlot === role).length;
+}
+
+function maxFrontline(forceSize: number): number {
+  const minimum = Math.ceil(forceSize * FRONTLINE_MINIMUM);
+  return Math.max(minimum, Math.floor(forceSize * FRONTLINE_MAXIMUM));
+}
+
+function hasMutualExclusion(candidate: Candidate, force: readonly Candidate[]): boolean {
+  return force.some(selected =>
+    candidate.eligibility.excludesUnits?.includes(selected.unitType)
+    || selected.eligibility.excludesUnits?.includes(candidate.unitType));
+}
+
+function canAddCandidate(
+  candidate: Candidate,
+  force: readonly Candidate[],
+  context: BarbarianForceCompositionContext,
+): boolean {
+  if (hasMutualExclusion(candidate, force)) return false;
+  if (candidate.eligibility.maxPerCamp !== undefined
+    && force.filter(selected => selected.unitType === candidate.unitType).length >= candidate.eligibility.maxPerCamp) {
+    return false;
+  }
+
+  const role = candidate.eligibility.roleSlot;
+  const size = context.forceSize;
+  if (role === 'frontline' && countRole(force, 'frontline') >= maxFrontline(size)) return false;
+  if ((role === 'ranged' || role === 'siege')
+    && countRole(force, 'ranged') + countRole(force, 'siege') >= Math.floor(size * RANGED_AND_SIEGE_MAXIMUM)) return false;
+  if (role === 'mobile' && countRole(force, 'mobile') >= Math.floor(size * MOBILE_MAXIMUM)) return false;
+  if (role === 'specialist' && countRole(force, 'specialist') >= Math.floor(size * SPECIALIST_MAXIMUM)) return false;
+  if (role === 'anti-air' && countRole(force, 'anti-air') >= 1) return false;
+  if (role === 'siege' && !context.escalated
+    && countRole(force, 'siege') >= 1) return false;
+  if (!context.escalated && candidate.eligibility.maxPerCampBeforeEscalation !== undefined
+    && force.filter(selected => selected.unitType === candidate.unitType).length
+      >= candidate.eligibility.maxPerCampBeforeEscalation) return false;
+
+  const frontlineNeeded = Math.ceil(size * FRONTLINE_MINIMUM) - countRole(force, 'frontline');
+  const slotsAfterSelection = size - force.length - 1;
+  return role === 'frontline' || slotsAfterSelection >= frontlineNeeded;
+}
+
+/**
+ * Creates a deterministic, data-driven prospective camp force. This is dark
+ * until #699 owns the live reinforcement integration.
+ */
+export function composeBarbarianForce(context: BarbarianForceCompositionContext): UnitType[] {
+  const size = normalizeForceSize(context.forceSize);
+  if (size === 0) return [];
+
+  const normalizedContext = { ...context, era: normalizeEra(context.era), forceSize: size };
+  const candidates = candidatesFor(normalizedContext);
+  const frontlineFallback = candidates.find(candidate => candidate.eligibility.roleSlot === 'frontline');
+  const fallback = frontlineFallback ?? candidates[0];
+  if (!fallback) return [];
+
+  const rng = seededLcg(context.seed);
+  const force: Candidate[] = [];
+  for (let slot = 0; slot < size; slot++) {
+    const legal = candidates.filter(candidate => canAddCandidate(candidate, force, normalizedContext));
+    if (legal.length === 0) break;
+    force.push(weightedPick(legal, legal.map(candidate => candidate.eligibility.weight), rng));
+  }
+
+  return force.length > 0 ? force.map(candidate => candidate.unitType) : [fallback.unitType];
+}

--- a/tests/systems/barbarian-force-composer.test.ts
+++ b/tests/systems/barbarian-force-composer.test.ts
@@ -1,0 +1,127 @@
+import { getBarbarianEligibility } from '@/systems/barbarian-roster';
+import { composeBarbarianForce } from '@/systems/barbarian-force-composer';
+
+function countByRole(force: ReturnType<typeof composeBarbarianForce>) {
+  return force.reduce<Record<string, number>>((counts, unitType) => {
+    const eligibility = getBarbarianEligibility(unitType);
+    if (eligibility.status === 'eligible') {
+      counts[eligibility.roleSlot] = (counts[eligibility.roleSlot] ?? 0) + 1;
+    }
+    return counts;
+  }, {});
+}
+
+describe('composeBarbarianForce', () => {
+  it('is deterministic for the same complete composition context', () => {
+    const context = { era: 6, forceSize: 10, escalated: false, seed: 73421 };
+
+    expect(composeBarbarianForce(context)).toEqual(composeBarbarianForce(context));
+  });
+
+  it.each([1, 3, 6, 8, 10, 12])('uses only legal era-%i unit definitions', (era) => {
+    const force = composeBarbarianForce({ era, forceSize: 10, escalated: false, seed: era * 11 });
+
+    // Some eras intentionally have too few legal role families to fill every
+    // requested slot without breaking a composition cap.
+    expect(force.length).toBeGreaterThan(0);
+    expect(force.length).toBeLessThanOrEqual(10);
+    for (const unitType of force) {
+      const eligibility = getBarbarianEligibility(unitType);
+      expect(eligibility.status).toBe('eligible');
+      if (eligibility.status === 'eligible') {
+        expect(eligibility.eraWindow.min).toBeLessThanOrEqual(era);
+        expect(eligibility.eraWindow.max ?? Infinity).toBeGreaterThanOrEqual(era);
+      }
+    }
+  });
+
+  it('keeps a full force within the approved combined-arms caps', () => {
+    const force = composeBarbarianForce({ era: 10, forceSize: 10, escalated: false, seed: 809 });
+    const roles = countByRole(force);
+    const siegeCount = force.filter(unitType => {
+      const eligibility = getBarbarianEligibility(unitType);
+      return eligibility.status === 'eligible' && eligibility.roleSlot === 'siege';
+    }).length;
+
+    expect(roles.frontline).toBeGreaterThanOrEqual(4);
+    expect(roles.frontline).toBeLessThanOrEqual(6);
+    expect((roles.ranged ?? 0) + siegeCount).toBeLessThanOrEqual(3);
+    expect(roles.mobile ?? 0).toBeLessThanOrEqual(4);
+    expect(roles.specialist ?? 0).toBeLessThanOrEqual(2);
+    expect(roles['anti-air'] ?? 0).toBeLessThanOrEqual(1);
+    expect(siegeCount).toBeLessThanOrEqual(1);
+  });
+
+  it.each([1, 3, 6, 8, 10, 12].flatMap(era => [17, 43, 91].map(seed => ({ era, seed }))))
+  ('preserves caps for era $era and seed $seed', ({ era, seed }) => {
+    const forceSize = 10;
+    const force = composeBarbarianForce({ era, forceSize, escalated: false, seed });
+    const roles = countByRole(force);
+    const siegeCount = roles.siege ?? 0;
+
+    expect(roles.frontline ?? 0).toBeGreaterThanOrEqual(Math.ceil(forceSize * 0.4));
+    expect(roles.frontline ?? 0).toBeLessThanOrEqual(Math.floor(forceSize * 0.6));
+    expect((roles.ranged ?? 0) + siegeCount).toBeLessThanOrEqual(Math.floor(forceSize * 0.3));
+    expect(roles.mobile ?? 0).toBeLessThanOrEqual(Math.floor(forceSize * 0.4));
+    expect(roles.specialist ?? 0).toBeLessThanOrEqual(Math.floor(forceSize * 0.25));
+    expect(roles['anti-air'] ?? 0).toBeLessThanOrEqual(1);
+    expect(siegeCount).toBeLessThanOrEqual(1);
+  });
+
+  it('does not admit observation-gated specialists without a supplied observation', () => {
+    const force = composeBarbarianForce({ era: 10, forceSize: 10, escalated: false, seed: 99 });
+
+    expect(force).not.toContain('anti_tank_gun');
+    expect(force).not.toContain('mobile_aa');
+  });
+
+  it('admits observed counters while preserving their per-force caps', () => {
+    const force = composeBarbarianForce({
+      era: 10,
+      forceSize: 20,
+      escalated: false,
+      observedThreats: ['armor', 'air'],
+      seed: 429,
+    });
+
+    expect(force.filter(unitType => unitType === 'mobile_aa')).toHaveLength(1);
+    expect(force.filter(unitType => unitType === 'anti_tank_gun').length).toBeLessThanOrEqual(5);
+  });
+
+  it('never selects mutually exclusive heavy and light cavalry together', () => {
+    const force = composeBarbarianForce({ era: 6, forceSize: 20, escalated: false, seed: 551 });
+
+    expect(force.includes('cavalry') && force.includes('cuirassier')).toBe(false);
+  });
+
+  it('has an era-safe frontline fallback and no resource or difficulty input', () => {
+    const force = composeBarbarianForce({ era: 99, forceSize: 1, escalated: false, seed: 7 });
+
+    expect(force).toHaveLength(1);
+    expect(getBarbarianEligibility(force[0]!).status).toBe('eligible');
+    expect(composeBarbarianForce({ era: 6, forceSize: 8, escalated: false, seed: 3 }))
+      .toEqual(composeBarbarianForce({ era: 6, forceSize: 8, escalated: false, seed: 3 }));
+  });
+
+  it('falls back to the earliest playable era instead of returning an empty force', () => {
+    const force = composeBarbarianForce({ era: 0, forceSize: 1, escalated: false, seed: 7 });
+
+    expect(force).toHaveLength(1);
+    expect(['warrior', 'axeman']).toContain(force[0]);
+  });
+
+  it('normalizes a non-finite era to the earliest playable force', () => {
+    const force = composeBarbarianForce({ era: Number.NaN, forceSize: 1, escalated: false, seed: 7 });
+
+    expect(force).toHaveLength(1);
+    expect(['warrior', 'axeman']).toContain(force[0]);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])('rejects non-finite force size %p', (forceSize) => {
+    expect(composeBarbarianForce({ era: 6, forceSize, escalated: false, seed: 1 })).toEqual([]);
+  });
+
+  it('returns no members when no force is requested', () => {
+    expect(composeBarbarianForce({ era: 6, forceSize: 0, escalated: false, seed: 1 })).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #697

## Summary

- Adds a pure, deterministic weighted composer for prospective barbarian combined-arms forces.
- Enforces typed era legality, observation gates, reciprocal exclusions, and approved role/cap limits.
- Normalizes malformed inputs safely so invalid eras cannot admit every roster entry and invalid force sizes cannot loop unboundedly.

## Out of scope

- Live camp spawning and reinforcement integration (#699).
- Persisted camp-local armor/air observations (#698).
- Player-facing barbarian UI, audio, save-schema, and notification changes.

## Why this is safe to merge partial

This slice introduces no player-visible surface or runtime caller. It is a pure, directly tested data consumer; current spawn behavior, difficulty behavior, AI knowledge boundaries, solo play, hot-seat presentation, saves, and audio remain unchanged until the downstream integration slices ship.

## Validation

- `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-force-composer.test.ts tests/systems/barbarian-roster.test.ts tests/systems/barbarian-system.test.ts`
- `scripts/check-src-rule-violations.sh src/systems/barbarian-force-composer.ts`
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test:durable` and `yarn test:durable:status` (passed for `8856e55d`)

No screenshots: this change has no UI or renderer surface.