### PR TITLE
fix(787): GameSession state-mutation audit — Phase 5 (panel-actions-controller.ts + city-panel.ts)

### DIFF
--- a/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
+++ b/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
@@ -1302,7 +1302,7 @@ Current code, verified against the real file (`panel-actions-controller.ts:483-4
 
 The real callback is `onTalkLevelChange` (typed `(level: CouncilTalkLevel) => void` in `src/ui/council-panel.ts:7`), not a guessed name — verified by reading the file directly before writing this task, per this repo's `spec-fidelity.md` convention of not carrying an unverified claim into an implementation step. `CouncilTalkLevel` (`src/core/types.ts:1540`) is `'quiet' | 'normal' | 'chatty' | 'chaos'`.
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
     it('onTalkLevelChange publishes the new council talk level through session subscribers', () => {
@@ -1322,12 +1322,12 @@ The real callback is `onTalkLevelChange` (typed `(level: CouncilTalkLevel) => vo
 
 Import `CouncilTalkLevel` from `@/core/types` at the top of the test file if not already imported.
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onTalkLevelChange"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onTalkLevelChange: (level) => {
@@ -1336,12 +1336,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
       },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onTalkLevelChange"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -1445,7 +1445,7 @@ Current call sites:
   });
 ```
 
-- [ ] **Step 1: Update the interface.** In `CityPanelCallbacks`:
+- [x] **Step 1: Update the interface.** In `CityPanelCallbacks`:
 
 ```ts
   onBuild: (cityId: string, itemId: string) => GameState | void;
@@ -1455,7 +1455,7 @@ Current call sites:
   onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => GameState | void;
 ```
 
-- [ ] **Step 2: Update the 3 call sites to pass the return value to `rerenderPanel`.**
+- [x] **Step 2: Update the 3 call sites to pass the return value to `rerenderPanel`.**
 
 ```ts
   panel.querySelectorAll('.build-item').forEach(el => {
@@ -1497,7 +1497,7 @@ Current call sites:
   });
 ```
 
-- [ ] **Step 3: Do not commit this task alone.** Continue directly to Task 5.3 — the two land in one commit together (Task 5.3's Step 5 covers both).
+- [x] **Step 3: Do not commit this task alone.** Continue directly to Task 5.3 — the two land in one commit together (Task 5.3's Step 5 covers both).
 
 ### Task 5.3: `panel-actions-controller.ts`'s 4 city-production handlers
 
@@ -1552,7 +1552,7 @@ Current code:
       },
 ```
 
