### PR TITLE
fix(787): GameSession state-mutation audit — Phase 4 (selection-controller.ts)

### DIFF
--- a/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
+++ b/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
@@ -59,7 +59,7 @@ function ensurePlayerWarState(targetCivId: string): void {
 
 Two bugs here, both fixed by the same rewrite: (1) `deps.currentCiv().diplomacy = ...` and `targetCiv.diplomacy = ...` mutate the live state object directly (Shape B); (2) the trailing `setStateWithoutRefresh` means even a naive fix of just those two lines would still never publish — the function's real terminal write is the opportunistic-penalty result, not the two diplomacy mutations.
 
-- [ ] **Step 1: Write the failing test.** Add to the existing `describe('ensurePlayerWarState', ...)` block in `tests/app/controllers/player-action-controller.test.ts` (after the existing 3 tests, before the closing `});` at line 290):
+- [x] **Step 1: Write the failing test.** Add to the existing `describe('ensurePlayerWarState', ...)` block in `tests/app/controllers/player-action-controller.test.ts` (after the existing 3 tests, before the closing `});` at line 290):
 
 ```ts
     it('publishes the war declaration to session subscribers, not just the renderer', () => {
@@ -75,12 +75,12 @@ Two bugs here, both fixed by the same rewrite: (1) `deps.currentCiv().diplomacy 
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "publishes the war declaration"`
 Expected: FAIL — `listener` was never called, because the current code path ends in `setStateWithoutRefresh`, which never calls `publish()`.
 
-- [ ] **Step 3: Write minimal implementation.** Replace the function body:
+- [x] **Step 3: Write minimal implementation.** Replace the function body:
 
 ```ts
 function ensurePlayerWarState(targetCivId: string): void {
@@ -108,12 +108,12 @@ function ensurePlayerWarState(targetCivId: string): void {
 
 Note: keyed by `cp` (already `= deps.session.getState().currentPlayer`, the same id `deps.currentCiv()` looks up), not a `.id` field, so no assumption about `Civilization` carrying its own id is introduced.
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "ensurePlayerWarState"`
 Expected: PASS — all 4 tests in the block (the 3 pre-existing behavioral ones plus the new publish test).
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
@@ -154,7 +154,7 @@ Current code:
 
 No chained non-refreshing write here — this one is a clean Shape-A conversion.
 
-- [ ] **Step 1: Write the failing test.** Replace the existing `'rests a real damaged unit, heals via restUnit, and deselects'` test (`tests/app/controllers/player-action-controller.test.ts:312-323`) to also assert publish:
+- [x] **Step 1: Write the failing test.** Replace the existing `'rests a real damaged unit, heals via restUnit, and deselects'` test (`tests/app/controllers/player-action-controller.test.ts:312-323`) to also assert publish:
 
 ```ts
     it('rests a real damaged unit, heals via restUnit, deselects, and publishes to subscribers', () => {
@@ -174,12 +174,12 @@ No chained non-refreshing write here — this one is a clean Shape-A conversion.
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "rests a real damaged unit"`
 Expected: FAIL on `expect(listener).toHaveBeenCalledTimes(1)` — 0 calls, since the current code never calls `commit`/`update`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
   function restAction(): void {
@@ -220,12 +220,12 @@ Wait — check this before running: the test at Step 1 still asserts `expect(dep
 
 This is the pattern for every remaining task in this plan: **do not delete a manual `renderLoop.setGameState`/`hud.update` call just because `commit`/`update` now also does it** — these controller unit tests construct their own unwired `createGameSession` instance per test, so the manual call is still the only thing driving the test double's assertion. Only delete a manual call if a specific task's own test coverage proves it's safe to (none in this plan require it — see the corrected Global Constraints intent below).
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "rests a real damaged unit"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
@@ -271,7 +271,7 @@ Current code:
 
 This is architecture-debt only today (per the spec's severity review) — `deps.hud.update()` is already called manually at the end, so the HUD is not currently stale. But `conquestMinorCiv` is called with `deps.session.getState()` *after* the flagged mutation, meaning it operates on the already-mutated live object rather than a value passed explicitly — and the result then goes through `setStateWithoutRefresh` rather than `commit`, relying entirely on the trailing manual `renderLoop.setGameState` + `hud.update()` to catch up. Fix: fold the unit mutation into one input state, call `conquestMinorCiv` on that explicit value, and `commit` its result.
 
-- [ ] **Step 1: Write the failing test.** Extend the existing `'conquers the minor civ and transfers its city after a successful movement'` test (`tests/app/controllers/player-action-controller.test.ts:576-589`):
+- [x] **Step 1: Write the failing test.** Extend the existing `'conquers the minor civ and transfers its city after a successful movement'` test (`tests/app/controllers/player-action-controller.test.ts:576-589`):
 
 ```ts
     it('conquers the minor civ, transfers its city, publishes once, and clears the mover\'s movement points', () => {
@@ -294,12 +294,12 @@ This is architecture-debt only today (per the spec's severity review) — `deps.
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "conquers the minor civ, transfers its city, publishes once"`
 Expected: FAIL on `expect(listener).toHaveBeenCalledTimes(1)` — the current code path ends in `setStateWithoutRefresh`, which never calls `publish()`, so `listener` sees 0 calls.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
   function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
@@ -326,12 +326,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalledTimes(1)` — the current co
   }
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/player-action-controller.test.ts -t "executeMinorCivConquest"`
 Expected: PASS — both tests in the block.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/player-action-controller.ts tests/app/controllers/player-action-controller.test.ts
@@ -340,10 +340,10 @@ git commit -m "fix(player-action-controller): route executeMinorCivConquest's un
 
 ### Phase 1 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
-- [ ] Confirm `getCurrentCiv`/`deps.currentCiv()` in `src/app/cross-cutting-helpers.ts` was **not modified** — the decision from the spec (keep its read-only convenience shape) holds because both flagged sites in this phase converted at their call site, not the helper.
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 1 (player-action-controller.ts)`. Body lists all 3 conversions individually, per Global Constraints.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [x] Confirm `getCurrentCiv`/`deps.currentCiv()` in `src/app/cross-cutting-helpers.ts` was **not modified** — the decision from the spec (keep its read-only convenience shape) holds because both flagged sites in this phase converted at their call site, not the helper.
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 1 (player-action-controller.ts)`. Body lists all 3 conversions individually, per Global Constraints.
 
 ---
 
@@ -401,7 +401,7 @@ Current code, `onComplete` (hot-seat, `campaign-entry-controller.ts:254-263`):
           },
 ```
 
-- [ ] **Step 1: Write the failing test.** Add to `describe('showGameModeSelection', ...)` in `tests/app/controllers/campaign-entry-controller.test.ts`, after the existing solo/hot-seat tests around line 306:
+- [x] **Step 1: Write the failing test.** Add to `describe('showGameModeSelection', ...)` in `tests/app/controllers/campaign-entry-controller.test.ts`, after the existing solo/hot-seat tests around line 306:
 
 ```ts
     it('the solo path applies a persisted councilTalkLevel to the freshly constructed game', async () => {
@@ -440,12 +440,12 @@ Current code, `onComplete` (hot-seat, `campaign-entry-controller.ts:254-263`):
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/campaign-entry-controller.test.ts -t "applies a persisted councilTalkLevel"`
 Expected: This specific test actually **passes today** even with the bug, because the mutation does land on the object `deps.session.getState()` returns (same reference) before the assertion reads it back — the test as written can't distinguish the mutation bug from correct behavior. This is intentional: skip to Step 3, then use Step 4's assertion (not Step 2) as the real regression check. Note this in the PR body rather than silently having a step that doesn't fail — the spec's "currently observable staleness" table already flags this site as having no live user-facing symptom; this task is architecture-cleanliness, not a behavior fix, and the test proves the settings value ends up correct after the refactor, not that the refactor was necessary.
 
-- [ ] **Step 3: Write minimal implementation.** `onStartSolo`:
+- [x] **Step 3: Write minimal implementation.** `onStartSolo`:
 
 ```ts
           onStartSolo: (config) => {
@@ -489,12 +489,12 @@ Expected: This specific test actually **passes today** even with the bug, becaus
           },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/campaign-entry-controller.test.ts -t "showGameModeSelection"`
 Expected: PASS — the new test plus the two pre-existing solo/hot-seat tests (their `expect(deps.session.getState()).not.toBe(beforeState)` and `.gameTitle` assertions are unaffected, since `setStateWithoutRefresh` still runs and still replaces the reference).
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/campaign-entry-controller.ts tests/app/controllers/campaign-entry-controller.test.ts
@@ -503,9 +503,9 @@ git commit -m "fix(campaign-entry-controller): merge persisted councilTalkLevel 
 
 ### Phase 2 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 2 (campaign-entry-controller.ts)`. Body notes both sites are architecture-cleanliness (no live user-facing bug — settings never visible before the first real `commit`/`enterCampaign` publish), citing the spec's severity table.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 2 (campaign-entry-controller.ts)`. Body notes both sites are architecture-cleanliness (no live user-facing bug — settings never visible before the first real `commit`/`enterCampaign` publish), citing the spec's severity table.
 
 ---
 
@@ -569,7 +569,7 @@ function findSectionButton(container: HTMLElement, sectionTitle: string, buttonI
 
 Within "Choose Research", research-choice buttons are appended before the "Open Tech Panel" button, so index 0 is always the first available tech choice. Within "Choose Production", each city's row appends its build button before that row's "Open City" button, so index 0 is always the first idle city's build choice. Both hold regardless of how many techs/cities are available, so the test doesn't need to know a specific tech id or item id ahead of time — it can assert "one new entry appeared" instead.
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
 ```ts
   describe('showRequiredChoicesIfNeeded callbacks', () => {
@@ -612,12 +612,12 @@ Within "Choose Research", research-choice buttons are appended before the "Open 
 
 Add the `findSectionButton` helper (shown above) near this file's other test helpers, not inline in each test.
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts -t "showRequiredChoicesIfNeeded callbacks"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()` in both tests — current code never calls `commit`/`update`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onChooseResearch: (techId) => {
@@ -644,17 +644,17 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()` in both tests — curren
       },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts -t "showRequiredChoicesIfNeeded callbacks"`
 Expected: PASS.
 
-- [ ] **Step 5: Run the full turn-flow-controller suite** (this file also has timing-sensitive round/handoff tests elsewhere that must not regress from this change).
+- [x] **Step 5: Run the full turn-flow-controller suite** (this file also has timing-sensitive round/handoff tests elsewhere that must not regress from this change).
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/turn-flow-controller.test.ts`
 Expected: PASS, all tests.
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
 ```bash
 git add src/app/controllers/turn-flow-controller.ts tests/app/controllers/turn-flow-controller.test.ts
@@ -663,10 +663,10 @@ git commit -m "fix(turn-flow-controller): route required-choice research/build q
 
 ### Phase 3 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test:ai-playability` — expect exit 0 (required for this phase per the spec: it touches turn-advancement-adjacent code).
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 3 (turn-flow-controller.ts)`.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test:ai-playability` — expect exit 0 (required for this phase per the spec: it touches turn-advancement-adjacent code).
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 3 (turn-flow-controller.ts)`.
 
 ---
 
@@ -729,7 +729,7 @@ Two flagged mutations here (espionage assignment, conditional unit assignment) �
 
 Note the disguise picker only renders when `disguiseOptions.length > 1` (`src/ui/selected-unit-info.ts:772-805`), which requires a spy tier ≥ 1 — `spy_scout` (tier 0) only ever offers "No Disguise" and renders no picker at all. Use `spy_informant` (tier 1) so "As Warrior" is a real, clickable option.
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
   describe('onSetDisguise', () => {
@@ -763,12 +763,12 @@ Note the disguise picker only renders when `disguiseOptions.length > 1` (`src/ui
 
 Note the field is `disguiseAs` (verified against `src/ui/selected-unit-info.ts:798`'s `spy?.disguiseAs`), not `disguisedAs`.
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onSetDisguise"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
         onSetDisguise: (uid, disguise) => {
@@ -794,12 +794,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
         },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onSetDisguise"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
@@ -950,7 +950,7 @@ function tryUntilInfiltrate(
 }
 ```
 
-- [ ] **Step 1: Write failing tests covering all 4 branches.**
+- [x] **Step 1: Write failing tests covering all 4 branches.**
 
 ```ts
   describe('onInfiltrate', () => {
@@ -989,19 +989,19 @@ function tryUntilInfiltrate(
 
 Each test proves the branch's own distinguishing state via `tryUntilInfiltrate`'s deterministic search rather than asserting a `listener` call on every single test — the publish-plumbing itself only needs proving once per handler (the codebase-wide convention this whole plan follows), and `onSetDisguise`/`onEmbed`'s tests already do that for the same `session.commit` call path this handler also uses. Re-verify against a fresh `yarn vitest run` before treating any of these 4 as flaky: `tryUntil`'s 200-iteration cap matches the existing system-level helper's own cap and has never needed raising there, but if a branch reliably fails to be found, that's a sign the fixture (city ownership, spy status, unit position) doesn't actually satisfy `onInfiltrate`'s own preconditions (`src/app/controllers/selection-controller.ts:405-420`) — fix the fixture, don't raise the cap blindly.
 
-- [ ] **Step 2: Run tests to verify they fail.**
+- [x] **Step 2: Run tests to verify they fail.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onInfiltrate"`
 Expected: FAIL on each branch's `listener` assertion.
 
-- [ ] **Step 3: Write minimal implementation** — the full rewritten handler shown above.
+- [x] **Step 3: Write minimal implementation** — the full rewritten handler shown above.
 
-- [ ] **Step 4: Run tests to verify they pass.**
+- [x] **Step 4: Run tests to verify they pass.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onInfiltrate"`
 Expected: PASS, all 4 branch tests.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
@@ -1038,7 +1038,7 @@ Current code:
         },
 ```
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
   describe('onEmbed', () => {
@@ -1074,12 +1074,12 @@ Current code:
   });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onEmbed"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
         onEmbed: (uid) => {
@@ -1113,12 +1113,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
         },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "onEmbed"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
@@ -1129,7 +1129,9 @@ git commit -m "fix(selection-controller): route onEmbed's espionage/unit/civ mut
 
 **Files:**
 - Modify: `src/app/controllers/selection-controller.ts:653-684`
-- Test: `tests/app/controllers/selection-controller.test.ts` (new `describe('startAutoExplore / cancelAutoExplore', ...)`)
+- Test: `tests/app/controllers/selection-controller.test.ts` (extend the two existing flat `it(...)` tests at lines 329 and 342 — see drift correction below)
+
+**Drift correction (found during Phase 4 prereq check, 2026-08-16):** the plan's original draft below adds a *new* `describe('startAutoExplore / cancelAutoExplore', ...)` block. That would duplicate coverage — this file already has `'startAutoExplore arms auto-explore automation and re-selects the unit'` (line 329) and `'cancelAutoExplore clears automation and re-selects only if currently selected'` (line 342) as flat `it(...)` tests directly under the top-level `describe('SelectionController', ...)`, with the same fixture setup this task's draft would otherwise recreate. Per this repo's own convention (Phase 1 Task 1.2 extended an existing test rather than duplicating it), **extend these two existing tests in place** to add the `session.subscribe(listener)` + `expect(listener).toHaveBeenCalled()` assertions, rather than adding the new describe block shown below. The implementation step (Step 3) is unaffected by this correction — only the test step changes.
 
 Current code:
 
@@ -1170,7 +1172,7 @@ Current code:
 
 Verified: `applyAutoExploreOrder(state: GameState, unitId: string, options: { bus?: EventBus }): ExecuteUnitMoveResult | null` (`src/systems/auto-explore-system.ts:93-97`) does not mutate `state` and does not return a new `GameState` — it returns a move-intent result that this call site's original code already discards without applying (`applyAutoExploreOrder(session.getState(), unitId, { bus });` with no assignment). That discard is existing behavior outside this task's scope (this task only fixes the flagged `session.getState().units[unitId] = ...` mutation two lines above it) — preserve the call exactly as-is, unexamined further, rather than "fixing" a discarded-return-value pattern this task was never asked to change.
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
   describe('startAutoExplore / cancelAutoExplore', () => {
@@ -1206,12 +1208,12 @@ Verified: `applyAutoExploreOrder(state: GameState, unitId: string, options: { bu
 
 `startAutoExplore`/`cancelAutoExplore` are confirmed public on `SelectionController` (`src/app/controllers/selection-controller.ts:120-121`, returned from the factory at lines 772-773), so calling them directly on `controller` is correct — no context-menu indirection needed.
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "startAutoExplore / cancelAutoExplore"`
 Expected: FAIL on both `listener` assertions.
 
-- [ ] **Step 3: Write minimal implementation** (assuming `applyAutoExploreOrder` returns a value rather than mutating — confirm per the note above and adjust if wrong):
+- [x] **Step 3: Write minimal implementation** (assuming `applyAutoExploreOrder` returns a value rather than mutating — confirm per the note above and adjust if wrong):
 
 ```ts
   function startAutoExplore(unitId: string): void {
@@ -1250,12 +1252,12 @@ Expected: FAIL on both `listener` assertions.
   }
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/selection-controller.test.ts -t "startAutoExplore / cancelAutoExplore"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/selection-controller.ts tests/app/controllers/selection-controller.test.ts
@@ -1264,10 +1266,10 @@ git commit -m "fix(selection-controller): route startAutoExplore/cancelAutoExplo
 
 ### Phase 4 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
-- [ ] Re-run the inventory grep against `selection-controller.ts` — confirm 0 remaining matches (15 sites, 4 tasks: 2 + 8 + 3 + 2 = 15).
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 4 (selection-controller.ts)`.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0. (487 test files, 7987 passed / 3 skipped, all hook smoke tests passed.)
+- [x] Re-run the inventory grep against `selection-controller.ts` — confirm 0 remaining matches (15 sites, 4 tasks: 2 + 8 + 3 + 2 = 15).
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 4 (selection-controller.ts)`.
 
 ---
 

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -510,10 +510,20 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
                  c.position.q === unit.position.q && c.position.r === unit.position.r,
           );
           if (!city) return;
-          session.getState().espionage![session.getState().currentPlayer] = embedSpy(civEsp, uid, city.id, city.position);
-          delete session.getState().units[uid];
-          session.getState().civilizations[session.getState().currentPlayer].units =
-            session.getState().civilizations[session.getState().currentPlayer].units.filter(id => id !== uid);
+          const currentPlayer = session.getState().currentPlayer;
+          const { [uid]: _removed, ...remainingUnits } = session.getState().units;
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: embedSpy(civEsp, uid, city.id, city.position) },
+            units: remainingUnits,
+            civilizations: {
+              ...session.getState().civilizations,
+              [currentPlayer]: {
+                ...session.getState().civilizations[currentPlayer],
+                units: session.getState().civilizations[currentPlayer].units.filter(id => id !== uid),
+              },
+            },
+          });
           deselectUnit();
           renderLoop.setGameState(session.getState());
           deps.updateHUD();

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -682,16 +682,17 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
     const unit = session.getState().units[unitId];
     if (!unit || unit.owner !== session.getState().currentPlayer) return;
 
-    session.getState().units[unitId] = {
+    const withAutomation = {
       ...unit,
       automation: {
-        mode: 'auto-explore',
+        mode: 'auto-explore' as const,
         startedTurn: session.getState().turn,
         lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
       },
     };
+    session.commit({ ...session.getState(), units: { ...session.getState().units, [unitId]: withAutomation } });
 
-    if (session.getState().units[unitId].movementPointsLeft > 0 && !session.getState().units[unitId].hasActed) {
+    if (withAutomation.movementPointsLeft > 0 && !withAutomation.hasActed) {
       applyAutoExploreOrder(session.getState(), unitId, { bus });
     }
 
@@ -703,7 +704,8 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
   function cancelAutoExplore(unitId: string): void {
     const unit = session.getState().units[unitId];
     if (!unit?.automation) return;
-    delete session.getState().units[unitId].automation;
+    const { automation: _removed, ...withoutAutomation } = unit;
+    session.commit({ ...session.getState(), units: { ...session.getState().units, [unitId]: withoutAutomation } });
     renderLoop.setGameState(session.getState());
     deps.updateHUD();
     if (selection.getSelectedUnitId() === unitId) {

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -442,6 +442,11 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
           const currentPlayer = session.getState().currentPlayer;
           let nextUnits = session.getState().units;
           let nextCivilizations = session.getState().civilizations;
+          // Deferred until after session.commit() below so that any bus listener reading
+          // session.getState() synchronously (e.g. register-espionage-presentation.ts's
+          // 'espionage:spy-caught-infiltrating' handler) observes the post-mutation state,
+          // not the state as it stood before this action published.
+          let runSideEffects: () => void;
 
           if (result.removeUnitFromMap) {
             // Era 2+: spy removed from map, stationed inside city
@@ -451,8 +456,11 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
             nextCivilizations = civUnits
               ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
               : nextCivilizations;
-            deps.showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
-            bus.emit('espionage:spy-infiltrated', { civId: currentPlayer, spyId: uid, cityId: targetCity.id });
+            runSideEffects = () => {
+              deps.showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
+              bus.emit('espionage:spy-infiltrated', { civId: currentPlayer, spyId: uid, cityId: targetCity.id });
+              deselectUnit();
+            };
           } else if (result.era1ScoutResult !== undefined) {
             // Era 1 (spy_scout): spy stays on map, infiltrationCityId + 5-turn city vision already set
             const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), currentPlayer, uid);
@@ -468,7 +476,10 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
               };
             }
             nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
-            deps.showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
+            runSideEffects = () => {
+              deps.showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
+              selectUnit(uid);
+            };
           } else if (result.caught) {
             // Caught: remove unit from map (spy lost)
             const { [uid]: _removed, ...remainingUnits } = nextUnits;
@@ -477,11 +488,17 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
             nextCivilizations = civUnits
               ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
               : nextCivilizations;
-            bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: currentPlayer, spyId: uid, cityId: targetCity.id });
+            runSideEffects = () => {
+              bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: currentPlayer, spyId: uid, cityId: targetCity.id });
+              deselectUnit();
+            };
           } else {
             const cooldown = result.civEsp.spies[uid]?.cooldownTurns ?? 3;
-            deps.showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
             nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
+            runSideEffects = () => {
+              deps.showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
+              selectUnit(uid);
+            };
           }
 
           session.commit({
@@ -491,11 +508,7 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
             civilizations: nextCivilizations,
           });
 
-          if (result.removeUnitFromMap || result.caught) {
-            deselectUnit();
-          } else {
-            selectUnit(uid);
-          }
+          runSideEffects();
 
           renderLoop.setGameState(session.getState());
           deps.updateHUD();

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -438,48 +438,62 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
             ...result.civEsp,
             spies: { ...result.civEsp.spies, [uid]: { ...spyAfterAttempt, targetCivId: targetCity.owner } },
           } : result.civEsp;
-          session.getState().espionage![session.getState().currentPlayer] = civEspWithTarget;
+
+          const currentPlayer = session.getState().currentPlayer;
+          let nextUnits = session.getState().units;
+          let nextCivilizations = session.getState().civilizations;
 
           if (result.removeUnitFromMap) {
             // Era 2+: spy removed from map, stationed inside city
-            delete session.getState().units[uid];
-            const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
-            if (civUnits) {
-              session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
-            }
+            const { [uid]: _removed, ...remainingUnits } = nextUnits;
+            nextUnits = remainingUnits;
+            const civUnits = nextCivilizations[currentPlayer].units;
+            nextCivilizations = civUnits
+              ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
+              : nextCivilizations;
             deps.showNotification(`Spy successfully infiltrated ${targetCity.name}. Open Intel panel to issue orders.`, 'success');
-            bus.emit('espionage:spy-infiltrated', { civId: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
-            deselectUnit();
+            bus.emit('espionage:spy-infiltrated', { civId: currentPlayer, spyId: uid, cityId: targetCity.id });
           } else if (result.era1ScoutResult !== undefined) {
             // Era 1 (spy_scout): spy stays on map, infiltrationCityId + 5-turn city vision already set
-            const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), session.getState().currentPlayer, uid);
+            const missionResult = resolveMissionResult('scout_area', targetCity.owner, targetCity.id, session.getState(), currentPlayer, uid);
             const tilesToReveal = missionResult.tilesToReveal ?? [];
             if (tilesToReveal.length > 0) {
-              const visibilityTiles = { ...(session.getState().civilizations[session.getState().currentPlayer].visibility?.tiles ?? {}) };
+              const visibilityTiles = { ...(nextCivilizations[currentPlayer].visibility?.tiles ?? {}) };
               for (const coord of tilesToReveal) {
                 visibilityTiles[`${coord.q},${coord.r}`] = 'visible';
               }
-              session.getState().civilizations[session.getState().currentPlayer].visibility = {
-                ...session.getState().civilizations[session.getState().currentPlayer].visibility!,
-                tiles: visibilityTiles,
+              nextCivilizations = {
+                ...nextCivilizations,
+                [currentPlayer]: { ...nextCivilizations[currentPlayer], visibility: { ...nextCivilizations[currentPlayer].visibility!, tiles: visibilityTiles } },
               };
             }
-            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+            nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
             deps.showNotification(`Scout revealed ${tilesToReveal.length} tile${tilesToReveal.length !== 1 ? 's' : ''} around ${targetCity.name}.`, 'success');
-            selectUnit(uid);
           } else if (result.caught) {
             // Caught: remove unit from map (spy lost)
-            delete session.getState().units[uid];
-            const civUnits = session.getState().civilizations[session.getState().currentPlayer].units;
-            if (civUnits) {
-              session.getState().civilizations[session.getState().currentPlayer].units = civUnits.filter(id => id !== uid);
-            }
-            bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: session.getState().currentPlayer, spyId: uid, cityId: targetCity.id });
-            deselectUnit();
+            const { [uid]: _removed, ...remainingUnits } = nextUnits;
+            nextUnits = remainingUnits;
+            const civUnits = nextCivilizations[currentPlayer].units;
+            nextCivilizations = civUnits
+              ? { ...nextCivilizations, [currentPlayer]: { ...nextCivilizations[currentPlayer], units: civUnits.filter(id => id !== uid) } }
+              : nextCivilizations;
+            bus.emit('espionage:spy-caught-infiltrating', { capturingCivId: targetCity.owner, spyOwner: currentPlayer, spyId: uid, cityId: targetCity.id });
           } else {
             const cooldown = result.civEsp.spies[uid]?.cooldownTurns ?? 3;
             deps.showNotification(`Spy failed to infiltrate ${targetCity.name}. Lying low for ${cooldown} turns.`, 'info');
-            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+            nextUnits = { ...nextUnits, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } };
+          }
+
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: civEspWithTarget },
+            units: nextUnits,
+            civilizations: nextCivilizations,
+          });
+
+          if (result.removeUnitFromMap || result.caught) {
+            deselectUnit();
+          } else {
             selectUnit(uid);
           }
 

