### PR TITLE
fix(787): GameSession state-mutation audit — Phase 2 (campaign-entry-controller.ts)

### DIFF
--- a/src/app/controllers/campaign-entry-controller.ts
+++ b/src/app/controllers/campaign-entry-controller.ts
@@ -220,7 +220,7 @@ export function createCampaignEntryController(deps: CampaignEntryControllerDeps)
         showCampaignSetup(deps.uiLayer, {
           initialTitle: title,
           onStartSolo: (config) => {
-            deps.session.setStateWithoutRefresh(createNewGame({
+            const newGame = createNewGame({
               civType: config.civType,
               mapSize: config.mapSize,
               opponentCount: config.opponentCount,
@@ -232,10 +232,12 @@ export function createCampaignEntryController(deps: CampaignEntryControllerDeps)
               mapScript: config.mapScript,
               startPlacementMode: config.startPlacementMode,
               opponentChallenge: config.opponentChallenge,
-            }));
-            if (currentSettings.councilTalkLevel) {
-              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
-            }
+            });
+            deps.session.setStateWithoutRefresh(
+              currentSettings.councilTalkLevel
+                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
+                : newGame,
+            );
             deps.startGame();
           },
           onCustomCivilizationsChanged: (customCivilizations) => {
@@ -252,10 +254,12 @@ export function createCampaignEntryController(deps: CampaignEntryControllerDeps)
         modePanel.remove();
         showHotSeatSetup(deps.uiLayer, {
           onComplete: (config, opponentChallenge) => {
-            deps.session.setStateWithoutRefresh(createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard'));
-            if (currentSettings.councilTalkLevel) {
-              deps.session.getState().settings.councilTalkLevel = currentSettings.councilTalkLevel;
-            }
+            const newGame = createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard');
+            deps.session.setStateWithoutRefresh(
+              currentSettings.councilTalkLevel
+                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
+                : newGame,
+            );
             enterCampaign(
               deps.session.getState(),
               `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,

--- a/src/app/controllers/campaign-entry-controller.ts
+++ b/src/app/controllers/campaign-entry-controller.ts
@@ -31,7 +31,7 @@ import {
   loadSaveEntry,
   rewriteLoadedSaveEntry,
 } from '@/storage/save-manager';
-import { applyPersistedUserSettings } from '@/storage/settings-merge';
+import { applyPersistedUserSettings, applyCouncilTalkLevelOverride } from '@/storage/settings-merge';
 import { createSavePanel } from '@/ui/save-panel';
 import { showGameModeSelect } from '@/ui/game-mode-select';
 import { showCampaignSetup } from '@/ui/campaign-setup';
@@ -233,11 +233,7 @@ export function createCampaignEntryController(deps: CampaignEntryControllerDeps)
               startPlacementMode: config.startPlacementMode,
               opponentChallenge: config.opponentChallenge,
             });
-            deps.session.setStateWithoutRefresh(
-              currentSettings.councilTalkLevel
-                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
-                : newGame,
-            );
+            deps.session.setStateWithoutRefresh(applyCouncilTalkLevelOverride(newGame, currentSettings.councilTalkLevel));
             deps.startGame();
           },
           onCustomCivilizationsChanged: (customCivilizations) => {
@@ -255,11 +251,7 @@ export function createCampaignEntryController(deps: CampaignEntryControllerDeps)
         showHotSeatSetup(deps.uiLayer, {
           onComplete: (config, opponentChallenge) => {
             const newGame = createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard');
-            deps.session.setStateWithoutRefresh(
-              currentSettings.councilTalkLevel
-                ? { ...newGame, settings: { ...newGame.settings, councilTalkLevel: currentSettings.councilTalkLevel } }
-                : newGame,
-            );
+            deps.session.setStateWithoutRefresh(applyCouncilTalkLevelOverride(newGame, currentSettings.councilTalkLevel));
             enterCampaign(
               deps.session.getState(),
               `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,

--- a/src/storage/settings-merge.ts
+++ b/src/storage/settings-merge.ts
@@ -26,3 +26,22 @@ export function applyPersistedUserSettings(
     },
   };
 }
+
+/**
+ * Overrides a freshly constructed game's councilTalkLevel with the player's
+ * persisted preference.
+ *
+ * Distinct from `applyPersistedUserSettings` above: that function preserves an
+ * *existing save's own* councilTalkLevel and only fills in the persisted
+ * default when the save has none. A brand-new game from `createNewGame`/
+ * `createHotSeatGame` always has some default already (`'normal'`), so that
+ * guard would never fire here -- this helper must override it unconditionally
+ * whenever a persisted preference exists.
+ */
+export function applyCouncilTalkLevelOverride(
+  state: GameState,
+  councilTalkLevel: GameState['settings']['councilTalkLevel'] | undefined,
+): GameState {
+  if (!councilTalkLevel) return state;
+  return { ...state, settings: { ...state.settings, councilTalkLevel } };
+}

--- a/tests/app/controllers/campaign-entry-controller.test.ts
+++ b/tests/app/controllers/campaign-entry-controller.test.ts
@@ -369,5 +369,38 @@ describe('CampaignEntryController', () => {
       expect(deps.session.getState()).not.toBe(beforeState);
       expect(deps.session.getState().hotSeat).toBeDefined();
     });
+
+    it('the hot-seat path applies a persisted councilTalkLevel to the freshly constructed game', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state, {
+        userSettingsStore: {
+          getPersisted: () => undefined,
+          refresh: vi.fn().mockResolvedValue({ customCivilizations: [], councilTalkLevel: 'chatty' }),
+          getMasterVolume: () => 0.8,
+          setCustomCivilizations: vi.fn(),
+          getOverrides: () => ({}),
+        },
+      });
+      const campaignEntry = createCampaignEntryController(deps);
+      const callbacks = captureModeSelectCallbacks();
+      let capturedHotSeatCallbacks: hotseatSetupModule.HotSeatSetupCallbacks | undefined;
+      vi.mocked(hotseatSetupModule.showHotSeatSetup).mockImplementation((_layer, cb) => {
+        capturedHotSeatCallbacks = cb;
+      });
+
+      campaignEntry.showGameModeSelection();
+      await callbacks.onChooseHotSeat('Talkative Hot Seat Campaign');
+      expect(capturedHotSeatCallbacks).toBeDefined();
+
+      const beforeState = deps.session.getState();
+      const players: HotSeatPlayer[] = [
+        { name: 'Alice', slotId: 'player', civType: beforeState.civilizations['player'].civType, isHuman: true },
+      ];
+      const hotSeatConfig: HotSeatConfig = { playerCount: 2, mapSize: 'small', players };
+
+      capturedHotSeatCallbacks!.onComplete(hotSeatConfig, 'standard');
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('chatty');
+    });
   });
 });

