### PR TITLE
fix(787): GameSession state-mutation audit — Phase 3 (turn-flow-controller.ts)

### DIFF
--- a/src/app/controllers/turn-flow-controller.ts
+++ b/src/app/controllers/turn-flow-controller.ts
@@ -258,14 +258,24 @@ export function createTurnFlowController(deps: TurnFlowControllerDeps): TurnFlow
       researchChoices,
       cityChoices,
       onChooseResearch: (techId) => {
-        deps.currentCiv().techState = enqueueResearch(deps.currentCiv().techState, techId);
+        const civ = deps.currentCiv();
+        session.commit({
+          ...session.getState(),
+          civilizations: {
+            ...session.getState().civilizations,
+            [session.getState().currentPlayer]: { ...civ, techState: enqueueResearch(civ.techState, techId) },
+          },
+        });
         deps.showNotification(`Researching ${techId}...`, 'info');
         refreshRequiredChoicesAfterAction();
       },
       onChooseCityBuild: (cityId, itemId) => {
         const city = session.getState().cities[cityId];
         if (!city) return;
-        session.getState().cities[cityId] = enqueueCityProduction(city, itemId);
+        session.commit({
+          ...session.getState(),
+          cities: { ...session.getState().cities, [cityId]: enqueueCityProduction(city, itemId) },
+        });
         deps.showNotification(`${city.name}: queued ${itemId}`, 'info');
         refreshRequiredChoicesAfterAction();
       },

--- a/tests/app/controllers/turn-flow-controller.test.ts
+++ b/tests/app/controllers/turn-flow-controller.test.ts
@@ -157,6 +157,24 @@ async function flushMicrotasks(times = 5): Promise<void> {
   }
 }
 
+/**
+ * `required-choice-panel.ts` gives no id/data-* attribute to individual
+ * research/build buttons -- only each section's `<h3>` heading text is a
+ * stable anchor. Within "Choose Research", index 0 is always the first
+ * available tech choice (it's appended before "Open Tech Panel"); within
+ * "Choose Production", index 0 is always the first idle city's build choice
+ * (appended before that row's "Open City" button) -- both hold regardless of
+ * how many techs/cities are on offer.
+ */
+function findSectionButton(container: HTMLElement, sectionTitle: string, buttonIndex = 0): HTMLButtonElement {
+  const heading = Array.from(container.querySelectorAll('h3')).find(h => h.textContent === sectionTitle);
+  const section = heading?.closest('section');
+  const buttons = section ? Array.from(section.querySelectorAll('button')) : [];
+  const button = buttons[buttonIndex];
+  if (!button) throw new Error(`No button at index ${buttonIndex} in section "${sectionTitle}"`);
+  return button as HTMLButtonElement;
+}
+
 describe('createTurnFlowController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -574,6 +592,55 @@ describe('createTurnFlowController', () => {
       turnFlow.refreshRequiredChoicesAfterAction();
       expect(host.isInteractionBlocked()).toBe(false);
       expect(deps.uiLayer.querySelector('#required-choice-panel')).toBeFalsy();
+    });
+  });
+
+  describe('showRequiredChoicesIfNeeded callbacks (#787 phase 3 -- single-owner commit)', () => {
+    it('onChooseResearch publishes the queued tech through session subscribers', () => {
+      const state = makeFixture();
+      state.civilizations['player']!.techState.currentResearch = null;
+      const testUiLayer = document.createElement('div');
+      const deps = baseDeps(state, {
+        uiLayer: testUiLayer,
+        getElementById: id => testUiLayer.querySelector(`#${id}`),
+      });
+      const turnFlow = createTurnFlowController(deps);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      turnFlow.showRequiredChoicesIfNeeded();
+      const panel = deps.uiLayer.querySelector('#required-choice-panel') as HTMLElement;
+      expect(panel).toBeTruthy();
+      findSectionButton(panel, 'Choose Research', 0).click();
+
+      // currentResearch started null (needsResearchChoice's precondition), so
+      // enqueueResearch sets currentResearch directly rather than appending to
+      // researchQueue -- see enqueueResearch's `!state.currentResearch` branch.
+      expect(deps.session.getState().civilizations['player']!.techState.currentResearch).not.toBeNull();
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onChooseCityBuild publishes the queued production through session subscribers', () => {
+      const state = makeFixture();
+      const template = Object.values(state.cities)[0]!;
+      state.cities['idle-city'] = { ...template, id: 'idle-city', owner: 'player', name: 'Idle City', productionQueue: [] };
+      state.civilizations['player']!.cities = ['idle-city'];
+      const testUiLayer = document.createElement('div');
+      const deps = baseDeps(state, {
+        uiLayer: testUiLayer,
+        getElementById: id => testUiLayer.querySelector(`#${id}`),
+      });
+      const turnFlow = createTurnFlowController(deps);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      turnFlow.showRequiredChoicesIfNeeded();
+      const panel = deps.uiLayer.querySelector('#required-choice-panel') as HTMLElement;
+      expect(panel).toBeTruthy();
+      findSectionButton(panel, 'Choose Production', 0).click();
+
+      expect(deps.session.getState().cities['idle-city']!.productionQueue.length).toBe(1);
+      expect(listener).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 3 of the GameSession state-mutation audit (spec: `docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md`, plan: `docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md`). Continues from Phase 2 (#836, merged).

Fixes the 2 flagged sites in `turn-flow-controller.ts`'s `showRequiredChoicesIfNeeded`: `onChooseResearch` and `onChooseCityBuild` both mutated `session.getState()` directly instead of publishing through `session.commit()`. Architecture-debt only, not a live user-facing bug — both sites already had a manual `renderLoop.setGameState` + `updateHUD()` pair immediately after them via `refreshRequiredChoicesAfterAction()`. Fixed for the single-owner contract and to reach zero for Phase 6's regression guard.

**Deviation from the plan's draft test assertions:** the plan's sketch asserted `researchQueue.length` grows by one after clicking a research choice. `enqueueResearch` actually sets `currentResearch` directly (not append to `researchQueue`) when `currentResearch` was previously unset — the exact precondition `needsResearchChoice` requires before this panel shows at all. Verified against `enqueueResearch` (`src/systems/planning-system.ts`) and updated the test to assert `currentResearch` is set, per this repo's spec-fidelity rule that plan text describing current code behavior must be checked against the actual implementation.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` (full suite, 487 files / 7981 tests) — passes
- [x] `yarn test:ai-playability` — passes (required for this phase; touches turn-advancement-adjacent code)
- [x] New tests proving `onChooseResearch` and `onChooseCityBuild` publish through `session.subscribe` listeners, driving the real (unmocked) required-choice panel via DOM clicks
- [x] Re-ran the inventory grep against `turn-flow-controller.ts` — 0 remaining direct-mutation-through-`getState()` sites in `showRequiredChoicesIfNeeded`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>