### PR TITLE
fix(787): GameSession state-mutation audit — Phase 1 (player-action-controller.ts)

### DIFF
--- a/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
+++ b/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
@@ -1,0 +1,2481 @@
+# GameSession State-Mutation Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do NOT use subagent-driven-development or spawn any subagent for this plan** — this project's `CLAUDE.md` explicitly forbids subagents/parallel agents; execute every task inline in the current session.
+
+**Goal:** Eliminate the 44 call sites across 6 app-layer files that mutate the `GameState` object returned by `session.getState()` directly instead of publishing through `session.commit()`/`session.update()`, so every state change reaches both `GameSession` subscribers (`renderLoop.setGameState`, `hud.update()`) — not just whichever one a given site happens to call by hand.
+
+**Architecture:** No new `GameSession` API. Each flagged site becomes a spread-copy `GameState` passed to `session.commit(next)` or built inside `session.update(state => next)`, matching the existing "Immutable Turn Processing" convention already used by `src/systems/**`. Delivered as 6 phases (one PR each), grouped by file, closing with a grep-based regression test and a real-time edit hook so the count can never silently climb back up.
+
+**Tech Stack:** TypeScript, Vitest (`@vitest-environment jsdom` for controller tests), the existing `createGameSession` test double (the real implementation, not a mock).
+
+**Spec:** `docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md` — read it first if anything below is ambiguous; this plan implements it exactly, including the two hazards its review pass found (chained non-refreshing writes, and the `city-panel.ts` closure-staleness regression risk).
+
+## Global Constraints
+
+- Run every command via `bash scripts/run-with-mise.sh yarn <cmd>` — never `eval "$(mise activate bash)" && yarn <cmd>`.
+- Never spawn a subagent or parallel agent for any part of this plan (project policy).
+- All work happens in the current worktree (already verified on branch `claude/gamesession-state-mutation-audit-ffa5ef` with `core.hooksPath` correctly set to `.githooks`).
+- Before converting any flagged site, read its enclosing function to its actual end — not just the flagged line — and check for a trailing `setStateWithoutRefresh` or second mutation that would otherwise silently absorb the fix (confirmed hazard at `ensurePlayerWarState`, Task 1.1).
+- Where a call site's manual `renderLoop.setGameState(...)` and/or `hud.update()`/`deps.updateHUD()` companion call becomes redundant because `commit`/`update` now performs the same effect, delete the redundant manual call — do not leave both.
+- `src/ui/city-panel.ts`'s `onBuild`, `onMoveQueueItem`, `onRemoveQueueItem`, `onSetIdleProduction` callback types must widen to `(...) => GameState | void` and their call sites must switch from bare `rerenderPanel()` to `rerenderPanel(nextState)`, in the **same commit** as `panel-actions-controller.ts`'s 4 corresponding sites (Phase 5, Tasks 5.2-5.3) — landing one without the other is a regression, not a partial fix.
+- `panel-actions-controller.test.ts`'s existing "queues real production via the live city state and refreshes the renderer" test must be **rewritten**, not extended (Task 5.4) — it currently passes only because of the mutation bug it's meant to guard against.
+- Every phase ends with `bash scripts/run-with-mise.sh yarn build` and `bash scripts/run-with-mise.sh yarn test`, both exit 0, before that phase's commit(s) are considered done. Phase 3 additionally runs `bash scripts/run-with-mise.sh yarn test:ai-playability`.
+- Each converted site is its own line in that phase's PR body (matching the `#787` Phase 14 precedent) — no silent bundling.
+- Re-run the inventory greps from the spec at the start of each phase; line numbers below are as of 2026-08-15 and will drift.
+
+---
+
+## Phase 1 — `player-action-controller.ts` (+ `cross-cutting-helpers.ts` decision)
+
+Sets the template: smallest phase, contains one instance of the chained-write hazard, and confirms `getCurrentCiv()`/`deps.currentCiv()` keeps its current read-only shape (no code change to `cross-cutting-helpers.ts` itself — the decision is "don't touch it," verified by this phase's tests still passing with the helper unchanged).
+
+### Task 1.1: `ensurePlayerWarState` — bilateral diplomacy + chained opportunistic-penalty write
+
+**Files:**
+- Modify: `src/app/controllers/player-action-controller.ts:256-268`
+- Test: `tests/app/controllers/player-action-controller.test.ts:259-290` (extend existing `describe('ensurePlayerWarState', ...)`)
+
+**Interfaces:**
+- Consumes: `GameSession.update(fn: (state: GameState) => GameState): void` (already exists, `src/app/ports.ts:39`); `declareWar(state: DiplomacyState, targetCivId: string, turn: number): DiplomacyState` (`src/systems/diplomacy-system.ts:110`, unchanged); `applyOpportunisticWarPenaltyIfCrisisStruck(state: GameState, attackerId: string, defenderId: string, bus: EventBus): GameState` (unchanged, already imported in this file).
+- Produces: no new exports — `ensurePlayerWarState(targetCivId: string): void` keeps its existing signature on `PlayerActionController`.
+
+The current code (read it now to confirm line numbers haven't drifted):
+
+```ts
+function ensurePlayerWarState(targetCivId: string): void {
+    const targetCiv = deps.session.getState().civilizations[targetCivId];
+    if (!targetCiv || !isMajorCivOwner(targetCivId)) return;
+
+    const cp = deps.session.getState().currentPlayer;
+    const alreadyAtWar = deps.currentCiv().diplomacy?.atWarWith.includes(targetCivId) ?? false;
+    if (alreadyAtWar) return;
+
+    deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivId, deps.session.getState().turn);
+    targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, deps.session.getState().turn);
+    deps.bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
+    deps.session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(deps.session.getState(), cp, targetCivId, deps.bus));
+  }
+```
+
+Two bugs here, both fixed by the same rewrite: (1) `deps.currentCiv().diplomacy = ...` and `targetCiv.diplomacy = ...` mutate the live state object directly (Shape B); (2) the trailing `setStateWithoutRefresh` means even a naive fix of just those two lines would still never publish — the function's real terminal write is the opportunistic-penalty result, not the two diplomacy mutations.
+
+- [ ] **Step 1: Write the failing test.** Add to the existing `describe('ensurePlayerWarState', ...)` block in `tests/app/controllers/player-action-controller.test.ts` (after the existing 3 tests, before the closing `});` at line 290):
+
+```ts
+    it('publishes the war declaration to session subscribers, not just the renderer', () => {
+      const { state, aiCivId } = makeFixture('war-state-publishes');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.ensurePlayerWarState(aiCivId);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(deps.session.getState());
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "publishes the war declaration"`
+Expected: FAIL — `listener` was never called, because the current code path ends in `setStateWithoutRefresh`, which never calls `publish()`.
+
+- [ ] **Step 3: Write minimal implementation.** Replace the function body:
+
+```ts
+function ensurePlayerWarState(targetCivId: string): void {
+    const targetCiv = deps.session.getState().civilizations[targetCivId];
+    if (!targetCiv || !isMajorCivOwner(targetCivId)) return;
+
+    const cp = deps.session.getState().currentPlayer;
+    const attackerCiv = deps.currentCiv();
+    const alreadyAtWar = attackerCiv.diplomacy?.atWarWith.includes(targetCivId) ?? false;
+    if (alreadyAtWar) return;
+
+    const turn = deps.session.getState().turn;
+    const withDeclaredWar = {
+      ...deps.session.getState(),
+      civilizations: {
+        ...deps.session.getState().civilizations,
+        [cp]: { ...attackerCiv, diplomacy: declareWar(attackerCiv.diplomacy, targetCivId, turn) },
+        [targetCivId]: { ...targetCiv, diplomacy: declareWar(targetCiv.diplomacy, cp, turn) },
+      },
+    };
+    deps.bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
+    deps.session.commit(applyOpportunisticWarPenaltyIfCrisisStruck(withDeclaredWar, cp, targetCivId, deps.bus));
+  }
+```
+
+Note: keyed by `cp` (already `= deps.session.getState().currentPlayer`, the same id `deps.currentCiv()` looks up), not a `.id` field, so no assumption about `Civilization` carrying its own id is introduced.
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "ensurePlayerWarState"`
+Expected: PASS — all 4 tests in the block (the 3 pre-existing behavioral ones plus the new publish test).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
+git commit -m "fix(player-action-controller): publish ensurePlayerWarState through commit, not setStateWithoutRefresh
+
+Both civs' diplomacy were mutated directly on the live state object,
+then the function's real terminal write (the opportunistic-war-penalty
+result) went through setStateWithoutRefresh -- meaning even fixing the
+two mutation lines alone would never have published. Unified all three
+writes into one session.commit() call."
+```
+
+### Task 1.2: `restAction` — direct unit mutation
+
+**Files:**
+- Modify: `src/app/controllers/player-action-controller.ts:270-280`
+- Test: `tests/app/controllers/player-action-controller.test.ts:312-323` (extend existing test)
+
+**Interfaces:**
+- Consumes: `GameSession.commit(next: GameState): void`; `restUnit(unit: Unit): Unit` (unchanged, already imported).
+- Produces: no signature change to `restAction(): void`.
+
+Current code:
+
+```ts
+  function restAction(): void {
+    const selectedUnitId = deps.selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+    const unit = deps.session.getState().units[selectedUnitId];
+    if (!unit || !canHeal(unit)) return;
+
+    deps.session.getState().units[selectedUnitId] = restUnit(unit);
+    deps.showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
+    deps.selectionController.deselectUnit();
+    deps.renderLoop.setGameState(deps.session.getState());
+  }
+```
+
+No chained non-refreshing write here — this one is a clean Shape-A conversion.
+
+- [ ] **Step 1: Write the failing test.** Replace the existing `'rests a real damaged unit, heals via restUnit, and deselects'` test (`tests/app/controllers/player-action-controller.test.ts:312-323`) to also assert publish:
+
+```ts
+    it('rests a real damaged unit, heals via restUnit, deselects, and publishes to subscribers', () => {
+      const { state } = makeFixture('rest-damaged');
+      placeUnit(state, 'warrior', 'warrior-1', { q: 0, r: 0 }, { health: 50 });
+      const { deps, controller } = build(state, { selection: { getSelectedUnitId: vi.fn(() => 'warrior-1'), setPendingIntent: vi.fn() } });
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.restAction();
+
+      expect(deps.session.getState().units['warrior-1'].isResting).toBe(true);
+      expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('heal'), 'info');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "rests a real damaged unit"`
+Expected: FAIL on `expect(listener).toHaveBeenCalledTimes(1)` — 0 calls, since the current code never calls `commit`/`update`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+  function restAction(): void {
+    const selectedUnitId = deps.selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+    const unit = deps.session.getState().units[selectedUnitId];
+    if (!unit || !canHeal(unit)) return;
+
+    deps.session.commit({
+      ...deps.session.getState(),
+      units: { ...deps.session.getState().units, [selectedUnitId]: restUnit(unit) },
+    });
+    deps.showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
+    deps.selectionController.deselectUnit();
+  }
+```
+
+`deps.renderLoop.setGameState(deps.session.getState())` is deleted — `session.commit()` now performs that in production via the `bootstrap.ts` subscribe wiring, and the test above still passes because `deps.renderLoop.setGameState` is a separately-injected mock the test doesn't require to be called via this exact line (see Step 4).
+
+Wait — check this before running: the test at Step 1 still asserts `expect(deps.renderLoop.setGameState).toHaveBeenCalled();`, but `deps.renderLoop` in this test's `createGameSession`-based fixture is **not** wired to `session.subscribe` (that wiring only exists in `bootstrap.ts`, not in this unit test's `makeDeps`). Deleting the manual call would make that assertion fail. Since this is a controller **unit** test with an unwired `renderLoop` mock, keep the manual `deps.renderLoop.setGameState(deps.session.getState())` call — only the `session.getState().units[...] = ...` mutation is the bug; the manual renderer refresh alongside a proper `commit()` is redundant only in the real app (where `bootstrap.ts` already subscribes `renderLoop`), not incorrect. Revise Step 3's implementation to keep it:
+
+```ts
+  function restAction(): void {
+    const selectedUnitId = deps.selection.getSelectedUnitId();
+    if (!selectedUnitId) return;
+    const unit = deps.session.getState().units[selectedUnitId];
+    if (!unit || !canHeal(unit)) return;
+
+    deps.session.commit({
+      ...deps.session.getState(),
+      units: { ...deps.session.getState().units, [selectedUnitId]: restUnit(unit) },
+    });
+    deps.showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
+    deps.selectionController.deselectUnit();
+    deps.renderLoop.setGameState(deps.session.getState());
+  }
+```
+
+This is the pattern for every remaining task in this plan: **do not delete a manual `renderLoop.setGameState`/`hud.update` call just because `commit`/`update` now also does it** — these controller unit tests construct their own unwired `createGameSession` instance per test, so the manual call is still the only thing driving the test double's assertion. Only delete a manual call if a specific task's own test coverage proves it's safe to (none in this plan require it — see the corrected Global Constraints intent below).
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "rests a real damaged unit"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
+git commit -m "fix(player-action-controller): publish restAction's unit rest through session.commit"
+```
+
+**Correction to this plan's Global Constraints, discovered in Task 1.2:** delete a redundant manual `renderLoop.setGameState`/`hud.update`/`updateHUD` call only where it is truly dead code after the fix — in production that's most of them, once `commit`/`update` triggers the same effect via `bootstrap.ts`'s subscribe wiring, but every controller unit test in this codebase builds its own `createGameSession` **without** that subscribe wiring, so a manual call being asserted by an existing test must stay unless that test is also being rewritten in the same task. Apply this per-task, not as a blanket deletion rule — Task 1.1 had no manual calls to preserve; this task and most that follow do.
+
+### Task 1.3: `executeMinorCivConquest` — unit mutation feeding a `setStateWithoutRefresh` chain
+
+**Files:**
+- Modify: `src/app/controllers/player-action-controller.ts:429-448`
+- Test: `tests/app/controllers/player-action-controller.test.ts:557-590` (extend existing tests)
+
+**Interfaces:**
+- Consumes: `conquestMinorCiv(state: GameState, minorCivId: string, conquerorId: string): { state: GameState; conquered: boolean; transitions: ... }` (unchanged).
+- Produces: no signature change to `executeMinorCivConquest`.
+
+Current code:
+
+```ts
+  function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
+    const cityName = deps.session.getState().cities[cityId]?.name ?? 'City-State';
+    const movement = deps.selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(deps.session.getState(), unitId, target, {
+      actor: 'player',
+      civId: deps.session.getState().currentPlayer,
+      bus: deps.bus,
+      foreignCityEntryId: cityId,
+    }));
+    if (!movement.ok) return;
+    const movedUnit = deps.session.getState().units[unitId];
+    if (movedUnit) deps.session.getState().units[unitId] = { ...movedUnit, movementPointsLeft: 0 };
+    const conquered = conquestMinorCiv(deps.session.getState(), minorCivId, deps.session.getState().currentPlayer);
+    deps.session.setStateWithoutRefresh(conquered.state);
+    emitMinorCivQuestTransitions(deps.bus, conquered.transitions, deps.session.getState());
+    if (conquered.conquered) deps.bus.emit('minor-civ:destroyed', { minorCivId, conquerorId: deps.session.getState().currentPlayer });
+    deps.showNotification(`${cityName} has been conquered!`, 'success');
+    SFX.tap();
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+  }
+```
+
+This is architecture-debt only today (per the spec's severity review) — `deps.hud.update()` is already called manually at the end, so the HUD is not currently stale. But `conquestMinorCiv` is called with `deps.session.getState()` *after* the flagged mutation, meaning it operates on the already-mutated live object rather than a value passed explicitly — and the result then goes through `setStateWithoutRefresh` rather than `commit`, relying entirely on the trailing manual `renderLoop.setGameState` + `hud.update()` to catch up. Fix: fold the unit mutation into one input state, call `conquestMinorCiv` on that explicit value, and `commit` its result.
+
+- [ ] **Step 1: Write the failing test.** Extend the existing `'conquers the minor civ and transfers its city after a successful movement'` test (`tests/app/controllers/player-action-controller.test.ts:576-589`):
+
+```ts
+    it('conquers the minor civ, transfers its city, publishes once, and clears the mover\'s movement points', () => {
+      const { state } = makeFixture('minor-civ-conquest-success');
+      const mcId = Object.keys(state.minorCivs)[0]!;
+      const cityId = state.minorCivs[mcId].cityId;
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.executeMinorCivConquest('attacker-1', { q: 0, r: 0 }, mcId, cityId);
+
+      const updated = deps.session.getState();
+      expect(updated.minorCivs[mcId].isDestroyed).toBe(true);
+      expect(updated.cities[cityId]?.owner).toBe('player');
+      expect(updated.units['attacker-1']?.movementPointsLeft).toBe(0);
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('conquered'), 'success');
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "conquers the minor civ, transfers its city, publishes once"`
+Expected: FAIL on `expect(listener).toHaveBeenCalledTimes(1)` — the current code path ends in `setStateWithoutRefresh`, which never calls `publish()`, so `listener` sees 0 calls.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+  function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
+    const cityName = deps.session.getState().cities[cityId]?.name ?? 'City-State';
+    const movement = deps.selectionController.executeAnimatedUnitMove(unitId, () => executeUnitMove(deps.session.getState(), unitId, target, {
+      actor: 'player',
+      civId: deps.session.getState().currentPlayer,
+      bus: deps.bus,
+      foreignCityEntryId: cityId,
+    }));
+    if (!movement.ok) return;
+    const movedUnit = deps.session.getState().units[unitId];
+    const stateAfterMove = movedUnit
+      ? { ...deps.session.getState(), units: { ...deps.session.getState().units, [unitId]: { ...movedUnit, movementPointsLeft: 0 } } }
+      : deps.session.getState();
+    const conquered = conquestMinorCiv(stateAfterMove, minorCivId, stateAfterMove.currentPlayer);
+    deps.session.commit(conquered.state);
+    emitMinorCivQuestTransitions(deps.bus, conquered.transitions, deps.session.getState());
+    if (conquered.conquered) deps.bus.emit('minor-civ:destroyed', { minorCivId, conquerorId: deps.session.getState().currentPlayer });
+    deps.showNotification(`${cityName} has been conquered!`, 'success');
+    SFX.tap();
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "executeMinorCivConquest"`
+Expected: PASS — both tests in the block.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
+git commit -m "fix(player-action-controller): route executeMinorCivConquest's unit mutation through session.commit"
+```
+
+### Phase 1 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [ ] Confirm `getCurrentCiv`/`deps.currentCiv()` in `src/app/cross-cutting-helpers.ts` was **not modified** — the decision from the spec (keep its read-only convenience shape) holds because both flagged sites in this phase converted at their call site, not the helper.
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 1 (player-action-controller.ts)`. Body lists all 3 conversions individually, per Global Constraints.
+
+---
+
+## Phase 2 — `campaign-entry-controller.ts`
+
+Both flagged sites mutate `deps.session.getState().settings.councilTalkLevel` directly, immediately after a `setStateWithoutRefresh(createNewGame(...)/createHotSeatGame(...))` call that already replaced the state object with a new one — so the fix here is to fold the settings override into that same state-construction step rather than mutate the freshly-created object afterward.
+
+### Task 2.1: `onStartSolo` and `onComplete` (hot-seat) — settings override merged into game creation
+
+**Files:**
+- Modify: `src/app/controllers/campaign-entry-controller.ts:222-238` (`onStartSolo`), `:254-263` (`onComplete`, hot-seat)
+- Test: `tests/app/controllers/campaign-entry-controller.test.ts` (extend `describe('showGameModeSelection', ...)`)
+
+**Interfaces:**
+- Consumes: `GameSession.setStateWithoutRefresh(next: GameState): void` (kept — this phase's fix does not need to become a `commit`, since the councilTalkLevel merge happens *before* the first refresh either caller needs; `deps.startGame()`/`enterCampaign(...)` are what actually publish the initial state a moment later, unchanged by this task).
+- Produces: no signature change.
+
+Current code, `onStartSolo` (`campaign-entry-controller.ts:222-239`):
+
+```ts
+          onStartSolo: (config) => {
+            deps.session.setStateWithoutRefresh(createNewGame({
+              civType: config.civType,
+              mapSize: config.mapSize,
+              opponentCount: config.opponentCount,
+              gameTitle: config.gameTitle,
+              // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
+              settingsOverrides: { ...deps.userSettingsStore.getOverrides(), ...config.settingsOverrides },
+              customCivilizations: config.customCivilizations,
+              seed: config.seed,
+              mapScript: config.mapScript,
+              startPlacementMode: config.startPlacementMode,
+              opponentChallenge: config.opponentChallenge,
+            }));
+            if (currentSettings.councilTalkLevel) {
+              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
+            }
+            deps.startGame();
+          },
+```
+
+Current code, `onComplete` (hot-seat, `campaign-entry-controller.ts:254-263`):
+
+```ts
+          onComplete: (config, opponentChallenge) => {
+            deps.session.setStateWithoutRefresh(createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard'));
+            if (currentSettings.councilTalkLevel) {
+              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
+            }
+            enterCampaign(
+              deps.session.getState(),
+              `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,
+              true,
+            );
+          },
+```
+
+- [ ] **Step 1: Write the failing test.** Add to `describe('showGameModeSelection', ...)` in `tests/app/controllers/campaign-entry-controller.test.ts`, after the existing solo/hot-seat tests around line 306:
+
+```ts
+    it('the solo path applies a persisted councilTalkLevel to the freshly constructed game', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state, {
+        userSettingsStore: {
+          getPersisted: () => undefined,
+          refresh: vi.fn().mockResolvedValue({ customCivilizations: [], councilTalkLevel: 'verbose' }),
+          getMasterVolume: () => 0.8,
+          setCustomCivilizations: vi.fn(),
+          getOverrides: () => ({}),
+        },
+      });
+      const campaignEntry = createCampaignEntryController(deps);
+      const callbacks = captureModeSelectCallbacks();
+      let capturedSoloCallbacks: campaignSetupModule.CampaignSetupCallbacks | undefined;
+      vi.mocked(campaignSetupModule.showCampaignSetup).mockImplementation((_layer, cb) => {
+        capturedSoloCallbacks = cb;
+        return document.createElement('div');
+      });
+
+      campaignEntry.showGameModeSelection();
+      await callbacks.onChooseSolo('Talkative Council Game');
+      expect(capturedSoloCallbacks).toBeDefined();
+
+      const beforeState = deps.session.getState();
+      const soloConfig: SoloSetupConfig = {
+        civType: beforeState.civilizations['player'].civType,
+        mapSize: 'small',
+        opponentCount: 1,
+        gameTitle: 'Talkative Council Game',
+      };
+      capturedSoloCallbacks!.onStartSolo(soloConfig);
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('verbose');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/campaign-entry-controller.test.ts -t "applies a persisted councilTalkLevel"`
+Expected: This specific test actually **passes today** even with the bug, because the mutation does land on the object `deps.session.getState()` returns (same reference) before the assertion reads it back — the test as written can't distinguish the mutation bug from correct behavior. This is intentional: skip to Step 3, then use Step 4's assertion (not Step 2) as the real regression check. Note this in the PR body rather than silently having a step that doesn't fail — the spec's "currently observable staleness" table already flags this site as having no live user-facing symptom; this task is architecture-cleanliness, not a behavior fix, and the test proves the settings value ends up correct after the refactor, not that the refactor was necessary.
+
+- [ ] **Step 3: Write minimal implementation.** `onStartSolo`:
+
+```ts
+          onStartSolo: (config) => {
+            const newGame = createNewGame({
+              civType: config.civType,
+              mapSize: config.mapSize,
+              opponentCount: config.opponentCount,
+              gameTitle: config.gameTitle,
+              // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
+              settingsOverrides: { ...deps.userSettingsStore.getOverrides(), ...config.settingsOverrides },
+              customCivilizations: config.customCivilizations,
+              seed: config.seed,
+              mapScript: config.mapScript,
+              startPlacementMode: config.startPlacementMode,
+              opponentChallenge: config.opponentChallenge,
+            });
+            deps.session.setStateWithoutRefresh(
+              currentSettings.councilTalkLevel
+                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
+                : newGame,
+            );
+            deps.startGame();
+          },
+```
+
+`onComplete` (hot-seat):
+
+```ts
+          onComplete: (config, opponentChallenge) => {
+            const newGame = createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard');
+            deps.session.setStateWithoutRefresh(
+              currentSettings.councilTalkLevel
+                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
+                : newGame,
+            );
+            enterCampaign(
+              deps.session.getState(),
+              `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,
+              true,
+            );
+          },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/campaign-entry-controller.test.ts -t "showGameModeSelection"`
+Expected: PASS — the new test plus the two pre-existing solo/hot-seat tests (their `expect(deps.session.getState()).not.toBe(beforeState)` and `.gameTitle` assertions are unaffected, since `setStateWithoutRefresh` still runs and still replaces the reference).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/campaign-entry-controller.ts tests/app/controllers/campaign-entry-controller.test.ts
+git commit -m "fix(campaign-entry-controller): merge persisted councilTalkLevel into game construction instead of mutating the created state"
+```
+
+### Phase 2 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 2 (campaign-entry-controller.ts)`. Body notes both sites are architecture-cleanliness (no live user-facing bug — settings never visible before the first real `commit`/`enterCampaign` publish), citing the spec's severity table.
+
+---
+
+## Phase 3 — `turn-flow-controller.ts`
+
+Both sites already have a manual `renderLoop.setGameState` + `updateHUD()` pair immediately after them via `refreshRequiredChoicesAfterAction()` — architecture-debt only, not a live bug. Fixed for the single-owner contract and to reach zero for Phase 6's regression guard.
+
+### Task 3.1: `onChooseResearch` and `onChooseCityBuild` inside `showRequiredChoicesIfNeeded`
+
+**Files:**
+- Modify: `src/app/controllers/turn-flow-controller.ts:255-270`
+- Test: `tests/app/controllers/turn-flow-controller.test.ts` (new tests in the relevant existing `describe` block covering `showRequiredChoicesIfNeeded`)
+
+**Interfaces:**
+- Consumes: `enqueueResearch(techState: TechState, techId: string): TechState` (unchanged); `enqueueCityProduction(city: City, itemId: string): City` (`src/systems/planning-system.ts:15`, unchanged).
+- Produces: no signature change.
+
+Current code (`turn-flow-controller.ts:255-270`):
+
+```ts
+      onChooseResearch: (techId) => {
+        deps.currentCiv().techState = enqueueResearch(deps.currentCiv().techState, techId);
+        deps.showNotification(`Researching ${techId}...`, 'info');
+        refreshRequiredChoicesAfterAction();
+      },
+      onChooseCityBuild: (cityId, itemId) => {
+        const city = session.getState().cities[cityId];
+        if (!city) return;
+        session.getState().cities[cityId] = enqueueCityProduction(city, itemId);
+        deps.showNotification(`${city.name}: queued ${itemId}`, 'info');
+        refreshRequiredChoicesAfterAction();
+      },
+```
+
+Where `refreshRequiredChoicesAfterAction` (`turn-flow-controller.ts:188-192`, unchanged by this task) is:
+
+```ts
+  function refreshRequiredChoicesAfterAction(): void {
+    deps.getElementById('required-choice-panel')?.remove();
+    closePlanningPanels(document);
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+```
+
+- [ ] **Step 1: Find or write a test harness that reaches these callbacks.** Search first: `grep -n "onChooseResearch\|onChooseCityBuild\|showRequiredChoicesIfNeeded" tests/app/controllers/turn-flow-controller.test.ts`. If existing tests already capture `createRequiredChoicePanel`'s callbacks (this codebase's convention, per Phase 1/2/5's tests, is to mock the panel factory and capture the callbacks object passed to it), extend that pattern; otherwise add:
+
+```ts
+vi.mock('@/ui/required-choice-panel', () => ({ createRequiredChoicePanel: vi.fn() }));
+```
+
+at the top of the test file (only if not already present — check first), then:
+
+```ts
+  describe('showRequiredChoicesIfNeeded callbacks', () => {
+    it('onChooseResearch publishes the queued tech through session subscribers', () => {
+      const { state } = makeFixture('required-choice-research');
+      // arrange an idle-research condition so showRequiredChoicesIfNeeded opens the panel
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+      controller.showRequiredChoicesIfNeeded();
+      const options = mockedCallArg<{ onChooseResearch: (techId: string) => void }>(createRequiredChoicePanel, 0, 1);
+
+      const someTechId = Object.keys(deps.session.getState().civilizations.player.techState.researchQueue.length
+        ? {}
+        : {})[0]; // placeholder replaced below once the real available-tech id is known from the fixture
+
+      options.onChooseResearch('pottery');
+
+      expect(deps.session.getState().civilizations.player.techState.researchQueue).toContain('pottery');
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onChooseCityBuild publishes the queued production through session subscribers', () => {
+      const { state } = makeFixture('required-choice-build');
+      state.cities['idle-city'] = makeCity('idle-city');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+      controller.showRequiredChoicesIfNeeded();
+      const options = mockedCallArg<{ onChooseCityBuild: (cityId: string, itemId: string) => void }>(createRequiredChoicePanel, 0, 1);
+
+      options.onChooseCityBuild('idle-city', 'warrior');
+
+      expect(deps.session.getState().cities['idle-city'].productionQueue).toContain('warrior');
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+```
+
+Before running, replace the `someTechId` placeholder line — it is a **planning placeholder for this plan document only**, not something to leave in the implementation: when writing this test for real, read `tests/app/controllers/turn-flow-controller.test.ts`'s existing fixture setup for `showRequiredChoicesIfNeeded`/idle-research conditions (search for an existing test that already opens this panel for a research choice) and copy its exact arrangement so `onChooseResearch` is reachable with a real available tech id, then delete the placeholder line entirely — do not commit code containing it.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts -t "showRequiredChoicesIfNeeded callbacks"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()` in both tests — current code never calls `commit`/`update`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onChooseResearch: (techId) => {
+        const civ = deps.currentCiv();
+        session.commit({
+          ...session.getState(),
+          civilizations: {
+            ...session.getState().civilizations,
+            [session.getState().currentPlayer]: { ...civ, techState: enqueueResearch(civ.techState, techId) },
+          },
+        });
+        deps.showNotification(`Researching ${techId}...`, 'info');
+        refreshRequiredChoicesAfterAction();
+      },
+      onChooseCityBuild: (cityId, itemId) => {
+        const city = session.getState().cities[cityId];
+        if (!city) return;
+        session.commit({
+          ...session.getState(),
+          cities: { ...session.getState().cities, [cityId]: enqueueCityProduction(city, itemId) },
+        });
+        deps.showNotification(`${city.name}: queued ${itemId}`, 'info');
+        refreshRequiredChoicesAfterAction();
+      },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts -t "showRequiredChoicesIfNeeded callbacks"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full turn-flow-controller suite** (this file also has timing-sensitive round/handoff tests elsewhere that must not regress from this change).
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts`
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/app/controllers/turn-flow-controller.ts tests/app/controllers/turn-flow-controller.test.ts
+git commit -m "fix(turn-flow-controller): route required-choice research/build queueing through session.commit"
+```
+
+### Phase 3 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test:ai-playability` — expect exit 0 (required for this phase per the spec: it touches turn-advancement-adjacent code).
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 3 (turn-flow-controller.ts)`.
+
+---
+
+## Phase 4 — `selection-controller.ts`
+
+15 sites across 3 handler groups inside the unit-info panel's callback object (all under one `session`-scoped closure — no `deps.session`, just `session`, per this file's own factory parameter naming). No turn-flow risk; heaviest single-domain phase.
+
+### Task 4.1: `onSetDisguise`
+
+**Files:**
+- Modify: `src/app/controllers/selection-controller.ts:388-404`
+- Test: `tests/app/controllers/selection-controller.test.ts` (new `describe('onSetDisguise', ...)` or extend existing espionage coverage — search first: `grep -n "onSetDisguise" tests/app/controllers/selection-controller.test.ts`)
+
+**Interfaces:**
+- Consumes: `setDisguise(civEsp: EspionageCivState, spyId: string, disguise: UnitType | null): EspionageCivState` (unchanged).
+- Produces: no signature change.
+
+Current code:
+
+```ts
+        onSetDisguise: (uid, disguise) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.hasActed) return;
+          if (unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const spy = civEsp.spies[uid];
+          if (!spy || spy.status !== 'idle') return;
+          session.getState().espionage![session.getState().currentPlayer] = setDisguise(civEsp, uid, disguise);
+          if (disguise !== null) {
+            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+          }
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          selectUnit(uid);
+          deps.showNotification(disguise ? `Spy disguised as ${disguise}.` : 'Disguise removed.', 'info');
+        },
+```
+
+Two flagged mutations here (espionage assignment, conditional unit assignment) — both belong to the same handler and must land in one `commit`.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+  describe('onSetDisguise', () => {
+    it('sets the disguise and marks the unit acted, publishing through session subscribers', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'spy-1', { position: { q: 0, r: 0 } });
+      state.espionage = { player: createEspionageCivState() };
+      state.espionage.player.spies['spy-1'] = {
+        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_scout',
+        targetCivId: null, targetCityId: null, position: null,
+        status: 'idle', experience: 0, currentMission: null,
+        cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+      };
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.selectUnit('spy-1');
+      const options = mockedCallArg<{ onSetDisguise: (uid: string, disguise: UnitType | null) => void }>(renderSelectedUnitInfo, 0, 2);
+      options.onSetDisguise('spy-1', 'warrior');
+
+      const updated = deps.session.getState();
+      expect(updated.espionage!.player.spies['spy-1'].disguisedAs).toBe('warrior');
+      expect(updated.units['spy-1'].hasActed).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+```
+
+Before writing this for real: check `tests/app/controllers/selection-controller.test.ts`'s existing fixture helpers (`makeFixture`, `placePlayerUnit`, and how `renderSelectedUnitInfo`'s callbacks are captured — search `mockedCallArg.*renderSelectedUnitInfo` in that file) and match the established pattern and argument indices exactly rather than guessing them; the shape above is illustrative of the assertions needed, not a verbatim drop-in.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onSetDisguise"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+        onSetDisguise: (uid, disguise) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.hasActed) return;
+          if (unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const spy = civEsp.spies[uid];
+          if (!spy || spy.status !== 'idle') return;
+          const currentPlayer = session.getState().currentPlayer;
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: setDisguise(civEsp, uid, disguise) },
+            units: disguise !== null
+              ? { ...session.getState().units, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } }
+              : session.getState().units,
+          });
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          selectUnit(uid);
+          deps.showNotification(disguise ? `Spy disguised as ${disguise}.` : 'Disguise removed.', 'info');
+        },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onSetDisguise"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
+git commit -m "fix(selection-controller): route onSetDisguise's espionage/unit mutation through session.commit"
+```
+
+### Task 4.2: `onInfiltrate`
+
+**Files:**
+- Modify: `src/app/controllers/selection-controller.ts:405-484`
+- Test: `tests/app/controllers/selection-controller.test.ts` (extend/add `describe('onInfiltrate', ...)`, covering all 4 branches: `removeUnitFromMap`, `era1ScoutResult`, `caught`, and the default failed-but-not-caught path)
+
+**Interfaces:**
+- Consumes: `attemptInfiltration(...)` (unchanged); `resolveMissionResult(...)` (unchanged).
+- Produces: no signature change.
+
+This is the largest single handler (8 flagged sites across 4 branches). Current code, full handler:
+
+```ts
+        onInfiltrate: (uid) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const targetCity = Object.values(session.getState().cities).find(
+            c => c.owner !== session.getState().currentPlayer &&
+                 c.position.q === unit.position.q && c.position.r === unit.position.r,
+          );
+          if (!targetCity) { deps.showNotification('No enemy city at this location.', 'info'); return; }
+
+          const alreadyInside = Object.values(civEsp.spies).some(
+            s => s.infiltrationCityId === targetCity.id &&
+                 (s.status === 'stationed' || s.status === 'on_mission'),
+          );
+          if (alreadyInside) { deps.showNotification('You already have a spy in that city.', 'info'); return; }
+
+          const cityCI = session.getState().espionage![targetCity.owner]?.counterIntelligence[targetCity.id] ?? 0;
+          const chance = getInfiltrationSuccessChance(unit.type as UnitType, civEsp.spies[uid]?.experience ?? 0, cityCI);
+          const preview = `Infiltrate ${targetCity.name}?\n\nSuccess chance: ${Math.round(chance * 100)}%\nCity CI: ${cityCI}\n\nIf caught, spy may be lost permanently.`;
+          if (!window.confirm(preview)) return;
+
+          const seed = `infiltrate-${uid}-${session.getState().turn}`;
+          const result = attemptInfiltration(
+            civEsp, uid, unit.type as UnitType, targetCity.id, targetCity.position, cityCI, seed,
+          );
+          const spyAfterAttempt = result.civEsp.spies[uid];
+          const civEspWithTarget = spyAfterAttempt ? {
+            ...result.civEsp,
+            spies: { ...result.civEsp.spies, [uid]: { ...spyAfterAttempt, targetCivId: targetCity.owner } },
+          } : result.civEsp;
+
+          const currentPlayer = session.getState().currentPlayer;
+          let nextUnits = session.getState().units;
+          let nextCivilizations = session.getState().civilizations;
+
+          if (result.removeUnitFromMap) {
+            const { [uid]: _removed, ...remainingUnits } = nextUnits;
+            nextUnits = remainingUnits;
+            const civUnits = nextCivilizations[currentPlayer].units;
+            nextCivilizations = civUnits
+              ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
+              : nextCivilizations;
+            deps.showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
+            bus.emit('espionage:spy-infiltrated', { civId: currentPlayer, spyId: uid, cityId: targetCity.id });
+          } else if (result.era1ScoutResult !== undefined) {
+            const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), currentPlayer, uid);
+            const tilesToReveal = missionResult.tilesToReveal ?? [];
+            if (tilesToReveal.length > 0) {
+              const visibilityTiles = { ...(nextCivilizations[currentPlayer].visibility?.tiles ?? {}) };
+              for (const coord of tilesToReveal) {
+                visibilityTiles[`${coord.q},${coord.r}`] = 'visible';
+              }
+              nextCivilizations = {
+                ...nextCivilizations,
+                [currentPlayer]: { ...nextCivilizations[currentPlayer], visibility: { ...nextCivilizations[currentPlayer].visibility!, tiles: visibilityTiles } },
+              };
+            }
+            nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
+            deps.showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
+          } else if (result.caught) {
+            const { [uid]: _removed, ...remainingUnits } = nextUnits;
+            nextUnits = remainingUnits;
+            const civUnits = nextCivilizations[currentPlayer].units;
+            nextCivilizations = civUnits
+              ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
+              : nextCivilizations;
+            bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: currentPlayer, spyId: uid, cityId: targetCity.id });
+          } else {
+            const cooldown = result.civEsp.spies[uid]?.cooldownTurns ?? 3;
+            deps.showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
+            nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
+          }
+
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: civEspWithTarget },
+            units: nextUnits,
+            civilizations: nextCivilizations,
+          });
+
+          if (result.removeUnitFromMap || result.caught) {
+            deselectUnit();
+          } else {
+            selectUnit(uid);
+          }
+
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+        },
+```
+
+Behavior-preserving note: the original code emitted `bus.emit(...)` for the `removeUnitFromMap` and `caught` branches *before* the final state mutation happened (since the mutations were interleaved with the emits in-place); the rewrite above keeps emit ordering identical relative to the other statements in each branch — only the *mechanism* of building `nextUnits`/`nextCivilizations` changed from in-place mutation to accumulated spread-copies, committed once at the end instead of write-as-you-go.
+
+- [ ] **Step 1: Write failing tests covering all 4 branches.** Search `tests/app/controllers/selection-controller.test.ts` first for any existing `onInfiltrate` coverage to extend rather than duplicate. At minimum, add one test per branch asserting (a) the branch's distinguishing state change, and (b) a subscribed listener fires:
+
+```ts
+  describe('onInfiltrate', () => {
+    it('era-2+ unit types remove the unit from the map and station the spy (removeUnitFromMap branch)', () => {
+      // Arrange a unit type/experience/CI combination that resolves to removeUnitFromMap,
+      // matching whatever helper (if any) existing infiltration tests in this file already
+      // use to force that branch deterministically -- check attemptInfiltration's existing
+      // test coverage in tests/systems/ for the exact inputs that select this branch.
+      // ... arrange ...
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      options.onInfiltrate('spy-1');
+
+      expect(deps.session.getState().units['spy-1']).toBeUndefined();
+      expect(deps.session.getState().civilizations.player.units).not.toContain('spy-1');
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('era-1 scout infiltration reveals tiles and marks the unit acted without removing it (era1ScoutResult branch)', () => {
+      // ... arrange for era1ScoutResult ...
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      options.onInfiltrate('scout-1');
+
+      expect(deps.session.getState().units['scout-1'].hasActed).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('a caught spy is removed from the map (caught branch)', () => {
+      // ... arrange for result.caught ...
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      options.onInfiltrate('spy-2');
+
+      expect(deps.session.getState().units['spy-2']).toBeUndefined();
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('a failed-but-not-caught attempt marks the unit acted and keeps it on the map (default branch)', () => {
+      // ... arrange for the default (not caught, not era1, not removeUnitFromMap) outcome ...
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      options.onInfiltrate('spy-3');
+
+      expect(deps.session.getState().units['spy-3'].hasActed).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+```
+
+The `// arrange` comments above are explicitly **not** placeholders to leave in committed code — they mark research the implementer must do against `attemptInfiltration`'s real signature and existing test fixtures in `tests/systems/espionage-system.test.ts` (or wherever it's tested) to pick concrete inputs that deterministically select each branch, before this task's Step 1 is actually complete. Do not check in a test with an unresolved arrange step.
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onInfiltrate"`
+Expected: FAIL on each branch's `listener` assertion.
+
+- [ ] **Step 3: Write minimal implementation** — the full rewritten handler shown above.
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onInfiltrate"`
+Expected: PASS, all 4 branch tests.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
+git commit -m "fix(selection-controller): route onInfiltrate's 4 outcome branches through one session.commit"
+```
+
+### Task 4.3: `onEmbed`
+
+**Files:**
+- Modify: `src/app/controllers/selection-controller.ts:485-503`
+- Test: `tests/app/controllers/selection-controller.test.ts` (new `describe('onEmbed', ...)`)
+
+Current code:
+
+```ts
+        onEmbed: (uid) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const city = Object.values(session.getState().cities).find(
+            c => c.owner === session.getState().currentPlayer &&
+                 c.position.q === unit.position.q && c.position.r === unit.position.r,
+          );
+          if (!city) return;
+          session.getState().espionage![session.getState().currentPlayer] = embedSpy(civEsp, uid, city.id, city.position);
+          delete session.getState().units[uid];
+          session.getState().civilizations[session.getState().currentPlayer].units =
+            session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== uid);
+          deselectUnit();
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          deps.showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
+        },
+```
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+  describe('onEmbed', () => {
+    it('embeds the spy, removes the unit from the map, and publishes through session subscribers', () => {
+      const state = makeFixture();
+      state.cities['friendly-city'] = makeCity('friendly-city', { owner: 'player', position: { q: 0, r: 0 } });
+      state.civilizations.player.cities = ['friendly-city'];
+      placePlayerUnit(state, 'spy-1', { position: { q: 0, r: 0 } });
+      state.espionage = { player: createEspionageCivState() };
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.selectUnit('spy-1');
+      const options = mockedCallArg<{ onEmbed: (uid: string) => void }>(renderSelectedUnitInfo, 0, 2);
+      options.onEmbed('spy-1');
+
+      const updated = deps.session.getState();
+      expect(updated.units['spy-1']).toBeUndefined();
+      expect(updated.civilizations.player.units).not.toContain('spy-1');
+      expect(updated.espionage!.player.spies['spy-1'].status).toBe('embedded');
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+```
+
+Match this test's exact fixture helpers and `mockedCallArg` argument indices to whatever `tests/app/controllers/selection-controller.test.ts` already establishes for Task 4.1/4.2's tests — write them consistently, not independently guessed per task.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onEmbed"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+        onEmbed: (uid) => {
+          const unit = session.getState().units[uid];
+          if (!unit || unit.owner !== session.getState().currentPlayer) return;
+          const civEsp = session.getState().espionage?.[session.getState().currentPlayer];
+          if (!civEsp) return;
+          const city = Object.values(session.getState().cities).find(
+            c => c.owner === session.getState().currentPlayer &&
+                 c.position.q === unit.position.q && c.position.r === unit.position.r,
+          );
+          if (!city) return;
+          const currentPlayer = session.getState().currentPlayer;
+          const { [uid]: _removed, ...remainingUnits } = session.getState().units;
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: embedSpy(civEsp, uid, city.id, city.position) },
+            units: remainingUnits,
+            civilizations: {
+              ...session.getState().civilizations,
+              [currentPlayer]: {
+                ...session.getState().civilizations[currentPlayer],
+                units: session.getState().civilizations[currentPlayer].units.filter(id => id !== uid),
+              },
+            },
+          });
+          deselectUnit();
+          renderLoop.setGameState(session.getState());
+          deps.updateHUD();
+          deps.showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
+        },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onEmbed"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
+git commit -m "fix(selection-controller): route onEmbed's espionage/unit/civ mutation through session.commit"
+```
+
+### Task 4.4: `startAutoExplore` and `cancelAutoExplore`
+
+**Files:**
+- Modify: `src/app/controllers/selection-controller.ts:653-684`
+- Test: `tests/app/controllers/selection-controller.test.ts` (new `describe('startAutoExplore / cancelAutoExplore', ...)`)
+
+Current code:
+
+```ts
+  function startAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit || unit.owner !== session.getState().currentPlayer) return;
+
+    session.getState().units[unitId] = {
+      ...unit,
+      automation: {
+        mode: 'auto-explore',
+        startedTurn: session.getState().turn,
+        lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
+      },
+    };
+
+    if (session.getState().units[unitId].movementPointsLeft > 0 && !session.getState().units[unitId].hasActed) {
+      applyAutoExploreOrder(session.getState(), unitId, { bus });
+    }
+
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    selectUnit(unitId);
+  }
+
+  function cancelAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit?.automation) return;
+    delete session.getState().units[unitId].automation;
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    if (selection.getSelectedUnitId() === unitId) {
+      selectUnit(unitId);
+    }
+  }
+```
+
+Note `applyAutoExploreOrder(session.getState(), unitId, { bus })` — check this function's actual signature and return type before converting (`grep -n "export function applyAutoExploreOrder" src/`): if it mutates `session` internally itself (unlikely, but verify) rather than returning a value, this task's implementation needs adjusting; if — as expected from this file's other patterns — it operates on the passed `state` value and its result needs to be applied, the fix must thread that result into the same `commit` as the `automation` assignment, not call it against a stale pre-automation state. Do not assume; read the function first.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+  describe('startAutoExplore / cancelAutoExplore', () => {
+    it('starts auto-explore automation and publishes through session subscribers', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'scout-1', { position: { q: 0, r: 0 } });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.startAutoExplore('scout-1');
+
+      expect(deps.session.getState().units['scout-1'].automation?.mode).toBe('auto-explore');
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('cancels auto-explore automation and publishes through session subscribers', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'scout-1', { position: { q: 0, r: 0 }, automation: { mode: 'auto-explore', startedTurn: 1, lastTargets: [] } });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.cancelAutoExplore('scout-1');
+
+      expect(deps.session.getState().units['scout-1'].automation).toBeUndefined();
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+```
+
+Check whether `startAutoExplore`/`cancelAutoExplore` are exposed on `SelectionController`'s public interface (like `ensurePlayerWarState` was in Task 1.1) before assuming `controller.startAutoExplore(...)` is callable directly — if they're private, find the actual public entry point (likely `openUnitContextMenu`'s `onStartAutoExplore`/`onCancelAutoExplore` callbacks) and drive the test through that instead.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "startAutoExplore / cancelAutoExplore"`
+Expected: FAIL on both `listener` assertions.
+
+- [ ] **Step 3: Write minimal implementation** (assuming `applyAutoExploreOrder` returns a value rather than mutating — confirm per the note above and adjust if wrong):
+
+```ts
+  function startAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit || unit.owner !== session.getState().currentPlayer) return;
+
+    const withAutomation = {
+      ...unit,
+      automation: {
+        mode: 'auto-explore' as const,
+        startedTurn: session.getState().turn,
+        lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
+      },
+    };
+    session.commit({ ...session.getState(), units: { ...session.getState().units, [unitId]: withAutomation } });
+
+    if (withAutomation.movementPointsLeft > 0 && !withAutomation.hasActed) {
+      applyAutoExploreOrder(session.getState(), unitId, { bus });
+    }
+
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    selectUnit(unitId);
+  }
+
+  function cancelAutoExplore(unitId: string): void {
+    const unit = session.getState().units[unitId];
+    if (!unit?.automation) return;
+    const { automation: _removed, ...withoutAutomation } = unit;
+    session.commit({ ...session.getState(), units: { ...session.getState().units, [unitId]: withoutAutomation } });
+    renderLoop.setGameState(session.getState());
+    deps.updateHUD();
+    if (selection.getSelectedUnitId() === unitId) {
+      selectUnit(unitId);
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "startAutoExplore / cancelAutoExplore"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
+git commit -m "fix(selection-controller): route startAutoExplore/cancelAutoExplore's unit mutation through session.commit"
+```
+
+### Phase 4 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [ ] Re-run the inventory grep against `selection-controller.ts` — confirm 0 remaining matches (15 sites, 4 tasks: 2 + 8 + 3 + 2 = 15).
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 4 (selection-controller.ts)`.
+
+---
+
+## Phase 5 — `panel-actions-controller.ts` + `src/ui/city-panel.ts`
+
+Heaviest phase: 21 sites plus the `city-panel.ts` callback-contract change the spec's review identified as required in the same commit as the 4 city-production sites (Tasks 5.2-5.3), plus rewriting the one existing test coupled to that bug (Task 5.4).
+
+### Task 5.1: `onSetCouncilTalkLevel` (council panel settings)
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:485-492`
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (new test in the council-panel describe block; search `grep -n "createCouncilPanel" tests/app/controllers/panel-actions-controller.test.ts` first)
+
+Current code (`panel-actions-controller.ts:485-492`, read exact lines first — this is the `createCouncilPanel` callback wiring):
+
+```ts
+    createCouncilPanel(deps.uiLayer, deps.session.getState(), {
+      // ...
+      onSetTalkLevel: (level) => {
+        deps.session.getState().settings.councilTalkLevel = level;
+        void saveSettings(deps.session.getState().settings);
+        // ...
+      },
+      // ...
+    });
+```
+
+(Confirm the exact surrounding callback name and structure by reading `panel-actions-controller.ts` around line 485 before editing — the spec's grep only captured the flagged line itself, not the enclosing callback's name.)
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('onSetTalkLevel publishes the new council talk level through session subscribers', () => {
+      const { state } = makeFixture('council-talk-level');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openCouncilPanel();
+      const options = mockedCallArg<{ onSetTalkLevel: (level: string) => void }>(createCouncilPanel, 0, 2);
+      options.onSetTalkLevel('verbose');
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('verbose');
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+Match the real method name for opening the council panel (`openCouncilPanel` is illustrative — confirm the controller's actual public method name first) and `createCouncilPanel`'s real callback property name and argument index against the source read in this task's preamble.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSetTalkLevel"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onSetTalkLevel: (level) => {
+        deps.session.commit({ ...deps.session.getState(), settings: { ...deps.session.getState().settings, councilTalkLevel: level } });
+        void saveSettings(deps.session.getState().settings);
+        // ... (rest of the callback body unchanged)
+      },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSetTalkLevel"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route council-panel talk-level setting through session.commit"
+```
+
+### Task 5.2: `city-panel.ts` — widen the 4 queue callback types and wire `rerenderPanel(nextState)`
+
+**Files:**
+- Modify: `src/ui/city-panel.ts:71-102` (interface), `:1451-1457` (`onBuild` call site), `:1498-1525` (`onRemoveQueueItem`/`onMoveQueueItem` call sites), `:1568-1575` (`onSetIdleProduction` call site)
+- Test: none new in this task — this is a type/wiring change with no independent behavior until Task 5.3's controller side lands; `yarn build` (TypeScript) is this task's verification, plus the existing `tests/ui/city-panel*.test.ts` suite must keep passing since the 4 callbacks stay optional-chained and backward compatible for any caller still returning `void`.
+
+**Interfaces:**
+- Produces: `CityPanelCallbacks.onBuild`, `.onMoveQueueItem`, `.onRemoveQueueItem`, `.onSetIdleProduction` all become `(...) => GameState | void` — the exact shape `.onSetCityFocus`/`.onToggleWorkedTile`/`.onRushBuyActiveProduction` already use. Task 5.3 (`panel-actions-controller.ts`) is the consumer of this new return contract.
+
+This task must land in the **same commit** as Task 5.3 — do not merge Task 5.2 alone (a mid-state where `city-panel.ts` expects a return value but `panel-actions-controller.ts` still returns `void` typechecks fine, since `GameState | void` accepts `void`, but leaves the actual bug unfixed and gives false confidence that "the city-panel.ts change landed"). Do them as one combined Step 3/commit below rather than two separate task commits, to avoid a landable-but-incomplete intermediate state.
+
+Current interface (`city-panel.ts:71-102`):
+
+```ts
+export interface CityPanelCallbacks {
+  onBuild: (cityId: string, itemId: string) => void;
+  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => void;
+  onRemoveQueueItem?: (cityId: string, index: number) => void;
+  onOpenWonderPanel: (cityId: string) => void;
+  onSetCityFocus?: (cityId: string, focus: Exclude<CityFocus, 'custom'>) => GameState | void;
+  onToggleWorkedTile?: (cityId: string, coord: HexCoord, worked: boolean) => GameState | void;
+  onPlaceBuilding?: (cityId: string, buildingId: string, row: number, col: number) => void;
+  onClose: () => void;
+  onTip?: (message: string) => void;
+  onPrevCity?: () => void;
+  onNextCity?: () => void;
+  onUpgradeUnit?: (unitId: string) => void;
+  onSelectUnit?: (unitId: string) => void;
+  onEstablishRoute?: (caravanId: string) => void;
+  onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => void;
+  onRushBuyActiveProduction?: (cityId: string) => GameState | void;
+  onAppeaseFaction?: (cityId: string) => GameState | void;
+  onConcedeToMovement?: (cityId: string) => GameState | void;
+  onQuarantineCrisis?: (crisisId: string, cityId: string) => GameState | void;
+  onRemedyCrisis?: (crisisId: string, cityId: string) => GameState | void;
+  onFindResources?: (
+    highlights: HexCoord[],
+    toasts: Array<{ message: string; type: 'info' | 'warning' }>,
+  ) => void;
+  onChooseCircularManufacturingMaterial?: (material: ResourceType) => void;
+}
+```
+
+Current call sites:
+
+```ts
+  panel.querySelectorAll('.build-item').forEach(el => {
+    el.addEventListener('click', () => {
+      const itemId = (el as HTMLElement).dataset.itemId!;
+      callbacks.onBuild(city.id, itemId);
+      rerenderPanel();
+    });
+  });
+```
+
+```ts
+  panel.querySelectorAll('[data-queue-action]').forEach(el => {
+    el.addEventListener('click', event => {
+      event.stopPropagation();
+      const action = (el as HTMLElement).dataset.queueAction;
+      const index = Number((el as HTMLElement).dataset.queueIndex);
+
+      if (!Number.isInteger(index)) {
+        return;
+      }
+
+      if (action === 'remove') {
+        callbacks.onRemoveQueueItem?.(city.id, index);
+        rerenderPanel();
+        return;
+      }
+
+      if (action === 'up' && index > 0) {
+        callbacks.onMoveQueueItem?.(city.id, index, index - 1);
+        rerenderPanel();
+        return;
+      }
+
+      if (action === 'down' && index < city.productionQueue.length - 1) {
+        callbacks.onMoveQueueItem?.(city.id, index, index + 1);
+        rerenderPanel();
+      }
+    });
+  });
+```
+
+```ts
+  panel.querySelectorAll<HTMLElement>('[data-idle-mode]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const raw = btn.dataset.idleMode;
+      const mode = raw === 'gold' || raw === 'science' ? raw : null;
+      callbacks.onSetIdleProduction?.(city.id, mode);
+      rerenderPanel();
+    });
+  });
+```
+
+- [ ] **Step 1: Update the interface.** In `CityPanelCallbacks`:
+
+```ts
+  onBuild: (cityId: string, itemId: string) => GameState | void;
+  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => GameState | void;
+  onRemoveQueueItem?: (cityId: string, index: number) => GameState | void;
+  // ... (onOpenWonderPanel through onEstablishRoute unchanged)
+  onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => GameState | void;
+```
+
+- [ ] **Step 2: Update the 3 call sites to pass the return value to `rerenderPanel`.**
+
+```ts
+  panel.querySelectorAll('.build-item').forEach(el => {
+    el.addEventListener('click', () => {
+      const itemId = (el as HTMLElement).dataset.itemId!;
+      const nextState = callbacks.onBuild(city.id, itemId);
+      rerenderPanel(nextState);
+    });
+  });
+```
+
+```ts
+      if (action === 'remove') {
+        const nextState = callbacks.onRemoveQueueItem?.(city.id, index);
+        rerenderPanel(nextState);
+        return;
+      }
+
+      if (action === 'up' && index > 0) {
+        const nextState = callbacks.onMoveQueueItem?.(city.id, index, index - 1);
+        rerenderPanel(nextState);
+        return;
+      }
+
+      if (action === 'down' && index < city.productionQueue.length - 1) {
+        const nextState = callbacks.onMoveQueueItem?.(city.id, index, index + 1);
+        rerenderPanel(nextState);
+      }
+```
+
+```ts
+  panel.querySelectorAll<HTMLElement>('[data-idle-mode]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const raw = btn.dataset.idleMode;
+      const mode = raw === 'gold' || raw === 'science' ? raw : null;
+      const nextState = callbacks.onSetIdleProduction?.(city.id, mode);
+      rerenderPanel(nextState);
+    });
+  });
+```
+
+- [ ] **Step 3: Do not commit this task alone.** Continue directly to Task 5.3 — the two land in one commit together (Task 5.3's Step 5 covers both).
+
+### Task 5.3: `panel-actions-controller.ts`'s 4 city-production handlers
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:660-689` (`onBuild`, `onMoveQueueItem`, `onRemoveQueueItem`), `:738-743` (`onSetIdleProduction`)
+- Test: `tests/app/controllers/panel-actions-controller.test.ts:680-692` — **rewrite**, not extend, per Global Constraints (Task 5.4 covers this explicitly and in full; write it as part of this task's Step 1, since the old assertion would otherwise mask the very bug this task fixes)
+
+**Interfaces:**
+- Consumes: Task 5.2's widened `CityPanelCallbacks` (`onBuild`, `onMoveQueueItem`, `onRemoveQueueItem`, `onSetIdleProduction` all now `(...) => GameState | void`).
+- Produces: no change to `PanelActionsController`'s own public surface.
+
+Current code:
+
+```ts
+      onBuild: (cityId, itemId) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (targetCity) {
+          try {
+            deps.session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
+            deps.renderLoop.setGameState(deps.session.getState());
+            deps.showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Queue limit reached';
+            deps.showNotification(`${targetCity.name}: ${message}`, 'warning');
+          }
+        }
+      },
+      onMoveQueueItem: (cityId, fromIndex, toIndex) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = reorderCityProduction(targetCity, fromIndex, toIndex);
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+      onRemoveQueueItem: (cityId, index) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = {
+          ...targetCity,
+          productionQueue: removeQueuedId(targetCity.productionQueue, index),
+          productionProgress: index === 0 ? 0 : targetCity.productionProgress,
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+```
+
+```ts
+      onSetIdleProduction: (cityId, mode) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.getState().cities[cityId] = setIdleProduction(targetCity, mode);
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+```
+
+- [ ] **Step 1: Write the failing test** (this replaces the coupled test — full content in Task 5.4; write it now as this task's Step 1 since it's the same edit):
+
+```ts
+    it('queues real production via session.commit, publishes to subscribers, and returns the fresh state for the panel to re-render', () => {
+      const { state } = makeFixture('city-panel-build');
+      state.cities['test-city'] = makeCity('test-city');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openCityPanelForCity(state.cities['test-city']);
+      const options = mockedCallArg<{ onBuild: (cityId: string, itemId: string) => GameState | void }>(createCityPanel, 0, 3);
+      const returned = options.onBuild('test-city', 'warrior');
+
+      expect(deps.session.getState().cities['test-city'].productionQueue).toContain('warrior');
+      expect(returned).toBe(deps.session.getState());
+      expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+      expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('Warrior'), 'info');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "queues real production via session.commit"`
+Expected: FAIL — `returned` is `undefined` (current `onBuild` returns `void`), and `listener` was never called.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onBuild: (cityId, itemId) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (targetCity) {
+          try {
+            deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: enqueueCityProduction(targetCity, itemId) } });
+            deps.renderLoop.setGameState(deps.session.getState());
+            deps.showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
+            return deps.session.getState();
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Queue limit reached';
+            deps.showNotification(`${targetCity.name}: ${message}`, 'warning');
+          }
+        }
+      },
+      onMoveQueueItem: (cityId, fromIndex, toIndex) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: reorderCityProduction(targetCity, fromIndex, toIndex) } });
+        deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
+      },
+      onRemoveQueueItem: (cityId, index) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.commit({
+          ...deps.session.getState(),
+          cities: {
+            ...deps.session.getState().cities,
+            [cityId]: {
+              ...targetCity,
+              productionQueue: removeQueuedId(targetCity.productionQueue, index),
+              productionProgress: index === 0 ? 0 : targetCity.productionProgress,
+            },
+          },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
+      },
+```
+
+```ts
+      onSetIdleProduction: (cityId, mode) => {
+        const targetCity = deps.session.getState().cities[cityId];
+        if (!targetCity) return;
+        deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: setIdleProduction(targetCity, mode) } });
+        deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
+      },
+```
+
+Note the `onBuild` catch-block path (queue-limit-reached error) deliberately still returns `undefined` — no state changed, so `rerenderPanel(undefined)` correctly falls back to `nextState ?? state`. That fallback is now stale-by-design only in the sense that nothing changed to make it stale; this is the one case where the closure-default behavior was never wrong.
+
+- [ ] **Step 4: Apply Task 5.2's `city-panel.ts` changes now** (Steps 1-2 from that task), since both files must land together.
+
+- [ ] **Step 5: Run tests to verify they pass.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "city-panel"`
+Expected: PASS.
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/city-panel.test.ts` (and any other `tests/ui/city-panel-*.test.ts` files — list them with `find tests/ui -iname "city-panel*"` first)
+Expected: PASS — the widened callback types are backward compatible (`GameState | void` accepts a `void`-returning mock), so pre-existing city-panel UI tests that pass plain `() => {}` callbacks should be unaffected.
+
+- [ ] **Step 6: Commit both files together.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts src/ui/city-panel.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller,city-panel): route city-production queue actions through session.commit and widen callbacks to return fresh state
+
+onBuild/onMoveQueueItem/onRemoveQueueItem/onSetIdleProduction previously
+mutated session.getState()'s object in place and returned void; the open
+city panel's rerenderPanel() call after each action only showed correct
+data because it defaulted to the same mutated object by shared reference.
+Converting the mutation to a genuine commit() without this companion
+change would have regressed the panel to stale -- both land together."
+```
+
+### Task 5.4: confirm the rewritten test fully replaces the coupled one
+
+**Files:**
+- Modify: `tests/app/controllers/panel-actions-controller.test.ts`
+
+This task is verification, not new code — Task 5.3's Step 1 already wrote the replacement test. Use this task to confirm the old assertion pattern is gone, not still present alongside the new one.
+
+- [ ] **Step 1:** `grep -n "queues real production" tests/app/controllers/panel-actions-controller.test.ts` — expect exactly one match (the rewritten test from Task 5.3), not two.
+- [ ] **Step 2:** Confirm no other test in this file still asserts `state.cities[...]` (the outer fixture variable) instead of `deps.session.getState().cities[...]` for any of the 4 converted handlers: `grep -n "^\s*expect(state\.cities" tests/app/controllers/panel-actions-controller.test.ts`. Fix any remaining ones the same way.
+- [ ] **Step 3: Commit if Step 2 found anything to fix; otherwise this task is a no-op check, fold its confirmation into Task 5.3's PR description.**
+
+### Task 5.5: tech-queue handlers (`onQueueResearch`, `onMoveQueuedResearch`, `onRemoveQueuedResearch`)
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:498-525`
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (new tests; search `grep -n "createTechPanel" tests/app/controllers/panel-actions-controller.test.ts` for existing coverage to extend first)
+
+Current code:
+
+```ts
+    createTechPanel(deps.uiLayer, deps.session.getState(), {
+      onQueueResearch: (techId) => {
+        try {
+          deps.currentCiv().techState = enqueueResearch(deps.currentCiv().techState, techId);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Queue limit reached';
+          deps.showNotification(message, 'warning');
+          return;
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.showNotification(`Queued research: ${techId}`, 'info');
+      },
+      onMoveQueuedResearch: (fromIndex, toIndex) => {
+        deps.currentCiv().techState = {
+          ...deps.currentCiv().techState,
+          researchQueue: moveQueuedId(deps.currentCiv().techState.researchQueue, fromIndex, toIndex),
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+      },
+      onRemoveQueuedResearch: (index) => {
+        deps.currentCiv().techState = {
+          ...deps.currentCiv().techState,
+          researchQueue: removeQueuedId(deps.currentCiv().techState.researchQueue, index),
+        };
+        deps.renderLoop.setGameState(deps.session.getState());
+        // (read the remainder of this callback before editing -- confirm whether it ends here or has more lines)
+      },
+    });
+```
+
+This site already calls `deps.hud.update()` manually in at least the first two handlers (confirm the third does too by reading the actual file before editing) — architecture-debt only, matching the spec's severity note for this group.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('onQueueResearch publishes the queued tech through session subscribers', () => {
+      const { state } = makeFixture('tech-panel-queue');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openTechPanel();
+      const options = mockedCallArg<{ onQueueResearch: (techId: string) => void }>(createTechPanel, 0, 2);
+      options.onQueueResearch('pottery');
+
+      expect(deps.session.getState().civilizations.player.techState.researchQueue).toContain('pottery');
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+Confirm `controller.openTechPanel` is the real public method name and `createTechPanel`'s callback argument index by reading the file — this codebase's convention (seen in Tasks 1.1-5.3) is consistent, but verify rather than assume for this specific panel.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onQueueResearch"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onQueueResearch: (techId) => {
+        const civ = deps.currentCiv();
+        let nextTechState;
+        try {
+          nextTechState = enqueueResearch(civ.techState, techId);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Queue limit reached';
+          deps.showNotification(message, 'warning');
+          return;
+        }
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: { ...deps.session.getState().civilizations, [deps.session.getState().currentPlayer]: { ...civ, techState: nextTechState } },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.showNotification(`Queued research: ${techId}`, 'info');
+      },
+      onMoveQueuedResearch: (fromIndex, toIndex) => {
+        const civ = deps.currentCiv();
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [deps.session.getState().currentPlayer]: {
+              ...civ,
+              techState: { ...civ.techState, researchQueue: moveQueuedId(civ.techState.researchQueue, fromIndex, toIndex) },
+            },
+          },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+      },
+      onRemoveQueuedResearch: (index) => {
+        const civ = deps.currentCiv();
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [deps.session.getState().currentPlayer]: {
+              ...civ,
+              techState: { ...civ.techState, researchQueue: removeQueuedId(civ.techState.researchQueue, index) },
+            },
+          },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        // preserve whatever this callback's original remaining lines were, reading the real file first
+      },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onQueueResearch"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route tech-panel queue handlers through session.commit"
+```
+
+### Task 5.6: espionage `onAssignDefensive`
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:867-886`
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (new `describe` for espionage-panel handlers if none exists; search `grep -n "createEspionagePanel" tests/app/controllers/panel-actions-controller.test.ts` first)
+
+Current code:
+
+```ts
+      onAssignDefensive: (spyId) => {
+        const target = chooseFriendlyCityTarget();
+        if (!target) return;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = embedSpy(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+          target.cityId,
+          target.position,
+        );
+        const unit = deps.session.getState().units[spyId];
+        if (unit) {
+          delete deps.session.getState().units[spyId];
+          deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
+            deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.filter(id => id !== spyId);
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        const cityName = deps.session.getState().cities[target.cityId]?.name ?? target.cityId;
+        deps.showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
+      },
+```
+
+This handler closes+reopens the espionage panel via `deps.router.open('espionage')` after committing (no closure-staleness risk like `city-panel.ts`), but still skips `hud.update()` — a live bug per the spec's severity table.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('onAssignDefensive embeds the spy, removes the unit, and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-assign-defensive');
+      state.cities['home-city'] = makeCity('home-city', { owner: 'player' });
+      state.civilizations.player.cities = ['home-city'];
+      placeUnit(state, 'spy_scout', 'spy-1', { q: 0, r: 0 });
+      placeSpy(state, 'spy-1');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onAssignDefensive: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      // chooseFriendlyCityTarget() likely drives a window.prompt/confirm or an internal picker --
+      // check the real implementation before writing this test and stub whatever it needs
+      // (e.g. vi.spyOn(window, 'prompt')) to deterministically pick 'home-city'.
+      options.onAssignDefensive('spy-1');
+
+      const updated = deps.session.getState();
+      expect(updated.units['spy-1']).toBeUndefined();
+      expect(updated.espionage!.player.spies['spy-1'].status).toBe('embedded');
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+Confirm `controller.openEspionagePanel`'s real name and how `chooseFriendlyCityTarget` resolves a target (read `panel-actions-controller.ts` around this handler) before finalizing this test — the comment above marks required research, not something to leave unresolved in committed code.
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onAssignDefensive"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()` (and likely `expect(deps.hud.update).toHaveBeenCalled()` too, since it's currently never called for this handler).
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onAssignDefensive: (spyId) => {
+        const target = chooseFriendlyCityTarget();
+        if (!target) return;
+        const currentPlayer = deps.session.getState().currentPlayer;
+        const unit = deps.session.getState().units[spyId];
+        const nextEspionage = {
+          ...deps.session.getState().espionage,
+          [currentPlayer]: embedSpy(deps.session.getState().espionage![currentPlayer], spyId, target.cityId, target.position),
+        };
+        let nextUnits = deps.session.getState().units;
+        let nextCivilizations = deps.session.getState().civilizations;
+        if (unit) {
+          const { [spyId]: _removed, ...remainingUnits } = nextUnits;
+          nextUnits = remainingUnits;
+          nextCivilizations = {
+            ...nextCivilizations,
+            [currentPlayer]: { ...nextCivilizations[currentPlayer], units: nextCivilizations[currentPlayer].units.filter(id => id !== spyId) },
+          };
+        }
+        deps.session.commit({ ...deps.session.getState(), espionage: nextEspionage, units: nextUnits, civilizations: nextCivilizations });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.router.open('espionage');
+        const cityName = deps.session.getState().cities[target.cityId]?.name ?? target.cityId;
+        deps.showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
+      },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onAssignDefensive"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route onAssignDefensive's espionage/unit mutation through session.commit and call hud.update"
+```
+
+### Task 5.7: espionage `onStartMission`, `onRecall`, `onVerifyAgent`
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:887-929`
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (extend the espionage-panel describe block from Task 5.6)
+
+Current code (all 3, same shape):
+
+```ts
+      onStartMission: (spyId) => {
+        const spy = deps.session.getState().espionage?.[deps.session.getState().currentPlayer]?.spies[spyId];
+        if (!spy) return;
+        const mission = chooseMission(spyId);
+        if (!mission) return;
+        let targetCivId = spy.targetCivId ?? undefined;
+        let targetCityId = spy.targetCityId ?? undefined;
+        if (!missionRequiresPlacedSpy(mission)) {
+          const target = chooseForeignCityTarget();
+          if (!target) return;
+          targetCivId = target.civId;
+          targetCityId = target.cityId;
+        }
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = startMission(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+          mission,
+          deps.currentCivDef()?.bonusEffect,
+          targetCivId,
+          targetCityId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification(`Mission ${mission} started.`, 'info');
+      },
+      onRecall: (spyId) => {
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = recallSpy(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification('Spy recalled.', 'info');
+      },
+      onVerifyAgent: (spyId) => {
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = verifyAgent(
+          deps.session.getState().espionage![deps.session.getState().currentPlayer],
+          spyId,
+        );
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.router.open('espionage');
+        deps.showNotification('Agent verified and cleared.', 'success');
+      },
+```
+
+None of these 3 currently call `hud.update()` — all live bugs per the spec's severity table.
+
+- [ ] **Step 1: Write the failing tests.**
+
+```ts
+    it('onStartMission commits the started mission and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-start-mission');
+      placeSpy(state, 'spy-1', { status: 'stationed', targetCivId: 'ai', targetCityId: 'foreign-city' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onStartMission: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      // chooseMission() resolves via window.prompt in this file (see chooseMission's definition
+      // above onAssignDefensive) -- stub window.prompt to return a valid SpyMissionType before calling.
+      options.onStartMission('spy-1');
+
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].status).not.toBe('stationed');
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onRecall commits the recalled spy and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-recall');
+      placeSpy(state, 'spy-1', { status: 'on_mission' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onRecall: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onRecall('spy-1');
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onVerifyAgent commits the cleared agent and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-verify');
+      placeSpy(state, 'spy-1', { status: 'suspected' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onVerifyAgent: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onVerifyAgent('spy-1');
+
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onStartMission|onRecall|onVerifyAgent"`
+Expected: FAIL, all 3, on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onStartMission: (spyId) => {
+        const spy = deps.session.getState().espionage?.[deps.session.getState().currentPlayer]?.spies[spyId];
+        if (!spy) return;
+        const mission = chooseMission(spyId);
+        if (!mission) return;
+        let targetCivId = spy.targetCivId ?? undefined;
+        let targetCityId = spy.targetCityId ?? undefined;
+        if (!missionRequiresPlacedSpy(mission)) {
+          const target = chooseForeignCityTarget();
+          if (!target) return;
+          targetCivId = target.civId;
+          targetCityId = target.cityId;
+        }
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: {
+            ...deps.session.getState().espionage,
+            [currentPlayer]: startMission(deps.session.getState().espionage![currentPlayer], spyId, mission, deps.currentCivDef()?.bonusEffect, targetCivId, targetCityId),
+          },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.router.open('espionage');
+        deps.showNotification(`Mission ${mission} started.`, 'info');
+      },
+      onRecall: (spyId) => {
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: recallSpy(deps.session.getState().espionage![currentPlayer], spyId) },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.router.open('espionage');
+        deps.showNotification('Spy recalled.', 'info');
+      },
+      onVerifyAgent: (spyId) => {
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: verifyAgent(deps.session.getState().espionage![currentPlayer], spyId) },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
+        deps.router.open('espionage');
+        deps.showNotification('Agent verified and cleared.', 'success');
+      },
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onStartMission|onRecall|onVerifyAgent"`
+Expected: PASS, all 3.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route onStartMission/onRecall/onVerifyAgent through session.commit and call hud.update"
+```
+
+### Task 5.8: espionage `onExfiltrate` and `onUnembed`
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:930-969` (`onExfiltrate`), `:990-1007` (`onUnembed`)
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (extend the espionage-panel describe block)
+
+Current code, `onExfiltrate`:
+
+```ts
+      onExfiltrate: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'stationed') return;
+        const capital = getCapitalCity(deps.session.getState(), deps.session.getState().currentPlayer);
+        if (!capital) { deps.showNotification('Cannot exfiltrate — no capital found.', 'warning'); return; }
+
+        const existingPositions = new Set(
+          Object.values(deps.session.getState().units).map(u => `${u.position.q},${u.position.r}`),
+        );
+        let spawnPos = capital.position;
+        if (existingPositions.has(`${spawnPos.q},${spawnPos.r}`)) {
+          const adjacent = hexesInRange(capital.position, 1).filter(
+            c => !(c.q === capital.position.q && c.r === capital.position.r) &&
+                 !existingPositions.has(`${c.q},${c.r}`) &&
+                 deps.session.getState().map.tiles[hexKey(c)],
+          );
+          if (adjacent.length === 0) {
+            deps.showNotification('Cannot exfiltrate — no free tile near capital.', 'warning');
+            return;
+          }
+          spawnPos = adjacent[0];
+        }
+
+        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, spawnPos, deps.session.getState().idCounters);
+        deps.session.getState().units[newUnit.id] = newUnit;
+        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
+          [...(deps.session.getState().civilizations[deps.session.getState().currentPlayer].units ?? []), newUnit.id];
+        const updatedSpy = {
+          ...spy, id: newUnit.id, status: 'cooldown' as const,
+          cooldownTurns: 8, infiltrationCityId: null, cityVisionTurnsLeft: 0, targetCivId: null, cooldownMode: undefined,
+        };
+        const { [spyId]: _old, ...rest } = ownerEsp!.spies;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification('Spy exfiltrated. Available again in 8 turns.', 'info');
+      },
+```
+
+Current code, `onUnembed`:
+
+```ts
+      onUnembed: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
+        const city = deps.session.getState().cities[spy.targetCityId];
+        if (!city) return;
+        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, city.position, deps.session.getState().idCounters);
+        deps.session.getState().units[newUnit.id] = newUnit;
+        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.push(newUnit.id);
+        const unembedded = unembedSpy(ownerEsp!, spyId);
+        const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
+        const { [spyId]: _old, ...rest } = unembedded.spies;
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
+      },
+```
+
+- [ ] **Step 1: Write the failing tests.**
+
+```ts
+    it('onExfiltrate spawns a fresh unit at the capital, updates espionage state, and publishes', () => {
+      const { state } = makeFixture('espionage-exfiltrate');
+      state.cities['capital'] = makeCity('capital', { owner: 'player', position: { q: 5, r: 5 } });
+      state.civilizations.player.cities = ['capital'];
+      placeSpy(state, 'spy-1', { status: 'stationed' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onExfiltrate: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onExfiltrate('spy-1');
+
+      const updated = deps.session.getState();
+      expect(Object.values(updated.units).some(u => u.type === 'spy_scout')).toBe(true);
+      expect(updated.espionage!.player.spies['spy-1']).toBeUndefined();
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onUnembed spawns a fresh unit at the target city, updates espionage state, and publishes', () => {
+      const { state } = makeFixture('espionage-unembed');
+      state.cities['target-city'] = makeCity('target-city', { owner: 'ai', position: { q: 3, r: 3 } });
+      placeSpy(state, 'spy-1', { status: 'embedded', targetCityId: 'target-city' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onUnembed: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onUnembed('spy-1');
+
+      const updated = deps.session.getState();
+      expect(Object.values(updated.units).some(u => u.type === 'spy_scout')).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onExfiltrate|onUnembed"`
+Expected: FAIL, both, on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onExfiltrate: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'stationed') return;
+        const capital = getCapitalCity(deps.session.getState(), deps.session.getState().currentPlayer);
+        if (!capital) { deps.showNotification('Cannot exfiltrate — no capital found.', 'warning'); return; }
+
+        const existingPositions = new Set(
+          Object.values(deps.session.getState().units).map(u => `${u.position.q},${u.position.r}`),
+        );
+        let spawnPos = capital.position;
+        if (existingPositions.has(`${spawnPos.q},${spawnPos.r}`)) {
+          const adjacent = hexesInRange(capital.position, 1).filter(
+            c => !(c.q === capital.position.q && c.r === capital.position.r) &&
+                 !existingPositions.has(`${c.q},${c.r}`) &&
+                 deps.session.getState().map.tiles[hexKey(c)],
+          );
+          if (adjacent.length === 0) {
+            deps.showNotification('Cannot exfiltrate — no free tile near capital.', 'warning');
+            return;
+          }
+          spawnPos = adjacent[0];
+        }
+
+        const currentPlayer = deps.session.getState().currentPlayer;
+        const newUnit = createUnit(spy.unitType, currentPlayer, spawnPos, deps.session.getState().idCounters);
+        const updatedSpy = {
+          ...spy, id: newUnit.id, status: 'cooldown' as const,
+          cooldownTurns: 8, infiltrationCityId: null, cityVisionTurnsLeft: 0, targetCivId: null, cooldownMode: undefined,
+        };
+        const { [spyId]: _old, ...rest } = ownerEsp!.spies;
+        deps.session.commit({
+          ...deps.session.getState(),
+          units: { ...deps.session.getState().units, [newUnit.id]: newUnit },
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [currentPlayer]: { ...deps.session.getState().civilizations[currentPlayer], units: [...(deps.session.getState().civilizations[currentPlayer].units ?? []), newUnit.id] },
+          },
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } } },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification('Spy exfiltrated. Available again in 8 turns.', 'info');
+      },
+```
+
+```ts
+      onUnembed: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
+        const city = deps.session.getState().cities[spy.targetCityId];
+        if (!city) return;
+        const currentPlayer = deps.session.getState().currentPlayer;
+        const newUnit = createUnit(spy.unitType, currentPlayer, city.position, deps.session.getState().idCounters);
+        const unembedded = unembedSpy(ownerEsp!, spyId);
+        const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
+        const { [spyId]: _old, ...rest } = unembedded.spies;
+        deps.session.commit({
+          ...deps.session.getState(),
+          units: { ...deps.session.getState().units, [newUnit.id]: newUnit },
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [currentPlayer]: { ...deps.session.getState().civilizations[currentPlayer], units: [...deps.session.getState().civilizations[currentPlayer].units, newUnit.id] },
+          },
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } } },
+        });
+        deps.renderLoop.setGameState(deps.session.getState());
+        deps.getElementById('espionage-panel')?.remove();
+        deps.router.open('espionage');
+        deps.showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
+      },
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onExfiltrate|onUnembed"`
+Expected: PASS, both.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route onExfiltrate/onUnembed's unit-spawn mutation through session.commit"
+```
+
+### Task 5.9: espionage `onSweep`
+
+**Files:**
+- Modify: `src/app/controllers/panel-actions-controller.ts:1008-1020` (confirm exact end line by reading the file — the spec's grep captured line 1013 as the flagged assignment, with `deps.renderLoop.setGameState` following at 1019 per the original inventory)
+- Test: `tests/app/controllers/panel-actions-controller.test.ts` (extend the espionage-panel describe block)
+
+Current code:
+
+```ts
+      onSweep: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        if (!ownerEsp) return;
+        const seed = `sweep-${spyId}-${deps.session.getState().turn}`;
+        const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, deps.session.getState());
+        deps.session.getState().espionage![deps.session.getState().currentPlayer] = updatedEsp;
+        if (detectedSpyIds.length > 0) {
+          deps.showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
+        } else {
+          deps.showNotification('Sweep complete — no enemy spies detected.', 'info');
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+```
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('onSweep commits the sweep result and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-sweep');
+      placeSpy(state, 'sweeper-1', { status: 'embedded' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onSweep: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onSweep('sweeper-1');
+
+      expect(deps.showNotification).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSweep"`
+Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
+
+- [ ] **Step 3: Write minimal implementation.**
+
+```ts
+      onSweep: (spyId) => {
+        const ownerEsp = deps.session.getState().espionage?.[deps.session.getState().currentPlayer];
+        if (!ownerEsp) return;
+        const seed = `sweep-${spyId}-${deps.session.getState().turn}`;
+        const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, deps.session.getState());
+        deps.session.commit({ ...deps.session.getState(), espionage: { ...deps.session.getState().espionage, [deps.session.getState().currentPlayer]: updatedEsp } });
+        if (detectedSpyIds.length > 0) {
+          deps.showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
+        } else {
+          deps.showNotification('Sweep complete — no enemy spies detected.', 'info');
+        }
+        deps.renderLoop.setGameState(deps.session.getState());
+      },
+```
+
+- [ ] **Step 4: Run test to verify it passes.**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSweep"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
+git commit -m "fix(panel-actions-controller): route onSweep's espionage-state commit through session.commit"
+```
+
+### Phase 5 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0 (this includes `tests/ui/city-panel*.test.ts`).
+- [ ] Re-run the inventory grep against `panel-actions-controller.ts` — confirm 0 remaining matches. Expected breakdown (verified 21 = 1 + 4 + 3 + 3 + 3 + 6 + 1): Task 5.1=1 (settings), Task 5.3=4 (onBuild/onMoveQueueItem/onRemoveQueueItem/onSetIdleProduction), Task 5.5=3 (onQueueResearch/onMoveQueuedResearch/onRemoveQueuedResearch), Task 5.6=3 (onAssignDefensive's espionage-assign/delete-unit/civ-units-filter), Task 5.7=3 (onStartMission/onRecall/onVerifyAgent, one site each), Task 5.8=6 (onExfiltrate's units/civ-units/espionage-assign ×3 + onUnembed's units/civ-units/espionage-assign ×3), Task 5.9=1 (onSweep). If the re-run grep finds a residual site not covered by Tasks 5.1-5.9, add one more task before closing this phase rather than closing with a known gap.
+- [ ] Confirm `src/ui/city-panel.ts` has zero remaining `void`-only queue callbacks (Task 5.2/5.3 covered all 4).
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 5 (panel-actions-controller.ts + city-panel.ts)`. Body must explicitly call out the `city-panel.ts` companion change and the test rewrite (Task 5.4) as its own line items, per Global Constraints.
+
+---
+
+## Phase 6 — Regression guard
+
+Both the grep-based boundary test and the real-time edit hook, added only once Phases 1-5 have driven the inventory to zero.
+
+### Task 6.1: `architecture-boundaries.test.ts` boundary test
+
+**Files:**
+- Modify: `tests/app/architecture-boundaries.test.ts`
+
+**Interfaces:**
+- Consumes: `readdirSync`, `readFileSync` (already imported in this file, per its existing `controllers depend on ports...` test).
+- Produces: no new exports — this is a test-only addition.
+
+- [ ] **Step 1: Re-run the full inventory** from the spec's grep commands against the current `src/` tree, restricted to `src/app/**`, `src/presentation/**`, `src/ui/**`, excluding `src/app/game-session.ts` and `src/app/ports.ts`:
+
+```bash
+grep -rnE "getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]" src/app src/presentation src/ui --include="*.ts" | grep -v "src/app/game-session.ts\|src/app/ports.ts"
+grep -rnE "delete [A-Za-z0-9_.]*getState\(\)" src/app src/presentation src/ui --include="*.ts"
+grep -rnE "getState\(\)(\.[A-Za-z0-9_]+|\[[^]]+\])+\.(push|splice|pop|shift|unshift|sort|reverse)\(" src/app src/presentation src/ui --include="*.ts"
+```
+
+Expected: zero output from all three, confirming Phases 1-5 closed the count. If anything remains, stop here and add a Task 6.0 to convert it before proceeding — do not add a passing test with a documented allowlist for a real leftover site; the spec's whole point is zero, not "zero except these."
+
+- [ ] **Step 2: Write the test.** Add to `tests/app/architecture-boundaries.test.ts`, after the existing `'controllers depend on ports...'` test:
+
+```ts
+it('no app/presentation/ui file mutates the object returned by session.getState() directly', () => {
+  // GameSession.commit()/update() are the only sanctioned publish path (see
+  // src/app/ports.ts's GameSession doc comment). Mutating getState()'s return
+  // value in place bypasses both subscribers (renderLoop, hud) that only fire
+  // through commit/update -- see docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md.
+  const dirs = [
+    resolve(__dirname, '../../src/app'),
+    resolve(__dirname, '../../src/presentation'),
+    resolve(__dirname, '../../src/ui'),
+  ];
+  const excluded = new Set(['game-session.ts', 'ports.ts']);
+  const mutationPatterns = [
+    /getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^\]]+\])+\s*=[^=]/,
+    /delete [A-Za-z0-9_.]*getState\(\)/,
+    /getState\(\)(\.[A-Za-z0-9_]+|\[[^\]]+\])+\.(push|splice|pop|shift|unshift|sort|reverse)\(/,
+  ];
+
+  function walk(dir: string): string[] {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    return entries.flatMap(entry => {
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return entry.name.endsWith('.ts') && !excluded.has(entry.name) ? [full] : [];
+    });
+  }
+
+  for (const dir of dirs) {
+    for (const file of walk(dir)) {
+      const source = readFileSync(file, 'utf8');
+      for (const line of source.split('\n')) {
+        for (const pattern of mutationPatterns) {
+          expect(pattern.test(line), `${file}: ${line}`).toBe(false);
+        }
+      }
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes** (Phases 1-5 already emptied the inventory, so this should pass immediately — it's a regression guard, not a TDD-from-red test).
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/architecture-boundaries.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Prove the guard actually catches a violation** (temporary, do not commit): add a throwaway line like `deps.session.getState().turn = 1;` to any file under `src/app/`, re-run the test, confirm it fails with a message naming the file and line, then revert the throwaway line.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/app/architecture-boundaries.test.ts
+git commit -m "test(architecture-boundaries): ban direct mutation through session.getState() in app/presentation/ui"
+```
+
+### Task 6.2: `check-src-edit.sh` real-time companion check
+
+**Files:**
+- Modify: `.claude/hooks/check-src-edit.sh`
+- Test: `tests/hooks/check-src-edit.test.sh`
+
+**Interfaces:**
+- Consumes: the hook's existing `append()` helper function (already defined in the file, used by every other check block).
+
+- [ ] **Step 1: Add block-case and allow-case fixtures to the smoke test.** In `tests/hooks/check-src-edit.test.sh`, after the existing `# --- block: cities[0] in a UI file ---` block (or any existing block near the top), add:
+
+```bash
+# --- block: direct mutation through session.getState() in src/app ---
+cat > "$tmp/src/ui/panel.ts" <<'EOF'
+session.getState().cities[cityId] = enqueueCityProduction(city, itemId);
+EOF
+expect_block "$tmp/src/ui/panel.ts" "getState() mutation in src/ui"
+
+# --- allow: reading getState() without mutating it ---
+cat > "$tmp/src/ui/reader.ts" <<'EOF'
+const city = session.getState().cities[cityId];
+EOF
+expect_allow "$tmp/src/ui/reader.ts" "getState() read-only in src/ui"
+```
+
+- [ ] **Step 2: Run the smoke test to verify it fails.**
+
+Run: `bash tests/hooks/check-src-edit.test.sh`
+Expected: FAIL on the new `expect_block` case (`check-src-edit.sh` doesn't check this pattern yet, so it exits 0 instead of the expected 2).
+
+- [ ] **Step 3: Write minimal implementation.** Add a new check block to `.claude/hooks/check-src-edit.sh`, placed near the existing "direct state mutation in turn processing" block (mirroring its structure), before the final `if [ -n "$violations" ]; then`:
+
+```bash
+# --- direct mutation through session.getState() outside game-session.ts/ports.ts ---
+case "$file_path" in
+  */src/app/game-session.ts|*/src/app/ports.ts)
+    : # allowed: game-session.ts is the one sanctioned mutation path; ports.ts is types-only
+    ;;
+  *)
+    if grep -nE 'getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]' "$file_path" | grep -v '//' >/dev/null; then
+      lines="$(grep -nE 'getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]' "$file_path" | grep -v '//' | head -5)"
+      append "Direct mutation through session.getState() detected -- use session.commit()/session.update() instead (see docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md):
+$lines"
+    fi
+    if grep -nE 'delete [A-Za-z0-9_.]*getState\(\)' "$file_path" >/dev/null; then
+      lines="$(grep -nE 'delete [A-Za-z0-9_.]*getState\(\)' "$file_path" | head -5)"
+      append "delete through session.getState() detected -- build a new object and use session.commit()/session.update() instead:
+$lines"
+    fi
+    ;;
+esac
+```
+
+- [ ] **Step 4: Run the smoke test to verify it passes.**
+
+Run: `bash tests/hooks/check-src-edit.test.sh`
+Expected: PASS, all cases (existing ones plus the 2 new ones).
+
+- [ ] **Step 5: Run the full test suite once more** to confirm this hook change doesn't break anything else (it's a hook script, not directly exercised by `yarn test`, but `tests/hooks/run.sh` — if that's how hook smoke tests are wired into `yarn test`, per `.claude/rules/hooks-and-tooling.md` — must still pass):
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add .claude/hooks/check-src-edit.sh tests/hooks/check-src-edit.test.sh
+git commit -m "feat(check-src-edit): catch direct mutation through session.getState() at edit time"
+```
+
+### Phase 6 close-out
+
+- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 6 (regression guard)`. Body confirms the inventory is verified at zero as of this PR and links Phases 1-5.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every numbered section of the design spec maps to a phase/task above — Problem/inventory → Phases 1-5's per-file task breakdown; Scope (including the `city-panel.ts` addition) → Task 5.2/5.3; Fix pattern's chained-write hazard → Task 1.1 and Task 1.3; Fix pattern's `city-panel.ts` hazard → Tasks 5.2-5.4; Regression guard → Phase 6; Behavioral test per site → every task's Step 1/listener assertion; Phasing → the 6 phases match the spec's list one-to-one.
+
+**Placeholder scan:** two intentional exceptions, both explicitly called out as research-required rather than left silent: Task 4.2's `// arrange` comments (branch-selecting inputs for `attemptInfiltration` depend on that function's real signature, which this plan-writing pass did not read) and Task 3.1's `someTechId` line (depends on `turn-flow-controller.test.ts`'s existing idle-research fixture, not read during this pass). Both are marked as "resolve before this task's Step 1 is complete, do not commit as-is" rather than left as ordinary steps — an implementer following `superpowers:executing-plans` must treat these two as blocking sub-steps, not skip them.
+
+**Type consistency:** `GameState | void` is used consistently for the 4 `city-panel.ts` callbacks (Task 5.2) and their `panel-actions-controller.ts` implementations (Task 5.3) — matching the pre-existing `onSetCityFocus`/`onToggleWorkedTile`/`onRushBuyActiveProduction` shape exactly, not a new convention. `session.commit(next: GameState)` and `session.update(fn: (state: GameState) => GameState): void` are used with consistent signatures across every task, matching `src/app/ports.ts`'s existing `GameSession` interface (unchanged by this plan). Every task's `deps.session`/`session` naming matches its file's actual factory-parameter convention (`deps.session.getState()` in `player-action-controller.ts`, `panel-actions-controller.ts`, `campaign-entry-controller.ts`; bare `session.getState()` in `selection-controller.ts`, `turn-flow-controller.ts` — confirmed against the actual source reads this plan is based on, not assumed uniform).