-- [ ] **Step 1: Write the failing test** (this replaces the coupled test — full content in Task 5.4; write it now as this task's Step 1 since it's the same edit):
+- [x] **Step 1: Write the failing test** (this replaces the coupled test — full content in Task 5.4; write it now as this task's Step 1 since it's the same edit):
 
 ```ts
     it('queues real production via session.commit, publishes to subscribers, and returns the fresh state for the panel to re-render', () => {
@@ -1574,12 +1574,12 @@ Current code:
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "queues real production via session.commit"`
 Expected: FAIL — `returned` is `undefined` (current `onBuild` returns `void`), and `listener` was never called.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onBuild: (cityId, itemId) => {
@@ -1634,9 +1634,9 @@ Expected: FAIL — `returned` is `undefined` (current `onBuild` returns `void`),
 
 Note the `onBuild` catch-block path (queue-limit-reached error) deliberately still returns `undefined` — no state changed, so `rerenderPanel(undefined)` correctly falls back to `nextState ?? state`. That fallback is now stale-by-design only in the sense that nothing changed to make it stale; this is the one case where the closure-default behavior was never wrong.
 
-- [ ] **Step 4: Apply Task 5.2's `city-panel.ts` changes now** (Steps 1-2 from that task), since both files must land together.
+- [x] **Step 4: Apply Task 5.2's `city-panel.ts` changes now** (Steps 1-2 from that task), since both files must land together.
 
-- [ ] **Step 5: Run tests to verify they pass.**
+- [x] **Step 5: Run tests to verify they pass.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "city-panel"`
 Expected: PASS.
@@ -1644,7 +1644,7 @@ Expected: PASS.
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/city-panel.test.ts` (and any other `tests/ui/city-panel-*.test.ts` files — list them with `find tests/ui -iname "city-panel*"` first)
 Expected: PASS — the widened callback types are backward compatible (`GameState | void` accepts a `void`-returning mock), so pre-existing city-panel UI tests that pass plain `() => {}` callbacks should be unaffected.
 
-- [ ] **Step 6: Commit both files together.**
+- [x] **Step 6: Commit both files together.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts src/ui/city-panel.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -1665,9 +1665,9 @@ change would have regressed the panel to stale -- both land together."
 
 This task is verification, not new code — Task 5.3's Step 1 already wrote the replacement test. Use this task to confirm the old assertion pattern is gone, not still present alongside the new one.
 
-- [ ] **Step 1:** `grep -n "queues real production" tests/app/controllers/panel-actions-controller.test.ts` — expect exactly one match (the rewritten test from Task 5.3), not two.
-- [ ] **Step 2:** Confirm no other test in this file still asserts `state.cities[...]` (the outer fixture variable) instead of `deps.session.getState().cities[...]` for any of the 4 converted handlers: `grep -n "^\s*expect(state\.cities" tests/app/controllers/panel-actions-controller.test.ts`. Fix any remaining ones the same way.
-- [ ] **Step 3: Commit if Step 2 found anything to fix; otherwise this task is a no-op check, fold its confirmation into Task 5.3's PR description.**
+- [x] **Step 1:** `grep -n "queues real production" tests/app/controllers/panel-actions-controller.test.ts` — expect exactly one match (the rewritten test from Task 5.3), not two.
+- [x] **Step 2:** Confirm no other test in this file still asserts `state.cities[...]` (the outer fixture variable) instead of `deps.session.getState().cities[...]` for any of the 4 converted handlers: `grep -n "^\s*expect(state\.cities" tests/app/controllers/panel-actions-controller.test.ts`. Fix any remaining ones the same way.
+- [x] **Step 3: Commit if Step 2 found anything to fix; otherwise this task is a no-op check, fold its confirmation into Task 5.3's PR description.**
 
 ### Task 5.5: tech-queue handlers (`onQueueResearch`, `onMoveQueuedResearch`, `onRemoveQueuedResearch`)
 
@@ -1713,7 +1713,7 @@ Current code:
 
 Verified against the real file (`panel-actions-controller.ts:498-527`) — all 3 handlers call `deps.hud.update()` manually, confirming the spec's severity note: architecture-debt only, not a currently-observable HUD bug.
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
     it('onQueueResearch publishes the queued tech through session subscribers', () => {
@@ -1733,12 +1733,12 @@ Verified against the real file (`panel-actions-controller.ts:498-527`) — all 3
 
 Confirm `controller.openTechPanel` is the real public method name and `createTechPanel`'s callback argument index by reading the file — this codebase's convention (seen in Tasks 1.1-5.3) is consistent, but verify rather than assume for this specific panel.
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onQueueResearch"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onQueueResearch: (techId) => {
@@ -1791,12 +1791,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
       },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onQueueResearch"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -1838,7 +1838,7 @@ This handler closes+reopens the espionage panel via `deps.router.open('espionage
 
 **Verified target-picker mechanism:** `chooseFriendlyCityTarget()` (`panel-actions-controller.ts:820-839`, a closure inside the same registrar as this handler) calls `window.prompt(message, choices[0].id)` — jsdom's `window.prompt` returns `null` unless stubbed, so the test must stub it. Since the prompt's second argument is always the first valid choice's id, a generic stub that echoes the suggested default resolves this deterministically without hardcoding a specific city id: `vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);`. The same stub covers `chooseForeignCityTarget` (Task 5.7) and `chooseMission` (Task 5.7) too, since both follow the identical `window.prompt(msg, choices[0])` pattern — add it once per test that reaches any of these three pickers.
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
     it('onAssignDefensive embeds the spy, removes the unit, and publishes through session subscribers', () => {
@@ -1866,12 +1866,12 @@ This handler closes+reopens the espionage panel via `deps.router.open('espionage
 
 `controller.openEspionagePanel` is confirmed public on `PanelActionsController` (`panel-actions-controller.ts:125`).
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onAssignDefensive"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()` (and likely `expect(deps.hud.update).toHaveBeenCalled()` too, since it's currently never called for this handler).
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onAssignDefensive: (spyId) => {
@@ -1902,12 +1902,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()` (and likely `expect(deps
       },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onAssignDefensive"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -1970,7 +1970,7 @@ Current code (all 3, same shape):
 
 None of these 3 currently call `hud.update()` — all live bugs per the spec's severity table.
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
 ```ts
     it('onStartMission commits the started mission and publishes through session subscribers', () => {
@@ -2019,12 +2019,12 @@ None of these 3 currently call `hud.update()` — all live bugs per the spec's s
     });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail.**
+- [x] **Step 2: Run tests to verify they fail.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onStartMission|onRecall|onVerifyAgent"`
 Expected: FAIL, all 3, on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onStartMission: (spyId) => {
@@ -2077,12 +2077,12 @@ Expected: FAIL, all 3, on `expect(listener).toHaveBeenCalled()`.
       },
 ```
 
-- [ ] **Step 4: Run tests to verify they pass.**
+- [x] **Step 4: Run tests to verify they pass.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onStartMission|onRecall|onVerifyAgent"`
 Expected: PASS, all 3.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -2162,7 +2162,7 @@ Current code, `onUnembed`:
       },
 ```
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
 ```ts
     it('onExfiltrate spawns a fresh unit at the capital, updates espionage state, and publishes', () => {
@@ -2202,12 +2202,12 @@ Current code, `onUnembed`:
     });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail.**
+- [x] **Step 2: Run tests to verify they fail.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onExfiltrate|onUnembed"`
 Expected: FAIL, both, on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onExfiltrate: (spyId) => {
@@ -2285,12 +2285,12 @@ Expected: FAIL, both, on `expect(listener).toHaveBeenCalled()`.
       },
 ```
 
-- [ ] **Step 4: Run tests to verify they pass.**
+- [x] **Step 4: Run tests to verify they pass.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onExfiltrate|onUnembed"`
 Expected: PASS, both.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -2321,7 +2321,7 @@ Current code:
       },
 ```
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
 ```ts
     it('onSweep commits the sweep result and publishes through session subscribers', () => {
@@ -2340,12 +2340,12 @@ Current code:
     });
 ```
 
-- [ ] **Step 2: Run test to verify it fails.**
+- [x] **Step 2: Run test to verify it fails.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSweep"`
 Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
 
-- [ ] **Step 3: Write minimal implementation.**
+- [x] **Step 3: Write minimal implementation.**
 
 ```ts
       onSweep: (spyId) => {
@@ -2363,12 +2363,12 @@ Expected: FAIL on `expect(listener).toHaveBeenCalled()`.
       },
 ```
 
-- [ ] **Step 4: Run test to verify it passes.**
+- [x] **Step 4: Run test to verify it passes.**
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/controllers/panel-actions-controller.test.ts -t "onSweep"`
 Expected: PASS.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add src/app/controllers/panel-actions-controller.ts tests/app/controllers/panel-actions-controller.test.ts
@@ -2377,11 +2377,11 @@ git commit -m "fix(panel-actions-controller): route onSweep's espionage-state co
 
 ### Phase 5 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0 (this includes `tests/ui/city-panel*.test.ts`).
-- [ ] Re-run the inventory grep against `panel-actions-controller.ts` — confirm 0 remaining matches. Expected breakdown (verified 21 = 1 + 4 + 3 + 3 + 3 + 6 + 1): Task 5.1=1 (settings), Task 5.3=4 (onBuild/onMoveQueueItem/onRemoveQueueItem/onSetIdleProduction), Task 5.5=3 (onQueueResearch/onMoveQueuedResearch/onRemoveQueuedResearch), Task 5.6=3 (onAssignDefensive's espionage-assign/delete-unit/civ-units-filter), Task 5.7=3 (onStartMission/onRecall/onVerifyAgent, one site each), Task 5.8=6 (onExfiltrate's units/civ-units/espionage-assign ×3 + onUnembed's units/civ-units/espionage-assign ×3), Task 5.9=1 (onSweep). If the re-run grep finds a residual site not covered by Tasks 5.1-5.9, add one more task before closing this phase rather than closing with a known gap.
-- [ ] Confirm `src/ui/city-panel.ts` has zero remaining `void`-only queue callbacks (Task 5.2/5.3 covered all 4).
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 5 (panel-actions-controller.ts + city-panel.ts)`. Body must explicitly call out the `city-panel.ts` companion change and the test rewrite (Task 5.4) as its own line items, per Global Constraints.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0 (this includes `tests/ui/city-panel*.test.ts`).
+- [x] Re-run the inventory grep against `panel-actions-controller.ts` — confirm 0 remaining matches. Expected breakdown (verified 21 = 1 + 4 + 3 + 3 + 3 + 6 + 1): Task 5.1=1 (settings), Task 5.3=4 (onBuild/onMoveQueueItem/onRemoveQueueItem/onSetIdleProduction), Task 5.5=3 (onQueueResearch/onMoveQueuedResearch/onRemoveQueuedResearch), Task 5.6=3 (onAssignDefensive's espionage-assign/delete-unit/civ-units-filter), Task 5.7=3 (onStartMission/onRecall/onVerifyAgent, one site each), Task 5.8=6 (onExfiltrate's units/civ-units/espionage-assign ×3 + onUnembed's units/civ-units/espionage-assign ×3), Task 5.9=1 (onSweep). If the re-run grep finds a residual site not covered by Tasks 5.1-5.9, add one more task before closing this phase rather than closing with a known gap.
+- [x] Confirm `src/ui/city-panel.ts` has zero remaining `void`-only queue callbacks (Task 5.2/5.3 covered all 4).
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 5 (panel-actions-controller.ts + city-panel.ts)`. Body must explicitly call out the `city-panel.ts` companion change and the test rewrite (Task 5.4) as its own line items, per Global Constraints.
 
 ---
 

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -487,7 +487,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         deps.getElementById('council-panel')?.remove();
       },
       onTalkLevelChange: (level) => {
-        deps.session.getState().settings.councilTalkLevel = level;
+        deps.session.commit({ ...deps.session.getState(), settings: { ...deps.session.getState().settings, councilTalkLevel: level } });
         void saveSettings(deps.session.getState().settings);
       },
     });

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -497,30 +497,50 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
     deps.hud.closeDrawer();
     createTechPanel(deps.uiLayer, deps.session.getState(), {
       onQueueResearch: (techId) => {
+        const civ = deps.currentCiv();
+        let nextTechState;
         try {
-          deps.currentCiv().techState = enqueueResearch(deps.currentCiv().techState, techId);
+          nextTechState = enqueueResearch(civ.techState, techId);
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Queue limit reached';
           deps.showNotification(message, 'warning');
           return;
         }
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: { ...deps.session.getState().civilizations, [deps.session.getState().currentPlayer]: { ...civ, techState: nextTechState } },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
         deps.hud.update();
         deps.showNotification(`Queued research: ${techId}`, 'info');
       },
       onMoveQueuedResearch: (fromIndex, toIndex) => {
-        deps.currentCiv().techState = {
-          ...deps.currentCiv().techState,
-          researchQueue: moveQueuedId(deps.currentCiv().techState.researchQueue, fromIndex, toIndex),
-        };
+        const civ = deps.currentCiv();
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [deps.session.getState().currentPlayer]: {
+              ...civ,
+              techState: { ...civ.techState, researchQueue: moveQueuedId(civ.techState.researchQueue, fromIndex, toIndex) },
+            },
+          },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
         deps.hud.update();
       },
       onRemoveQueuedResearch: (index) => {
-        deps.currentCiv().techState = {
-          ...deps.currentCiv().techState,
-          researchQueue: removeQueuedId(deps.currentCiv().techState.researchQueue, index),
-        };
+        const civ = deps.currentCiv();
+        deps.session.commit({
+          ...deps.session.getState(),
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [deps.session.getState().currentPlayer]: {
+              ...civ,
+              techState: { ...civ.techState, researchQueue: removeQueuedId(civ.techState.researchQueue, index) },
+            },
+          },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
         deps.hud.update();
       },

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -897,19 +897,25 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
       onAssignDefensive: (spyId) => {
         const target = chooseFriendlyCityTarget();
         if (!target) return;
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = embedSpy(
-          deps.session.getState().espionage![deps.session.getState().currentPlayer],
-          spyId,
-          target.cityId,
-          target.position,
-        );
+        const currentPlayer = deps.session.getState().currentPlayer;
         const unit = deps.session.getState().units[spyId];
+        const nextEspionage = {
+          ...deps.session.getState().espionage,
+          [currentPlayer]: embedSpy(deps.session.getState().espionage![currentPlayer], spyId, target.cityId, target.position),
+        };
+        let nextUnits = deps.session.getState().units;
+        let nextCivilizations = deps.session.getState().civilizations;
         if (unit) {
-          delete deps.session.getState().units[spyId];
-          deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
-            deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.filter(id => id !== spyId);
+          const { [spyId]: _removed, ...remainingUnits } = nextUnits;
+          nextUnits = remainingUnits;
+          nextCivilizations = {
+            ...nextCivilizations,
+            [currentPlayer]: { ...nextCivilizations[currentPlayer], units: nextCivilizations[currentPlayer].units.filter(id => id !== spyId) },
+          };
         }
+        deps.session.commit({ ...deps.session.getState(), espionage: nextEspionage, units: nextUnits, civilizations: nextCivilizations });
         deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
         deps.router.open('espionage');
         const cityName = deps.session.getState().cities[target.cityId]?.name ?? target.cityId;
         deps.showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -933,33 +933,38 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
           targetCivId = target.civId;
           targetCityId = target.cityId;
         }
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = startMission(
-          deps.session.getState().espionage![deps.session.getState().currentPlayer],
-          spyId,
-          mission,
-          deps.currentCivDef()?.bonusEffect,
-          targetCivId,
-          targetCityId,
-        );
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: {
+            ...deps.session.getState().espionage,
+            [currentPlayer]: startMission(deps.session.getState().espionage![currentPlayer], spyId, mission, deps.currentCivDef()?.bonusEffect, targetCivId, targetCityId),
+          },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
         deps.router.open('espionage');
         deps.showNotification(`Mission ${mission} started.`, 'info');
       },
       onRecall: (spyId) => {
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = recallSpy(
-          deps.session.getState().espionage![deps.session.getState().currentPlayer],
-          spyId,
-        );
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: recallSpy(deps.session.getState().espionage![currentPlayer], spyId) },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
         deps.router.open('espionage');
         deps.showNotification('Spy recalled.', 'info');
       },
       onVerifyAgent: (spyId) => {
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = verifyAgent(
-          deps.session.getState().espionage![deps.session.getState().currentPlayer],
-          spyId,
-        );
+        const currentPlayer = deps.session.getState().currentPlayer;
+        deps.session.commit({
+          ...deps.session.getState(),
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: verifyAgent(deps.session.getState().espionage![currentPlayer], spyId) },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
+        deps.hud.update();
         deps.router.open('espionage');
         deps.showNotification('Agent verified and cleared.', 'success');
       },

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -993,16 +993,22 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
           spawnPos = adjacent[0];
         }
 
-        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, spawnPos, deps.session.getState().idCounters);
-        deps.session.getState().units[newUnit.id] = newUnit;
-        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units =
-          [...(deps.session.getState().civilizations[deps.session.getState().currentPlayer].units ?? []), newUnit.id];
+        const currentPlayer = deps.session.getState().currentPlayer;
+        const newUnit = createUnit(spy.unitType, currentPlayer, spawnPos, deps.session.getState().idCounters);
         const updatedSpy = {
           ...spy, id: newUnit.id, status: 'cooldown' as const,
           cooldownTurns: 8, infiltrationCityId: null, cityVisionTurnsLeft: 0, targetCivId: null, cooldownMode: undefined,
         };
         const { [spyId]: _old, ...rest } = ownerEsp!.spies;
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } };
+        deps.session.commit({
+          ...deps.session.getState(),
+          units: { ...deps.session.getState().units, [newUnit.id]: newUnit },
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [currentPlayer]: { ...deps.session.getState().civilizations[currentPlayer], units: [...(deps.session.getState().civilizations[currentPlayer].units ?? []), newUnit.id] },
+          },
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: { ...ownerEsp!, spies: { ...rest, [newUnit.id]: updatedSpy } } },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
         // Refresh panel in place
         deps.getElementById('espionage-panel')?.remove();
@@ -1034,13 +1040,20 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
         const city = deps.session.getState().cities[spy.targetCityId];
         if (!city) return;
-        const newUnit = createUnit(spy.unitType, deps.session.getState().currentPlayer, city.position, deps.session.getState().idCounters);
-        deps.session.getState().units[newUnit.id] = newUnit;
-        deps.session.getState().civilizations[deps.session.getState().currentPlayer].units.push(newUnit.id);
+        const currentPlayer = deps.session.getState().currentPlayer;
+        const newUnit = createUnit(spy.unitType, currentPlayer, city.position, deps.session.getState().idCounters);
         const unembedded = unembedSpy(ownerEsp!, spyId);
         const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
         const { [spyId]: _old, ...rest } = unembedded.spies;
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
+        deps.session.commit({
+          ...deps.session.getState(),
+          units: { ...deps.session.getState().units, [newUnit.id]: newUnit },
+          civilizations: {
+            ...deps.session.getState().civilizations,
+            [currentPlayer]: { ...deps.session.getState().civilizations[currentPlayer], units: [...deps.session.getState().civilizations[currentPlayer].units, newUnit.id] },
+          },
+          espionage: { ...deps.session.getState().espionage, [currentPlayer]: { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } } },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
         deps.getElementById('espionage-panel')?.remove();
         deps.router.open('espionage');

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -662,9 +662,10 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         const targetCity = deps.session.getState().cities[cityId];
         if (targetCity) {
           try {
-            deps.session.getState().cities[cityId] = enqueueCityProduction(targetCity, itemId);
+            deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: enqueueCityProduction(targetCity, itemId) } });
             deps.renderLoop.setGameState(deps.session.getState());
             deps.showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
+            return deps.session.getState();
           } catch (error) {
             const message = error instanceof Error ? error.message : 'Queue limit reached';
             deps.showNotification(`${targetCity.name}: ${message}`, 'warning');
@@ -674,18 +675,26 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
       onMoveQueueItem: (cityId, fromIndex, toIndex) => {
         const targetCity = deps.session.getState().cities[cityId];
         if (!targetCity) return;
-        deps.session.getState().cities[cityId] = reorderCityProduction(targetCity, fromIndex, toIndex);
+        deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: reorderCityProduction(targetCity, fromIndex, toIndex) } });
         deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
       },
       onRemoveQueueItem: (cityId, index) => {
         const targetCity = deps.session.getState().cities[cityId];
         if (!targetCity) return;
-        deps.session.getState().cities[cityId] = {
-          ...targetCity,
-          productionQueue: removeQueuedId(targetCity.productionQueue, index),
-          productionProgress: index === 0 ? 0 : targetCity.productionProgress,
-        };
+        deps.session.commit({
+          ...deps.session.getState(),
+          cities: {
+            ...deps.session.getState().cities,
+            [cityId]: {
+              ...targetCity,
+              productionQueue: removeQueuedId(targetCity.productionQueue, index),
+              productionProgress: index === 0 ? 0 : targetCity.productionProgress,
+            },
+          },
+        });
         deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
       },
       onOpenWonderPanel: (selectedCityId) => {
         openWonderPanelForCityId(selectedCityId);
@@ -738,8 +747,9 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
       onSetIdleProduction: (cityId, mode) => {
         const targetCity = deps.session.getState().cities[cityId];
         if (!targetCity) return;
-        deps.session.getState().cities[cityId] = setIdleProduction(targetCity, mode);
+        deps.session.commit({ ...deps.session.getState(), cities: { ...deps.session.getState().cities, [cityId]: setIdleProduction(targetCity, mode) } });
         deps.renderLoop.setGameState(deps.session.getState());
+        return deps.session.getState();
       },
       onRushBuyActiveProduction: (cityId) => {
         const targetCity = deps.session.getState().cities[cityId];

--- a/src/app/controllers/panel-actions-controller.ts
+++ b/src/app/controllers/panel-actions-controller.ts
@@ -1064,7 +1064,7 @@ export function createPanelActionsController(deps: PanelActionsControllerDeps): 
         if (!ownerEsp) return;
         const seed = `sweep-${spyId}-${deps.session.getState().turn}`;
         const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, deps.session.getState());
-        deps.session.getState().espionage![deps.session.getState().currentPlayer] = updatedEsp;
+        deps.session.commit({ ...deps.session.getState(), espionage: { ...deps.session.getState().espionage, [deps.session.getState().currentPlayer]: updatedEsp } });
         if (detectedSpyIds.length > 0) {
           deps.showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
         } else {

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -69,9 +69,9 @@ import {
 } from '@/systems/economy-system';
 
 export interface CityPanelCallbacks {
-  onBuild: (cityId: string, itemId: string) => void;
-  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => void;
-  onRemoveQueueItem?: (cityId: string, index: number) => void;
+  onBuild: (cityId: string, itemId: string) => GameState | void;
+  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => GameState | void;
+  onRemoveQueueItem?: (cityId: string, index: number) => GameState | void;
   onOpenWonderPanel: (cityId: string) => void;
   onSetCityFocus?: (cityId: string, focus: Exclude<CityFocus, 'custom'>) => GameState | void;
   onToggleWorkedTile?: (cityId: string, coord: HexCoord, worked: boolean) => GameState | void;
@@ -87,7 +87,7 @@ export interface CityPanelCallbacks {
   /** Opens the destination-city picker for an idle trade unit — same path as
    *  selected-unit-info.ts's Establish Route button. */
   onEstablishRoute?: (caravanId: string) => void;
-  onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => void;
+  onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => GameState | void;
   onRushBuyActiveProduction?: (cityId: string) => GameState | void;
   onAppeaseFaction?: (cityId: string) => GameState | void;
   onConcedeToMovement?: (cityId: string) => GameState | void;
@@ -1508,8 +1508,8 @@ export function createCityPanel(
   panel.querySelectorAll('.build-item').forEach(el => {
     el.addEventListener('click', () => {
       const itemId = (el as HTMLElement).dataset.itemId!;
-      callbacks.onBuild(city.id, itemId);
-      rerenderPanel();
+      const nextState = callbacks.onBuild(city.id, itemId);
+      rerenderPanel(nextState);
     });
   });
 
@@ -1561,20 +1561,20 @@ export function createCityPanel(
       }
 
       if (action === 'remove') {
-        callbacks.onRemoveQueueItem?.(city.id, index);
-        rerenderPanel();
+        const nextState = callbacks.onRemoveQueueItem?.(city.id, index);
+        rerenderPanel(nextState);
         return;
       }
 
       if (action === 'up' && index > 0) {
-        callbacks.onMoveQueueItem?.(city.id, index, index - 1);
-        rerenderPanel();
+        const nextState = callbacks.onMoveQueueItem?.(city.id, index, index - 1);
+        rerenderPanel(nextState);
         return;
       }
 
       if (action === 'down' && index < city.productionQueue.length - 1) {
-        callbacks.onMoveQueueItem?.(city.id, index, index + 1);
-        rerenderPanel();
+        const nextState = callbacks.onMoveQueueItem?.(city.id, index, index + 1);
+        rerenderPanel(nextState);
       }
     });
   });
@@ -1624,8 +1624,8 @@ export function createCityPanel(
     btn.addEventListener('click', () => {
       const raw = btn.dataset.idleMode;
       const mode = raw === 'gold' || raw === 'science' ? raw : null;
-      callbacks.onSetIdleProduction?.(city.id, mode);
-      rerenderPanel();
+      const nextState = callbacks.onSetIdleProduction?.(city.id, mode);
+      rerenderPanel(nextState);
     });
   });
 

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -130,8 +130,9 @@ function addPirateFixture(state: GameState, hqPosition: HexCoord, unitPosition: 
 }
 
 function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDeps> = {}) {
+  const session = createGameSession(state);
   return {
-    session: createGameSession(state),
+    session,
     bus: new EventBus(),
     uiLayer: document.createElement('div'),
     getElementById: vi.fn((id: string) => document.getElementById(id)),
@@ -154,7 +155,7 @@ function makeDeps(state: GameState, overrides: Partial<PanelActionsControllerDep
     focusNotificationTarget: vi.fn(),
     focusPirateTarget: vi.fn(),
     applyPirateActionResult: vi.fn(),
-    currentCiv: vi.fn(() => state.civilizations[state.currentPlayer]),
+    currentCiv: vi.fn(() => session.getState().civilizations[session.getState().currentPlayer]),
     currentCivDef: vi.fn(() => undefined),
     diplomacyActions: {
       handleDiplomaticAction: vi.fn(),
@@ -544,17 +545,32 @@ describe('PanelActionsController', () => {
       const options = mockedCallArg<{ onQueueResearch: (techId: string) => void }>(createTechPanel, 0, 2);
       options.onQueueResearch('fire');
 
-      expect(state.civilizations.player.techState.currentResearch).toBe('fire');
+      expect(deps.session.getState().civilizations.player.techState.currentResearch).toBe('fire');
       expect(deps.renderLoop.setGameState).toHaveBeenCalled();
       expect(deps.hud.update).toHaveBeenCalled();
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('fire'), 'info');
+    });
+
+    it('onQueueResearch publishes the queued tech through session subscribers', () => {
+      const { state } = makeFixture('tech-panel-queue-publish');
+      state.civilizations.player.techState.currentResearch = 'fire';
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openTechPanel();
+      const options = mockedCallArg<{ onQueueResearch: (techId: string) => void }>(createTechPanel, 0, 2);
+      options.onQueueResearch('writing');
+
+      expect(deps.session.getState().civilizations.player.techState.researchQueue).toContain('writing');
+      expect(listener).toHaveBeenCalled();
     });
 
     it('reorders and removes queued research via the real planning-system helpers', () => {
       const { state } = makeFixture('tech-panel-reorder');
       state.civilizations.player.techState.currentResearch = 'fire';
       state.civilizations.player.techState.researchQueue = ['writing', 'wheel'];
-      const { controller } = build(state);
+      const { deps, controller } = build(state);
 
       controller.openTechPanel();
       const options = mockedCallArg<{
@@ -563,10 +579,10 @@ describe('PanelActionsController', () => {
       }>(createTechPanel, 0, 2);
 
       options.onMoveQueuedResearch(0, 1);
-      expect(state.civilizations.player.techState.researchQueue).toEqual(['wheel', 'writing']);
+      expect(deps.session.getState().civilizations.player.techState.researchQueue).toEqual(['wheel', 'writing']);
 
       options.onRemoveQueuedResearch(0);
-      expect(state.civilizations.player.techState.researchQueue).toEqual(['writing']);
+      expect(deps.session.getState().civilizations.player.techState.researchQueue).toEqual(['writing']);
     });
   });
 

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -1015,5 +1015,41 @@ describe('PanelActionsController', () => {
       expect(deps.session.getState().units[exfiltrated!.id].position).toEqual(state.cities['capital-city'].position);
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('exfiltrated'), 'info');
     });
+
+    it('onExfiltrate spawns a fresh unit at the capital, updates espionage state, and publishes', () => {
+      const { state } = makeFixture('espionage-exfiltrate-publish');
+      state.cities['capital'] = makeCity('capital', { owner: 'player', position: { q: 5, r: 5 } });
+      state.civilizations.player.cities = ['capital'];
+      placeSpy(state, 'spy-1', { status: 'stationed' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onExfiltrate: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onExfiltrate('spy-1');
+
+      const updated = deps.session.getState();
+      expect(Object.values(updated.units).some(u => u.type === 'spy_scout')).toBe(true);
+      expect(updated.espionage!.player.spies['spy-1']).toBeUndefined();
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onUnembed spawns a fresh unit at the target city, updates espionage state, and publishes', () => {
+      const { state } = makeFixture('espionage-unembed');
+      state.cities['target-city'] = makeCity('target-city', { owner: 'ai-1', position: { q: 3, r: 3 } });
+      placeSpy(state, 'spy-1', { status: 'embedded', targetCityId: 'target-city' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onUnembed: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onUnembed('spy-1');
+
+      const updated = deps.session.getState();
+      expect(Object.values(updated.units).some(u => u.type === 'spy_scout')).toBe(true);
+      expect(listener).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -841,6 +841,28 @@ describe('PanelActionsController', () => {
       expect(deps.uiLayer.children.length).toBeGreaterThan(0);
     });
 
+    it('onAssignDefensive embeds the spy, removes the unit, and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-assign-defensive');
+      state.cities['home-city'] = makeCity('home-city', { owner: 'player' });
+      state.civilizations.player.cities = ['home-city'];
+      placeUnit(state, 'spy_scout', 'spy-1', { q: 0, r: 0 });
+      placeSpy(state, 'spy-1');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+      vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onAssignDefensive: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onAssignDefensive('spy-1');
+
+      const updated = deps.session.getState();
+      expect(updated.units['spy-1']).toBeUndefined();
+      expect(updated.espionage!.player.spies['spy-1'].status).toBe('embedded');
+      expect(deps.hud.update).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+    });
+
     it('recalls a stationed spy via the real system call and reopens the panel through router', () => {
       const { state } = makeFixture('espionage-recall');
       placeSpy(state, 'spy-1', { status: 'stationed', targetCivId: 'ai-1', targetCityId: 'foreign-city' });

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -872,10 +872,56 @@ describe('PanelActionsController', () => {
       const options = mockedCallArg<{ onRecall: (spyId: string) => void }>(createEspionagePanel, 0, 1);
       options.onRecall('spy-1');
 
-      expect(state.espionage!.player.spies['spy-1'].status).not.toBe('stationed');
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].status).not.toBe('stationed');
       expect(deps.renderLoop.setGameState).toHaveBeenCalled();
       expect(deps.router.open).toHaveBeenCalledWith('espionage');
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('recalled'), 'info');
+    });
+
+    it('onStartMission commits the started mission and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-start-mission-publish');
+      state.civilizations.player.techState.completed = ['espionage-scouting'];
+      placeSpy(state, 'spy-1', { status: 'stationed', targetCivId: 'ai-1', targetCityId: 'foreign-city' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+      vi.spyOn(window, 'prompt').mockImplementation((_msg, defaultValue) => defaultValue ?? null);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onStartMission: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onStartMission('spy-1');
+
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].status).not.toBe('stationed');
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onRecall commits the recalled spy and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-recall-publish');
+      placeSpy(state, 'spy-1', { status: 'on_mission' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onRecall: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onRecall('spy-1');
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('onVerifyAgent commits the cleared agent and publishes through session subscribers', () => {
+      const { state } = makeFixture('espionage-verify-publish');
+      placeSpy(state, 'spy-1', { status: 'embedded', turnedBy: 'ai-1' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onVerifyAgent: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onVerifyAgent('spy-1');
+
+      expect(deps.session.getState().espionage!.player.spies['spy-1'].turnedBy).toBeUndefined();
+      expect(listener).toHaveBeenCalled();
     });
 
     it('verifies a captured-then-cleared agent via the real system call', () => {

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -691,17 +691,21 @@ describe('PanelActionsController', () => {
       expect(createCityPanel).toHaveBeenCalledWith(deps.uiLayer, state.cities['test-city'], deps.session.getState(), expect.anything());
     });
 
-    it('queues real production via the live city state and refreshes the renderer', () => {
+    it('queues real production via session.commit, publishes to subscribers, and returns the fresh state for the panel to re-render', () => {
       const { state } = makeFixture('city-panel-build');
       state.cities['test-city'] = makeCity('test-city');
       const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
 
       controller.openCityPanelForCity(state.cities['test-city']);
-      const options = mockedCallArg<{ onBuild: (cityId: string, itemId: string) => void }>(createCityPanel, 0, 3);
-      options.onBuild('test-city', 'warrior');
+      const options = mockedCallArg<{ onBuild: (cityId: string, itemId: string) => GameState | void }>(createCityPanel, 0, 3);
+      const returned = options.onBuild('test-city', 'warrior');
 
-      expect(state.cities['test-city'].productionQueue).toContain('warrior');
+      expect(deps.session.getState().cities['test-city'].productionQueue).toContain('warrior');
+      expect(returned).toBe(deps.session.getState());
       expect(deps.renderLoop.setGameState).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
       expect(deps.showNotification).toHaveBeenCalledWith(expect.stringContaining('Warrior'), 'info');
     });
 

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -9,7 +9,7 @@ import { createUnit } from '@/systems/unit-system';
 import { createEspionageCivState } from '@/systems/espionage-system';
 import type { PirateFocusTarget } from '@/systems/pirate-presentation';
 import type { NotificationMapTarget } from '@/core/notification-log';
-import type { GameState, HexCoord, Spy } from '@/core/types';
+import type { CouncilTalkLevel, GameState, HexCoord, Spy } from '@/core/types';
 import {
   createPanelActionsController,
   type PanelActionsControllerDeps,
@@ -517,6 +517,20 @@ describe('PanelActionsController', () => {
 
       expect(deps.session.getState().settings.councilTalkLevel).toBe('detailed');
       expect(saveSettings).toHaveBeenCalledWith(expect.objectContaining({ councilTalkLevel: 'detailed' }));
+    });
+
+    it('onTalkLevelChange publishes the new council talk level through session subscribers', () => {
+      const { state } = makeFixture('council-talk-level');
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openCouncilPanel();
+      const options = mockedCallArg<{ onTalkLevelChange: (level: CouncilTalkLevel) => void }>(createCouncilPanel, 0, 2);
+      options.onTalkLevelChange('chatty');
+
+      expect(deps.session.getState().settings.councilTalkLevel).toBe('chatty');
+      expect(listener).toHaveBeenCalled();
     });
   });
 

--- a/tests/app/controllers/panel-actions-controller.test.ts
+++ b/tests/app/controllers/panel-actions-controller.test.ts
@@ -951,6 +951,23 @@ describe('PanelActionsController', () => {
       expect(deps.router.open).toHaveBeenCalledWith('espionage');
     });
 
+    it('onSweep commits the sweep result, publishes through session subscribers, and still refreshes the panel', () => {
+      const { state } = makeFixture('espionage-sweep-publish');
+      placeSpy(state, 'sweeper-1', { status: 'embedded' });
+      const { deps, controller } = build(state);
+      const listener = vi.fn();
+      deps.session.subscribe(listener);
+
+      controller.openEspionagePanel();
+      const options = mockedCallArg<{ onSweep: (spyId: string) => void }>(createEspionagePanel, 0, 1);
+      options.onSweep('sweeper-1');
+
+      expect(deps.showNotification).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
+      expect(deps.getElementById).toHaveBeenCalledWith('espionage-panel');
+      expect(deps.router.open).toHaveBeenCalledWith('espionage');
+    });
+
     it('toggles cooldown mode for a real spy on cooldown', () => {
       const { state } = makeFixture('espionage-cooldown');
       placeSpy(state, 'spy-1', { status: 'cooldown', cooldownMode: 'stay_low' });


### PR DESCRIPTION
## Summary

Phase 5 of the [GameSession state-mutation audit](docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md) (issue #787). Converts all 21 flagged direct-mutation sites in `panel-actions-controller.ts` to `session.commit()`, so every change reaches both `GameSession` subscribers (`renderLoop.setGameState`, `hud.update()`) instead of whichever one each site happened to call by hand.

Converted sites, one per commit:
- Task 5.1: `onTalkLevelChange` (council panel settings) — 1 site
- Task 5.2+5.3: `onBuild`/`onMoveQueueItem`/`onRemoveQueueItem`/`onSetIdleProduction` (city production queue) — 4 sites
- Task 5.5: `onQueueResearch`/`onMoveQueuedResearch`/`onRemoveQueuedResearch` (tech queue) — 3 sites
- Task 5.6: `onAssignDefensive` (espionage-assign/delete-unit/civ-units-filter) — 3 sites
- Task 5.7: `onStartMission`/`onRecall`/`onVerifyAgent` — 3 sites
- Task 5.8: `onExfiltrate`/`onUnembed` (unit-spawn mutations) — 6 sites
- Task 5.9: `onSweep` — 1 site

**`city-panel.ts` companion change (Tasks 5.2-5.3, required in the same commit per the plan):** `onBuild`, `onMoveQueueItem`, `onRemoveQueueItem`, `onSetIdleProduction` widen from `void` to `GameState | void`, and their 3 call sites switch from bare `rerenderPanel()` to `rerenderPanel(nextState)`. The panel's refresh previously worked only because the mutated object shared a reference with `rerenderPanel`'s closure-captured default state; converting the mutation to a real `commit()` (a new object) without this companion change would have silently regressed the open city panel to stale data.

**Test rewrite (Task 5.4):** the one pre-existing test coupled to the mutation bug (`'queues real production via the live city state...'`) is rewritten, not extended, since it only passed because of the bug it's meant to guard against. Verified exactly one occurrence remains and no other test in the file still asserts against the outer fixture `state.cities[...]` instead of `deps.session.getState()`.

## Drift found and fixed beyond the plan's own snapshot

A pre-flight drift check against the live repo (plan was authored 2026-08-15, this branch started from a slightly earlier `main`) surfaced two gaps not caught by the plan's own snapshots, both fixed as part of this phase:

1. **`onSweep`'s panel-refresh calls.** The live handler already calls `deps.getElementById('espionage-panel')?.remove()` and `deps.router.open('espionage')` after `setGameState` (predates the plan, added in `211c35c8`). The plan's Task 5.9 snapshot and proposed replacement code omitted both lines. Implementing it as literally written would have silently dropped panel refresh on sweep — caught because an existing test (`'sweeps with a real seed...'`) already asserts `router.open` fires. Preserved both lines in the fix.
2. **Two more tests coupled to the same outer-`state`-vs-`session.getState()` bug the plan only flagged for city-panel (Task 5.4).** `openTechPanel`'s `onQueueResearch`/`onMoveQueuedResearch`/`onRemoveQueuedResearch` tests and `openEspionagePanel`'s `onRecall` test all asserted against the outer fixture `state` object rather than `deps.session.getState()`, so they would have silently started failing once those handlers converted to a real `commit()` (a new object) instead of an in-place mutation. Rewritten to assert against live session state, same treatment as Task 5.4's city-panel fix.
3. **Test-harness fix required by (2):** `panel-actions-controller.test.ts`'s `makeDeps().currentCiv` mock was bound to the stale outer `state` fixture rather than the live session (`selection-controller.test.ts`/`turn-flow-controller.test.ts`/`map-interaction-controller.test.ts` already use the live-session pattern; this file hadn't been updated). This made a chained reorder-then-remove tech-queue test fail incorrectly after the fix landed, since the second handler call read a stale pre-commit civ snapshot. Fixed to match the established pattern.

## Test plan

- [x] `bash scripts/run-with-mise.sh yarn build` — exit 0
- [x] `bash scripts/run-with-mise.sh yarn test` — exit 0 (487 test files, 8001 tests, 3 skipped; includes `tests/ui/city-panel*.test.ts`)
- [x] Re-ran the inventory grep against `panel-actions-controller.ts` — 0 remaining matches (21/21 converted)
- [x] Confirmed `city-panel.ts` has zero remaining `void`-only queue callbacks (all 4 widened to `GameState | void`)
- [x] Pre-push hook (full suite + build) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)