--- a/src/app/controllers/selection-controller.ts
+++ b/src/app/controllers/selection-controller.ts
@@ -393,10 +393,14 @@ export function createSelectionController(deps: SelectionControllerDeps): Select
           if (!civEsp) return;
           const spy = civEsp.spies[uid];
           if (!spy || spy.status !== 'idle') return;
-          session.getState().espionage![session.getState().currentPlayer] = setDisguise(civEsp, uid, disguise);
-          if (disguise !== null) {
-            session.getState().units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
-          }
+          const currentPlayer = session.getState().currentPlayer;
+          session.commit({
+            ...session.getState(),
+            espionage: { ...session.getState().espionage, [currentPlayer]: setDisguise(civEsp, uid, disguise) },
+            units: disguise !== null
+              ? { ...session.getState().units, [uid]: { ...unit, hasActed: true, movementPointsLeft: 0 } }
+              : session.getState().units,
+          });
           renderLoop.setGameState(session.getState());
           deps.updateHUD();
           selectUnit(uid);

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -49,6 +49,7 @@ function findButtonByText(container: HTMLElement, text: string): HTMLButtonEleme
 function tryUntilInfiltrate(
   unitType: Unit['type'],
   predicate: (state: GameState, uid: string) => boolean,
+  setup?: (deps: SelectionControllerDeps) => void,
 ): { deps: SelectionControllerDeps; uid: string } | null {
   for (let i = 0; i < 200; i++) {
     const uid = `infiltrator-${i}`;
@@ -67,6 +68,7 @@ function tryUntilInfiltrate(
     const deps = baseDeps(state);
     const controller = createSelectionController(deps);
     vi.spyOn(window, 'confirm').mockReturnValue(true);
+    setup?.(deps);
 
     controller.selectUnit(uid);
     const panel = document.getElementById('info-panel')!;
@@ -472,6 +474,22 @@ describe('SelectionController', () => {
       const found = tryUntilInfiltrate('spy_scout', (state, uid) => state.espionage!.player.spies[uid]?.status === 'captured');
       expect(found).not.toBeNull();
       expect(found!.deps.session.getState().units[found!.uid]).toBeUndefined();
+    });
+
+    it('espionage:spy-caught-infiltrating fires only after the mutation is published, so listeners observe post-commit state', () => {
+      let capturedUnitAtEmitTime: unknown;
+      const found = tryUntilInfiltrate(
+        'spy_scout',
+        (state, uid) => state.espionage!.player.spies[uid]?.status === 'captured',
+        deps => {
+          deps.bus.on('espionage:spy-caught-infiltrating', ({ spyId }) => {
+            // A synchronous listener firing before session.commit() would still see the unit on the map.
+            capturedUnitAtEmitTime = deps.session.getState().units[spyId];
+          });
+        },
+      );
+      expect(found).not.toBeNull();
+      expect(capturedUnitAtEmitTime).toBeUndefined();
     });
 
     it('a failed-but-not-caught attempt marks the unit acted and keeps it on the map (default branch)', () => {

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import { createUnit } from '@/systems/unit-system';
+import { createEspionageCivState } from '@/systems/espionage-system';
 import type { GameState, Unit } from '@/core/types';
 import { createGameSession } from '@/app/game-session';
 import { createSelectionStore } from '@/app/selection-store';
@@ -37,6 +38,12 @@ function placePlayerUnit(state: GameState, id: string, overrides: Partial<Unit> 
   state.units[id] = { ...template, id, owner: 'player', position: { q: 0, r: 0 }, ...overrides };
   if (!state.civilizations.player.units.includes(id)) state.civilizations.player.units.push(id);
   return state.units[id];
+}
+
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(b => b.textContent === text);
+  if (!button) throw new Error(`No button with exact text "${text}" found in container`);
+  return button as HTMLButtonElement;
 }
 
 function fakeRenderer(overrides: Partial<SelectionControllerRenderer> = {}): SelectionControllerRenderer {
@@ -375,5 +382,33 @@ describe('SelectionController', () => {
 
     expect(() => controller.refreshCurrentPlayerVisibility()).not.toThrow();
     expect(deps.scanBeastSightings).toHaveBeenCalledTimes(1);
+  });
+
+  describe('onSetDisguise', () => {
+    it('sets the disguise and marks the unit acted, publishing through session subscribers', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'spy-1', { type: 'spy_informant', position: { q: 0, r: 0 } });
+      state.espionage = { player: createEspionageCivState() };
+      state.espionage.player.spies['spy-1'] = {
+        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_informant',
+        targetCivId: null, targetCityId: null, position: null,
+        status: 'idle', experience: 0, currentMission: null,
+        cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+      };
+      document.body.innerHTML = '<div id="info-panel"></div>';
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.selectUnit('spy-1');
+      const panel = document.getElementById('info-panel')!;
+      findButtonByText(panel, 'As Warrior').click();
+
+      const updated = deps.session.getState();
+      expect(updated.espionage!.player.spies['spy-1'].disguiseAs).toBe('warrior');
+      expect(updated.units['spy-1'].hasActed).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -366,31 +366,37 @@ describe('SelectionController', () => {
     expect(deps.renderLoop.setSelectedUnitId).toHaveBeenCalledWith('u1');
   });
 
-  it('startAutoExplore arms auto-explore automation and re-selects the unit', () => {
+  it('startAutoExplore arms auto-explore automation, re-selects the unit, and publishes through session subscribers', () => {
     const state = makeFixture();
     placePlayerUnit(state, 'u1', { movementPointsLeft: 0 });
     document.body.innerHTML = '<div id="info-panel"></div>';
     const deps = baseDeps(state);
     const controller = createSelectionController(deps);
+    const listener = vi.fn();
+    deps.session.subscribe(listener);
 
     controller.startAutoExplore('u1');
 
     expect(deps.session.getState().units.u1.automation?.mode).toBe('auto-explore');
     expect(deps.selection.getSelectedUnitId()).toBe('u1');
+    expect(listener).toHaveBeenCalled();
   });
 
-  it('cancelAutoExplore clears automation and re-selects only if currently selected', () => {
+  it('cancelAutoExplore clears automation, re-selects only if currently selected, and publishes through session subscribers', () => {
     const state = makeFixture();
     placePlayerUnit(state, 'u1', { automation: { mode: 'auto-explore', startedTurn: 1, lastTargets: [] } });
     document.body.innerHTML = '<div id="info-panel"></div>';
     const deps = baseDeps(state);
     const controller = createSelectionController(deps);
     controller.selectUnit('u1');
+    const listener = vi.fn();
+    deps.session.subscribe(listener);
 
     controller.cancelAutoExplore('u1');
 
     expect(deps.session.getState().units.u1.automation).toBeUndefined();
     expect(deps.selection.getSelectedUnitId()).toBe('u1');
+    expect(listener).toHaveBeenCalled();
   });
 
   it('cancelJourney clears automation via a committed state change', () => {

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -46,6 +46,39 @@ function findButtonByText(container: HTMLElement, text: string): HTMLButtonEleme
   return button as HTMLButtonElement;
 }
 
+function tryUntilInfiltrate(
+  unitType: Unit['type'],
+  predicate: (state: GameState, uid: string) => boolean,
+): { deps: SelectionControllerDeps; uid: string } | null {
+  for (let i = 0; i < 200; i++) {
+    const uid = `infiltrator-${i}`;
+    const state = makeFixture();
+    const template = Object.values(state.cities)[0]!;
+    state.cities['enemy-city'] = { ...template, id: 'enemy-city', owner: 'ai-1', position: { q: 0, r: 0 } };
+    placePlayerUnit(state, uid, { type: unitType, position: { q: 0, r: 0 } });
+    state.espionage = { player: createEspionageCivState() };
+    state.espionage.player.spies[uid] = {
+      id: uid, owner: 'player', name: 'Agent', unitType,
+      targetCivId: null, targetCityId: null, position: null,
+      status: 'idle', experience: 0, currentMission: null,
+      cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+    };
+    document.body.innerHTML = '<div id="info-panel"></div>';
+    const deps = baseDeps(state);
+    const controller = createSelectionController(deps);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    controller.selectUnit(uid);
+    const panel = document.getElementById('info-panel')!;
+    findButtonByText(panel, 'Infiltrate City').click();
+
+    if (predicate(deps.session.getState(), uid)) {
+      return { deps, uid };
+    }
+  }
+  return null;
+}
+
 function fakeRenderer(overrides: Partial<SelectionControllerRenderer> = {}): SelectionControllerRenderer {
   return {
     hasMovingUnit: () => false,
@@ -409,6 +442,39 @@ describe('SelectionController', () => {
       expect(updated.espionage!.player.spies['spy-1'].disguiseAs).toBe('warrior');
       expect(updated.units['spy-1'].hasActed).toBe(true);
       expect(listener).toHaveBeenCalled();
+    });
+  });
+
+  describe('onInfiltrate', () => {
+    it('era-2+ unit types remove the unit from the map and station the spy (removeUnitFromMap branch)', () => {
+      const found = tryUntilInfiltrate('spy_informant', (state, uid) => state.units[uid] === undefined);
+      expect(found).not.toBeNull();
+      const state = found!.deps.session.getState();
+      expect(state.civilizations.player.units).not.toContain(found!.uid);
+      expect(state.espionage!.player.spies[found!.uid].status).toBe('stationed');
+    });
+
+    it('era-1 scout infiltration reveals tiles and marks the unit acted without removing it (era1ScoutResult branch)', () => {
+      const found = tryUntilInfiltrate('spy_scout', (state, uid) => state.units[uid]?.hasActed === true && state.units[uid] !== undefined);
+      expect(found).not.toBeNull();
+      const state = found!.deps.session.getState();
+      expect(state.units[found!.uid].hasActed).toBe(true);
+      expect(state.espionage!.player.spies[found!.uid].infiltrationCityId).toBe('enemy-city');
+    });
+
+    it('a caught spy is removed from the map (caught branch)', () => {
+      const found = tryUntilInfiltrate('spy_scout', (state, uid) => state.espionage!.player.spies[uid]?.status === 'captured');
+      expect(found).not.toBeNull();
+      expect(found!.deps.session.getState().units[found!.uid]).toBeUndefined();
+    });
+
+    it('a failed-but-not-caught attempt marks the unit acted and keeps it on the map (default branch)', () => {
+      const found = tryUntilInfiltrate(
+        'spy_scout',
+        (state, uid) => state.units[uid] !== undefined && state.espionage!.player.spies[uid]?.status === 'cooldown',
+      );
+      expect(found).not.toBeNull();
+      expect(found!.deps.session.getState().units[found!.uid].hasActed).toBe(true);
     });
   });
 });

--- a/tests/app/controllers/selection-controller.test.ts
+++ b/tests/app/controllers/selection-controller.test.ts
@@ -477,4 +477,36 @@ describe('SelectionController', () => {
       expect(found!.deps.session.getState().units[found!.uid].hasActed).toBe(true);
     });
   });
+
+  describe('onEmbed', () => {
+    it('embeds the spy, removes the unit from the map, and publishes through session subscribers', () => {
+      const state = makeFixture();
+      const template = Object.values(state.cities)[0]!;
+      state.cities['friendly-city'] = { ...template, id: 'friendly-city', owner: 'player', position: { q: 0, r: 0 } };
+      state.civilizations.player.cities = ['friendly-city'];
+      placePlayerUnit(state, 'spy-1', { type: 'spy_scout', position: { q: 0, r: 0 } });
+      state.espionage = { player: createEspionageCivState() };
+      state.espionage.player.spies['spy-1'] = {
+        id: 'spy-1', owner: 'player', name: 'Agent', unitType: 'spy_scout',
+        targetCivId: null, targetCityId: null, position: null,
+        status: 'idle', experience: 0, currentMission: null,
+        cooldownTurns: 0, promotion: undefined, promotionAvailable: false, feedsFalseIntel: false,
+      };
+      document.body.innerHTML = '<div id="info-panel"></div>';
+      const deps = baseDeps(state);
+      const controller = createSelectionController(deps);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.selectUnit('spy-1');
+      const panel = document.getElementById('info-panel')!;
+      findButtonByText(panel, 'Embed (counter-espionage)').click();
+
+      const updated = deps.session.getState();
+      expect(updated.units['spy-1']).toBeUndefined();
+      expect(updated.civilizations.player.units).not.toContain('spy-1');
+      expect(updated.espionage!.player.spies['spy-1'].status).toBe('embedded');
+      expect(listener).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the GameSession state-mutation audit (spec: `docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md`, plan: `docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md`). Continues from Phase 3 (#838, merged).

Converts all 15 flagged direct-mutation sites in `selection-controller.ts` (espionage handlers + unit-automation), all under the file's `session`-scoped closure, into single `session.commit()` calls:

- `onSetDisguise` — espionage disguise assignment + conditional unit-acted mutation (2 sites) folded into one commit.
- `onInfiltrate` — all 4 outcome branches (`removeUnitFromMap`, era-1 scout result, `caught`, default fail) accumulate into `nextUnits`/`nextCivilizations` and commit once at the end (8 sites).
- `onEmbed` — espionage assignment + unit removal + civ unit-list filter folded into one commit (3 sites).
- `startAutoExplore` / `cancelAutoExplore` — unit automation set/clear now goes through `session.commit` (2 sites).

Architecture-debt only — every site already had a manual `renderLoop.setGameState` + `deps.updateHUD()` pair right after it, so there's no live user-facing HUD-staleness bug here; this closes the gap for the single-owner `commit`/`update` contract and moves Phase 4's inventory count to zero ahead of Phase 6's regression guard.

**Deviations from the plan's draft, found during this phase's own prereq/drift check:**
1. Task 4.4's draft proposed a brand-new `describe('startAutoExplore / cancelAutoExplore', ...)` test block. The test file already had two flat `it(...)` tests covering this exact behavior (added before this plan existed) — extended those in place with `session.subscribe`/listener assertions instead of duplicating coverage, matching this same plan's own convention from Phase 1 Task 1.2 ("extend existing test" over "add a parallel one").
2. `onInfiltrate`'s 4 branch tests (per the plan's own explanatory note) don't assert a `listener` call individually — they were confirmed to pass even against the pre-fix code, since `session.getState()` returns the same live-mutated object either way. Only `onSetDisguise`/`onEmbed`'s tests assert the publish plumbing directly; `onInfiltrate`'s tests instead prove each branch's distinguishing state via the `tryUntilInfiltrate` deterministic search, per the plan's existing rationale.

**Bug found and fixed in a follow-up self-review pass:** `onInfiltrate`'s initial conversion still emitted `espionage:spy-infiltrated`/`espionage:spy-caught-infiltrating` *before* `session.commit()` in 2 of its 4 branches. `register-espionage-presentation.ts`'s synchronous `espionage:spy-caught-infiltrating` listener reads `session.getState()` at emit time, so it would have observed pre-mutation state — exactly the single-owner violation this audit exists to close. Not observably broken today (the fields that listener currently reads don't change during infiltration), but fragile and wrong. Fixed by deferring all of a branch's notifications/emits/select-or-deselect into a `runSideEffects()` closure invoked after `session.commit()`. Added a regression test that registers a bus listener and asserts it observes post-commit state; verified it fails against the old (buggy) ordering before confirming it passes against the fix.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` (full suite, 487 files / 7988 tests passed, 3 skipped) — passes, including hook smoke tests
- [x] New/extended tests proving `onSetDisguise`, `onInfiltrate` (all 4 branches), `onEmbed`, and `startAutoExplore`/`cancelAutoExplore` drive the real (unmocked) selected-unit-info panel via DOM clicks and publish through `session.subscribe` listeners
- [x] New regression test proving `espionage:spy-caught-infiltrating` fires only after the mutation is published (verified it fails against the pre-fix emit-before-commit ordering)
- [x] Re-ran the inventory grep against `selection-controller.ts` — 0 remaining direct-mutation-through-`getState()` sites (was 15)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>