--- a/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
+++ b/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
@@ -409,7 +409,7 @@ Current code, `onComplete` (hot-seat, `campaign-entry-controller.ts:254-263`):
       const deps = baseDeps(state, {
         userSettingsStore: {
           getPersisted: () => undefined,
-          refresh: vi.fn().mockResolvedValue({ customCivilizations: [], councilTalkLevel: 'verbose' }),
+          refresh: vi.fn().mockResolvedValue({ customCivilizations: [], councilTalkLevel: 'chatty' }),
           getMasterVolume: () => 0.8,
           setCustomCivilizations: vi.fn(),
           getOverrides: () => ({}),
@@ -436,7 +436,7 @@ Current code, `onComplete` (hot-seat, `campaign-entry-controller.ts:254-263`):
       };
       capturedSoloCallbacks!.onStartSolo(soloConfig);
 
-      expect(deps.session.getState().settings.councilTalkLevel).toBe('verbose');
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('chatty');
     });
 ```
 
@@ -550,53 +550,67 @@ Where `refreshRequiredChoicesAfterAction` (`turn-flow-controller.ts:188-192`, un
     deps.updateHUD();
 ```
 
-- [ ] **Step 1: Find or write a test harness that reaches these callbacks.** Search first: `grep -n "onChooseResearch\|onChooseCityBuild\|showRequiredChoicesIfNeeded" tests/app/controllers/turn-flow-controller.test.ts`. If existing tests already capture `createRequiredChoicePanel`'s callbacks (this codebase's convention, per Phase 1/2/5's tests, is to mock the panel factory and capture the callbacks object passed to it), extend that pattern; otherwise add:
+**Correction from this plan's own review pass:** the original draft of this task assumed `createRequiredChoicePanel` is mocked in this test file, following the capture-the-callbacks pattern used elsewhere in this plan. It is not — `tests/app/controllers/turn-flow-controller.test.ts` renders this panel for real into `deps.uiLayer` (confirmed by reading the file: no `vi.mock('@/ui/required-choice-panel', ...)` exists, and the existing `'required choices — resolving multiple idle-city choices...'` test at line 530 asserts against `deps.uiLayer.querySelector('#required-choice-panel')`, a real DOM node). Adding a mock here would break that existing test, which depends on the panel being real. This task instead drives the real rendered panel via DOM clicks, matching that existing test's convention.
+
+**Files it opens with (confirmed real signatures):** `needsResearchChoice(state, civId)` (`src/systems/planning-system.ts:154`) is `true` when `civ.techState.currentResearch` is falsy and at least one tech is available — set `state.civilizations.player.techState.currentResearch = undefined` to force it. `getIdleCityIds(state, civId)` (`src/systems/planning-system.ts:124`) treats a city with an empty `productionQueue` as idle — the existing Phase-12 test at `turn-flow-controller.test.ts:537-542` already establishes a real-city (not settler-founded) fixture pattern for this; reuse it rather than inventing a new one.
+
+`src/ui/required-choice-panel.ts` gives no `id`/`data-*` attribute to individual research/build buttons — only their container `<section>`'s `<h3>` heading text ("Choose Research" / "Choose Production") is a stable anchor. Add a small helper to select by section rather than by brittle DOM index or by guessing a specific tech/item's display label:
 
 ```ts
-vi.mock('@/ui/required-choice-panel', () => ({ createRequiredChoicePanel: vi.fn() }));
+function findSectionButton(container: HTMLElement, sectionTitle: string, buttonIndex = 0): HTMLButtonElement {
+  const heading = Array.from(container.querySelectorAll('h3')).find(h => h.textContent === sectionTitle);
+  const section = heading?.closest('section');
+  const buttons = section ? Array.from(section.querySelectorAll('button')) : [];
+  const button = buttons[buttonIndex];
+  if (!button) throw new Error(`No button at index ${buttonIndex} in section "${sectionTitle}"`);
+  return button as HTMLButtonElement;
+}
 ```
 
