### PR TITLE
feat(barbarians): compose bounded catalog reinforcements (#699)

### DIFF
--- a/docs/superpowers/plans/2026-08-16-issue-699-catalog-driven-barbarian-reinforcements.md
+++ b/docs/superpowers/plans/2026-08-16-issue-699-catalog-driven-barbarian-reinforcements.md
@@ -4,7 +4,7 @@
 
 **Goal:** Activate #699's bounded barbarian reinforcements through the existing eligibility catalog so every future unit is explicitly eligible or excluded.
 
-**Architecture:** `barbarian-roster.ts` remains the complete classification table. `barbarian-force-composer.ts` becomes the sole selector of a legal reinforcement from era, existing camp force, coarse local observations, and deterministic seed. `processPurposefulBarbarians` supplies only camp-local inputs; the turn manager continues creating the selected unit.
+**Architecture:** `barbarian-roster.ts` remains the complete classification table. `barbarian-force-composer.ts` becomes the sole selector of a legal reinforcement from era, the complete existing camp force, coarse local observations, and a deterministic seed. `processPurposefulBarbarians` establishes sensing and a viewer-safe intended target before selection; the turn manager continues creating the selected unit.
 
 **Tech Stack:** TypeScript, Vitest, serializable `GameState`, existing seeded LCG utilities.
 
@@ -14,7 +14,7 @@
 
 #696 already adds `BARBARIAN_ELIGIBILITY_BY_UNIT` as `Record<UnitType, BarbarianEligibility>`; #697 already has an inert deterministic composer; and #698 persists camp-local `armor` / `air` observations. The only missing connection is `chooseBarbarianSpawnType()` in `src/systems/barbarian-system.ts`, which still reads the legacy `BARBARIAN_ROSTER_BY_ERA`.
 
-No new UI, notification, save shape, unit type, art/audio asset, difficulty legality rule, resource rule, or mass upgrade belongs here. #700 retains global spawn-cap and balance auditing. “Bounded” in this change means declared era windows, role shares, mutual exclusions, and per-camp specialist caps.
+No new UI, notification, save shape, unit type, art/audio asset, difficulty *legality* rule, resource rule, or mass upgrade belongs here. #700 retains global spawn-cap and balance auditing. “Bounded” in this change means declared era windows, role shares, mutual exclusions, and per-camp specialist caps. Existing unit presentations and visibility-scoped spawn notifications remain the player-facing explanation.
 
 ## Task 1: Make the catalog executable and future-safe
 
@@ -119,7 +119,7 @@ Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-forc
 
 Expected: FAIL because `selectBarbarianReinforcement` is absent.
 
-- [ ] **Step 3: Implement the selector inside the composer.** Add a context with `assignedUnitTypes`, `escalated`, and `seed`. Convert only catalog-eligible assigned types to internal `Candidate` values and use the existing `canAddCandidate()` predicate with `forceSize: assigned.length + 1`. Return `undefined` when every candidate violates a cap; do not bypass a cap as fallback. Keep `composeBarbarianForce()` and route both APIs through the same candidate/cap helpers.
+- [ ] **Step 3: Implement the selector inside the composer.** Add a context with `assignedUnitTypes`, `escalated`, and `seed`. Convert every catalog-*eligible* assigned type to an internal `Candidate` through a new `candidateFromEligibility()` helper that deliberately ignores its era window and observation requirement: a still-live Chariot must continue consuming its mobile slot after E4. Use `candidateForContext()` only for a newly admitted candidate. Call the existing `canAddCandidate()` predicate with `forceSize: assigned.length + 1`. Return `undefined` when every candidate violates a cap; do not bypass a cap as fallback. Keep `composeBarbarianForce()` and route both APIs through the same candidate/cap helpers.
 
 ```ts
 export interface BarbarianReinforcementContext extends BarbarianReinforcementCandidateContext {
@@ -134,7 +134,7 @@ export function selectBarbarianReinforcement(
   const normalized = { ...context, era: normalizeEra(context.era) };
   const forceSize = context.assignedUnitTypes.length + 1;
   const force = context.assignedUnitTypes
-    .map(type => candidateForContext(type, { ...normalized, forceSize }))
+    .map(candidateFromEligibility)
     .filter((candidate): candidate is Candidate => candidate !== null);
   const selectionContext = { ...normalized, forceSize };
   const legal = candidatesFor(selectionContext)
@@ -165,7 +165,7 @@ git commit -m "feat(699): select bounded camp reinforcements"
 - Modify: `tests/systems/barbarian-system.test.ts`
 - Modify: `tests/core/turn-manager.test.ts`
 
-- [ ] **Step 1: Write failing end-to-end tests.** Through `processPurposefulBarbarians()`, make a camp due at era 9/10 and assert a selected unit is a generic legal candidate. Prove current armor observation permits the armor counter, a missing/expired observation does not, existing Mobile AA blocks a second one, and existing barbarians stay unchanged after an era change. Through `processTurn()`, assert the selected unit is created as `barbarian` and assigned to its spawning camp.
+- [ ] **Step 1: Write failing end-to-end tests.** Through `processPurposefulBarbarians()`, make a camp due at era 9/10 and assert a selected unit is a generic legal candidate. Prove the camp senses and records a local armor/air fact before choosing that same turn's due reinforcement; a missing/expired observation does not unlock a specialist; an existing Mobile AA blocks a second; and existing barbarians stay unchanged after an era change while still counting toward caps. Add a hidden high-era-city negative case: it must not affect a camp without a valid sensed target. Through `processTurn()`, assert the selected unit is created as `barbarian`, gets its camp-home mapping, has a valid existing renderer/SFX catalog entry, and sends only the existing visibility-scoped spawn notification.
 
 ```ts
 it('uses only active camp-local pressure for a due reinforcement', () => {
@@ -189,12 +189,19 @@ Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-syst
 
 Expected: FAIL because live selection still calls `chooseBarbarianSpawnType()`.
 
-- [ ] **Step 3: Replace only the legacy selector.** Delete `chooseBarbarianSpawnType()`. For each due camp, retain its current nearest-city target/era calculation, read `getActiveCampPressure(observationState, camp.id, state.turn)`, and call the composer. Keep occupancy checks, coordinate selection, cooldown updates, the turn-manager creation mutation, camp-home mapping, and event emission unchanged. Omit a spawn only when no bounded candidate is legal.
+- [ ] **Step 3: Replace only the legacy selector.** Delete `chooseBarbarianSpawnType()`. Move sensing and `observeCampPressureFromSensedUnits()` before due-spawn selection so the current turn's earned local facts can affect it. Establish a candidate plan before selection; use a target owner only when that plan is still valid *and* its city/unit target was sensed by this camp. Otherwise pass no intended target to `resolveNeutralPressureEra()`, retaining its local lower-median fallback. Derive `seed` with the previous deterministic `gameId:turn:campId` hash in this function. Read `getActiveCampPressure(observationState, camp.id, state.turn)` and call the composer. Keep occupancy checks, coordinate selection, cooldown updates, the turn-manager creation mutation, camp-home mapping, event emission, and visibility-scoped notification text unchanged. Omit a spawn only when no bounded candidate is legal.
 
 ```ts
+const intendedTargetId = existingValid && plan?.target.kind === 'city'
+  ? state.cities[plan.target.id]?.owner
+  : existingValid && plan?.target.kind === 'unit'
+    ? state.units[plan.target.id]?.owner
+    : undefined;
+const seed = [...`${state.gameId ?? 'game'}:${state.turn}:${camp.id}`]
+  .reduce((value, character) => (value * 31 + character.charCodeAt(0)) >>> 0, 1);
 const observedThreats = getActiveCampPressure(observationState, camp.id, state.turn);
 const unitType = selectBarbarianReinforcement({
-  era: resolveNeutralPressureEra(state, camp.position, target?.owner) ?? 1,
+  era: resolveNeutralPressureEra(state, camp.position, intendedTargetId) ?? 1,
   assignedUnitTypes: assigned.map(unit => unit.type),
   observedThreats,
   escalated: camp.strength >= 8,
@@ -226,7 +233,7 @@ git commit -m "feat(699): wire catalog into barbarian reinforcements"
 
 - [ ] **Step 1: Add reviewed-window fixtures.** Table-drive Chariot E2–4, Trebuchet E4–6, Cavalry/Cuirassier E6–8 mutual exclusion, Armored Car E9–11, armor-gated Anti-Tank Gun E9+, air-gated one-per-camp Mobile AA E10+, and Mechanized Infantry E10+. These fixtures must call the generic APIs, never a hardcoded selector branch.
 
-- [ ] **Step 2: Add negative and parity coverage.** Prove excluded naval/air/unique/crisis/deterrence units are never candidates; the same camp input has identical legality for Explorer, Standard, and Veteran; and candidate selection reads neither global unit state, player research, resources, nor current viewer. Verify saved observations and their expiry through the existing #698 pressure test path.
+- [ ] **Step 2: Add negative, difficulty, hot-seat, and persistence coverage.** Prove excluded naval/air/unique/crisis/deterrence units are never candidates; the same camp input has identical legality for Explorer, Standard, and Veteran; and candidate selection reads neither global unit state, player research, resources, nor current viewer. Add a small target-scoped pressure-profile helper using `resolvePressureSeverityForCiv()`: a human target uses its own challenge, an AI target is always Standard, and no profile changes legal candidates. Test two human owners with different saved challenges and nearby camps independently, including notification recipients at handoff. Load a schema-14 save containing active/expired camp facts, then process a due reinforcement to prove migration/normalization and post-load selection agree with a fresh state.
 
 - [ ] **Step 3: Run narrow verification.**
 
@@ -266,4 +273,3 @@ The PR description must state that #699 activates #696–#698, that every future
 - **Coverage:** Task 1 makes future omissions fail in the catalog; Task 2 applies one shared cap-aware selector; Task 3 reaches the real turn path; Task 4 covers exact approved windows and verification.
 - **No scope drift:** This plan adds no persistence or presentation behavior and preserves #700's audit ownership.
 - **Type consistency:** candidate context contains era/observations; reinforcement context adds assigned types, escalation, and seed; the live caller can derive each from existing camp-local state.
-

--- a/docs/superpowers/plans/2026-08-16-issue-699-catalog-driven-barbarian-reinforcements.md
+++ b/docs/superpowers/plans/2026-08-16-issue-699-catalog-driven-barbarian-reinforcements.md
@@ -1,0 +1,269 @@
+# Catalog-Driven Barbarian Reinforcements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate #699's bounded barbarian reinforcements through the existing eligibility catalog so every future unit is explicitly eligible or excluded.
+
+**Architecture:** `barbarian-roster.ts` remains the complete classification table. `barbarian-force-composer.ts` becomes the sole selector of a legal reinforcement from era, existing camp force, coarse local observations, and deterministic seed. `processPurposefulBarbarians` supplies only camp-local inputs; the turn manager continues creating the selected unit.
+
+**Tech Stack:** TypeScript, Vitest, serializable `GameState`, existing seeded LCG utilities.
+
+---
+
+## Scope and current seams
+
+#696 already adds `BARBARIAN_ELIGIBILITY_BY_UNIT` as `Record<UnitType, BarbarianEligibility>`; #697 already has an inert deterministic composer; and #698 persists camp-local `armor` / `air` observations. The only missing connection is `chooseBarbarianSpawnType()` in `src/systems/barbarian-system.ts`, which still reads the legacy `BARBARIAN_ROSTER_BY_ERA`.
+
+No new UI, notification, save shape, unit type, art/audio asset, difficulty legality rule, resource rule, or mass upgrade belongs here. #700 retains global spawn-cap and balance auditing. “Bounded” in this change means declared era windows, role shares, mutual exclusions, and per-camp specialist caps.
+
+## Task 1: Make the catalog executable and future-safe
+
+**Files:**
+- Modify: `src/systems/barbarian-force-composer.ts`
+- Modify: `tests/systems/barbarian-roster.test.ts`
+- Modify: `tests/systems/barbarian-force-composer.test.ts`
+
+- [ ] **Step 1: Write the failing catalog tests.** Keep the existing exact-key assertion between `UNIT_DEFINITIONS` and `BARBARIAN_ELIGIBILITY_BY_UNIT`, then add a generic loop over every entry. It must prove eligible entries appear at their lower boundary, disappear one era below and (when finite) one era above, and observation-gated entries require their own typed observation. Do not use the #699 eight-unit list as production logic.
+
+```ts
+it('makes every eligible catalog entry selectable only in its declared window', () => {
+  for (const [unitType, eligibility] of Object.entries(BARBARIAN_ELIGIBILITY_BY_UNIT) as [UnitType, BarbarianEligibility][]) {
+    if (eligibility.status === 'excluded') continue;
+    const observedThreats = eligibility.requiresObservation ? [eligibility.requiresObservation] : [];
+    expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.min, observedThreats }))
+      .toContain(unitType);
+    expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.min - 1, observedThreats }))
+      .not.toContain(unitType);
+    if (eligibility.eraWindow.max !== undefined) {
+      expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.max + 1, observedThreats }))
+        .not.toContain(unitType);
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run RED.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts`
+
+Expected: FAIL because `getBarbarianReinforcementCandidates` does not exist.
+
+- [ ] **Step 3: Export the pure candidate query from the existing composer.** Reuse `candidateForContext()` and `candidatesFor()`; do not copy eligibility conditions into the roster or barbarian system.
+
+```ts
+export interface BarbarianReinforcementCandidateContext {
+  era: number;
+  observedThreats?: readonly BarbarianObservationRequirement[];
+}
+
+export function getBarbarianReinforcementCandidates(
+  context: BarbarianReinforcementCandidateContext,
+): UnitType[] {
+  return candidatesFor({
+    ...context, era: normalizeEra(context.era),
+    forceSize: 1, escalated: false, seed: 0,
+  }).map(candidate => candidate.unitType);
+}
+```
+
+- [ ] **Step 4: Run GREEN.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/systems/barbarian-force-composer.ts tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts
+git commit -m "test(699): enforce catalog-driven barbarian eligibility"
+```
+
+## Task 2: Select one bounded reinforcement against the existing camp force
+
+**Files:**
+- Modify: `src/systems/barbarian-force-composer.ts`
+- Modify: `tests/systems/barbarian-force-composer.test.ts`
+
+- [ ] **Step 1: Write the failing selector tests.** Prove a fixed context repeats exactly; an unobserved camp cannot select Anti-Tank Gun/Mobile AA; an existing Mobile AA prevents another; Cavalry and Cuirassier cannot coexist; and every returned type belongs to the generic candidate query.
+
+```ts
+it('selects only a catalog candidate legal for the current camp context', () => {
+  const context = {
+    era: 10, escalated: false, seed: 429,
+    assignedUnitTypes: ['tank', 'rifleman'],
+    observedThreats: ['armor', 'air'],
+  } as const;
+  const selected = selectBarbarianReinforcement(context);
+
+  expect(selected).toBeDefined();
+  expect(getBarbarianReinforcementCandidates(context)).toContain(selected);
+  expect(selectBarbarianReinforcement(context)).toBe(selected);
+});
+
+it('honors per-camp and mutual-exclusion metadata from existing units', () => {
+  expect(selectBarbarianReinforcement({
+    era: 10, escalated: false, seed: 1,
+    assignedUnitTypes: ['mobile_aa'], observedThreats: ['air'],
+  })).not.toBe('mobile_aa');
+  expect(selectBarbarianReinforcement({
+    era: 6, escalated: false, seed: 1,
+    assignedUnitTypes: ['cavalry'], observedThreats: [],
+  })).not.toBe('cuirassier');
+});
+```
+
+- [ ] **Step 2: Run RED.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-force-composer.test.ts`
+
+Expected: FAIL because `selectBarbarianReinforcement` is absent.
+
+- [ ] **Step 3: Implement the selector inside the composer.** Add a context with `assignedUnitTypes`, `escalated`, and `seed`. Convert only catalog-eligible assigned types to internal `Candidate` values and use the existing `canAddCandidate()` predicate with `forceSize: assigned.length + 1`. Return `undefined` when every candidate violates a cap; do not bypass a cap as fallback. Keep `composeBarbarianForce()` and route both APIs through the same candidate/cap helpers.
+
+```ts
+export interface BarbarianReinforcementContext extends BarbarianReinforcementCandidateContext {
+  assignedUnitTypes: readonly UnitType[];
+  escalated: boolean;
+  seed: number;
+}
+
+export function selectBarbarianReinforcement(
+  context: BarbarianReinforcementContext,
+): UnitType | undefined {
+  const normalized = { ...context, era: normalizeEra(context.era) };
+  const forceSize = context.assignedUnitTypes.length + 1;
+  const force = context.assignedUnitTypes
+    .map(type => candidateForContext(type, { ...normalized, forceSize }))
+    .filter((candidate): candidate is Candidate => candidate !== null);
+  const selectionContext = { ...normalized, forceSize };
+  const legal = candidatesFor(selectionContext)
+    .filter(candidate => canAddCandidate(candidate, force, selectionContext));
+  return legal.length === 0
+    ? undefined
+    : weightedPick(legal, legal.map(candidate => candidate.eligibility.weight), seededLcg(context.seed)).unitType;
+}
+```
+
+- [ ] **Step 4: Run GREEN.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-force-composer.test.ts`
+
+Expected: PASS, including the original prospective-force cap tests.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/systems/barbarian-force-composer.ts tests/systems/barbarian-force-composer.test.ts
+git commit -m "feat(699): select bounded camp reinforcements"
+```
+
+## Task 3: Wire the live selector to only camp-local facts
+
+**Files:**
+- Modify: `src/systems/barbarian-system.ts`
+- Modify: `tests/systems/barbarian-system.test.ts`
+- Modify: `tests/core/turn-manager.test.ts`
+
+- [ ] **Step 1: Write failing end-to-end tests.** Through `processPurposefulBarbarians()`, make a camp due at era 9/10 and assert a selected unit is a generic legal candidate. Prove current armor observation permits the armor counter, a missing/expired observation does not, existing Mobile AA blocks a second one, and existing barbarians stay unchanged after an era change. Through `processTurn()`, assert the selected unit is created as `barbarian` and assigned to its spawning camp.
+
+```ts
+it('uses only active camp-local pressure for a due reinforcement', () => {
+  const state = purposefulState();
+  state.turn = 20;
+  state.barbarianCamps['camp-a'] = { ...state.barbarianCamps['camp-a'], spawnCooldown: 1 };
+  state.barbarianCampPressure = { 'camp-a': { armorLastObservedTurn: 20 } };
+
+  const result = processPurposefulBarbarians(state);
+  const spawnedType = result.spawnedUnits.find(spawn => spawn.campId === 'camp-a')?.unitType;
+
+  expect(spawnedType).toBeDefined();
+  expect(getBarbarianReinforcementCandidates({ era: 9, observedThreats: ['armor'] }))
+    .toContain(spawnedType);
+});
+```
+
+- [ ] **Step 2: Run RED.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-system.test.ts tests/core/turn-manager.test.ts`
+
+Expected: FAIL because live selection still calls `chooseBarbarianSpawnType()`.
+
+- [ ] **Step 3: Replace only the legacy selector.** Delete `chooseBarbarianSpawnType()`. For each due camp, retain its current nearest-city target/era calculation, read `getActiveCampPressure(observationState, camp.id, state.turn)`, and call the composer. Keep occupancy checks, coordinate selection, cooldown updates, the turn-manager creation mutation, camp-home mapping, and event emission unchanged. Omit a spawn only when no bounded candidate is legal.
+
+```ts
+const observedThreats = getActiveCampPressure(observationState, camp.id, state.turn);
+const unitType = selectBarbarianReinforcement({
+  era: resolveNeutralPressureEra(state, camp.position, target?.owner) ?? 1,
+  assignedUnitTypes: assigned.map(unit => unit.type),
+  observedThreats,
+  escalated: camp.strength >= 8,
+  seed,
+});
+if (spawnPosition && unitType) {
+  spawnedUnits.push({ ...spawn, position: spawnPosition, unitType });
+}
+```
+
+- [ ] **Step 4: Run targeted GREEN and source rules.**
+
+Run: `scripts/check-src-rule-violations.sh src/systems/barbarian-system.ts src/systems/barbarian-force-composer.ts`
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts tests/systems/barbarian-system.test.ts tests/core/turn-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/systems/barbarian-system.ts tests/systems/barbarian-system.test.ts tests/core/turn-manager.test.ts
+git commit -m "feat(699): wire catalog into barbarian reinforcements"
+```
+
+## Task 4: Complete the generic regression matrix and verify
+
+**Files:** Review all source and test files modified in Tasks 1–3.
+
+- [ ] **Step 1: Add reviewed-window fixtures.** Table-drive Chariot E2–4, Trebuchet E4–6, Cavalry/Cuirassier E6–8 mutual exclusion, Armored Car E9–11, armor-gated Anti-Tank Gun E9+, air-gated one-per-camp Mobile AA E10+, and Mechanized Infantry E10+. These fixtures must call the generic APIs, never a hardcoded selector branch.
+
+- [ ] **Step 2: Add negative and parity coverage.** Prove excluded naval/air/unique/crisis/deterrence units are never candidates; the same camp input has identical legality for Explorer, Standard, and Veteran; and candidate selection reads neither global unit state, player research, resources, nor current viewer. Verify saved observations and their expiry through the existing #698 pressure test path.
+
+- [ ] **Step 3: Run narrow verification.**
+
+Run: `scripts/check-src-rule-violations.sh src/systems/barbarian-roster.ts src/systems/barbarian-force-composer.ts src/systems/barbarian-system.ts`
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts tests/systems/barbarian-pressure.test.ts tests/systems/barbarian-system.test.ts tests/core/turn-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Review and run PR-grade verification.**
+
+Run: `git diff --check`
+
+Run: `git diff --stat origin/main...HEAD`
+
+Run: `git diff --stat`
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+
+Run: `bash scripts/run-with-mise.sh yarn test:durable`
+
+Run: `bash scripts/run-with-mise.sh yarn test:durable:status`
+
+Expected: every command exits zero; durable status belongs to the current `HEAD` and working tree.
+
+- [ ] **Step 5: Commit the matrix.**
+
+```bash
+git add tests/systems/barbarian-roster.test.ts tests/systems/barbarian-force-composer.test.ts tests/systems/barbarian-system.test.ts tests/core/turn-manager.test.ts
+git commit -m "test(699): cover bounded reinforcement contract"
+```
+
+The PR description must state that #699 activates #696–#698, that every future `UnitType` requires typed eligibility/exclusion, and that #700 owns broad spawn-cap/balance audit.
+
+## Plan self-review
+
+- **Coverage:** Task 1 makes future omissions fail in the catalog; Task 2 applies one shared cap-aware selector; Task 3 reaches the real turn path; Task 4 covers exact approved windows and verification.
+- **No scope drift:** This plan adds no persistence or presentation behavior and preserves #700's audit ownership.
+- **Type consistency:** candidate context contains era/observations; reinforcement context adds assigned types, escalation, and seed; the live caller can derive each from existing camp-local state.
+

--- a/src/systems/barbarian-force-composer.ts
+++ b/src/systems/barbarian-force-composer.ts
@@ -23,6 +23,12 @@ export interface BarbarianReinforcementCandidateContext {
   observedThreats?: readonly BarbarianObservationRequirement[];
 }
 
+export interface BarbarianReinforcementContext extends BarbarianReinforcementCandidateContext {
+  assignedUnitTypes: readonly UnitType[];
+  escalated: boolean;
+  seed: number;
+}
+
 interface Candidate {
   unitType: UnitType;
   eligibility: EligibleBarbarianUnit;
@@ -55,6 +61,11 @@ function candidateForContext(
   return { unitType, eligibility };
 }
 
+function candidateFromEligibility(unitType: UnitType): Candidate | null {
+  const eligibility = BARBARIAN_ELIGIBILITY_BY_UNIT[unitType];
+  return eligibility.status === 'eligible' ? { unitType, eligibility } : null;
+}
+
 function candidatesFor(context: BarbarianForceCompositionContext): Candidate[] {
   const candidates: Candidate[] = [];
   for (const unitType of Object.keys(BARBARIAN_ELIGIBILITY_BY_UNIT) as UnitType[]) {
@@ -74,6 +85,28 @@ export function getBarbarianReinforcementCandidates(
     escalated: false,
     seed: 0,
   }).map(candidate => candidate.unitType);
+}
+
+export function selectBarbarianReinforcement(
+  context: BarbarianReinforcementContext,
+): UnitType | undefined {
+  const era = normalizeEra(context.era);
+  const forceSize = context.assignedUnitTypes.length + 1;
+  const selectionContext: BarbarianForceCompositionContext = {
+    era,
+    forceSize,
+    escalated: context.escalated,
+    seed: context.seed,
+    observedThreats: context.observedThreats,
+  };
+  const force = context.assignedUnitTypes
+    .map(candidateFromEligibility)
+    .filter((candidate): candidate is Candidate => candidate !== null);
+  const legal = candidatesFor(selectionContext)
+    .filter(candidate => canAddCandidate(candidate, force, selectionContext));
+  return legal.length === 0
+    ? undefined
+    : weightedPick(legal, legal.map(candidate => candidate.eligibility.weight), seededLcg(context.seed)).unitType;
 }
 
 function countRole(force: readonly Candidate[], role: EligibleBarbarianUnit['roleSlot']): number {

--- a/src/systems/barbarian-force-composer.ts
+++ b/src/systems/barbarian-force-composer.ts
@@ -18,6 +18,11 @@ export interface BarbarianForceCompositionContext {
   observedThreats?: readonly BarbarianObservationRequirement[];
 }
 
+export interface BarbarianReinforcementCandidateContext {
+  era: number;
+  observedThreats?: readonly BarbarianObservationRequirement[];
+}
+
 interface Candidate {
   unitType: UnitType;
   eligibility: EligibleBarbarianUnit;
@@ -57,6 +62,18 @@ function candidatesFor(context: BarbarianForceCompositionContext): Candidate[] {
     if (candidate) candidates.push(candidate);
   }
   return candidates.sort((left, right) => left.unitType.localeCompare(right.unitType));
+}
+
+export function getBarbarianReinforcementCandidates(
+  context: BarbarianReinforcementCandidateContext,
+): UnitType[] {
+  return candidatesFor({
+    ...context,
+    era: normalizeEra(context.era),
+    forceSize: 1,
+    escalated: false,
+    seed: 0,
+  }).map(candidate => candidate.unitType);
 }
 
 function countRole(force: readonly Candidate[], role: EligibleBarbarianUnit['roleSlot']): number {

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -11,7 +11,7 @@ import type {
   UnitType,
 } from '@/core/types';
 import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
-import { OPPONENT_CHALLENGE_PROFILES, resolveOpponentChallenge } from '@/core/opponent-challenge';
+import { OPPONENT_CHALLENGE_PROFILES, resolveOpponentChallenge, resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { canAttackByProfileOnMap } from './attack-targeting';
 import {
   hexKey,
@@ -26,7 +26,8 @@ import { recordHuntCampKillerIfApplicable } from './hunt-crisis-linkage';
 import { resolveCivilizationEra } from './tech-definitions';
 import { classifyOwner } from '@/core/owner-kind';
 import { resolveNeutralPressureEra } from './era-resolution';
-import { observeCampPressureFromSensedUnits } from './barbarian-pressure';
+import { getActiveCampPressure, observeCampPressureFromSensedUnits } from './barbarian-pressure';
+import { selectBarbarianReinforcement } from './barbarian-force-composer';
 
 // Seeded LCG — avoids Math.random() per project rules
 function lcg(seed: number): () => number {
@@ -346,12 +347,21 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
   const cityAttackOrders: BarbarianCityAttackOrder[] = [];
   const pillageOrders: BarbarianPillageOrder[] = [];
   let observationState = state;
-  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+  const defaultProfile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
 
   for (const camp of camps) {
     const assigned = barbarianUnits.filter(unit =>
       opponentAI.barbarianHomeCampByUnitId[unit.id] === camp.id);
     const assignedIds = assigned.map(unit => unit.id);
+    const sensedUnits = Object.values(state.units)
+      .filter(unit =>
+        unit.owner !== 'barbarian'
+        && !unit.transportId
+        && sensedByCamp(state, camp, assigned, unit.position))
+      .sort((a, b) =>
+        barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
+        || a.id.localeCompare(b.id));
+    observationState = observeCampPressureFromSensedUnits(observationState, camp.id, sensedUnits);
     const spawn = campTick.spawnedUnits.find(candidate => candidate.campId === camp.id);
     if (spawn) {
       const occupied = new Set(Object.values(state.units)
@@ -363,24 +373,23 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
           barbarianDistance(state, a, camp.position) - barbarianDistance(state, b, camp.position)
           || a.q - b.q
           || a.r - b.r)[0];
-      if (spawnPosition) {
+      const seed = [...`${state.gameId ?? 'game'}:${state.turn}:${camp.id}`]
+        .reduce((value, character) => (value * 31 + character.charCodeAt(0)) >>> 0, 1);
+      const unitType = selectBarbarianReinforcement({
+        era: resolveNeutralPressureEra(state, camp.position) ?? 1,
+        assignedUnitTypes: assigned.map(unit => unit.type),
+        observedThreats: getActiveCampPressure(observationState, camp.id, state.turn),
+        escalated: camp.strength >= 8,
+        seed,
+      });
+      if (spawnPosition && unitType) {
         spawnedUnits.push({
           ...spawn,
           position: spawnPosition,
-          unitType: chooseBarbarianSpawnType(state, camp.id, assigned),
+          unitType,
         });
       }
     }
-
-    const sensedUnits = Object.values(state.units)
-      .filter(unit =>
-        unit.owner !== 'barbarian'
-        && !unit.transportId
-        && sensedByCamp(state, camp, assigned, unit.position))
-      .sort((a, b) =>
-        barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
-        || a.id.localeCompare(b.id));
-    observationState = observeCampPressureFromSensedUnits(observationState, camp.id, sensedUnits);
     const campThreat = sensedUnits.find(unit =>
       UNIT_DEFINITIONS[unit.type].strength > 0
       && barbarianDistance(state, camp.position, unit.position) <= BARBARIAN_DEFENSE_RADIUS);
@@ -465,7 +474,7 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
     // raids over chasing a lone worker/caravan; player-side pillage rules never
     // change by difficulty — only this raid-target preference does.
     if (!plan) {
-      plan = profile.pillageAggressivenessMultiplier > 1
+      plan = defaultProfile.pillageAggressivenessMultiplier > 1
         ? (tryRaidResourcePlan() ?? tryRaidUnitPlan())
         : (tryRaidUnitPlan() ?? tryRaidResourcePlan());
     }
@@ -525,6 +534,17 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
     }
     plan = { ...plan, assignedUnitIds: assignedIds };
     opponentAI.barbarianCamps[camp.id] = plan;
+
+    const planTargetOwnerId = plan.target.kind === 'unit'
+      ? state.units[plan.target.id]?.owner
+      : plan.target.kind === 'city'
+        ? state.cities[plan.target.id]?.owner
+        : plan.target.kind === 'resource'
+          ? state.map.tiles[hexKey(plan.target.position)]?.owner
+          : undefined;
+    const profile = OPPONENT_CHALLENGE_PROFILES[planTargetOwnerId
+      ? resolvePressureSeverityForCiv(state, planTargetOwnerId)
+      : resolveOpponentChallenge(state)];
 
     for (const unit of assigned) {
       if (unit.movementPointsLeft <= 0 || unit.hasActed) continue;

--- a/tests/systems/barbarian-force-composer.test.ts
+++ b/tests/systems/barbarian-force-composer.test.ts
@@ -1,5 +1,9 @@
 import { getBarbarianEligibility } from '@/systems/barbarian-roster';
-import { composeBarbarianForce } from '@/systems/barbarian-force-composer';
+import {
+  composeBarbarianForce,
+  getBarbarianReinforcementCandidates,
+  selectBarbarianReinforcement,
+} from '@/systems/barbarian-force-composer';
 
 function countByRole(force: ReturnType<typeof composeBarbarianForce>) {
   return force.reduce<Record<string, number>>((counts, unitType) => {
@@ -123,5 +127,28 @@ describe('composeBarbarianForce', () => {
 
   it('returns no members when no force is requested', () => {
     expect(composeBarbarianForce({ era: 6, forceSize: 0, escalated: false, seed: 1 })).toEqual([]);
+  });
+
+  it('selects only a legal catalog candidate for the existing camp force', () => {
+    const context = {
+      era: 10, escalated: false, seed: 429,
+      assignedUnitTypes: ['tank', 'rifleman'], observedThreats: ['armor', 'air'],
+    } as const;
+    const selected = selectBarbarianReinforcement(context);
+
+    expect(selected).toBeDefined();
+    expect(getBarbarianReinforcementCandidates(context)).toContain(selected);
+    expect(selectBarbarianReinforcement(context)).toBe(selected);
+  });
+
+  it('counts existing units for per-camp and mutual-exclusion caps after their spawn window', () => {
+    expect(selectBarbarianReinforcement({
+      era: 10, escalated: false, seed: 1,
+      assignedUnitTypes: ['mobile_aa'], observedThreats: ['air'],
+    })).not.toBe('mobile_aa');
+    expect(selectBarbarianReinforcement({
+      era: 9, escalated: false, seed: 1,
+      assignedUnitTypes: ['cavalry'], observedThreats: [],
+    })).not.toBe('cuirassier');
   });
 });

--- a/tests/systems/barbarian-roster.test.ts
+++ b/tests/systems/barbarian-roster.test.ts
@@ -4,6 +4,8 @@ import {
   BARBARIAN_ELIGIBILITY_BY_UNIT,
   getBarbarianEligibility,
 } from '@/systems/barbarian-roster';
+import { getBarbarianReinforcementCandidates } from '@/systems/barbarian-force-composer';
+import type { BarbarianEligibility, UnitType } from '@/core/types';
 
 describe('barbarian eligibility catalog', () => {
   it('classifies every current unit definition so future units fail closed', () => {
@@ -45,6 +47,24 @@ describe('barbarian eligibility catalog', () => {
     expect(BARBARIAN_ELIGIBILITY_BY_UNIT.mechanized_infantry).toMatchObject({
       status: 'eligible', eraWindow: { min: 10 }, roleSlot: 'frontline', rarity: 'uncommon',
     });
+  });
+
+  it('makes every eligible catalog entry selectable only inside its declared window', () => {
+    for (const [unitType, eligibility] of Object.entries(BARBARIAN_ELIGIBILITY_BY_UNIT) as [UnitType, BarbarianEligibility][]) {
+      if (eligibility.status === 'excluded') continue;
+      const observedThreats = eligibility.requiresObservation ? [eligibility.requiresObservation] : [];
+
+      expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.min, observedThreats }))
+        .toContain(unitType);
+      if (eligibility.eraWindow.min > 1) {
+        expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.min - 1, observedThreats }))
+          .not.toContain(unitType);
+      }
+      if (eligibility.eraWindow.max !== undefined) {
+        expect(getBarbarianReinforcementCandidates({ era: eligibility.eraWindow.max + 1, observedThreats }))
+          .not.toContain(unitType);
+      }
+    }
   });
 
   it.each([

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -15,6 +15,8 @@ import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { createUnit } from '@/systems/unit-system';
 import { applyPillageToState } from '@/systems/pillage-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { selectBarbarianReinforcement } from '@/systems/barbarian-force-composer';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -291,6 +293,27 @@ describe('processPurposefulBarbarians', () => {
 
     expect(result.barbarianCampPressure).toEqual({ 'camp-a': { armorLastObservedTurn: state.turn } });
     expect(JSON.stringify(result.barbarianCampPressure)).not.toContain(distantTank.id);
+  });
+
+  it('uses the deterministic catalog selector for a due camp reinforcement', () => {
+    const state = purposefulState();
+    state.turn = 20;
+    state.barbarianCamps['camp-a'] = { ...state.barbarianCamps['camp-a'], spawnCooldown: 1 };
+    state.cities.town = { id: 'town', owner: 'player', position: { q: 7, r: 5 }, hp: 50 } as never;
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.techState.completed = TECH_TREE
+      .filter(tech => tech.era <= 10)
+      .map(tech => tech.id);
+    state.barbarianCampPressure = { 'camp-a': { armorLastObservedTurn: 20, airLastObservedTurn: 20 } };
+
+    const seed = [...`${state.gameId ?? 'game'}:${state.turn}:camp-a`]
+      .reduce((value, character) => (value * 31 + character.charCodeAt(0)) >>> 0, 1);
+    const expected = selectBarbarianReinforcement({
+      era: 10, assignedUnitTypes: [], observedThreats: ['armor', 'air'], escalated: false, seed,
+    });
+
+    expect(processPurposefulBarbarians(state).spawnedUnits)
+      .toContainEqual(expect.objectContaining({ campId: 'camp-a', unitType: expected }));
   });
 
   it('uses the final roster band beyond its declared maximum era', () => {


### PR DESCRIPTION
Closes #699

## Summary

- Activates the typed barbarian eligibility catalog for deterministic, bounded reinforcements.
- Uses camp-local expiring armor/air observations for counter eligibility and preserves role/cap accounting for existing legacy units.
- Keeps reinforcement information local, preserves existing unit presentation/notifications, and resolves human-targeted pressure by personal challenge while AI targets remain Standard.

## Verification

- `scripts/check-src-rule-violations.sh src/systems/barbarian-system.ts src/systems/barbarian-force-composer.ts`
- Focused regression suite: 171 tests
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test:durable` and status (passed for `25df5f56`)
- Push hook verification passed; remote branch matches local HEAD.