--- a/tests/app/controllers/campaign-entry-controller.test.ts
+++ b/tests/app/controllers/campaign-entry-controller.test.ts
@@ -305,6 +305,41 @@ describe('CampaignEntryController', () => {
       expect(deps.startGame).toHaveBeenCalledTimes(1);
     });
 
+    it('the solo path applies a persisted councilTalkLevel to the freshly constructed game', async () => {
+      const state = makeFixture();
+      const deps = baseDeps(state, {
+        userSettingsStore: {
+          getPersisted: () => undefined,
+          refresh: vi.fn().mockResolvedValue({ customCivilizations: [], councilTalkLevel: 'chatty' }),
+          getMasterVolume: () => 0.8,
+          setCustomCivilizations: vi.fn(),
+          getOverrides: () => ({}),
+        },
+      });
+      const campaignEntry = createCampaignEntryController(deps);
+      const callbacks = captureModeSelectCallbacks();
+      let capturedSoloCallbacks: campaignSetupModule.CampaignSetupCallbacks | undefined;
+      vi.mocked(campaignSetupModule.showCampaignSetup).mockImplementation((_layer, cb) => {
+        capturedSoloCallbacks = cb;
+        return document.createElement('div');
+      });
+
+      campaignEntry.showGameModeSelection();
+      await callbacks.onChooseSolo('Talkative Council Game');
+      expect(capturedSoloCallbacks).toBeDefined();
+
+      const beforeState = deps.session.getState();
+      const soloConfig: SoloSetupConfig = {
+        civType: beforeState.civilizations['player'].civType,
+        mapSize: 'small',
+        opponentCount: 1,
+        gameTitle: 'Talkative Council Game',
+      };
+      capturedSoloCallbacks!.onStartSolo(soloConfig);
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('chatty');
+    });
+
     it('the hot-seat path constructs a new game via createHotSeatGame and persists before entering', async () => {
       const state = makeFixture();
       const deps = baseDeps(state);

--- a/tests/storage/settings-merge.test.ts
+++ b/tests/storage/settings-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyPersistedUserSettings } from '@/storage/settings-merge';
+import { applyPersistedUserSettings, applyCouncilTalkLevelOverride } from '@/storage/settings-merge';
 import type { GameState } from '@/core/types';
 
 function stateWith(councilTalkLevel?: GameState['settings']['councilTalkLevel']): GameState {
@@ -37,5 +37,34 @@ describe('applyPersistedUserSettings', () => {
     applyPersistedUserSettings(state, persistedWith('chatty'));
 
     expect(state.settings.councilTalkLevel).toBeUndefined();
+  });
+});
+
+describe('applyCouncilTalkLevelOverride', () => {
+  it("overrides a freshly constructed game's default councilTalkLevel with the persisted preference", () => {
+    // Unlike applyPersistedUserSettings, a brand-new game always has SOME
+    // default councilTalkLevel already (createNewGame sets 'normal') -- this
+    // helper must override it unconditionally, not skip because one is present.
+    const state = stateWith('normal');
+
+    const merged = applyCouncilTalkLevelOverride(state, 'chatty');
+
+    expect(merged.settings.councilTalkLevel).toBe('chatty');
+  });
+
+  it('returns the state unchanged when no councilTalkLevel is persisted', () => {
+    const state = stateWith('normal');
+
+    const merged = applyCouncilTalkLevelOverride(state, undefined);
+
+    expect(merged).toBe(state);
+  });
+
+  it('does not mutate the state it is given', () => {
+    const state = stateWith('normal');
+
+    applyCouncilTalkLevelOverride(state, 'chatty');
+
+    expect(state.settings.councilTalkLevel).toBe('normal');
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of the GameSession state-mutation audit (spec: `docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md`, plan: `docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md`). Continues from Phase 1 (#835, merged).

Fixes the 2 flagged sites in `campaign-entry-controller.ts`: `onStartSolo` and `onComplete` (hot-seat) both mutated `deps.session.getState().settings.councilTalkLevel` directly on the freshly-constructed game state, immediately after `setStateWithoutRefresh(createNewGame(...)/createHotSeatGame(...))` had already replaced the state object. Architecture-cleanliness only, not a live user-facing bug — settings are never visible before the first real publish (`enterCampaign`/`startGame`) that follows these two sites.

**Found during review, fixed in the same PR:** the initial fix duplicated an identical 4-line settings-merge ternary in both callbacks. Extracted to `applyCouncilTalkLevelOverride` in `src/storage/settings-merge.ts`, co-located with the existing (but semantically distinct) `applyPersistedUserSettings` helper — that one preserves an *existing save's* own `councilTalkLevel`; this one must unconditionally override a *freshly constructed* game's default (`createNewGame` always sets `'normal'`), so reusing the existing helper as-is would have silently no-op'd.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` (full suite, 486 files / 7969 tests) — passes
- [x] New test proving the solo path applies a persisted `councilTalkLevel` to the constructed game
- [x] New unit tests for `applyCouncilTalkLevelOverride` (override, no-op when unset, non-mutating)
- [x] Re-ran the inventory grep against `campaign-entry-controller.ts` — 0 remaining direct-mutation-through-`getState()` sites

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>