-at the top of the test file (only if not already present — check first), then:
+Within "Choose Research", research-choice buttons are appended before the "Open Tech Panel" button, so index 0 is always the first available tech choice. Within "Choose Production", each city's row appends its build button before that row's "Open City" button, so index 0 is always the first idle city's build choice. Both hold regardless of how many techs/cities are available, so the test doesn't need to know a specific tech id or item id ahead of time — it can assert "one new entry appeared" instead.
+
+- [ ] **Step 1: Write the failing tests.**
 
 ```ts
   describe('showRequiredChoicesIfNeeded callbacks', () => {
     it('onChooseResearch publishes the queued tech through session subscribers', () => {
       const { state } = makeFixture('required-choice-research');
-      // arrange an idle-research condition so showRequiredChoicesIfNeeded opens the panel
+      state.civilizations.player.techState.currentResearch = undefined;
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
+      const queueBefore = deps.session.getState().civilizations.player.techState.researchQueue.length;
+
       controller.showRequiredChoicesIfNeeded();
-      const options = mockedCallArg<{ onChooseResearch: (techId: string) => void }>(createRequiredChoicePanel, 0, 1);
+      const panel = deps.uiLayer.querySelector('#required-choice-panel') as HTMLElement;
+      expect(panel).toBeTruthy();
+      findSectionButton(panel, 'Choose Research', 0).click();
 
-      const someTechId = Object.keys(deps.session.getState().civilizations.player.techState.researchQueue.length
-        ? {}
-        : {})[0]; // placeholder replaced below once the real available-tech id is known from the fixture
-
-      options.onChooseResearch('pottery');
-
-      expect(deps.session.getState().civilizations.player.techState.researchQueue).toContain('pottery');
+      expect(deps.session.getState().civilizations.player.techState.researchQueue.length).toBe(queueBefore + 1);
       expect(listener).toHaveBeenCalled();
     });
 
     it('onChooseCityBuild publishes the queued production through session subscribers', () => {
       const { state } = makeFixture('required-choice-build');
-      state.cities['idle-city'] = makeCity('idle-city');
+      const template = Object.values(state.cities)[0]!;
+      state.cities['idle-city'] = { ...template, id: 'idle-city', owner: 'player', name: 'Idle City', productionQueue: [] };
+      state.civilizations.player.cities = ['idle-city'];
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
+
       controller.showRequiredChoicesIfNeeded();
-      const options = mockedCallArg<{ onChooseCityBuild: (cityId: string, itemId: string) => void }>(createRequiredChoicePanel, 0, 1);
+      const panel = deps.uiLayer.querySelector('#required-choice-panel') as HTMLElement;
+      expect(panel).toBeTruthy();
+      findSectionButton(panel, 'Choose Production', 0).click();
 
-      options.onChooseCityBuild('idle-city', 'warrior');
-
-      expect(deps.session.getState().cities['idle-city'].productionQueue).toContain('warrior');
+      expect(deps.session.getState().cities['idle-city'].productionQueue.length).toBe(1);
       expect(listener).toHaveBeenCalled();
     });
   });
 ```
 
-Before running, replace the `someTechId` placeholder line — it is a **planning placeholder for this plan document only**, not something to leave in the implementation: when writing this test for real, read `tests/app/controllers/turn-flow-controller.test.ts`'s existing fixture setup for `showRequiredChoicesIfNeeded`/idle-research conditions (search for an existing test that already opens this panel for a research choice) and copy its exact arrangement so `onChooseResearch` is reachable with a real available tech id, then delete the placeholder line entirely — do not commit code containing it.
+Add the `findSectionButton` helper (shown above) near this file's other test helpers, not inline in each test.
 
 - [ ] **Step 2: Run test to verify it fails.**
 
@@ -660,6 +674,25 @@ git commit -m "fix(turn-flow-controller): route required-choice research/build q
 
 15 sites across 3 handler groups inside the unit-info panel's callback object (all under one `session`-scoped closure — no `deps.session`, just `session`, per this file's own factory parameter naming). No turn-flow risk; heaviest single-domain phase.
 
+**Correction from this plan's own review pass:** every test in the original draft of this phase assumed `tests/app/controllers/selection-controller.test.ts` follows the mocked-panel-factory-plus-`mockedCallArg` convention used in `player-action-controller.test.ts` and `panel-actions-controller.test.ts`. It does not — verified by reading the file directly: it has no `mockedCallArg` helper, no `build()` helper, no `makeCity()` helper, and does not mock `@/ui/selected-unit-info`. Its real conventions, confirmed from its existing tests (e.g. `'selecting a unit renders the info panel via the real DOM node'`), are:
+- `makeFixture()` takes no seed argument and returns a `GameState` directly (not `{ state }`).
+- `baseDeps(state, overrides)` builds deps (not `makeDeps`/`build`).
+- `createSelectionController(deps)` constructs the controller directly (not wrapped in a `build()` helper returning `{ deps, controller }`).
+- `renderSelectedUnitInfo` renders for real into a genuine `document.getElementById('info-panel')` node — reachable only by setting `document.body.innerHTML = '<div id="info-panel"></div>';` before calling `controller.selectUnit(id)`, then querying/clicking the real rendered buttons.
+- There is no `makeCity` helper; city fixtures elsewhere in this plan (e.g. `turn-flow-controller.test.ts`) borrow a template from `Object.values(state.cities)[0]!` and override fields — this file should do the same rather than introducing a new one-off helper.
+
+All 3 tasks below (4.1-4.3) are corrected to this real convention. Add this shared helper once, near this file's other helpers, before Task 4.1's test:
+
+```ts
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(b => b.textContent === text);
+  if (!button) throw new Error(`No button with exact text "${text}" found in container`);
+  return button as HTMLButtonElement;
+}
+```
+
+And import `createEspionageCivState` from `@/systems/espionage-system` at the top of the file if not already imported (it isn't, as of this plan's review).
+
 ### Task 4.1: `onSetDisguise`
 
 **Files:**
@@ -694,37 +727,41 @@ Current code:
 
 Two flagged mutations here (espionage assignment, conditional unit assignment) — both belong to the same handler and must land in one `commit`.
 
+Note the disguise picker only renders when `disguiseOptions.length > 1` (`src/ui/selected-unit-info.ts:772-805`), which requires a spy tier ≥ 1 — `spy_scout` (tier 0) only ever offers "No Disguise" and renders no picker at all. Use `spy_informant` (tier 1) so "As Warrior" is a real, clickable option.
+
 - [ ] **Step 1: Write the failing test.**
 
 ```ts
   describe('onSetDisguise', () => {
     it('sets the disguise and marks the unit acted, publishing through session subscribers', () => {
       const state = makeFixture();
-      placePlayerUnit(state, 'spy-1', { position: { q: 0, r: 0 } });
+      placePlayerUnit(state, 'spy-1', { type: 'spy_informant', position: { q: 0, r: 0 } });
       state.espionage = { player: createEspionageCivState() };
       state.espionage.player.spies['spy-1'] = {
-        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_scout',
+        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_informant',
         targetCivId: null, targetCityId: null, position: null,
         status: 'idle', experience: 0, currentMission: null,
         cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
       };
-      const { deps, controller } = build(state);
+      document.body.innerHTML = '<div id="info-panel"></div>';
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
       const listener = vi.fn();
       deps.session.subscribe(listener);
 
       controller.selectUnit('spy-1');
-      const options = mockedCallArg<{ onSetDisguise: (uid: string, disguise: UnitType | null) => void }>(renderSelectedUnitInfo, 0, 2);
-      options.onSetDisguise('spy-1', 'warrior');
+      const panel = document.getElementById('info-panel')!;
+      findButtonByText(panel, 'As Warrior').click();
 
       const updated = deps.session.getState();
-      expect(updated.espionage!.player.spies['spy-1'].disguisedAs).toBe('warrior');
+      expect(updated.espionage!.player.spies['spy-1'].disguiseAs).toBe('warrior');
       expect(updated.units['spy-1'].hasActed).toBe(true);
       expect(listener).toHaveBeenCalled();
     });
   });
 ```
 
-Before writing this for real: check `tests/app/controllers/selection-controller.test.ts`'s existing fixture helpers (`makeFixture`, `placePlayerUnit`, and how `renderSelectedUnitInfo`'s callbacks are captured — search `mockedCallArg.*renderSelectedUnitInfo` in that file) and match the established pattern and argument indices exactly rather than guessing them; the shape above is illustrative of the assertions needed, not a verbatim drop-in.
+Note the field is `disguiseAs` (verified against `src/ui/selected-unit-info.ts:798`'s `spy?.disguiseAs`), not `disguisedAs`.
 
 - [ ] **Step 2: Run test to verify it fails.**
 
@@ -876,62 +913,81 @@ This is the largest single handler (8 flagged sites across 4 branches). Current 
 
 Behavior-preserving note: the original code emitted `bus.emit(...)` for the `removeUnitFromMap` and `caught` branches *before* the final state mutation happened (since the mutations were interleaved with the emits in-place); the rewrite above keeps emit ordering identical relative to the other statements in each branch — only the *mechanism* of building `nextUnits`/`nextCivilizations` changed from in-place mutation to accumulated spread-copies, committed once at the end instead of write-as-you-go.
 
-- [ ] **Step 1: Write failing tests covering all 4 branches.** Search `tests/app/controllers/selection-controller.test.ts` first for any existing `onInfiltrate` coverage to extend rather than duplicate. At minimum, add one test per branch asserting (a) the branch's distinguishing state change, and (b) a subscribed listener fires:
+**Deterministic branch selection.** `attemptInfiltration` (`src/systems/espionage-system.ts:1809-1857`) is seeded via `` `infiltrate-${uid}-${session.getState().turn}` `` and its branch depends on two RNG rolls compared against `getInfiltrationSuccessChance`. Its own system-level test suite (`tests/systems/espionage-infiltration.test.ts:126-132`) already solves exactly this determinism problem with a `tryUntil` helper that iterates candidate seeds until a predicate matches — reuse that same idiom one level up, varying the spy's `uid` (which is what feeds the seed string) instead of the seed directly, since the controller test can't pass a seed straight through:
+
+```ts
+function tryUntilInfiltrate(
+  unitType: UnitType,
+  predicate: (state: GameState, uid: string) => boolean,
+): { deps: SelectionControllerDeps; uid: string } | null {
+  for (let i = 0; i < 200; i++) {
+    const uid = `infiltrator-${i}`;
+    const state = makeFixture();
+    const template = Object.values(state.cities)[0]!;
+    state.cities['enemy-city'] = { ...template, id: 'enemy-city', owner: 'ai-1', position: { q: 0, r: 0 } };
+    placePlayerUnit(state, uid, { type: unitType, position: { q: 0, r: 0 } });
+    state.espionage = { player: createEspionageCivState() };
+    state.espionage.player.spies[uid] = {
+      id: uid, owner: 'player', name: 'Agent', unitType,
+      targetCivId: null, targetCityId: null, position: null,
+      status: 'idle', experience: 0, currentMission: null,
+      cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+    };
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    controller.selectUnit(uid);
+    const panel = document.getElementById('info-panel')!;
+    findButtonByText(panel, 'Infiltrate City').click();
+
+    if (predicate(deps.session.getState(), uid)) {
+      return { deps, uid };
+    }
+  }
+  return null;
+}
+```
+
+- [ ] **Step 1: Write failing tests covering all 4 branches.**
 
 ```ts
   describe('onInfiltrate', () => {
     it('era-2+ unit types remove the unit from the map and station the spy (removeUnitFromMap branch)', () => {
-      // Arrange a unit type/experience/CI combination that resolves to removeUnitFromMap,
-      // matching whatever helper (if any) existing infiltration tests in this file already
-      // use to force that branch deterministically -- check attemptInfiltration's existing
-      // test coverage in tests/systems/ for the exact inputs that select this branch.
-      // ... arrange ...
-      const listener = vi.fn();
-      deps.session.subscribe(listener);
-
-      options.onInfiltrate('spy-1');
-
-      expect(deps.session.getState().units['spy-1']).toBeUndefined();
-      expect(deps.session.getState().civilizations.player.units).not.toContain('spy-1');
-      expect(listener).toHaveBeenCalled();
+      const found = tryUntilInfiltrate('spy_informant', (state, uid) => state.units[uid] === undefined);
+      expect(found).not.toBeNull();
+      const state = found!.deps.session.getState();
+      expect(state.civilizations.player.units).not.toContain(found!.uid);
+      expect(state.espionage!.player.spies[found!.uid].status).toBe('stationed');
     });
 
     it('era-1 scout infiltration reveals tiles and marks the unit acted without removing it (era1ScoutResult branch)', () => {
-      // ... arrange for era1ScoutResult ...
-      const listener = vi.fn();
-      deps.session.subscribe(listener);
-
-      options.onInfiltrate('scout-1');
-
-      expect(deps.session.getState().units['scout-1'].hasActed).toBe(true);
-      expect(listener).toHaveBeenCalled();
+      const found = tryUntilInfiltrate('spy_scout', (state, uid) => state.units[uid]?.hasActed === true && state.units[uid] !== undefined);
+      expect(found).not.toBeNull();
+      const state = found!.deps.session.getState();
+      expect(state.units[found!.uid].hasActed).toBe(true);
+      expect(state.espionage!.player.spies[found!.uid].infiltrationCityId).toBe('enemy-city');
     });
 
     it('a caught spy is removed from the map (caught branch)', () => {
-      // ... arrange for result.caught ...
-      const listener = vi.fn();
-      deps.session.subscribe(listener);
-
-      options.onInfiltrate('spy-2');
-
-      expect(deps.session.getState().units['spy-2']).toBeUndefined();
-      expect(listener).toHaveBeenCalled();
+      const found = tryUntilInfiltrate('spy_scout', (state, uid) => state.espionage!.player.spies[uid]?.status === 'captured');
+      expect(found).not.toBeNull();
+      expect(found!.deps.session.getState().units[found!.uid]).toBeUndefined();
     });
 
     it('a failed-but-not-caught attempt marks the unit acted and keeps it on the map (default branch)', () => {
-      // ... arrange for the default (not caught, not era1, not removeUnitFromMap) outcome ...
-      const listener = vi.fn();
-      deps.session.subscribe(listener);
-
-      options.onInfiltrate('spy-3');
-
-      expect(deps.session.getState().units['spy-3'].hasActed).toBe(true);
-      expect(listener).toHaveBeenCalled();
+      const found = tryUntilInfiltrate(
+        'spy_scout',
+        (state, uid) => state.units[uid] !== undefined && state.espionage!.player.spies[uid]?.status === 'cooldown',
+      );
+      expect(found).not.toBeNull();
+      expect(found!.deps.session.getState().units[found!.uid].hasActed).toBe(true);
     });
   });
 ```
 
-The `// arrange` comments above are explicitly **not** placeholders to leave in committed code — they mark research the implementer must do against `attemptInfiltration`'s real signature and existing test fixtures in `tests/systems/espionage-system.test.ts` (or wherever it's tested) to pick concrete inputs that deterministically select each branch, before this task's Step 1 is actually complete. Do not check in a test with an unresolved arrange step.
+Each test proves the branch's own distinguishing state via `tryUntilInfiltrate`'s deterministic search rather than asserting a `listener` call on every single test — the publish-plumbing itself only needs proving once per handler (the codebase-wide convention this whole plan follows), and `onSetDisguise`/`onEmbed`'s tests already do that for the same `session.commit` call path this handler also uses. Re-verify against a fresh `yarn vitest run` before treating any of these 4 as flaky: `tryUntil`'s 200-iteration cap matches the existing system-level helper's own cap and has never needed raising there, but if a branch reliably fails to be found, that's a sign the fixture (city ownership, spy status, unit position) doesn't actually satisfy `onInfiltrate`'s own preconditions (`src/app/controllers/selection-controller.ts:405-420`) — fix the fixture, don't raise the cap blindly.
 
 - [ ] **Step 2: Run tests to verify they fail.**
 
@@ -988,17 +1044,26 @@ Current code:
   describe('onEmbed', () => {
     it('embeds the spy, removes the unit from the map, and publishes through session subscribers', () => {
       const state = makeFixture();
-      state.cities['friendly-city'] = makeCity('friendly-city', { owner: 'player', position: { q: 0, r: 0 } });
+      const template = Object.values(state.cities)[0]!;
+      state.cities['friendly-city'] = { ...template, id: 'friendly-city', owner: 'player', position: { q: 0, r: 0 } };
       state.civilizations.player.cities = ['friendly-city'];
-      placePlayerUnit(state, 'spy-1', { position: { q: 0, r: 0 } });
+      placePlayerUnit(state, 'spy-1', { type: 'spy_scout', position: { q: 0, r: 0 } });
       state.espionage = { player: createEspionageCivState() };
-      const { deps, controller } = build(state);
+      state.espionage.player.spies['spy-1'] = {
+        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_scout',
+        targetCivId: null, targetCityId: null, position: null,
+        status: 'idle', experience: 0, currentMission: null,
+        cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+      };
+      document.body.innerHTML = '<div id="info-panel"></div>';
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
       const listener = vi.fn();
       deps.session.subscribe(listener);
 
       controller.selectUnit('spy-1');
-      const options = mockedCallArg<{ onEmbed: (uid: string) => void }>(renderSelectedUnitInfo, 0, 2);
-      options.onEmbed('spy-1');
+      const panel = document.getElementById('info-panel')!;
+      findButtonByText(panel, 'Embed (counter-espionage)').click();
 
       const updated = deps.session.getState();
       expect(updated.units['spy-1']).toBeUndefined();
@@ -1008,8 +1073,6 @@ Current code:
     });
   });
 ```
-
-Match this test's exact fixture helpers and `mockedCallArg` argument indices to whatever `tests/app/controllers/selection-controller.test.ts` already establishes for Task 4.1/4.2's tests — write them consistently, not independently guessed per task.
 
 - [ ] **Step 2: Run test to verify it fails.**
 
@@ -1105,7 +1168,7 @@ Current code:
   }
 ```
 
-Note `applyAutoExploreOrder(session.getState(), unitId, { bus })` — check this function's actual signature and return type before converting (`grep -n "export function applyAutoExploreOrder" src/`): if it mutates `session` internally itself (unlikely, but verify) rather than returning a value, this task's implementation needs adjusting; if — as expected from this file's other patterns — it operates on the passed `state` value and its result needs to be applied, the fix must thread that result into the same `commit` as the `automation` assignment, not call it against a stale pre-automation state. Do not assume; read the function first.
+Verified: `applyAutoExploreOrder(state: GameState, unitId: string, options: { bus?: EventBus }): ExecuteUnitMoveResult | null` (`src/systems/auto-explore-system.ts:93-97`) does not mutate `state` and does not return a new `GameState` — it returns a move-intent result that this call site's original code already discards without applying (`applyAutoExploreOrder(session.getState(), unitId, { bus });` with no assignment). That discard is existing behavior outside this task's scope (this task only fixes the flagged `session.getState().units[unitId] = ...` mutation two lines above it) — preserve the call exactly as-is, unexamined further, rather than "fixing" a discarded-return-value pattern this task was never asked to change.
 
 - [ ] **Step 1: Write the failing test.**
 
@@ -1114,7 +1177,8 @@ Note `applyAutoExploreOrder(session.getState(), unitId, { bus })` — check this
     it('starts auto-explore automation and publishes through session subscribers', () => {
       const state = makeFixture();
       placePlayerUnit(state, 'scout-1', { position: { q: 0, r: 0 } });
-      const { deps, controller } = build(state);
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
       const listener = vi.fn();
       deps.session.subscribe(listener);
 
@@ -1127,7 +1191,8 @@ Note `applyAutoExploreOrder(session.getState(), unitId, { bus })` — check this
     it('cancels auto-explore automation and publishes through session subscribers', () => {
       const state = makeFixture();
       placePlayerUnit(state, 'scout-1', { position: { q: 0, r: 0 }, automation: { mode: 'auto-explore', startedTurn: 1, lastTargets: [] } });
-      const { deps, controller } = build(state);
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
       const listener = vi.fn();
       deps.session.subscribe(listener);
 
@@ -1139,7 +1204,7 @@ Note `applyAutoExploreOrder(session.getState(), unitId, { bus })` — check this
   });
 ```
 
-Check whether `startAutoExplore`/`cancelAutoExplore` are exposed on `SelectionController`'s public interface (like `ensurePlayerWarState` was in Task 1.1) before assuming `controller.startAutoExplore(...)` is callable directly — if they're private, find the actual public entry point (likely `openUnitContextMenu`'s `onStartAutoExplore`/`onCancelAutoExplore` callbacks) and drive the test through that instead.
+`startAutoExplore`/`cancelAutoExplore` are confirmed public on `SelectionController` (`src/app/controllers/selection-controller.ts:120-121`, returned from the factory at lines 772-773), so calling them directly on `controller` is correct — no context-menu indirection needed.
 
 - [ ] **Step 2: Run test to verify it fails.**
 
@@ -1216,60 +1281,62 @@ Heaviest phase: 21 sites plus the `city-panel.ts` callback-contract change the s
 - Modify: `src/app/controllers/panel-actions-controller.ts:485-492`
 - Test: `tests/app/controllers/panel-actions-controller.test.ts` (new test in the council-panel describe block; search `grep -n "createCouncilPanel" tests/app/controllers/panel-actions-controller.test.ts` first)
 
-Current code (`panel-actions-controller.ts:485-492`, read exact lines first — this is the `createCouncilPanel` callback wiring):
+Current code, verified against the real file (`panel-actions-controller.ts:483-494`):
 
 ```ts
+  function openCouncilPanel(): void {
+    deps.hud.closeDrawer();
     createCouncilPanel(deps.uiLayer, deps.session.getState(), {
-      // ...
-      onSetTalkLevel: (level) => {
+      onClose: () => {
+        deps.getElementById('council-panel')?.remove();
+      },
+      onTalkLevelChange: (level) => {
         deps.session.getState().settings.councilTalkLevel = level;
         void saveSettings(deps.session.getState().settings);
-        // ...
       },
-      // ...
     });
+  }
 ```
 
-(Confirm the exact surrounding callback name and structure by reading `panel-actions-controller.ts` around line 485 before editing — the spec's grep only captured the flagged line itself, not the enclosing callback's name.)
+The real callback is `onTalkLevelChange` (typed `(level: CouncilTalkLevel) => void` in `src/ui/council-panel.ts:7`), not a guessed name — verified by reading the file directly before writing this task, per this repo's `spec-fidelity.md` convention of not carrying an unverified claim into an implementation step. `CouncilTalkLevel` (`src/core/types.ts:1540`) is `'quiet' | 'normal' | 'chatty' | 'chaos'`.
 
 - [ ] **Step 1: Write the failing test.**
 
 ```ts
-    it('onSetTalkLevel publishes the new council talk level through session subscribers', () => {
+    it('onTalkLevelChange publishes the new council talk level through session subscribers', () => {
       const { state } = makeFixture('council-talk-level');
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
 
       controller.openCouncilPanel();
-      const options = mockedCallArg<{ onSetTalkLevel: (level: string) => void }>(createCouncilPanel, 0, 2);
-      options.onSetTalkLevel('verbose');
+      const options = mockedCallArg<{ onTalkLevelChange: (level: CouncilTalkLevel) => void }>(createCouncilPanel, 0, 2);
+      options.onTalkLevelChange('chatty');
 
-      expect(deps.session.getState().settings.councilTalkLevel).toBe('verbose');
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('chatty');
       expect(listener).toHaveBeenCalled();
     });
 ```
 
-Match the real method name for opening the council panel (`openCouncilPanel` is illustrative — confirm the controller's actual public method name first) and `createCouncilPanel`'s real callback property name and argument index against the source read in this task's preamble.
+Import `CouncilTalkLevel` from `@/core/types` at the top of the test file if not already imported.
 
 - [ ] **Step 2: Run test to verify it fails.**
 
-Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSetTalkLevel"`
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onTalkLevelChange"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
 - [ ] **Step 3: Write minimal implementation.**
 
 ```ts
-      onSetTalkLevel: (level) => {
+      onTalkLevelChange: (level) => {
         deps.session.commit({ ...deps.session.getState(), settings: { ...deps.session.getState().settings, councilTalkLevel: level } });
         void saveSettings(deps.session.getState().settings);
-        // ... (rest of the callback body unchanged)
       },
 ```
 
 - [ ] **Step 4: Run test to verify it passes.**
 
-Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSetTalkLevel"`
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onTalkLevelChange"`
 Expected: PASS.
 
 - [ ] **Step 5: Commit.**
@@ -1636,12 +1703,13 @@ Current code:
           researchQueue: removeQueuedId(deps.currentCiv().techState.researchQueue, index),
         };
         deps.renderLoop.setGameState(deps.session.getState());
-        // (read the remainder of this callback before editing -- confirm whether it ends here or has more lines)
+        deps.hud.update();
       },
+      onClose: () => {},
     });
 ```
 
-This site already calls `deps.hud.update()` manually in at least the first two handlers (confirm the third does too by reading the actual file before editing) — architecture-debt only, matching the spec's severity note for this group.
+Verified against the real file (`panel-actions-controller.ts:498-527`) — all 3 handlers call `deps.hud.update()` manually, confirming the spec's severity note: architecture-debt only, not a currently-observable HUD bug.
 
 - [ ] **Step 1: Write the failing test.**
 
@@ -1766,6 +1834,8 @@ Current code:
 
 This handler closes+reopens the espionage panel via `deps.router.open('espionage')` after committing (no closure-staleness risk like `city-panel.ts`), but still skips `hud.update()` — a live bug per the spec's severity table.
 
+**Verified target-picker mechanism:** `chooseFriendlyCityTarget()` (`panel-actions-controller.ts:820-839`, a closure inside the same registrar as this handler) calls `window.prompt(message, choices[0].id)` — jsdom's `window.prompt` returns `null` unless stubbed, so the test must stub it. Since the prompt's second argument is always the first valid choice's id, a generic stub that echoes the suggested default resolves this deterministically without hardcoding a specific city id: `vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);`. The same stub covers `chooseForeignCityTarget` (Task 5.7) and `chooseMission` (Task 5.7) too, since both follow the identical `window.prompt(msg, choices[0])` pattern — add it once per test that reaches any of these three pickers.
+
 - [ ] **Step 1: Write the failing test.**
 
 ```ts
@@ -1778,12 +1848,10 @@ This handler closes+reopens the espionage panel via `deps.router.open('espionage
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
+      vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);
 
       controller.openEspionagePanel();
       const options = mockedCallArg<{ onAssignDefensive: (spyId: string) => void }>(createEspionagePanel, 0, 1);
-      // chooseFriendlyCityTarget() likely drives a window.prompt/confirm or an internal picker --
-      // check the real implementation before writing this test and stub whatever it needs
-      // (e.g. vi.spyOn(window, 'prompt')) to deterministically pick 'home-city'.
       options.onAssignDefensive('spy-1');
 
       const updated = deps.session.getState();
@@ -1794,7 +1862,7 @@ This handler closes+reopens the espionage panel via `deps.router.open('espionage
     });
 ```
 
-Confirm `controller.openEspionagePanel`'s real name and how `chooseFriendlyCityTarget` resolves a target (read `panel-actions-controller.ts` around this handler) before finalizing this test — the comment above marks required research, not something to leave unresolved in committed code.
+`controller.openEspionagePanel` is confirmed public on `PanelActionsController` (`panel-actions-controller.ts:125`).
 
 - [ ] **Step 2: Run test to verify it fails.**
 
@@ -1909,11 +1977,10 @@ None of these 3 currently call `hud.update()` — all live bugs per the spec's s
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
+      vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);
 
       controller.openEspionagePanel();
       const options = mockedCallArg<{ onStartMission: (spyId: string) => void }>(createEspionagePanel, 0, 1);
-      // chooseMission() resolves via window.prompt in this file (see chooseMission's definition
-      // above onAssignDefensive) -- stub window.prompt to return a valid SpyMissionType before calling.
       options.onStartMission('spy-1');
 
       expect(deps.session.getState().espionage!.player.spies['spy-1'].status).not.toBe('stationed');
@@ -1936,7 +2003,7 @@ None of these 3 currently call `hud.update()` — all live bugs per the spec's s
 
     it('onVerifyAgent commits the cleared agent and publishes through session subscribers', () => {
       const { state } = makeFixture('espionage-verify');
-      placeSpy(state, 'spy-1', { status: 'suspected' });
+      placeSpy(state, 'spy-1', { status: 'embedded', turnedBy: 'ai' });
       const { deps, controller } = build(state);
       const listener = vi.fn();
       deps.session.subscribe(listener);
@@ -1945,6 +2012,7 @@ None of these 3 currently call `hud.update()` — all live bugs per the spec's s
       const options = mockedCallArg<{ onVerifyAgent: (spyId: string) => void }>(createEspionagePanel, 0, 1);
       options.onVerifyAgent('spy-1');
 
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].turnedBy).toBeUndefined();
       expect(listener).toHaveBeenCalled();
     });
 ```
@@ -2476,6 +2544,27 @@ git commit -m "feat(check-src-edit): catch direct mutation through session.getSt
 
 **Spec coverage:** every numbered section of the design spec maps to a phase/task above — Problem/inventory → Phases 1-5's per-file task breakdown; Scope (including the `city-panel.ts` addition) → Task 5.2/5.3; Fix pattern's chained-write hazard → Task 1.1 and Task 1.3; Fix pattern's `city-panel.ts` hazard → Tasks 5.2-5.4; Regression guard → Phase 6; Behavioral test per site → every task's Step 1/listener assertion; Phasing → the 6 phases match the spec's list one-to-one.
 
-**Placeholder scan:** two intentional exceptions, both explicitly called out as research-required rather than left silent: Task 4.2's `// arrange` comments (branch-selecting inputs for `attemptInfiltration` depend on that function's real signature, which this plan-writing pass did not read) and Task 3.1's `someTechId` line (depends on `turn-flow-controller.test.ts`'s existing idle-research fixture, not read during this pass). Both are marked as "resolve before this task's Step 1 is complete, do not commit as-is" rather than left as ordinary steps — an implementer following `superpowers:executing-plans` must treat these two as blocking sub-steps, not skip them.
+**Placeholder scan:** clean as of the second review pass below — the two exceptions this section originally flagged (Task 4.2's `// arrange` comments, Task 3.1's `someTechId` line) have both been resolved with real, verified code; see that pass's findings for what replaced them.
 
 **Type consistency:** `GameState | void` is used consistently for the 4 `city-panel.ts` callbacks (Task 5.2) and their `panel-actions-controller.ts` implementations (Task 5.3) — matching the pre-existing `onSetCityFocus`/`onToggleWorkedTile`/`onRushBuyActiveProduction` shape exactly, not a new convention. `session.commit(next: GameState)` and `session.update(fn: (state: GameState) => GameState): void` are used with consistent signatures across every task, matching `src/app/ports.ts`'s existing `GameSession` interface (unchanged by this plan). Every task's `deps.session`/`session` naming matches its file's actual factory-parameter convention (`deps.session.getState()` in `player-action-controller.ts`, `panel-actions-controller.ts`, `campaign-entry-controller.ts`; bare `session.getState()` in `selection-controller.ts`, `turn-flow-controller.ts` — confirmed against the actual source reads this plan is based on, not assumed uniform).
+
+## Second Review Pass (2026-08-15)
+
+A follow-up inline review across gameplay/UX/architecture/SOLID/TypeScript dimensions verified every guessed API call in this plan against the real source (not re-derived from memory) and fixed what didn't match. All fixes below are applied inline above, not left as open items.
+
+**Confirmed not applicable, checked rather than assumed:** gameplay balance, fun, new mechanics, player ages 7-43, play styles, difficulty modes, and SFX — this plan only changes *when* already-correct state mutations get published, never *what* they compute, so none of these dimensions have any surface here. Computer players — confirmed via `grep -rln "app/controllers" src/ai/` returning empty that AI turn processing never touches any of the 6 files this plan modifies. Data/saved games — no `GameState` field is added, removed, or retyped by any task, so no save-migration entry is needed anywhere in this plan.
+
+**Real bugs found in this plan's own code and fixed:**
+
+1. **Invalid TypeScript literal, used twice.** `CouncilTalkLevel` (`src/core/types.ts:1540`) is `'quiet' | 'normal' | 'chatty' | 'chaos'` — Tasks 2.1 and 5.1 both used `'verbose'`, which isn't a member of that union and would fail to typecheck. Fixed to `'chatty'` in both.
+2. **Wrong callback name.** Task 5.1 invented `onSetTalkLevel`; the real callback (`src/ui/council-panel.ts:7`, wired at `panel-actions-controller.ts:489`) is `onTalkLevelChange`. Fixed, and the task's "current code" block now matches the real file exactly instead of a paraphrase.
+3. **Invalid `SpyStatus` literal.** Task 5.7's `onVerifyAgent` test used `status: 'suspected'`, not a member of `SpyStatus` (`src/core/types.ts:816-823`). Fixed to `'embedded'` with `turnedBy: 'ai'` set, and the assertion now checks `turnedBy` is cleared (`verifyAgent`'s actual effect) instead of only checking a listener fired — the original assertion didn't verify the function did anything.
+4. **A test harness that would never have compiled.** Task 3.1 assumed `createRequiredChoicePanel` was mocked, following the pattern used in every other phase's tests. It isn't — `turn-flow-controller.test.ts` renders it for real (confirmed: no `vi.mock` for that module exists, and an existing test in the same file already asserts against the real `#required-choice-panel` DOM node). Mocking it as originally drafted would have broken that existing test. Rewrote Task 3.1 to drive the real rendered panel via DOM clicks, using a `findSectionButton` helper keyed off the panel's `<h3>` section headings (the only stable anchor available — no `id`/`data-*` attributes exist on individual choice buttons).
+5. **An entire phase built on the wrong test-file convention.** Every test in Tasks 4.1-4.4 assumed `selection-controller.test.ts` uses the same mocked-panel-plus-`mockedCallArg` pattern as the other controller test files. It doesn't: no `mockedCallArg` helper, no `build()` helper, no `makeCity()` helper exist in that file, and `renderSelectedUnitInfo` is never mocked there — it renders for real into a genuine `document.getElementById('info-panel')` node (confirmed from that file's own existing tests). Rewrote Tasks 4.1-4.4 to use the file's real helpers (`makeFixture()` with no args, `baseDeps`, `createSelectionController`) and real DOM interaction (a `findButtonByText` helper, `document.body.innerHTML` setup) instead of a mocked panel that was never going to exist.
+6. **A test that could never pass or fail meaningfully.** Task 4.2's four branch tests left `// arrange` comments describing research to do rather than code, and referenced an undefined `options` variable. `attemptInfiltration`'s branch is seeded by `` `infiltrate-${uid}-turn` `` and its own system-level test suite (`tests/systems/espionage-infiltration.test.ts:126-132`) already solves forcing each branch deterministically with a `tryUntil`-over-candidate-seeds helper — reused that exact idiom one level up (`tryUntilInfiltrate`, varying `uid` instead of a raw seed, since the controller can't take a seed directly) instead of inventing a new mechanism.
+7. **Wrong disguise-picker assumptions.** Task 4.1 used `unitType: 'spy_scout'` and asserted a field called `disguisedAs`. `spy_scout` is disguise tier 0, which only ever offers "No Disguise" and never renders the picker at all (`src/ui/selected-unit-info.ts:772-805`) — switched to `spy_informant` (tier 1) so "As Warrior" is a real clickable option. The field is `disguiseAs` (`src/core/types.ts:884`), not `disguisedAs`.
+8. **Three unresolved `window.prompt` hedges.** Tasks 5.6 and 5.7's tests noted that `chooseFriendlyCityTarget`/`chooseForeignCityTarget`/`chooseMission` "likely" use `window.prompt` without stubbing it — jsdom's `window.prompt` returns `null` unless stubbed, so these tests would have failed at the `if (!selection) return null;`/`if (!mission) return;` guard before ever reaching the mutation under test. Verified all three follow the identical `window.prompt(msg, choices[0])` shape (`panel-actions-controller.ts:799-863`) and added one generic stub (`vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null)`) that resolves all three without hardcoding a specific city/mission id.
+9. **Non-existent test helper.** Task 4.3 referenced `makeCity()`, which doesn't exist in `selection-controller.test.ts`. Switched to the template-borrow pattern (`Object.values(state.cities)[0]!` + override) already established in this same plan's `turn-flow-controller.test.ts` tasks, rather than introducing a one-off helper found nowhere else in the file.
+10. **A stale hedge resolved to "no action needed."** Task 4.4 flagged `applyAutoExploreOrder`'s return-value handling as unverified. Its real signature (`src/systems/auto-explore-system.ts:93-97`) returns `ExecuteUnitMoveResult | null` and the *original* code already discards that return value without applying it — confirmed this is pre-existing, out-of-scope behavior the task should preserve verbatim, not something this task needs to fix.
+
+**Architecture/SOLID note deliberately not changed:** Task 4.2's rewrite tests each branch's distinguishing state directly rather than re-asserting a `session.subscribe` listener fires on all 4 — the publish-plumbing this whole audit is about is already proven once per handler by Tasks 4.1 and 4.3 (which share the same `session.commit` call path `onInfiltrate` uses), so repeating that assertion 4 more times in the same handler would be redundant coverage of the same fact, not stronger evidence of it.

--- a/docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md
+++ b/docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md
@@ -25,11 +25,17 @@ cases, manually call `renderLoop.setGameState(session.getState())` to patch
 over the missing publish.
 
 Because `renderLoop.setGameState` is called by hand but `hud.update()` is not,
-**every one of these 44 sites silently skips the HUD refresh.** The renderer
-catches up; the HUD (yield rates, notifications, turn counter — see
-`CLAUDE.md`'s "HUD should show per-turn yield rates... not just totals") does
-not, until some unrelated later action happens to call `commit`/`update` and
-catch it up incidentally.
+**most of these sites silently skip the HUD refresh** — but not uniformly; see
+"Severity is uneven" below. Where the HUD is skipped, it (yield rates,
+notifications, turn counter — see `CLAUDE.md`'s "HUD should show per-turn
+yield rates... not just totals") stays stale until some unrelated later
+action happens to call `commit`/`update` and catch it up incidentally.
+
+**Second-pass review (2026-08-15) found a sharper problem than HUD lag: at
+least one panel's own refresh currently works only *because* of the mutation
+bug, not despite it** — see "Fix pattern" and the `city-panel.ts` scope note
+below. Naively converting those sites would regress a currently-working
+surface into a stale one.
 
 This is separate from the **already in-flight** `#787` Phase 14
 (`setStateWithoutRefresh` debt audit — "14a" landed as of `db578fc9`). Phase 14
@@ -59,20 +65,24 @@ deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivI
 
 ## Full inventory (verified 2026-08-15, re-run before each phase per repo convention)
 
-| File | Sites | Shape | Notes |
-|---|---|---|---|
-| `src/app/controllers/player-action-controller.ts` | 4 | B×2, A×2 | L264-265 (`ensurePlayerWarState`, both civs), L276 (`restAction`), L439 (post-move unit) |
-| `src/app/controllers/campaign-entry-controller.ts` | 2 | A×2 | L237, L257 — duplicate `settings.councilTalkLevel` branches |
-| `src/app/controllers/turn-flow-controller.ts` | 2 | B×1, A×1 | L261 (tech queue), L268 (city production) |
-| `src/app/controllers/selection-controller.ts` | 15 | A×15 | Espionage actions (disguise, infiltrate, embed) + unit-automation clear/rest, all under a `session`-scoped closure |
-| `src/app/controllers/panel-actions-controller.ts` | 21 | B×3, A×18 | Espionage panel (embed/mission/recall/verify/spawn), city production (enqueue/reorder/idle-mode/focus), tech queue (B-shape, mirrors turn-flow-controller), settings |
-| `src/app/cross-cutting-helpers.ts` | 0 direct | — | Root-cause helper (`getCurrentCiv`) enabling all Shape-B sites above; not itself a mutation site |
-| **Total** | **44** | | |
+| File | Sites | Shape | Currently observable staleness | Notes |
+|---|---|---|---|---|
+| `src/app/controllers/player-action-controller.ts` | 4 | B×2, A×2 | HUD only (L264-267, L276); **neither** at L439 — `executeMinorCivConquest` already calls `hud.update()` manually at L447, so that site is architecture-debt only, not a live bug | L264-265 (`ensurePlayerWarState`, both civs — chains into a trailing `setStateWithoutRefresh` at L267, see Fix pattern), L276 (`restAction`), L439 (post-move unit, part of `executeMinorCivConquest`) |
+| `src/app/controllers/campaign-entry-controller.ts` | 2 | A×2 | HUD only | L237, L257 — duplicate `settings.councilTalkLevel` branches |
+| `src/app/controllers/turn-flow-controller.ts` | 2 | B×1, A×1 | **Neither** — `refreshRequiredChoicesAfterAction` (L188-192) already calls `renderLoop.setGameState` + `updateHUD()` manually right after both flagged sites; architecture-debt only | L261 (tech queue), L268 (city production) |
+| `src/app/controllers/selection-controller.ts` | 15 | A×15 | HUD, need per-site re-check during Phase 4 — not individually verified in this review pass | Espionage actions (disguise, infiltrate, embed) + unit-automation clear/rest, all under a `session`-scoped closure |
+| `src/app/controllers/panel-actions-controller.ts` | 21 | B×3, A×18 | HUD only for espionage sites (867-1019 — `deps.router.open('espionage')` fully rebuilds that panel from fresh state each time, so no panel-staleness risk there); **HUD + open-panel** for the 4 city-production sites (L665, L677, L683, L741) — see next section | Espionage panel (embed/mission/recall/verify/spawn), city production (enqueue/reorder/idle-mode/focus), tech queue (B-shape, mirrors turn-flow-controller), settings |
+| `src/app/cross-cutting-helpers.ts` | 0 direct | — | — | Root-cause helper (`getCurrentCiv`) enabling all Shape-B sites above; not itself a mutation site |
+| **Total** | **44** | | | |
 
 Exact line numbers are recorded in each phase's own PR (grep drifts between
 phases the same way Phase 14's 66-site count drifted from its original 46-site
 estimate — re-run the inventory grep at the start of each phase, don't trust
-this table's line numbers verbatim once other phases have landed).
+this table's line numbers verbatim once other phases have landed). The
+"currently observable staleness" column is a spot-check from this review
+pass, not an exhaustive per-site audit — each phase must verify its own
+sites' actual severity before writing PR-body claims, rather than assuming
+uniform HUD-only staleness (`spec-fidelity.md`'s overclaiming concern).
 
 Inventory greps used (rerun with `--include="*.ts"` from repo root):
 ```
@@ -85,7 +95,10 @@ grep -rn "currentCiv()\." src/app/ | grep -v "\.diplomacy\b"
 
 ## Scope
 
-**In scope:** the 6 files above.
+**In scope:** the 6 files above, **plus `src/ui/city-panel.ts`** (added in
+review — see "Fix pattern" below; not a `getState()` mutation site itself,
+but its callback contract must change in lockstep with 4 of
+`panel-actions-controller.ts`'s sites or Phase 5 introduces a regression).
 
 **Out of scope, deliberately:**
 - `src/systems/**`, `src/ai/**`, `src/core/**` — these functions take a local
@@ -160,6 +173,55 @@ its own line in the PR body**, not a silent bundle. Where a call site's
 `commit`/`update` now does it), delete the now-redundant manual call rather
 than leaving both.
 
+**Trace chained writes to the real terminal state-write before converting.**
+A flagged mutation is sometimes followed, in the same function, by a further
+non-refreshing write (`setStateWithoutRefresh`, or a second mutation) that
+would silently absorb the fix if only the flagged line is touched.
+Concretely: `ensurePlayerWarState` ([player-action-controller.ts:256-268](../../../src/app/controllers/player-action-controller.ts))
+mutates both civs' `.diplomacy` (Shape B, the flagged lines) and *then* calls
+`deps.session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(...))`
+— converting only the two flagged lines leaves the function's actual final
+state-write non-publishing. The correct fix unifies all three writes
+(attacker diplomacy, defender diplomacy, opportunistic-penalty) into one
+`session.update(state => ...)` call. Before converting any site, read the
+enclosing function to its actual end, not just the flagged line.
+
+**`city-panel.ts`'s four queue callbacks need a matching contract change, not
+just a mutation fix.** `onBuild`, `onMoveQueueItem`, `onRemoveQueueItem`, and
+`onSetIdleProduction` ([city-panel.ts:72-90](../../../src/ui/city-panel.ts))
+currently return `void`, and their handler in `city-panel.ts` calls bare
+`rerenderPanel()` — which defaults its `nextState` parameter to a **closure
+variable captured once when the panel opened**
+([city-panel.ts:1384](../../../src/ui/city-panel.ts)). Today the panel shows
+fresh data after these actions only because the flagged in-place mutation
+writes onto the exact same object that closure already points to — the panel
+refresh currently works *by accident of shared reference*, not by design.
+Converting `panel-actions-controller.ts`'s corresponding 4 sites (L665, L677,
+L683, L741) to genuine `session.commit()` (a new object) **without** also
+widening those 4 callback signatures to `GameState | void` and passing the
+result to `rerenderPanel(nextState)` — the pattern `onSetCityFocus` /
+`onToggleWorkedTile` / `onRushBuyActiveProduction` already use correctly
+([city-panel.ts:76-95](../../../src/ui/city-panel.ts)) — **regresses a
+currently-working panel into a stale one**, violating
+`.claude/rules/ui-panels.md`'s explicit rule: *"If a panel action mutates
+state that the same panel renders, the visible panel must refresh
+immediately... Updating only global state/HUD while leaving the open panel
+stale is a bug."* Phase 5 must convert these 4 sites and their `city-panel.ts`
+wiring together, in the same commit.
+
+**The existing test for this exact path is coupled to the bug and must be
+rewritten, not extended.** `panel-actions-controller.test.ts`'s "queues real
+production via the live city state and refreshes the renderer" test asserts
+`state.cities['test-city'].productionQueue` against the *outer* fixture
+variable, which only stays in sync with `deps.session.getState()` today
+because of the same in-place-mutation shortcut — and it mocks `createCityPanel`,
+so it cannot currently prove the visible panel re-renders either way. Phase 5
+must rewrite this assertion to read `deps.session.getState()` directly, and
+add real coverage that `createCityPanel` gets re-invoked with the fresh city
+after `onBuild`/`onMoveQueueItem`/`onRemoveQueueItem`/`onSetIdleProduction`
+(matching `docs/superpowers/plans/README.md`'s "test what the player sees,
+not just what state changed").
+
 ## Regression guard
 
 Add a new `it` block to `tests/app/architecture-boundaries.test.ts` (same file
@@ -171,6 +233,15 @@ counter that can only move one direction, same framing as this repo's other
 source-grep ratchets (e.g. the retired `refresh-bypass-ratchet.test.ts`) — add
 it in the **last** phase, once the count is verified at zero, so it isn't
 failing mid-arc.
+
+**Real-time backstop (recommended, cheaper than the test):**
+`.claude/hooks/check-src-edit.sh` already has a PostToolUse check for direct
+state mutation (`state\.(cities|units|civilizations)\[[^]]+\]\s*=`), but it's
+scoped to a bare `state` variable — the turn-processing convention — and does
+not match `getState()` chains, so it currently gives zero real-time feedback
+on this exact bug class. Add a companion block there in the same phase as the
+boundary test, mirroring the existing pattern, so future violations are
+caught at edit time instead of only at `yarn test` time.
 
 ## Behavioral test per site
 
@@ -197,13 +268,21 @@ convention (`#787` Phase 8a-d, 10b-a..g, 14):
    state update needs that guard).
 4. **`selection-controller.ts`** (15 sites) — heaviest single-domain
    (espionage + unit-automation), no turn-flow risk.
-5. **`panel-actions-controller.ts`** (21 sites) — heaviest overall (espionage
-   panel + city production + tech queue).
-6. **Regression guard** — add the boundary test from a verified zero count,
-   close the arc.
+5. **`panel-actions-controller.ts`** (21 sites) **+ `src/ui/city-panel.ts`**
+   — heaviest overall (espionage panel + city production + tech queue). The 4
+   city-production sites must land together with `city-panel.ts`'s callback
+   contract change (see "Fix pattern") and the rewrite of
+   `panel-actions-controller.test.ts`'s coupled queue test — not as follow-up
+   work, since shipping the mutation fix alone regresses the open panel.
+6. **Regression guard** — add the `architecture-boundaries.test.ts` boundary
+   test and the `check-src-edit.sh` real-time check (see "Regression guard"),
+   from a verified zero count, close the arc.
 
 Every phase runs `yarn build` and `yarn test` (per `CLAUDE.md`); Phase 3 also
-runs `yarn test:ai-playability`.
+runs `yarn test:ai-playability`. Phase 1 and Phase 5 each require reading
+their flagged functions to their actual end (not just the flagged line) per
+the chained-write note in "Fix pattern," since both phases contain a
+confirmed instance of that hazard.
 
 ## Risks
 
@@ -212,3 +291,6 @@ runs `yarn test:ai-playability`.
 | Inventory drifts between phases (new mutation sites added by unrelated feature work landing concurrently) | Re-run the inventory greps at the start of each phase, same practice Phase 14 uses |
 | A site's manual `renderLoop.setGameState()` call is deleted but the conversion misses a case where `renderLoop` and `hud` genuinely need different timing | Behavioral test asserts both subscribers fire; if a site turns out to need to stay split, document why at that site rather than silently leaving old code in place |
 | Converting a Shape-B site changes `getCurrentCiv()`'s contract for its other (read-only) callers | Explicitly not changing the helper's shape — only the 6 mutating call sites change, verified by grep before each phase closes |
+| **(found in review) Converting a flagged mutation without checking for a trailing non-refreshing write in the same function leaves the real bug unfixed while looking fixed** | "Trace chained writes to the real terminal state-write" requirement in Fix pattern; confirmed instance at `ensurePlayerWarState` |
+| **(found in review) A panel whose refresh currently works only via shared-object-reference "regresses to stale" once the underlying mutation becomes a genuine copy** | `city-panel.ts`'s 4 queue callbacks scoped into Phase 5 explicitly, converted in the same commit as their `panel-actions-controller.ts` call sites; searched all of `src/ui/*.ts` for the same `GameState \| void = state`-default pattern and confirmed `city-panel.ts` is the only file with this specific hazard shape |
+| **(found in review) The one existing test for the city-production queue path is coupled to the mutation bug and would give a false pass or false regression signal either way** | Phase 5 rewrites (not extends) that test to assert against `deps.session.getState()` and to prove `createCityPanel` is re-invoked with fresh data |

--- a/docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md
+++ b/docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md
@@ -1,0 +1,214 @@
+# GameSession state-mutation audit — design
+
+**Status:** approved for planning (2026-08-15). Feeds `writing-plans` next.
+
+## Problem
+
+`GameSession` (`src/app/game-session.ts`) is documented in `src/app/ports.ts` as
+"the single owner of game state" and states that `commit()` is "the ONLY correct
+way to publish a state change to the player." In practice, it has exactly two
+subscribers, wired once in `src/app/bootstrap.ts:454-455`:
+
+```ts
+session.subscribe(next => renderLoop.setGameState(next));
+session.subscribe(() => hud.update());
+```
+
+Both fire only when `session.commit(next)` or `session.update(fn)` runs.
+
+A full-repo grep of every `getState()` call site (`grep -rln "getState()" src/`,
+25 files, ~700 call sites, cross-checked against mutation-shaped regexes) found
+**44 sites across 6 app-layer files** that instead mutate the object returned
+by `session.getState()` directly — an assignment, a `delete`, or a mutating
+array method (`.push`) applied straight through the reference — then, in most
+cases, manually call `renderLoop.setGameState(session.getState())` to patch
+over the missing publish.
+
+Because `renderLoop.setGameState` is called by hand but `hud.update()` is not,
+**every one of these 44 sites silently skips the HUD refresh.** The renderer
+catches up; the HUD (yield rates, notifications, turn counter — see
+`CLAUDE.md`'s "HUD should show per-turn yield rates... not just totals") does
+not, until some unrelated later action happens to call `commit`/`update` and
+catch it up incidentally.
+
+This is separate from the **already in-flight** `#787` Phase 14
+(`setStateWithoutRefresh` debt audit — "14a" landed as of `db578fc9`). Phase 14
+audits call sites that go *through* the `GameSession` API (`setStateWithoutRefresh`)
+but intentionally skip the refresh, then decides per-site whether that's a bug.
+This audit is calls that bypass the API's write path (`commit`/`update`/
+`setStateWithoutRefresh`) *entirely*, mutating the live object out from under
+the session. The two debts share files and reviewers should expect some of
+Phase 14's remaining sites and this audit's sites to sit a few lines apart in
+the same functions, but they are different bugs with different fixes.
+
+## Two mutation shapes found
+
+**Shape A — direct write-through** (the majority, ~38 of 44 sites):
+```ts
+deps.session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
+deps.renderLoop.setGameState(deps.session.getState());   // hud.update() never runs
+```
+
+**Shape B — aliased-reference write** (6 sites, all routed through
+`getCurrentCiv()`/`deps.currentCiv()` in `src/app/cross-cutting-helpers.ts:62`,
+which returns `session.getState().civilizations[session.getState().currentPlayer]`
+— a live reference, not a copy):
+```ts
+deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivId, ...);
+```
+
+## Full inventory (verified 2026-08-15, re-run before each phase per repo convention)
+
+| File | Sites | Shape | Notes |
+|---|---|---|---|
+| `src/app/controllers/player-action-controller.ts` | 4 | B×2, A×2 | L264-265 (`ensurePlayerWarState`, both civs), L276 (`restAction`), L439 (post-move unit) |
+| `src/app/controllers/campaign-entry-controller.ts` | 2 | A×2 | L237, L257 — duplicate `settings.councilTalkLevel` branches |
+| `src/app/controllers/turn-flow-controller.ts` | 2 | B×1, A×1 | L261 (tech queue), L268 (city production) |
+| `src/app/controllers/selection-controller.ts` | 15 | A×15 | Espionage actions (disguise, infiltrate, embed) + unit-automation clear/rest, all under a `session`-scoped closure |
+| `src/app/controllers/panel-actions-controller.ts` | 21 | B×3, A×18 | Espionage panel (embed/mission/recall/verify/spawn), city production (enqueue/reorder/idle-mode/focus), tech queue (B-shape, mirrors turn-flow-controller), settings |
+| `src/app/cross-cutting-helpers.ts` | 0 direct | — | Root-cause helper (`getCurrentCiv`) enabling all Shape-B sites above; not itself a mutation site |
+| **Total** | **44** | | |
+
+Exact line numbers are recorded in each phase's own PR (grep drifts between
+phases the same way Phase 14's 66-site count drifted from its original 46-site
+estimate — re-run the inventory grep at the start of each phase, don't trust
+this table's line numbers verbatim once other phases have landed).
+
+Inventory greps used (rerun with `--include="*.ts"` from repo root):
+```
+grep -rnE "getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]" src/
+grep -rnE "delete [A-Za-z0-9_.]*getState\(\)" src/
+grep -rnE "getState\(\)(\.[A-Za-z0-9_]+|\[[^]]+\])+\.(push|splice|pop|shift|unshift|sort|reverse)\(" src/
+grep -rnE "\.diplomacy = (declareWar|makePeace|breakTreaty)" src/app/
+grep -rn "currentCiv()\." src/app/ | grep -v "\.diplomacy\b"
+```
+
+## Scope
+
+**In scope:** the 6 files above.
+
+**Out of scope, deliberately:**
+- `src/systems/**`, `src/ai/**`, `src/core/**` — these functions take a local
+  `state: GameState` parameter and never call `.getState()` themselves. They're
+  already governed by `.claude/rules/game-systems.md`'s "Immutable Turn
+  Processing" rule (spread-copy, return new `GameState`) and its existing test
+  coverage. Not re-audited here.
+- `src/app/game-session.ts` itself — its internal `state = fn(state)` / `state
+  = next` assignments inside `commit`/`update`/`setStateWithoutRefresh` are the
+  one sanctioned mutation path; that's what makes it "the single owner."
+- The ~650 *read-only* `getState()` call sites across the other 19 files
+  surfaced by the initial grep (`bootstrap.ts`, `game-session-controller.ts`,
+  `hud-controller.ts`, `map-interaction-controller.ts`, `diplomacy-actions-controller.ts`,
+  every `src/presentation/register-*.ts`, `src/ui/*.ts`, `src/audio/*-director.ts`)
+  — verified by inspection to only read through `getState()`, never assign
+  through it. Not touched.
+- `#787` Phase 14's `setStateWithoutRefresh` debt — different axis, tracked in
+  its own plan (`docs/superpowers/plans/2026-08-04-composition-root-decomposition.md`
+  Phase 14), already in progress. This audit does not change any
+  `setStateWithoutRefresh` call that isn't also one of the 44 mutation sites.
+- Compile-time enforcement (`DeepReadonly<GameState>` on `getState()`'s return
+  type) — considered and rejected. Every `src/systems/**` function accepts
+  `state: GameState` by value; a readonly return type would need either an
+  unsafe cast at every one of the ~650 read call sites or a signature change
+  across every systems function that takes state — turning a bounded audit
+  into a type-system rewrite. A grep-based regression test (below) gets the
+  same "no new sites" guarantee at a fraction of the blast radius, matching
+  this repo's existing convention (`tests/app/architecture-boundaries.test.ts`
+  is the same class of check).
+
+## Fix pattern
+
+`GameSession.update(fn)` is already the "read-modify-commit" primitive this
+needs — no new `GameSession` API. Each site becomes a spread-copy building a
+new `GameState`, passed to `session.commit(next)` (when the full next state is
+already assembled) or `session.update(state => next)` (when reading fresh
+state at update time avoids a stale-read race — e.g. two rapid actions against
+the same civ). This is the same spread-copy convention
+`.claude/rules/game-systems.md` already mandates for systems code:
+
+```ts
+// before (Shape A)
+deps.session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
+deps.renderLoop.setGameState(deps.session.getState());
+
+// after
+deps.session.commit({
+  ...deps.session.getState(),
+  cities: { ...deps.session.getState().cities, [cityId]: enqueueCityProduction(targetCity, itemId) },
+});
+```
+
+```ts
+// before (Shape B)
+deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivId, turn);
+
+// after — cross-cutting-helpers.ts's getCurrentCiv() keeps its current
+// read-only convenience shape (unchanged, to avoid widening this audit's
+// blast radius into every other read-only consumer of getCurrentCiv); only
+// the two mutating call sites change to build a new civ and commit it
+const civ = deps.currentCiv();
+deps.session.update(state => ({
+  ...state,
+  civilizations: { ...state.civilizations, [civ.id]: { ...civ, diplomacy: declareWar(civ.diplomacy, targetCivId, turn) } },
+}));
+```
+
+Each conversion is a behavior fix (the HUD now refreshes where it silently
+didn't before) — same framing Phase 14 uses: **list every converted site as
+its own line in the PR body**, not a silent bundle. Where a call site's
+`renderLoop.setGameState(...)` companion call becomes redundant (because
+`commit`/`update` now does it), delete the now-redundant manual call rather
+than leaving both.
+
+## Regression guard
+
+Add a new `it` block to `tests/app/architecture-boundaries.test.ts` (same file
+and style as the existing `document.getElementById` ban), scanning
+`src/app/**`, `src/presentation/**`, and `src/ui/**` (excluding
+`src/app/game-session.ts` and `src/app/ports.ts`) for the same three regex
+shapes used in this audit's inventory. Zero matches required. This is a
+counter that can only move one direction, same framing as this repo's other
+source-grep ratchets (e.g. the retired `refresh-bypass-ratchet.test.ts`) — add
+it in the **last** phase, once the count is verified at zero, so it isn't
+failing mid-arc.
+
+## Behavioral test per site
+
+For each converted site, the phase's tests must prove a `session.subscribe`
+listener actually fires post-action — not just that `session.getState()`
+returns the expected new value. Concretely: register a test-only subscriber
+(mirroring `hud.update()`'s role) before the action, assert it was called
+after. Several controller test files already assert `renderLoop.setGameState`
+was called for these actions; extend those rather than duplicating, and add
+the missing HUD-equivalent assertion alongside.
+
+## Phasing
+
+One PR per phase, mirroring this repo's existing per-file sub-phase
+convention (`#787` Phase 8a-d, 10b-a..g, 14):
+
+1. **`cross-cutting-helpers.ts` decision + `player-action-controller.ts`** (4
+   sites) — smallest, includes both mutation shapes, sets the template other
+   phases follow.
+2. **`campaign-entry-controller.ts`** (2 sites) — trivial, quick win.
+3. **`turn-flow-controller.ts`** (2 sites) — touches turn advancement; run
+   `yarn test:ai-playability` for this phase per Part VI of the composition-root
+   plan's testing rules (any change that can shift when the HUD/AI observe a
+   state update needs that guard).
+4. **`selection-controller.ts`** (15 sites) — heaviest single-domain
+   (espionage + unit-automation), no turn-flow risk.
+5. **`panel-actions-controller.ts`** (21 sites) — heaviest overall (espionage
+   panel + city production + tech queue).
+6. **Regression guard** — add the boundary test from a verified zero count,
+   close the arc.
+
+Every phase runs `yarn build` and `yarn test` (per `CLAUDE.md`); Phase 3 also
+runs `yarn test:ai-playability`.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Inventory drifts between phases (new mutation sites added by unrelated feature work landing concurrently) | Re-run the inventory greps at the start of each phase, same practice Phase 14 uses |
+| A site's manual `renderLoop.setGameState()` call is deleted but the conversion misses a case where `renderLoop` and `hud` genuinely need different timing | Behavioral test asserts both subscribers fire; if a site turns out to need to stay split, document why at that site rather than silently leaving old code in place |
+| Converting a Shape-B site changes `getCurrentCiv()`'s contract for its other (read-only) callers | Explicitly not changing the helper's shape — only the 6 mutating call sites change, verified by grep before each phase closes |

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -258,13 +258,21 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     if (!targetCiv || !isMajorCivOwner(targetCivId)) return;
 
     const cp = deps.session.getState().currentPlayer;
-    const alreadyAtWar = deps.currentCiv().diplomacy?.atWarWith.includes(targetCivId) ?? false;
+    const attackerCiv = deps.currentCiv();
+    const alreadyAtWar = attackerCiv.diplomacy?.atWarWith.includes(targetCivId) ?? false;
     if (alreadyAtWar) return;
 
-    deps.currentCiv().diplomacy = declareWar(deps.currentCiv().diplomacy, targetCivId, deps.session.getState().turn);
-    targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, deps.session.getState().turn);
+    const turn = deps.session.getState().turn;
+    const withDeclaredWar = {
+      ...deps.session.getState(),
+      civilizations: {
+        ...deps.session.getState().civilizations,
+        [cp]: { ...attackerCiv, diplomacy: declareWar(attackerCiv.diplomacy, targetCivId, turn) },
+        [targetCivId]: { ...targetCiv, diplomacy: declareWar(targetCiv.diplomacy, cp, turn) },
+      },
+    };
     deps.bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
-    deps.session.setStateWithoutRefresh(applyOpportunisticWarPenaltyIfCrisisStruck(deps.session.getState(), cp, targetCivId, deps.bus));
+    deps.session.commit(applyOpportunisticWarPenaltyIfCrisisStruck(withDeclaredWar, cp, targetCivId, deps.bus));
   }
 
   function restAction(): void {

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -263,16 +263,24 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     if (alreadyAtWar) return;
 
     const turn = deps.session.getState().turn;
-    const withDeclaredWar = {
+    // Commit the declared-war state BEFORE emitting: registerDiplomacyPresentation's
+    // 'diplomacy:war-declared' listener reads session.getState() synchronously to pick
+    // a notification reason from the post-declareWar relationship score (declareWar
+    // applies a -50 relationship hit, and describeWarReason's bands sit at -50/-20/0 --
+    // tight enough that reading pre-war state there would show the wrong reason).
+    // The opportunistic-crisis penalty below is a separate, later state stage and must
+    // not be visible to that listener either, matching this function's original
+    // (accidental, in-place-mutation-order) behavior exactly.
+    deps.session.commit({
       ...deps.session.getState(),
       civilizations: {
         ...deps.session.getState().civilizations,
         [cp]: { ...attackerCiv, diplomacy: declareWar(attackerCiv.diplomacy, targetCivId, turn) },
         [targetCivId]: { ...targetCiv, diplomacy: declareWar(targetCiv.diplomacy, cp, turn) },
       },
-    };
+    });
     deps.bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
-    deps.session.commit(applyOpportunisticWarPenaltyIfCrisisStruck(withDeclaredWar, cp, targetCivId, deps.bus));
+    deps.session.commit(applyOpportunisticWarPenaltyIfCrisisStruck(deps.session.getState(), cp, targetCivId, deps.bus));
   }
 
   function restAction(): void {

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -447,9 +447,11 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     }));
     if (!movement.ok) return;
     const movedUnit = deps.session.getState().units[unitId];
-    if (movedUnit) deps.session.getState().units[unitId] = { ...movedUnit, movementPointsLeft: 0 };
-    const conquered = conquestMinorCiv(deps.session.getState(), minorCivId, deps.session.getState().currentPlayer);
-    deps.session.setStateWithoutRefresh(conquered.state);
+    const stateAfterMove = movedUnit
+      ? { ...deps.session.getState(), units: { ...deps.session.getState().units, [unitId]: { ...movedUnit, movementPointsLeft: 0 } } }
+      : deps.session.getState();
+    const conquered = conquestMinorCiv(stateAfterMove, minorCivId, stateAfterMove.currentPlayer);
+    deps.session.commit(conquered.state);
     emitMinorCivQuestTransitions(deps.bus, conquered.transitions, deps.session.getState());
     if (conquered.conquered) deps.bus.emit('minor-civ:destroyed', { minorCivId, conquerorId: deps.session.getState().currentPlayer });
     deps.showNotification(`${cityName} has been conquered!`, 'success');

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -281,7 +281,10 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     const unit = deps.session.getState().units[selectedUnitId];
     if (!unit || !canHeal(unit)) return;
 
-    deps.session.getState().units[selectedUnitId] = restUnit(unit);
+    deps.session.commit({
+      ...deps.session.getState(),
+      units: { ...deps.session.getState().units, [selectedUnitId]: restUnit(unit) },
+    });
     deps.showNotification(`${UNIT_DEFINITIONS[unit.type].name} is resting and will heal +15 HP next turn`, 'info');
     deps.selectionController.deselectUnit();
     deps.renderLoop.setGameState(deps.session.getState());

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -321,10 +321,12 @@ describe('PlayerActionController', () => {
       expect(deps.session.getState().units['warrior-1'].isResting).toBeFalsy();
     });
 
-    it('rests a real damaged unit, heals via restUnit, and deselects', () => {
+    it('rests a real damaged unit, heals via restUnit, deselects, and publishes to subscribers', () => {
       const { state } = makeFixture('rest-damaged');
       placeUnit(state, 'warrior', 'warrior-1', { q: 0, r: 0 }, { health: 50 });
       const { deps, controller } = build(state, { selection: { getSelectedUnitId: vi.fn(() => 'warrior-1'), setPendingIntent: vi.fn() } });
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
 
       controller.restAction();
 
@@ -332,6 +334,7 @@ describe('PlayerActionController', () => {
       expect(deps.selectionController.deselectUnit).toHaveBeenCalledTimes(1);
       expect(deps.renderLoop.setGameState).toHaveBeenCalled();
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('heal'), 'info');
+      expect(listener).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -296,8 +296,34 @@ describe('PlayerActionController', () => {
 
       controller.ensurePlayerWarState(aiCivId);
 
-      expect(listener).toHaveBeenCalledTimes(1);
-      expect(listener).toHaveBeenCalledWith(deps.session.getState());
+      // Two publishes by design: the declared-war state, then the (possibly
+      // no-op) opportunistic-penalty state -- see the ordering test below for why
+      // the first commit must land before the 'diplomacy:war-declared' emit.
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(deps.session.getState());
+    });
+
+    it('has already published the declared war (including its relationship penalty) by the time diplomacy:war-declared fires', () => {
+      // registerDiplomacyPresentation's real listener for this event reads
+      // session.getState() synchronously to pick a notification reason from the
+      // post-declareWar relationship score (declareWar applies a -50 relationship
+      // hit). This test proves that invariant directly, without needing to wire
+      // the full presentation registrar.
+      const { state, aiCivId } = makeFixture('war-state-declared-visible-at-emit');
+      const relationshipBefore = state.civilizations[aiCivId].diplomacy.relationships['player'] ?? 0;
+      const { deps, controller } = build(state);
+      let relationshipAtEmitTime: number | undefined;
+      let atWarAtEmitTime = false;
+      deps.bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
+        const emitTimeState = deps.session.getState();
+        relationshipAtEmitTime = emitTimeState.civilizations[defenderId]?.diplomacy?.relationships[attackerId];
+        atWarAtEmitTime = emitTimeState.civilizations[attackerId].diplomacy.atWarWith.includes(defenderId);
+      });
+
+      controller.ensurePlayerWarState(aiCivId);
+
+      expect(atWarAtEmitTime).toBe(true);
+      expect(relationshipAtEmitTime).toBeLessThanOrEqual(relationshipBefore - 50);
     });
   });
 

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -287,6 +287,18 @@ describe('PlayerActionController', () => {
 
       expect(deps.session.getState().civilizations.player.diplomacy.atWarWith).toEqual([]);
     });
+
+    it('publishes the war declaration to session subscribers, not just the renderer', () => {
+      const { state, aiCivId } = makeFixture('war-state-publishes');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.ensurePlayerWarState(aiCivId);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(deps.session.getState());
+    });
   });
 
   describe('restAction', () => {

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -588,19 +588,24 @@ describe('PlayerActionController', () => {
       expect(deps.hud.update).not.toHaveBeenCalled();
     });
 
-    it('conquers the minor civ and transfers its city after a successful movement', () => {
+    it('conquers the minor civ, transfers its city, publishes once, and clears the mover\'s movement points', () => {
       const { state } = makeFixture('minor-civ-conquest-success');
       const mcId = Object.keys(state.minorCivs)[0]!;
       const cityId = state.minorCivs[mcId].cityId;
+      placeUnit(state, 'warrior', 'attacker-1', { q: 0, r: 0 });
       const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
 
       controller.executeMinorCivConquest('attacker-1', { q: 0, r: 0 }, mcId, cityId);
 
       const updated = deps.session.getState();
       expect(updated.minorCivs[mcId].isDestroyed).toBe(true);
       expect(updated.cities[cityId]?.owner).toBe('player');
+      expect(updated.units['attacker-1']?.movementPointsLeft).toBe(0);
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('conquered'), 'success');
       expect(deps.hud.update).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 1 of the GameSession state-mutation audit (spec: `docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md`, plan: `docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md`).

`GameSession` has exactly two subscribers (`renderLoop.setGameState`, `hud.update()`), wired only through `session.commit()`/`session.update()`. This PR fixes the 4 sites in `player-action-controller.ts` that instead mutated the object returned by `session.getState()` directly, bypassing that publish path.

Each converted site is its own fix:

1. **`ensurePlayerWarState`** — both civs' `.diplomacy` were mutated directly on the live state object, and the function's real terminal write (the opportunistic-war-penalty result) went through `setStateWithoutRefresh`, so even fixing the two mutation lines alone would never have published. Unified into two `session.commit()` calls: one for the declared-war state (needed *before* the `diplomacy:war-declared` event, since `registerDiplomacyPresentation`'s listener reads `session.getState()` synchronously to pick a notification reason from the post-`declareWar` relationship score — verified during review that the old buggy in-place-mutation code accidentally got this ordering right, and a naive single-commit-after-emit fix would have shown the wrong war-declared reason to the player), then one for the opportunistic-penalty state.
2. **`restAction`** — the resting unit was written directly into `session.getState().units[...]`; now built via spread and committed.
3. **`executeMinorCivConquest`** — the post-move unit mutation is now threaded explicitly into `conquestMinorCiv`'s input state and the result committed, instead of mutating in place then discarding the publish via `setStateWithoutRefresh`.

`src/app/cross-cutting-helpers.ts`'s `getCurrentCiv()` was deliberately left unchanged (per the design's scope decision) — only its 2 mutating call sites in this file were converted.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` (full suite, 486 files / 7965 tests) — passes
- [x] New test proving `ensurePlayerWarState` publishes to `session.subscribe` listeners
- [x] New test proving the war-declared event ordering invariant directly (state already reflects the war, including its relationship penalty, by the time the event fires)
- [x] Extended `restAction` and `executeMinorCivConquest` tests to assert publish behavior
- [x] Re-ran the inventory grep against `player-action-controller.ts` — 0 remaining direct-mutation-through-`getState()` sites

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>