### PR TITLE
fix(combat): undefended cities/camps block movement; restore naval attack legality

### DIFF
--- a/docs/superpowers/plans/2026-08-16-issue-843-undefended-city-movement.md
+++ b/docs/superpowers/plans/2026-08-16-issue-843-undefended-city-movement.md
@@ -1,0 +1,359 @@
+# Issue 843 Root-Cause Fix Plan: Undefended Enemy Cities Aren't Movement Obstacles
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the movement-range preview (highlights, tap-intent resolution, AI/auto-explore
+destination selection) agree with `validateUnitMove`'s actual rule that a foreign, non-allied
+city can never be entered by ordinary movement — regardless of whether it currently has a
+garrison. Today that agreement only holds by accident, for defended cities.
+
+**Architecture:** The single shared BFS in `src/systems/unit-system.ts`
+(`getMovementRange`/`getMovementRangeDetails`) becomes the one place that knows "a foreign,
+unallied city tile blocks movement the same way a hostile unit does." Every consumer
+(highlights, tap-intent, AI tactics, auto-explore) inherits the fix for free instead of
+re-deriving or re-patching the rule locally.
+
+**Tech Stack:** TypeScript, Vitest.
+
+---
+
+## Root cause (confirmed via reproduction)
+
+`validateUnitMove` (`src/systems/unit-movement-system.ts`) already forbids entering or pathing
+through a foreign, non-allied city via ordinary movement — that's the `'foreign-city'` reason,
+tested in `tests/systems/unit-movement-system.test.ts`. But that check only runs at the moment a
+move actually **executes**.
+
+The movement-range *preview* functions that drive the UI highlight, the tap-intent resolver, and
+AI/auto-explore destination scoring — `getMovementRange` and `getMovementRangeDetails` in
+`src/systems/unit-system.ts` — have **zero awareness of `state.cities`**. They only consider:
+
+1. Terrain passability (`isPassableForUnitInContext`)
+2. Unit occupancy (hostile / neutral / friendly, via `unitPositions`/`unitOwners`)
+3. Zone of Control (`getZoneOfControlAt`, itself purely unit-sourced — see
+   `src/systems/zone-of-control-system.ts`, which never reads `state.cities`)
+
+For a **defended** enemy city, the garrison unit standing on the city tile happens to trigger
+the existing hostile-occupant/ZOC logic, which incidentally makes that tile terminal (BFS won't
+walk past it) and only reachable when actually adjacent. That's why defended cities "work" today
+— by coincidence, not by design.
+
+For an **undefended** enemy city, there is no unit on the tile and it radiates no ZOC (ZOC is
+unit-sourced only). The BFS treats the city hex as completely ordinary, freely walkable terrain:
+it gets added to `reachable`/`movementRange` from arbitrarily far away (as long as movement
+points allow), and the BFS keeps walking straight through it into tiles beyond, as if the city
+weren't there at all.
+
+**Player-visible effect:** the city tile — and tiles behind it — get a blue "move" highlight
+implying they're legally reachable. Tapping the (falsely) highlighted city tile while not yet
+adjacent routes through `resolveSelectedUnitTapIntent` → `{kind:'move'}` (because
+`canReachCityAssault`'s `distance <= 1` check correctly fails) → ordinary move execution →
+`validateUnitMove`'s `'foreign-city'` rejection → the *"Move adjacent, then use the city assault
+action."* toast — even though the unit visibly has movement points left and the tile was shown
+as reachable. This exactly matches the reported screenshot: a Scout with 3/3 moves, 2 hexes from
+Sparta, with the "reachable" highlight leading it into a rejected move.
+
+**Reproduced directly** against `getMovementRangeDetails`: a unit 2 tiles from an undefended
+enemy city with 3 movement points not only sees the city tile marked reachable, the BFS walks
+straight past it to a 3rd tile beyond — the city is a complete no-op to the algorithm.
+
+**Confirmed by contrast:** an actual enemy *unit* 3 hexes away does **not** reproduce either
+symptom, because the Zone of Control it radiates (`getZoneOfControlAt` checks neighbors of every
+BFS destination for adjacent hostile combat units) correctly terminates the BFS one hex short,
+regardless of the enemy's own tile-occupant logic. Cities have no equivalent projection — this
+is the precise, complete gap.
+
+## Evidence this pattern already bit other code paths ("these bugs live together")
+
+- `src/ai/ai-tactics.ts` already has a hand-rolled `isForeignCityDestination()` helper applied at
+  **4 separate call sites** (movement-target filtering, ~lines 290, 652, 702, 732) whose purpose is
+  to strip a foreign city's own coordinate back out of `movementRange()`'s output before the AI
+  picks an ordinary-move destination — necessary because that coordinate is deliberately kept
+  reachable (for adjacent tap-to-assault purposes) even after the Task 1 fix below, the same way a
+  hostile-occupied tile is. **Correction after implementation:** this filter only ever protected
+  against the city's own coordinate, never against tiles *beyond* it — the "walk straight through
+  and keep going" half of this bug was live and unprotected for AI movement decisions until Task 1
+  fixed the shared BFS at its source. The filter itself is not dead code and was not removed; see
+  Task 3 for the verified AI-behavior regression this produced.
+- `src/systems/auto-explore-system.ts`'s `chooseAutoExploreMove()` has **no such filter**: an
+  auto-exploring scout can nominate an undefended enemy city as its "best" destination, and
+  `applyAutoExploreOrder()`'s `executeUnitMove()` call will then silently fail with
+  `'foreign-city'`, wasting that unit's turn with no player-visible explanation.
+- `src/input/selected-unit-tap-intent.ts`'s own internal `getMovementRange()` fallback (used
+  whenever a caller doesn't pass `movementRangeOverride`) inherits the same gap independently of
+  the highlight path.
+- The bug applies identically to **minor-civ (`mc-`) cities**, not just major-civ cities —
+  `resolveSelectedUnitTapIntent`'s `cityAtTarget` lookup is generic across `state.cities`
+  regardless of owner kind.
+- Companion (non-bug) finding: `buildSelectedUnitHighlights()` in
+  `src/input/selected-unit-highlights.ts` deliberately excludes `'city'` targets from
+  `attackTargets` for non-naval (land) units (naval city-bombardment was added in the Aug-14
+  Battery commit, `6c30c71c`). That's intentional — land-unit city assaults route through a
+  separate assault-preview/confirm-war-city UI flow, not the unit-vs-unit combat-preview panel —
+  so it's not a bug on its own, but it means the *only* thing currently stopping a blue
+  "move"-highlighted undefended city from producing a broken tap is that the unit happens to
+  already be adjacent. No change needed here once the range fix lands.
+- `MovementBlockerReason['code']` (`getMovementBlockerReason`, used by the `'blocked-movement'`
+  tap-intent branch) has no `'foreign-city'` variant, even though `UnitMoveValidationResult`'s
+  reason type does. Today this is masked because `canMove` is wrongly `true` for these tiles, so
+  `getMovementBlockerReason` is never consulted for them — but it will start being consulted
+  once Task 1 correctly excludes far-away city tiles from `movementRange`.
+- `unit-movement-system.ts`'s local `hasAlliance()` and `selected-unit-tap-intent.ts`'s local
+  `hasTreaty(..., 'alliance')` are near-duplicate reimplementations of the same "are these two
+  civs allied" check. The Task 1 fix needs a third copy of this exact check — this is the moment
+  to consolidate instead of adding a third divergent implementation.
+
+## Inline review (balance, fun, ages 7–43, play styles, difficulty/AI, UI/UX, architecture, extensibility, data, SFX, saves, testing, hot-seat)
+
+- **Balance / fun:** purely a correctness fix. Right now the bug makes conquering an undefended
+  city *harder* than intended (a legitimate "snipe the weak city before it's garrisoned" play is
+  silently blocked) — a net loss of fun, not a balance risk to guard against. The fix restores
+  existing, already-tuned city-siege math (`city-siege-system.ts`'s intrinsic defense/counter-fire)
+  unchanged; it adds no new numeric bonus, so no rebalancing follow-up is needed.
+- **New mechanics:** none introduced.
+- **Ages 7–43 / play styles:** younger and less-experienced players are the most likely to trust a
+  highlighted "reachable" tile at face value and get confused by a rejection with movement points
+  visibly remaining — this is exactly the reported failure. Aggressive/warmonger play (sniping
+  undefended cities before the owner can garrison them) is currently non-functional beyond
+  point-blank adjacency; the fix directly restores that play style for all ages/styles.
+- **Difficulty modes / AI:** `ai-tactics.ts` already defensively filters a city's own coordinate
+  out of its movement-target candidates (`isForeignCityDestination`), so AI approach behavior for
+  *that* coordinate is unaffected by Task 1. What the existing filter never covered — tiles
+  *beyond* an undefended city, reachable only by illegally walking through it — was a live,
+  untested AI defect until Task 1 fixed the shared BFS. Task 3 verifies both halves: existing AI
+  behavior around the city tile itself is unchanged, and the walk-through case is now correctly
+  blocked for AI move selection too, with a regression proving it.
+- **UI/UX:** once fixed, a non-adjacent enemy city stops being highlighted entirely (correctly —
+  it's not a legal move target), which removes the only cue a new player currently has that "this
+  is a reachable-soon war objective." Worth naming even though it's out of scope here: a distinct
+  "known objective" marker independent of movement range could be a good future, separate
+  enhancement. Not adding it in this bug-fix plan to avoid scope creep.
+- **Architecture:** the original Task 1 draft asked the BFS to "mirror" `validateUnitMove`'s
+  condition — mirroring in two places is exactly the failure pattern that caused this bug (the
+  rule was added to the executor and never propagated to the preview layer). Task 1 is revised
+  below to require **one shared predicate**, imported by both, so the two layers cannot drift
+  again. Confirmed safe to place in `unit-system.ts`: `unit-movement-system.ts` already imports
+  from it (`findPath`, `UNIT_DEFINITIONS`, …), so no new dependency cycle is introduced.
+- **Extensibility:** the companion #845 plan needs to extend this exact mechanism to
+  `state.barbarianCamps`. Task 1 is revised to build the blocking-tile check as a small, generic
+  "blocking map entity" lookup (coordinate → blocking reason) rather than a one-off city-only
+  branch, so #845 can add a camp entry to the same lookup instead of re-deriving BFS termination.
+- **Data / save migrations:** no `GameState` schema change and no new persisted field —
+  `movementRange`/`attackTargets` are always recomputed live, never saved. **No save migration
+  required** (checked against `save-migrations.ts`'s numbered-migration convention).
+- **SFX:** no new sound needed; the existing "blocked move" toast path is reused via Task 5's new
+  `getMovementBlockerReason` case, not replaced.
+- **Testing / hot-seat regressions:** the blocking predicate must key off the *acting unit's*
+  `unit.owner`, never `state.currentPlayer` — CLAUDE.md's Hot Seat rule calls this exact class of
+  bug out explicitly. The original draft used `unit.owner` in prose but had no test proving it.
+  Task 6 below now includes an explicit hot-seat regression: two human-controlled civs, switching
+  the active seat, confirming blocking recalculates for whichever civ's unit is currently
+  selected — not "whichever civ went first."
+- **Solo play:** already covered by Tasks 1 and 6's positive/negative cases (human vs AI civ).
+
+---
+
+### Task 1 — Teach the shared movement-range BFS about foreign, non-allied cities
+
+**Files:**
+- Modify: `src/systems/unit-system.ts` (`getMovementRange`, `getMovementRangeDetails`),
+  `src/systems/unit-movement-system.ts` (`validateUnitMove`)
+- Test: `tests/systems/unit-system.test.ts`, `tests/systems/unit-movement-system.test.ts`
+
+- [ ] Write failing tests for both range functions proving: (a) an undefended, non-allied enemy
+      city tile appears in `reachable` only when the mover can reach a tile adjacent to it — same
+      as a hostile unit — never from 2+ hexes away over open terrain; (b) the BFS never walks
+      through the city tile to hexes beyond it; (c) an **allied** foreign city (existing
+      `'alliance'` treaty) is unaffected and remains freely passable, matching
+      `validateUnitMove`'s existing exception.
+- [ ] Run `bash scripts/run-with-mise.sh yarn vitest run tests/systems/unit-system.test.ts`;
+      confirm the new assertions fail.
+- [ ] **Do not re-derive the blocking condition a second time inside the BFS.** Extract ONE
+      exported predicate in `unit-system.ts` — e.g. `getBlockingMapEntityAt(state, unit, coord):
+      { reason: 'foreign-city'; entityId: string } | null` — that returns the blocking reason for
+      a coordinate, currently checking only `state.cities` (`owner !== unit.owner` and no alliance
+      treaty, via Task 2's shared helper). Design it as a small lookup keyed by coordinate rather
+      than a city-specific branch, so the companion #845 plan can add a `state.barbarianCamps`
+      case to the *same* function instead of duplicating the BFS-termination wiring. Import this
+      predicate into BOTH `getMovementRangeDetails`'s BFS AND `validateUnitMove`'s `foreignCity`
+      check (replacing that check's inline logic) — this is the fix for the actual root cause:
+      the rule must live in exactly one place, not be mirrored across two. `unit-movement-system.ts`
+      already imports from `unit-system.ts` (`findPath`, `UNIT_DEFINITIONS`, …) so this introduces
+      no new dependency cycle.
+- [ ] In `getMovementRangeDetails`, treat a `getBlockingMapEntityAt` match exactly like a
+      hostile-occupied tile: add to `reachable` (so the already-adjacent tap-to-assault flow keeps
+      working) but mark `terminal = true` — never enqueue past it.
+- [ ] `getMovementRange` does not take `GameState` (only `unit`, `map`, occupancy dicts,
+      `hostileOwners`, `options`). Add this as an **additive, optional** parameter — e.g. an
+      optional `blockingKeys?: ReadonlySet<string>` — rather than threading `GameState` through, so
+      the 6 existing test files that call `getMovementRange(...)` directly keep compiling
+      unchanged. Export a small helper that the two live call sites (`selected-unit-tap-intent.ts`'s
+      fallback, `auto-explore-system.ts`) use to compute that set from `state` via
+      `getBlockingMapEntityAt` before calling `getMovementRange`.
+- [x] Re-ran the focused suite; new positive/negative/allied-exception cases pass and no existing
+      test regressed.
+
+**Critical correction found mid-implementation (this is why the checklist above is `[x]`, not the
+literal first draft):** the first implementation of `getBlockingMapEntityAt` added a blocking
+city's own tile to `reachable` whenever the BFS *visited* it, with no gate on hop count from the
+mover's actual position — matching only half of "behaves like a hostile unit," namely "don't walk
+through it." It did **not** match the other half: for a hostile *unit*, Zone of Control
+additionally makes every tile *adjacent* to that unit terminal too, which is what actually prevents
+the unit's own tile from ever being reached except from direct adjacency (any multi-hop approach
+must first cross a ZOC-limited tile one hex short). Cities radiate no such field, so without an
+explicit equivalent, the first draft still let a mover 2+ hexes away with enough movement points
+see the city highlighted "reachable" and still get the `'foreign-city'` rejection on tap — the
+exact original bug, just with the "walks past it" half fixed and the "reachable from far away"
+half untouched. A dedicated test (`'marks an already-adjacent undefended enemy city reachable...'`
+vs. `'does NOT mark a 2+-hexes-away undefended city reachable...'` in `unit-system.test.ts`)
+caught this by asserting the 2+-hexes-away case explicitly, which the first draft failed. **Fix:**
+both `getMovementRangeDetails` and `getMovementRange` now only add a blocking entity's tile to
+`reachable` when `fromStart`/`isFromStartPosition` is true (i.e. the neighbor is a literal 1-hop
+neighbor of the unit's actual starting position) — matching hostile-unit ZOC parity exactly, not
+just partially. See the extensive comment on this check in `unit-system.ts` and the corrected
+test suite in `tests/systems/unit-system.test.ts` for the full before/after contrast.
+
+### Task 2 — Share one alliance-check helper instead of adding a 3rd copy
+
+**Files:**
+- Modify: `src/systems/diplomacy-system.ts`, `src/systems/unit-movement-system.ts`,
+  `src/input/selected-unit-tap-intent.ts`, `src/systems/unit-system.ts`
+- Test: `tests/systems/diplomacy-system.test.ts`
+
+- [ ] Write a failing test for a new exported `hasAllianceTreaty(state, civA, civB)` in
+      `diplomacy-system.ts` (symmetric, matches the existing treaty-matching logic already
+      duplicated in `unit-movement-system.ts`'s local `hasAlliance()` and
+      `selected-unit-tap-intent.ts`'s local `hasTreaty(..., 'alliance')`).
+- [ ] Implement it once, then replace both existing local implementations with calls to the
+      shared helper, and use it inside Task 1's `getBlockingMapEntityAt` predicate and its
+      `blockingKeys` helper.
+- [ ] Re-run `unit-movement-system.test.ts` and `selected-unit-tap-intent`-covering suites to
+      confirm behavior is unchanged after de-duplication.
+
+### Task 3 — Verify AI is unaffected/improved by Task 1 (plan correction, see below)
+
+**Correction found during implementation:** this task originally assumed `isForeignCityDestination()`
+would become dead code once Task 1 landed. That assumption was **wrong** and has been verified
+wrong empirically, not just reasoned about: Task 1's fix still *includes* an undefended city's own
+coordinate in `getMovementRangeDetails`'s `reachable` set (deliberately — the same tile must stay
+reachable for the adjacent tap-to-assault highlighting to keep working, exactly mirroring how a
+hostile-occupied tile is handled). What Task 1 removes is the BFS walking *through* the city to
+tiles beyond it. `isForeignCityDestination()` only ever filtered the city's *own* coordinate out of
+AI move candidates — never tiles beyond it — so it is still load-bearing and was **not deleted**.
+Proof: the pre-existing test `'does not move into a peaceful foreign city outside capture
+legality'` in `tests/ai/ai-tactics.test.ts` asserts exactly the coordinate `isForeignCityDestination`
+guards, and continues to require that filter after the Task 1 fix.
+
+**Files:**
+- Test: `tests/ai/ai-tactics.test.ts` (no `src/ai/ai-tactics.ts` change)
+
+- [x] Added a new regression, `'does not path an AI unit through an undefended enemy city toward
+      a target beyond it (#843)'`, proving the genuinely new behavior Task 1 provides for AI: with
+      movement points sized to exactly the cost of the only shortest path between the mover and a
+      tile beyond the city (isolating "walked through" from "took a legal detour around"), the AI
+      never proposes a destination on the far side of an undefended city. This is the AI-facing
+      analogue of the player-facing highlight fix, and did not exist before this task.
+- [x] Confirmed via the full existing `ai-tactics.test.ts` suite (48 tests, including the
+      pre-existing peaceful-city test above) that no AI targeting behavior changed or regressed.
+
+### Task 4 — Auto-explore should not stall on an undefended enemy city
+
+**Correction found during implementation:** unlike `ai-tactics.ts`, `auto-explore-system.ts` had
+**no** filter excluding a blocking entity's own coordinate from its candidate destinations. Task 1
+deliberately keeps that coordinate in `getMovementRange`'s reachable set (see Task 3's correction),
+so this was not automatically fixed by Task 1 alone — confirmed by writing the regression test
+first, watching it fail, then fixing it. `chooseAutoExploreMove` could nominate the undefended
+city's own tile as its "best" destination (often the *highest*-scoring one, since it's typically
+adjacent to unexplored fog), which `executeUnitMove` then silently rejects, stalling the unit.
+
+**Files:**
+- Modify: `src/systems/auto-explore-system.ts` (`chooseAutoExploreMove`)
+- Test: `tests/systems/auto-explore-system.test.ts`
+
+- [x] Added a regression test proving an auto-exploring scout does not nominate an undefended
+      enemy city (placed at the coordinate the existing fixture already proves is otherwise the
+      clear best pick) as its destination. Confirmed it fails without the fix (reverted the source
+      change, reran, watched it fail with the exact predicted assertion) before restoring the fix.
+- [x] Fixed `chooseAutoExploreMove` to filter `getBlockingMapEntityKeys(state, unit)` out of its
+      candidate coordinates before scoring, mirroring `ai-tactics.ts`'s `isForeignCityDestination`
+      pattern but reusing the Task 1 shared helper instead of a parallel reimplementation.
+
+### Task 5 — Close the matching gap in `getMovementBlockerReason`
+
+**Files:**
+- Modify: `src/systems/unit-system.ts`
+- Test: `tests/systems/unit-system.test.ts`
+
+- [x] Added `'foreign-city'` to `MovementBlockerReason`'s code union and an optional
+      `blockingEntity?: BlockingMapEntity | null` option (caller-supplied, matching the
+      function's existing decoupled-from-`GameState` signature style) that takes priority over
+      terrain checks. Both call sites (`map-tap-intent.ts`, `selected-unit-movement-feedback.ts`)
+      now pass `getBlockingMapEntityAt(state, unit, target)`.
+- [x] Re-ran the focused suite: positive (`blockingEntity` wins over an otherwise-adjacent-passable
+      tile), negative (`null`/omitted falls through to normal terrain logic), and exact-message
+      cases all pass.
+
+### Task 6 — UI regression coverage at the highlight and tap-intent layers
+
+**Files:**
+- Test: `tests/input/selected-unit-highlights.test.ts`, `tests/input/map-tap-intent.test.ts`
+
+- [x] Added two regressions to `selected-unit-highlights.test.ts`: a land unit 2+ hexes from an
+      undefended enemy city (enough movement to otherwise cover the distance) has neither the city
+      hex nor anything beyond it in `movementRange`/`highlights`; a unit already adjacent to one
+      still has it in `movementRange`.
+- [x] Added a regression to `map-tap-intent.test.ts`: tapping a non-adjacent, undefended enemy city
+      resolves to `{kind:'blocked-movement', unitId, reason:{code:'foreign-city', message:'Move
+      adjacent, then use the city assault action.'}}` (post Task 5), not a silent `move`/`deselect`
+      that would fail downstream.
+- [x] The **adjacent** case was already covered by a pre-existing passing test
+      (`'previews a city assault when resolveSelectedUnitTapIntent returns assault-city'`), which
+      continued to pass unchanged — no new positive test needed.
+- [x] Added a **hot-seat regression** in `unit-system.test.ts` (`'#843 hot-seat: blocking follows
+      the acting unit's owner, not state.currentPlayer'`): two human-controlled civs sharing a
+      device, asserting `getBlockingMapEntityAt`/`getMovementRangeDetails` give byte-identical
+      results for the same civ-A unit regardless of which civ's seat is currently active —
+      matching CLAUDE.md's "never hardcode ownership checks, always use the acting unit's owner"
+      rule.
+
+### Task 7 — Cross-cutting verification
+
+**Files:** all changed source and test files.
+
+- [x] Ran `scripts/check-src-rule-violations.sh` against every changed `src/` path — clean.
+- [x] Ran the full suite: `bash scripts/run-with-mise.sh yarn test` — 487/487 test files,
+      8017/8020 tests passing (3 pre-existing skips), zero regressions.
+- [x] Ran `bash scripts/run-with-mise.sh yarn build` — clean, no type errors.
+- [x] Confirmed no save-schema change is needed: `movementRange`/`attackTargets`/the new blocking
+      predicate are all derived at render/decision time and never persisted, so
+      `save-migrations.ts` needs no new numbered migration for this fix.
+- [ ] **Manual browser verification: attempted, inconclusive — noting honestly rather than
+      claiming success.** Started the dev server and a solo game; the running app exposes no
+      debug hook or accessible in-memory game-state reference (`Object.keys(window)` has nothing
+      game-related), and no save exists yet in IndexedDB (`saves` object store empty, `localStorage`
+      empty) to hand-edit into an exact "undefended enemy city 2+ hexes away" scenario. Engineering
+      that exact map layout through normal procedural-generation play would take an unbounded
+      number of turns with no guarantee of ever landing the precise geometry needed. Given the
+      automated coverage already includes a verified reproduction-and-fix cycle (new tests
+      confirmed to fail against a `git stash`-reverted version of the fix, then pass against the
+      real fix, for both the highlight layer and the tap-intent layer) across solo and hot-seat
+      configurations, this is being logged as a known gap rather than a false completion claim.
+      If a fast way to load a hand-built save into a running game exists, this item should be
+      revisited with it.
+
+## Final review pass (before PR)
+
+Re-reviewed the *actual implementation* (not just this plan) across gameplay balance, fun, new
+mechanics, player ages 7–43, play styles, difficulty/AI, UI/UX, architecture, extensibility, data,
+SFX, save compatibility, testing, and solo/hot-seat regressions. One real gap found and closed:
+
+- **Testing gap:** the root-cause writeup asserted "the bug applies identically to minor-civ
+  (`mc-`) cities," but no automated test proved that claim — only major-civ cities had direct
+  coverage. Added `'blocks an undefended minor-civ (city-state) city the same as a major-civ
+  one'` to `unit-system.test.ts`'s `getBlockingMapEntityAt` suite, confirming the fix's
+  ownership-generic design (`state.cities` regardless of owner-id shape) actually holds.
+
+Everything else checked out against the established codebase conventions on direct inspection
+(hot-seat `currentPlayer` usage, SFX choice, notification routing, button styling scope, movement
+action-point gating, architecture-boundary tests) — see the #845 plan's final review section for
+two additional findings that came from the same pass but apply to that plan's changes.

--- a/docs/superpowers/plans/2026-08-16-issue-845-camp-entry-and-naval-domain.md
+++ b/docs/superpowers/plans/2026-08-16-issue-845-camp-entry-and-naval-domain.md
@@ -1,0 +1,380 @@
+# Issue 845 Root-Cause Fix Plan: Undefended Camps + Naval Attack-Domain Regression
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two independent, confirmed defects reported against #845: (1) a unit can walk
+straight onto/through an undefended barbarian camp instead of being offered an assault, and (2)
+a genuine regression that makes Galley and Trireme unable to attack any naval unit, pirates
+included.
+
+**Architecture:** Task 1 extends the same "map entity blocks ordinary movement" pattern being
+added for cities in the #843 plan (`2026-08-16-issue-843-undefended-city-movement.md`) to cover
+`state.barbarianCamps` as well. Task 2 is unrelated — a pure attack-legality fix in
+`attack-targeting.ts`, no movement code involved.
+
+**Tech Stack:** TypeScript, Vitest.
+
+---
+
+## Finding 1: undefended barbarian camps are not a movement obstacle at all (worse than #843)
+
+**Screenshot evidence:** an Archer with `Moves: 0/2` shown standing directly on top of a desert
+camp structure — "he disappeared into it" instead of attacking from range.
+
+**Root cause:** `state.barbarianCamps` (`src/core/types.ts` `BarbarianCamp`) is a third map-entity
+registry, parallel to `state.units` and `state.cities`, but it has **zero representation** in the
+movement system:
+
+- `grep -n "camp" src/systems/unit-movement-system.ts` — no matches. `validateUnitMove` has an
+  explicit `foreignCity` rejection for cities (see #843's plan) but nothing analogous for camps.
+  A camp tile is terrain-passable, so an ordinary move onto it simply **succeeds**.
+- `grep -n "camp" src/input/*.ts src/app/controllers/map-interaction-controller.ts` — no matches
+  either (aside from the unrelated `'lumber_camp'` worker-action string). There is no
+  `resolveSelectedUnitTapIntent`-style `'assault-camp'` intent at all.
+
+**Why this only shows up when the camp is undefended:** `processBarbarians` spawns each new
+raider directly onto its camp's own tile (`src/systems/barbarian-system.ts:631`,
+`spawnedUnits.push({ campId: camp.id, position: { ...camp.position } })`). While that raider is
+still standing there, attacking the camp tile is really attacking the raider — ordinary
+unit-vs-unit combat, which works today, and `applyCampDestructionAtTarget` (invoked from
+`player-action-controller.ts` after a defender is destroyed at that position) then destroys the
+camp as a side effect. The bug only appears in the (common) window where the camp currently has
+no garrison — the exact same "no defenses" condition as #843's city bug, and structurally the
+same defect class: **a special map entity that must block ordinary movement and offer a distinct
+action instead is invisible to the movement system unless a unit happens to be standing on it.**
+
+## Inline review of Finding 1 (balance, fun, ages 7–43, play styles, UI/UX, architecture, saves, hot-seat)
+
+- **Balance / fun:** clearing barbarian camps is a core early-game income/safety loop; right now
+  it silently fails the moment a camp has no visible garrison, which is common (raiders leave to
+  raid, or the spawn cooldown just hasn't fired yet). No numeric change needed once fixed — reuses
+  the existing `destroyCamp`/`applyCampDestructionAtTarget` flat-gold reward unchanged.
+- **Ages 7–43 / play styles:** completionist/explorer players ("clear every camp off the map")
+  are hit hardest, since they're the ones most likely to approach a camp between raider spawns.
+  For younger players especially, "my unit just walked into the enemy base and nothing happened"
+  reads as broken, not subtle — favor the simplest, most legible fix (see recommendation below).
+- **Design-call resolution:** an early draft of this task left "direct attack vs. dedicated panel"
+  open. **Recommendation: route it through the existing combat-preview → `executeAttack` path**,
+  treating the camp as a plain attackable target (no capture/raze choice, since a camp only has
+  one outcome — destroyed). This matches lower cognitive load for the youngest players, reuses an
+  already-tested interaction pattern instead of adding a new modal, and avoids duplicating the
+  city-capture panel's more complex two-choice UI for a mechanic that doesn't need it. Land this
+  as the default; only build a dedicated panel if a reviewer specifically wants one.
+- **Fun / flavor:** once a camp has a real "you attacked and destroyed it" moment instead of
+  silently vanishing, surface `camp.banditLordName` in the destruction notification when present
+  (`"Bandit Lord Kestrix's camp is destroyed! +18 gold"`) — the data already exists for named
+  resurgent camps and currently goes unused in this path; this is a cheap, high-value addition
+  once the interaction itself exists. Not required, but low-cost enough to bundle in.
+- **Architecture / extensibility:** reuse the #843 plan's `getBlockingMapEntityAt` predicate
+  (Task 1 there) rather than writing a parallel camp-specific BFS/validation check — add a
+  `state.barbarianCamps` case to that one function so both cities and camps share the same
+  BFS-termination and `validateUnitMove` rejection wiring.
+- **Data / saves:** no `GameState` schema change — camps are already a persisted registry
+  (`state.barbarianCamps`), untouched by this fix; the only "data" change is a new
+  `MovementBlockerReason`/validation reason string, which is derived, not persisted. **No save
+  migration required.**
+- **Hot-seat:** same requirement as #843 — the blocking check must key off the acting unit's
+  `owner`, not `state.currentPlayer`. Add the same two-human-civ, seat-switch regression as #843's
+  Task 6 once this camp case is added to the shared predicate.
+- **AI/difficulty:** barbarian camps are already primarily an AI-vs-environment concern (major
+  civs and AI already fight raiders when they spawn); this fix doesn't change combat outcomes,
+  only whether an *undefended* camp can be targeted at all, so no AI behavior change is expected
+  beyond "AI can now also clear undefended camps it previously couldn't." **Correction after
+  implementation:** the AI had a real, separate gap here, not just an inherited one — major-civ
+  AI plans can already target `kind: 'camp'` (`ai-plan-portfolio.ts`, `ai-objective-scoring.ts`,
+  `ai-round-scheduler.ts`), but `ai-tactics.ts` had no tactical action at all for an undefended
+  camp (only `ai-major-turn.ts`'s post-combat follow-up existed, gated on killing a defender
+  first) — the AI would path adjacent and then stall with nothing to do. Fixed with a new
+  `rankCampAssault` (`ai-tactics.ts`) and `'assault-camp'` execution case (`ai-major-turn.ts`),
+  confirmed via the same regression-first method as everywhere else in this arc.
+
+### Task 1 — Make undefended camps block ordinary movement and offer an assault action
+
+**Deviation from the original design call:** the inline review above recommended routing camp
+assault through the existing unit-vs-unit `combat-preview` → `executeAttack` path to avoid new UI.
+That turned out not to fit: `combat-preview`'s tap-intent branch requires a `defenderEntry` (a real
+unit occupying the target hex, via `selectDefenderEntryAtKey`), which an undefended camp by
+definition doesn't have — there's no "defender" object to plug into that path. Implemented instead:
+a new, minimal `assault-camp`/`assault-camp-preview` intent pair (parallel to the existing
+`assault-city`/`assault-preview`, not `combat-preview`), with a small inline preview panel in
+`map-interaction-controller.ts` (title + one gold-reward info line + Attack/Cancel) — no capture/
+raze choice, no strength comparison, since `destroyCamp` is a guaranteed flat-gold outcome. This is
+still the minimal option once the earlier plan's assumption didn't hold, and still avoids a
+dedicated `src/ui/` panel file.
+
+**Files actually touched:**
+- `src/systems/unit-system.ts` — `getBlockingMapEntityAt`/`getBlockingMapEntityKeys` extended with
+  a `state.barbarianCamps` case (`'barbarian-camp'` reason), plus a `unit.owner !== 'barbarian'`
+  exception so a barbarian-owned mover isn't blocked from its own camp.
+  `UnitMovementBlockerCode`/`MovementBlockerReason`'s code unions and
+  `BLOCKING_MAP_ENTITY_MESSAGES` gained the new reason — `validateUnitMove` and
+  `getMovementBlockerReason` needed **zero further changes**, since both already route through
+  the shared predicate/message map (the payoff of #843's Task 1 architecture decision).
+- `src/input/selected-unit-tap-intent.ts` — new `assault-camp` intent kind and
+  `canReachCampAssault` adjacency/strength/domain gate (mirrors `canReachCityAssault` but without
+  `attack-targeting.ts`'s profile/target system, since camps aren't part of it).
+- `src/input/map-tap-intent.ts` — new `assault-camp-preview` `MapTapIntent` kind.
+- `src/app/controllers/map-interaction-controller.ts` — new switch case building the preview panel
+  described above.
+- `src/app/controllers/player-action-controller.ts` — new `beginPlayerCampAssault(attackerId,
+  campId)`, mirroring `beginPlayerCityAssault`'s notification/quest-transition/advisor/diplomatic-
+  reaction sequence (reusing `applyCampDestructionAtTarget`, already imported here for the
+  post-combat case in `executeAttack`). Re-validates adjacency **and** re-checks for a garrisoning
+  unit at the execution layer, not just via the tap-intent gate — a test written for the "already
+  defended" case caught that the first draft trusted UI precedence alone and would have destroyed
+  a garrisoned camp outright if called directly; see `.claude/rules` movement-validation precedent.
+- `src/app/bootstrap.ts` — wires `beginPlayerCampAssault` through, same pattern as
+  `beginPlayerCityAssault`.
+- `src/ai/ai-tactics.ts` — **not** `basic-ai.ts` (that file is barbarian/pirate/minor-civ AI, not
+  major-civ AI, and was never in scope here). `isForeignCityDestination` renamed to
+  `isBlockedMoveDestination` and rebuilt on `getBlockingMapEntityAt` so it excludes camp
+  coordinates from ordinary AI move candidates too, not just city ones (4 call sites updated to
+  pass `unit` instead of `actorId`). New `rankCampAssault` (mirrors `rankCapture`) proposes an
+  `assault-camp` action when a `plan.target.kind === 'camp'` and the AI unit is adjacent to an
+  undefended one; new `assault-camp` variant on `AITacticalAction`, `actionId`, and
+  `applyPredictedAction`.
+- `src/ai/ai-major-turn.ts` — new `'assault-camp'` case in the real `executeAction` switch,
+  reusing `applyCampDestructionAtTarget` and emitting the same `barbarian:camp-destroyed` event/
+  quest-transition sequence its existing post-combat call site (`resolveAttackFollowUp`) already
+  does for the defended case.
+
+**Tests:** `tests/systems/unit-movement-system.test.ts`, `tests/systems/unit-system.test.ts`,
+`tests/input/selected-unit-tap-intent.test.ts`, `tests/input/map-tap-intent.test.ts`,
+`tests/app/controllers/player-action-controller.test.ts`,
+`tests/app/controllers/map-interaction-controller.test.ts` (mock update only),
+`tests/ai/ai-tactics.test.ts`, `tests/ai/ai-major-turn.test.ts`.
+
+- [x] `validateUnitMove` rejects an ordinary move onto an undefended `state.barbarianCamps` tile
+      with reason `'barbarian-camp'`, and does not path through one toward a tile beyond it —
+      confirmed via the shared predicate, no camp-specific validation code needed.
+- [x] `getBlockingMapEntityAt(state, unit, coord)` extended with the `state.barbarianCamps` case;
+      reused unchanged by `validateUnitMove`, `getMovementRangeDetails`/`getMovementRange`'s BFS,
+      and `getMovementBlockerReason` — no second, parallel blocking check was written.
+- [x] Wired the `assault-camp`/`assault-camp-preview` tap-intent and the `beginPlayerCampAssault`
+      executing action so tapping an adjacent undefended camp destroys it instead of moving onto
+      it. `camp.banditLordName` is included in the notification when present
+      (`"Kestrix the Cruel's camp destroyed! +35 gold"`), confirmed by a dedicated test.
+- [x] Added the regression proving a unit 2+ hexes from an undefended camp does not have that tile
+      in its movement range (`unit-movement-system.test.ts`'s `'does not path through an
+      undefended barbarian camp toward a tile beyond it'`), and a companion adjacent-case
+      regression at the tap-intent layer confirming the preview still opens correctly.
+- [x] Added the hot-seat regression: two human civs, switch `state.currentPlayer`, confirm camp
+      blocking is keyed off the acting unit's `owner` (`unit-system.test.ts`'s `'#845 hot-seat'`
+      describe block, mirroring #843's city version).
+- [x] Added the AI regression: an AI-controlled unit adjacent to an undefended camp with a
+      `kind: 'camp'` plan destroys it via `processMajorCivStrategicTurn`, mirroring the existing
+      defended-camp test in `ai-major-turn.test.ts` exactly (same events, same reward math), plus
+      a focused `rankUnitTacticalActions` test in `ai-tactics.test.ts` proving the `assault-camp`
+      candidate itself is offered.
+- [x] Every new/changed assertion above was confirmed to actually fail without its corresponding
+      source change (via `git stash` on the relevant source files, rerun, then restore) before
+      being counted as passing — not just reasoned about. The occupancy defense-in-depth gap
+      (previous bullet) was caught exactly this way, by a test, not by inspection.
+
+## Finding 2: Galley/Trireme cannot attack any naval unit — a regression from the #826 fix
+
+**Confirmed directly:** `getUnitAttackProfile('galley')` and `getUnitAttackProfile('trireme')`
+both currently return `targetDomains: ['land']` — i.e. these naval combat units are only
+"allowed" to attack land targets, and are blocked from attacking any naval unit (pirates
+included) by `canAttackUnitDomain`.
+
+**Root cause, precisely:** commit `1f8ac7fee2` ("fix: squash issues 823 through 827", 2026-08-14,
+implementing the #826 "domain-aware unit targeting" task from
+`docs/superpowers/plans/2026-08-14-issues-823-827-bug-squash.md`) changed
+`src/systems/attack-targeting.ts`'s `DEFAULT_ATTACK_PROFILE` from:
+
+```ts
+const DEFAULT_ATTACK_PROFILE: UnitAttackProfile = { kind: 'melee', range: 1, targets: ['unit', 'city'] };
+```
+
+to:
+
+```ts
+const DEFAULT_ATTACK_PROFILE: UnitAttackProfile = {
+  kind: 'melee', range: 1, targets: ['unit', 'city'], targetDomains: ['land'],
+};
+```
+
+and added `canAttackUnitDomain`:
+
+```ts
+export function canAttackUnitDomain(attacker: Unit, target: Unit): boolean {
+  const profile = getUnitAttackProfile(attacker.type);
+  const attackerDomain = UNIT_DEFINITIONS[attacker.type].domain ?? 'land';
+  const targetDomain = UNIT_DEFINITIONS[target.type].domain ?? 'land';
+  const targetDomains = profile.targetDomains
+    ?? (attackerDomain === 'land' && profile.kind === 'melee'
+      ? ['land']
+      : ['land', 'naval', 'air']);
+  return targetDomains.includes(targetDomain);
+}
+```
+
+The intent was clearly for the `profile.targetDomains ?? (attackerDomain === 'land' ... )`
+fallback to compute the right default **per attacker domain** whenever a unit's own
+`attackProfile` doesn't specify `targetDomains`. That fallback is correct in isolation. The bug
+is that `getUnitAttackProfile` resolves ANY unit lacking its own `attackProfile` (via
+`UNIT_DEFINITIONS[type].attackProfile ?? DEFAULT_ATTACK_PROFILE`) to the **same shared
+`DEFAULT_ATTACK_PROFILE` object** — and that object now has `targetDomains: ['land']` baked in
+directly. Because `profile.targetDomains` is therefore never `undefined` for these units, the
+smart per-attacker-domain fallback in `canAttackUnitDomain` never runs for them; they just
+inherit the blanket land-only restriction regardless of their own domain.
+
+`galley`, `trireme` (both `domain: 'naval'`) have no explicit `attackProfile` in
+`UNIT_DEFINITIONS` (`src/systems/unit-system.ts`), so both regressed silently the moment
+`DEFAULT_ATTACK_PROFILE` gained `targetDomains: ['land']`. (Other naval entries without an
+`attackProfile` — `transport`, `carrack`, `galleon`, `steamship`, `troop_transport`,
+`naval_trader`, `steamship_trader`, `cargo_freighter` — are non-combat/zero-strength, so
+`canAttackByProfileOnMap`'s `strength > 0` gate already excludes them; they aren't part of this
+regression.) This also explains why the AI's pirate-hunting tests (`basic-ai-pirates.test.ts`)
+still pass: `applyPirateAiResponse` resolves pirate combat through its own bespoke "canonical
+destruction" path, not through `canUnitAttackTarget`/`getAttackTargets` — so the AI never hit
+this bug, only the player's normal attack flow did.
+
+## Inline review of Finding 2 (balance, fun, ages 7–43, play styles, difficulty/AI, architecture, extensibility, saves)
+
+- **Severity:** this is a full early-game naval-combat blocker, not a cosmetic issue — every civ's
+  Galley and Trireme (the only combat ships available before Frigate) currently cannot legally
+  declare an attack against **any** naval unit, player or AI, pirate or not. Recommend landing
+  Task 2 first and independently of Task 1/#843 — it's a two-line, high-confidence, low-risk
+  revert of the regressive part of a two-day-old commit, with no dependency on the movement work.
+- **Balance / fun:** naval-focused strategies and coastal conquest are currently unplayable in
+  eras 1–2; this fix restores intended balance rather than changing it (the #826 fix's *intent* —
+  stopping land units from attacking ships — is fully preserved; only the accidental naval
+  self-block is removed).
+- **Ages 7–43 / play styles:** "I built ships and they can't fight" is a hard stop for any
+  naval-leaning player, young or experienced — there's no workaround available in-game, so this
+  isn't a matter of discoverability like the movement bugs, it's a dead mechanic until fixed.
+- **Difficulty modes / AI:** the pirate-hunting AI tests still pass because
+  `applyPirateAiResponse` resolves pirate combat through its own bespoke path, bypassing
+  `canUnitAttackTarget` entirely — so those tests prove nothing about regular AI-vs-AI or
+  AI-vs-player naval combat between major civs, which almost certainly *does* go through the same
+  broken `canUnitAttackTarget`/`getAttackTargets` path the player uses. That means this bug may
+  currently be suppressing **all** early-game AI naval aggression against non-pirate targets,
+  civ-wide, at every difficulty level — a much bigger behavioral change than "pirates only" once
+  fixed. **Added an explicit task below** to verify AI-vs-AI and AI-vs-player Galley/Trireme
+  combat before and after the fix, across at least two difficulty/aggression settings, so a
+  reviewer can see exactly how much AI behavior changes rather than discovering it in playtesting.
+- **Architecture / extensibility:** while auditing `UNIT_DEFINITIONS` for every unit lacking an
+  explicit `attackProfile` (the same shape of gap that caused this regression), two more instances
+  turned up that are **out of scope to fix here** but worth flagging rather than silently ignoring:
+  - `observation_balloon` (air, `strength: 6`, no `attackProfile`) — its own description text says
+    *"Cannot attack."* Today it's accidentally land-domain-restricted by this same bug; after the
+    fix it would default to `['land','naval','air']` (attacker domain `air`, so the smart fallback
+    doesn't hit the land-only branch), meaning it could newly attempt attacks against land/naval/
+    air targets — inconsistent with its own "Cannot attack" description text. This looks like a
+    `.claude/rules/content-description-honesty.md` question (does it have `strength: 6` by design
+    for some other reason, e.g. combat-log flavor, or should it have `strength: 0`?) rather than
+    something this attack-targeting fix should silently paper over. **Flagging for separate
+    follow-up, not fixing here.**
+  - `beast_sea_serpent` (naval, no `attackProfile`) — its description says "only ships and ranged
+    units can fight it," implying *other* units attack *it*, not that it attacks with a
+    profile-gated melee. Its missing `attackProfile` likely doesn't matter for this bug (beast
+    attacks probably route through `beast-system.ts`'s own logic, not
+    `canUnitAttackTarget`/`canAttackUnitDomain`), but that's unconfirmed. **Flagging for
+    verification, not assuming it needs the same fix.**
+- **Saves:** no schema change; `targetDomains` is static per-unit-type definition data, never
+  per-save-instance state. **No save migration required.**
+
+### Task 2 — Stop `DEFAULT_ATTACK_PROFILE` from overriding the per-domain fallback
+
+**Files:**
+- Modify: `src/systems/attack-targeting.ts`
+- Test: `tests/systems/attack-targeting.test.ts`
+
+- [x] Added failing tests: `canUnitAttackTarget`/`canAttackByProfileOnMap` allowing an adjacent
+      Galley to attack an adjacent pirate galley (and a Trireme vs. an enemy Trireme); a positive
+      control confirms a Warrior (land melee, default profile) still cannot attack a naval unit,
+      proving the #826 fix for land units survives. Confirmed all 3 fail pre-fix, pass post-fix
+      (verified via `git stash`-revert-and-rerun, not just reasoning).
+- [x] Ran `bash scripts/run-with-mise.sh yarn vitest run tests/systems/attack-targeting.test.ts`
+      before applying the fix; confirmed the new naval-attack assertions failed and the
+      land-melee-vs-naval assertion still passed (isolating exactly the regressed case).
+- [x] Removed the hardcoded `targetDomains: ['land']` from `DEFAULT_ATTACK_PROFILE`, restoring it
+      to `{ kind: 'melee', range: 1, targets: ['unit', 'city'] }` (`targetDomains` now genuinely
+      `undefined`), so `canAttackUnitDomain`'s existing per-attacker-domain fallback runs and
+      computes the correct default instead of a single blanket value. Pure revert of the
+      regressive part — `canAttackUnitDomain`'s own logic needed no change.
+- [x] Re-ran the focused suite plus `tests/ai/ai-tactics.test.ts` — #826's land-vs-naval
+      restriction holds (existing `'rejects land melee attacks against naval units...'` test still
+      passes unchanged, since Warrior/Spearman's `attackerDomain === 'land'` still hits the
+      fallback's `['land']` branch). One pre-existing test's literal expected-shape assertion
+      (`'gives warriors the default melee profile...'`) needed updating to drop `targetDomains`
+      from the expected object — documented inline why.
+- [x] Grepped `DEFAULT_ATTACK_PROFILE` — the only two references are its declaration and
+      `getUnitAttackProfile`'s fallback, both in `attack-targeting.ts`; no other caller assumes
+      the old shape.
+- [x] Added the AI-behavior regression: two tests in `ai-tactics.test.ts` (one per opponent
+      challenge tier, `'veteran'` and `'standard'`) proving an AI Galley/Trireme now proposes an
+      `attack` action against an adjacent hostile *civ* ship (not a pirate — the pirate-hunting
+      path never hit this bug, per the root-cause writeup above). Confirmed both fail pre-fix,
+      pass post-fix via the same revert-and-rerun method. Full suite: 487/487 files, 8022/8025
+      tests passing (3 pre-existing skips) after this fix, zero regressions.
+
+### Task 3 — Cross-cutting verification
+
+**Sequencing note:** Task 2 (naval domain) has no dependency on Task 1 (camps) or on the #843
+plan — land and verify it independently and first, per the severity note above.
+
+- [x] Ran `scripts/check-src-rule-violations.sh` against every changed `src/` path (all 13 files
+      touched across both findings) — clean.
+- [x] Ran the full suite: `bash scripts/run-with-mise.sh yarn test` — 487/487 test files,
+      8039/8042 tests passing (3 pre-existing skips), zero regressions, after both findings.
+- [x] Ran `bash scripts/run-with-mise.sh yarn build` — clean, no type errors.
+- [x] Confirmed no save-schema change is needed for either finding (checked in each inline review
+      above) — no `save-migrations.ts` entry added.
+- [ ] **Manual browser verification: same limitation as #843's plan** — attempted (dev server
+      running, solo game started), but the app exposes no debug hook or save-injection path
+      (IndexedDB `saves` store and `localStorage` both empty for an in-progress unsaved session),
+      so hand-engineering an exact "undefended camp/enemy ship adjacent to a war unit" scenario
+      isn't feasible without unbounded manual play. Logged as a known gap, not a false completion
+      claim — the automated coverage for both findings includes verified reproduction-and-fix
+      cycles (every new assertion confirmed to fail pre-fix via `git stash`-revert-and-rerun, not
+      just reasoned about) across solo and hot-seat configurations, and across the player and AI
+      execution paths.
+
+## Final review pass (before PR)
+
+Re-reviewed the *actual implementation* across the same dimensions as the #843 plan's final
+review section. Two real findings, both fixed:
+
+- **Naval fix side effect (content-honesty regression):** `observation_balloon` (air domain,
+  `strength: 6`, no explicit `attackProfile`) was flagged in this plan's own inline review as
+  "worth verifying, not fixing here." Verification during this pass confirmed it as a real,
+  measurable regression: pre-fix it was accidentally land-domain-restricted by the same bug that
+  broke Galley/Trireme; post-fix, an air-domain attacker with no profile of its own falls back to
+  the fully permissive `['land','naval','air']` set, so it would have newly been able to declare
+  attacks — directly contradicting its own `UNIT_DESCRIPTIONS` text, "Cannot attack." Confirmed
+  with `canAttackByProfileOnMap(balloon, target) === true` pre-fix. Fixed with an explicit
+  `attackProfile: { kind: 'melee', range: 1, targets: [] }` (leaves `strength: 6` untouched, since
+  that stat is used defensively when the balloon itself is attacked). Added a regression test in
+  `attack-targeting.test.ts`, confirmed to fail without the fix.
+  - Also checked `beast_sea_serpent` (the other unit this plan flagged as "unconfirmed"): beast
+    attacks resolve through `beast-system.ts`'s own turn-processing path
+    (`turn-manager.ts`'s `beastResult.attackOrders` → `resolveCombat` directly), never through
+    `canAttackByProfileOnMap`/`canUnitAttackTarget` — confirmed via search, not just inferred.
+    Player-vs-beast combat only checks the *player's own* attacker profile, not the beast's. No
+    fix needed; this was correctly left unconfirmed rather than fixed speculatively.
+- **Testing gap:** `chooseAutoExploreMove`'s regression coverage only exercised the undefended-
+  *city* case (inherited from the #843 plan's Task 4), even though an undefended *camp* is the
+  more common real-world case for a wandering scout (camps sit on open land far more often than
+  an enemy city is encountered mid-explore). Added
+  `'does not nominate an undefended barbarian camp as its own auto-explore destination'` to
+  `auto-explore-system.test.ts`.
+
+Everything else checked out on direct inspection against established codebase conventions:
+hot-seat `currentPlayer`/`attacker.owner` usage matches `executeAttack`'s existing pattern exactly
+(not a new bug); `SFX.combat()` on camp assault matches the existing "assault action resolved"
+convention used for city assault too, regardless of whether real combat occurred; the camp
+preview panel's buttons match the file's own established (if not `createGameButton`-based)
+styling convention — `map-interaction-controller.ts` is outside `ui-panels.md`'s hook-enforced
+path scope (`src/ui/**`, `src/renderer/**`, `src/main.ts`), and introducing 44px-touch-target
+buttons inconsistent with every *other* preview panel in the same file would be a worse,
+unrelated redesign, not a fix; `beginPlayerCampAssault`'s silent no-op on a missing
+attacker/camp matches `beginPlayerCityAssault`'s identical existing behavior. One tempting change
+was deliberately **not** made: giving land units a red "attack" highlight for an adjacent
+undefended city/camp (instead of the current blue "move" highlight) — an existing test
+(`'highlights a visible hostile city for a naval bombardment, but not for a land unit'`)
+encodes that land-unit city/camp assault deliberately routes through a separate preview flow
+with different highlight semantics than direct combat; reversing that is a real design decision,
+not a bug, and doing so here would contradict an existing intentional regression test.

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -416,6 +416,30 @@ function executeAction(
         followUps: [],
       };
     }
+    case 'assault-camp': {
+      // #845: the AI-facing counterpart to beginPlayerCampAssault (player-action-controller.ts)
+      // -- destroys an undefended camp in one step, mirroring the notification/quest-transition
+      // sequence applyCampDestructionAtTarget's other call site above (resolveAttackFollowUp)
+      // already runs after a camp's last defender dies in combat.
+      const camp = state.barbarianCamps[action.campId];
+      const attacker = state.units[action.unitId];
+      if (
+        !camp
+        || !attacker
+        || attacker.owner !== civId
+        || distance(state, attacker.position, camp.position) !== 1
+        || getUnitIdsAtCoord(buildUnitOccupancy(state.units), camp.position).length > 0
+      ) {
+        return { state, succeeded: false, followUps: [] };
+      }
+      const next = structuredClone(state);
+      next.units[action.unitId] = { ...attacker, hasMoved: true, hasActed: true, movementPointsLeft: 0 };
+      const destroyed = applyCampDestructionAtTarget(next, civId, camp.position, next.turn);
+      if (!destroyed.campId) return { state, succeeded: false, followUps: [] };
+      emitMinorCivQuestTransitions(bus, destroyed.questTransitions, destroyed.state);
+      bus.emit('barbarian:camp-destroyed', { campId: destroyed.campId, reward: destroyed.reward });
+      return { state: destroyed.state, succeeded: true, followUps: [] };
+    }
     case 'move':
     case 'withdraw': {
       const next = structuredClone(state);

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -54,6 +54,7 @@ import {
 import {
   findPath,
   getMovementRangeDetails,
+  getBlockingMapEntityAt,
   UNIT_DEFINITIONS,
 } from '@/systems/unit-system';
 import {
@@ -72,6 +73,7 @@ import { isAIHostileOwner } from './ai-hostility';
 import { getLegalRebaseDestinations, resolveAirStrike, resolveReconMission, rebaseAircraft, startIntercept } from '@/systems/air-operations-system';
 import { resolveCombatEra } from '@/systems/era-resolution';
 import { resolveNavalCityBombardment } from '@/systems/naval-city-bombardment-system';
+import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 
 export type AITacticalAction =
   | { kind: 'attack'; unitId: string; targetUnitId: string }
@@ -82,6 +84,7 @@ export type AITacticalAction =
   | { kind: 'air-intercept'; unitId: string }
   | { kind: 'air-rebase'; unitId: string; base: import('@/core/types').AirBaseRef }
   | { kind: 'capture-city'; unitId: string; cityId: string }
+  | { kind: 'assault-camp'; unitId: string; campId: string }
   | { kind: 'move'; unitId: string; destination: HexCoord }
   | { kind: 'withdraw'; unitId: string; destination: HexCoord }
   | { kind: 'found-city'; unitId: string; destination: HexCoord }
@@ -148,6 +151,8 @@ function actionId(action: AITacticalAction): string {
       return `air-rebase:${action.unitId}:${action.base.kind === 'city' ? action.base.cityId : action.base.unitId}`;
     case 'capture-city':
       return `capture-city:${action.unitId}:${action.cityId}`;
+    case 'assault-camp':
+      return `assault-camp:${action.unitId}:${action.campId}`;
     case 'move':
     case 'withdraw':
     case 'found-city':
@@ -219,14 +224,17 @@ function movementRange(state: GameState, actorId: string, unit: Unit): HexCoord[
       .length === 0);
 }
 
-function isForeignCityDestination(
+// #845: renamed from isForeignCityDestination and rebuilt on the shared getBlockingMapEntityAt
+// predicate (originally #843, extended for camps in #845) instead of a city-only reimplementation
+// -- movementRange() keeps a blocking entity's own tile "reachable" (for adjacent
+// assault-action purposes, see unit-system.ts), so every ordinary-move candidate list in this
+// file must still filter it back out here, the same way it always needed to for cities alone.
+function isBlockedMoveDestination(
   state: GameState,
-  actorId: string,
+  unit: Unit,
   destination: HexCoord,
 ): boolean {
-  return Object.values(state.cities).some(city =>
-    city.owner !== actorId
-    && hexKey(city.position) === hexKey(destination));
+  return getBlockingMapEntityAt(state, unit, destination) !== null;
 }
 
 function supportRemainsCohesive(
@@ -287,7 +295,7 @@ function rankWithdrawals(
   const destination = movementRange(context.state, context.actorId, unit)
     .filter(coord =>
       healingDistance(coord) < currentDistance
-      && !isForeignCityDestination(context.state, context.actorId, coord))
+      && !isBlockedMoveDestination(context.state, unit, coord))
     .sort((left, right) =>
       healingDistance(left) - healingDistance(right)
       || distance(context.state, unit.position, right)
@@ -485,6 +493,49 @@ function rankCapture(
   return [ranked({ kind: 'capture-city', unitId: unit.id, cityId: city.id }, Math.round(winProbability * 600))];
 }
 
+// #845: the AI previously had no way to destroy an undefended barbarian camp at all -- only
+// applyCampDestructionAtTarget's post-combat follow-up (ai-major-turn.ts) existed, which only
+// fires when the AI kills a garrisoning unit first. An AI with `plan.target.kind === 'camp'`
+// would move adjacent (via rankMoves, now correctly excluding the camp's own tile per
+// isBlockedMoveDestination) and then have no action at all for an undefended camp, stalling the
+// plan indefinitely. Mirrors rankCapture's structure; unlike a city there's no win-probability
+// variance to score by (destroyCamp is a guaranteed flat-gold outcome), so this uses the same
+// flat 600 rankCapture uses as its ceiling.
+function rankCampAssault(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  if (
+    context.allowOffensiveActions === false
+    || context.plan.target.kind !== 'camp'
+    || unit.hasActed
+    || unit.movementPointsLeft <= 0
+    || UNIT_DEFINITIONS[unit.type].strength <= 0
+    || (UNIT_DEFINITIONS[unit.type].domain ?? 'land') !== 'land'
+  ) {
+    return [];
+  }
+  const camp = context.state.barbarianCamps[context.plan.target.id];
+  if (!camp) return [];
+  if (getVisibility(
+    context.state.civilizations[context.actorId].visibility,
+    camp.position,
+  ) !== 'visible') {
+    return [];
+  }
+  if (distance(context.state, unit.position, camp.position) !== 1) return [];
+  const occupancy = buildUnitOccupancy(context.state.units);
+  if (getUnitIdsAtCoord(occupancy, camp.position).some(unitId =>
+    context.state.units[unitId]?.owner !== context.actorId)) {
+    return [];
+  }
+  const reachable = movementRange(context.state, context.actorId, unit)
+    .some(coord => hexKey(coord) === hexKey(camp.position));
+  if (!reachable) return [];
+
+  return [ranked({ kind: 'assault-camp', unitId: unit.id, campId: camp.id }, 600)];
+}
+
 function rankCivilianAndTransportActions(
   context: AITacticalContext,
   unit: Unit,
@@ -649,7 +700,7 @@ function rankMoves(
     .filter(destination =>
       distance(context.state, destination, target) < currentTargetDistance
       && supportRemainsCohesive(context, unit, destination)
-      && !isForeignCityDestination(context.state, context.actorId, destination))
+      && !isBlockedMoveDestination(context.state, unit, destination))
     .sort((left, right) =>
       distance(context.state, left, target) - distance(context.state, right, target)
       || distance(context.state, unit.position, right)
@@ -699,7 +750,7 @@ function rankReactivePursuitMoves(
   return movementRange(context.state, context.actorId, unit)
     .filter(destination =>
       distance(context.state, destination, threat.position) < currentDistance
-      && !isForeignCityDestination(context.state, context.actorId, destination))
+      && !isBlockedMoveDestination(context.state, unit, destination))
     .sort((left, right) =>
       distance(context.state, left, threat.position) - distance(context.state, right, threat.position)
       || hexKey(left).localeCompare(hexKey(right)))
@@ -729,7 +780,7 @@ function rankMobileAirDefenseEscortMoves(
   return movementRange(context.state, context.actorId, unit).flatMap(destination => {
     const target = targets.filter(candidate => distance(context.state, destination, candidate.position) <= capability.radius)
       .sort((left, right) => UNIT_DEFINITIONS[right.type].productionCost - UNIT_DEFINITIONS[left.type].productionCost || left.id.localeCompare(right.id))[0];
-    return target && !isForeignCityDestination(context.state, context.actorId, destination)
+    return target && !isBlockedMoveDestination(context.state, unit, destination)
       ? [ranked({ kind: 'move', unitId: unit.id, destination }, 550 + UNIT_DEFINITIONS[target.type].productionCost / 10)] : [];
   });
 }
@@ -758,6 +809,7 @@ export function rankUnitTacticalActions(
     ...rankAirSupport(context, unit),
     ...rankAttacks(context, unit),
     ...rankCapture(context, unit),
+    ...rankCampAssault(context, unit),
     ...rankMobileAirDefenseEscortMoves(context, unit),
     ...rankReactivePursuitMoves(context, unit),
     ...rankMoves(context, unit),
@@ -929,6 +981,12 @@ function applyPredictedAction(
         'occupy',
         next.turn,
       ).state;
+    }
+    case 'assault-camp': {
+      const camp = next.barbarianCamps[action.campId];
+      if (!camp) return next;
+      next.units[unit.id] = { ...unit, hasMoved: true, hasActed: true, movementPointsLeft: 0 };
+      return applyCampDestructionAtTarget(next, context.actorId, camp.position, next.turn).state;
     }
     case 'load': {
       const result = loadUnitOntoTransport(next, action.unitId, action.transportId);

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -430,6 +430,7 @@ export function createAppComposition(deps: AppCompositionDeps): AppComposition {
     executeAttack: playerActions.executeAttack,
     executeMinorCivConquest: playerActions.executeMinorCivConquest,
     beginPlayerCityAssault: playerActions.beginPlayerCityAssault,
+    beginPlayerCampAssault: playerActions.beginPlayerCampAssault,
     finalizePendingCityCaptureChoice: turnFlow.finalizePendingCityCaptureChoice,
   });
 

--- a/src/app/controllers/map-interaction-controller.ts
+++ b/src/app/controllers/map-interaction-controller.ts
@@ -98,6 +98,7 @@ export interface MapInteractionControllerDeps {
     precedingCombat?: CombatResult,
     embarkedAssault?: boolean,
   ) => 'pending' | 'resolved';
+  readonly beginPlayerCampAssault: (attackerId: string, campId: string) => void;
   readonly finalizePendingCityCaptureChoice: (disposition: 'occupy' | 'raze', attackerBonus?: CivBonusEffect) => void;
 }
 
@@ -573,6 +574,56 @@ export function createMapInteractionController(deps: MapInteractionControllerDep
             if (assaultStatus === 'resolved') {
               setTimeout(() => selectionController.selectNextUnit(), 400);
             }
+          });
+        }
+        return;
+      }
+
+      case 'assault-camp-preview': {
+        const attackerUnit = session.getState().units[intent.attackerId];
+        const camp = session.getState().barbarianCamps[intent.campId];
+        if (!attackerUnit || !camp) return;
+
+        const panel = deps.getElementById('info-panel');
+        if (panel) {
+          panel.style.display = 'block';
+          const previewDiv = document.createElement('div');
+          previewDiv.style.cssText = 'background:rgba(100,0,0,0.9);border-radius:12px;padding:12px 16px;';
+
+          const title = document.createElement('div');
+          title.style.cssText = 'font-size:13px;color:#e8c170;margin-bottom:6px;';
+          title.textContent = camp.banditLordName ? `Assault ${camp.banditLordName}'s Camp` : 'Assault Barbarian Camp';
+          previewDiv.appendChild(title);
+
+          const info = document.createElement('div');
+          info.style.cssText = 'font-size:11px;opacity:0.8;margin-bottom:8px;';
+          info.textContent = `${UNIT_DEFINITIONS[attackerUnit.type].name} destroys the camp for +${15 + camp.strength * 2} gold. No garrison to fight.`;
+          previewDiv.appendChild(info);
+
+          const btnRow = document.createElement('div');
+          btnRow.style.cssText = 'display:flex;gap:8px;';
+          const attackBtn = document.createElement('button');
+          attackBtn.id = 'btn-assault-camp-confirm';
+          attackBtn.textContent = 'Attack';
+          attackBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:#d94a4a;border:none;color:white;font-weight:bold;cursor:pointer;';
+          const cancelBtn = document.createElement('button');
+          cancelBtn.id = 'btn-cancel-assault-camp';
+          cancelBtn.textContent = 'Cancel';
+          cancelBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:rgba(255,255,255,0.15);border:none;color:white;cursor:pointer;';
+          btnRow.appendChild(attackBtn);
+          btnRow.appendChild(cancelBtn);
+          previewDiv.appendChild(btnRow);
+
+          panel.innerHTML = '';
+          panel.appendChild(previewDiv);
+
+          cancelBtn.addEventListener('click', selectionController.deselectUnit);
+          attackBtn.addEventListener('click', () => {
+            // Read live, as the assault-preview branch above does.
+            deps.beginPlayerCampAssault(selection.getSelectedUnitId()!, intent.campId);
+            renderLoop.setGameState(session.getState());
+            deps.updateHUD();
+            setTimeout(() => selectionController.selectNextUnit(), 400);
           });
         }
         return;

--- a/src/app/controllers/player-action-controller.ts
+++ b/src/app/controllers/player-action-controller.ts
@@ -69,13 +69,13 @@ import { removeRouteForUnit } from '@/systems/trade-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
 import { preach } from '@/systems/religion-system';
 import { createUnitDeleteConfirmationPanel } from '@/ui/unit-delete-confirmation-panel';
-import { UNIT_DEFINITIONS, canHeal, restUnit, createUnit } from '@/systems/unit-system';
+import { UNIT_DEFINITIONS, canHeal, restUnit, createUnit, getBlockingMapEntityAt } from '@/systems/unit-system';
 import { isMajorCivOwner } from '@/core/owner-kind';
 import { declareWar, modifyRelationship, resolveOpponentKind } from '@/systems/diplomacy-system';
 import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { getSpyCaptureRelationshipPenalty, expelSpy, executeSpy, startInterrogation } from '@/systems/espionage-system';
 import { getCapitalCity } from '@/systems/capital-system';
-import { hexKey, parseHexKey } from '@/systems/hex-utils';
+import { hexKey, parseHexKey, hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
@@ -120,6 +120,7 @@ export interface PlayerActionController {
     precedingCombat?: CombatResult,
     embarkedAssault?: boolean,
   ): 'pending' | 'resolved';
+  beginPlayerCampAssault(attackerId: string, campId: string): void;
   executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void;
 }
 
@@ -577,6 +578,75 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     return 'pending';
   }
 
+  /**
+   * Destroys an undefended barbarian camp the attacker is directly adjacent to (#845).
+   * Unlike `beginPlayerCityAssault`, a camp has no capture/raze choice -- `destroyCamp`
+   * always produces the same flat-gold outcome, so this consumes the unit's action and
+   * calls `applyCampDestructionAtTarget` in one step, mirroring the exact notification/
+   * quest-transition/advisor/diplomatic-reaction sequence `executeAttack` already runs
+   * when a camp's last defender dies (see below) -- this is just that same sequence
+   * reached without a defending unit to fight first.
+   */
+  function beginPlayerCampAssault(attackerId: string, campId: string): void {
+    const state = deps.session.getState();
+    const attacker = state.units[attackerId];
+    const camp = state.barbarianCamps[campId];
+    if (!attacker || !camp) return;
+
+    const blockingEntity = getBlockingMapEntityAt(state, attacker, camp.position);
+    const distance = state.map.wrapsHorizontally
+      ? wrappedHexDistance(attacker.position, camp.position, state.map.width)
+      : hexDistance(attacker.position, camp.position);
+    // Defense-in-depth (matching executeAttack's own hasActed re-check comment): a garrisoned
+    // camp must go through ordinary combat against its defender instead, not this direct
+    // one-step destroy path. The normal tap-intent flow already routes a garrisoned camp to
+    // combat-preview before it ever reaches resolveSelectedUnitTapIntent's camp check, but this
+    // execution-layer check must not trust that UI precedence alone.
+    const occupancy = buildUnitOccupancy(state.units);
+    const hasDefender = hasHostileUnitAtCoord(occupancy, camp.position, attacker.owner);
+    if (
+      attacker.hasActed
+      || blockingEntity?.reason !== 'barbarian-camp'
+      || blockingEntity.entityId !== campId
+      || distance !== 1
+      || hasDefender
+    ) {
+      deps.showNotification('That camp is no longer within reach.', 'warning');
+      return;
+    }
+
+    const banditLordName = camp.banditLordName;
+    deps.session.setStateWithoutRefresh({
+      ...state,
+      units: {
+        ...state.units,
+        [attackerId]: { ...attacker, hasActed: true, hasMoved: true, movementPointsLeft: 0 },
+      },
+    });
+
+    const destroyedCamp = applyCampDestructionAtTarget(
+      deps.session.getState(),
+      deps.session.getState().currentPlayer,
+      camp.position,
+      deps.session.getState().turn,
+    );
+    if (destroyedCamp.campId) {
+      deps.session.setStateWithoutRefresh(destroyedCamp.state);
+      emitMinorCivQuestTransitions(deps.bus, destroyedCamp.questTransitions, deps.session.getState());
+      const label = banditLordName ? `${banditLordName}'s camp` : 'Barbarian camp';
+      deps.showNotification(`${label} destroyed! +${destroyedCamp.reward} gold`, 'success');
+      deps.advisorSystem.resetMessage('treasurer_camp_reward');
+      deps.advisorSystem.check(deps.session.getState());
+      for (const mcId of Object.keys(deps.session.getState().minorCivs)) {
+        applyDiplomaticReaction(deps.session.getState(), 'camp_destroyed_nearby', deps.session.getState().currentPlayer, mcId);
+      }
+    }
+
+    SFX.combat();
+    deps.renderLoop.setGameState(deps.session.getState());
+    deps.hud.update();
+  }
+
   function executeAttack(attackerId: string, targetKey: string): void {
     const initialAttacker = deps.session.getState().units[attackerId];
     const targetCoord = parseHexKey(targetKey);
@@ -770,6 +840,7 @@ export function createPlayerActionController(deps: PlayerActionControllerDeps): 
     foundCityAction,
     executeUpgrade,
     beginPlayerCityAssault,
+    beginPlayerCampAssault,
     executeMinorCivConquest,
   };
 }

--- a/src/input/map-tap-intent.ts
+++ b/src/input/map-tap-intent.ts
@@ -1,6 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
 import type { PendingMapIntent, SelectionSnapshot } from '@/app/ports';
-import { getMovementBlockerReason, type MovementBlockerReason } from '@/systems/unit-system';
+import { getMovementBlockerReason, getBlockingMapEntityAt, type MovementBlockerReason } from '@/systems/unit-system';
 import { isWorkerBusy } from '@/systems/unit-movement-system';
 import { hexKey } from '@/systems/hex-utils';
 import { canUnitAttackBeast } from '@/systems/beast-system';
@@ -52,6 +52,7 @@ export type MapTapIntent =
   | { readonly kind: 'enemy-unit-info'; readonly unitId: string }
   | { readonly kind: 'combat-preview'; readonly attackerId: string; readonly defenderId: string; readonly targetCoord: HexCoord }
   | { readonly kind: 'assault-preview'; readonly attackerId: string; readonly cityId: string; readonly embarkedAssault: boolean }
+  | { readonly kind: 'assault-camp-preview'; readonly attackerId: string; readonly campId: string }
   | { readonly kind: 'confirm-war-city'; readonly attackerId: string; readonly cityId: string; readonly defenderId: string }
   | { readonly kind: 'confirm-war-minor-civ'; readonly attackerId: string; readonly cityId: string; readonly minorCivId: string }
   | { readonly kind: 'assault-minor-civ'; readonly attackerId: string; readonly coord: HexCoord; readonly cityId: string; readonly minorCivId: string }
@@ -146,6 +147,7 @@ export function resolveMapTapIntent(
       }
       const reason = getMovementBlockerReason(selectedUnit, coord, state.map, {
         completedTechs: state.civilizations[selectedUnit.owner]?.techState.completed ?? [],
+        blockingEntity: getBlockingMapEntityAt(state, selectedUnit, coord),
       });
       if (reason) {
         return { kind: 'blocked-movement', unitId: selectedUnitId, reason };
@@ -186,6 +188,9 @@ export function resolveMapTapIntent(
     const tapIntent = resolveSelectedUnitTapIntent(state, selectedUnitId, coord, selection.movementRange);
     if (tapIntent.kind === 'assault-city') {
       return { kind: 'assault-preview', attackerId: selectedUnitId, cityId: tapIntent.cityId, embarkedAssault: Boolean(tapIntent.embarkedAssault) };
+    }
+    if (tapIntent.kind === 'assault-camp') {
+      return { kind: 'assault-camp-preview', attackerId: selectedUnitId, campId: tapIntent.campId };
     }
     if (tapIntent.kind === 'confirm-war-city') {
       return { kind: 'confirm-war-city', attackerId: selectedUnitId, cityId: tapIntent.cityId, defenderId: tapIntent.defenderId };

--- a/src/input/selected-unit-movement-feedback.ts
+++ b/src/input/selected-unit-movement-feedback.ts
@@ -1,6 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
-import { getMovementBlockerReason } from '@/systems/unit-system';
+import { getMovementBlockerReason, getBlockingMapEntityAt } from '@/systems/unit-system';
 import {
   getLandUnitWaterRecoveryTapMessage,
   type LandUnitWaterRecovery,
@@ -30,7 +30,7 @@ export function handleSelectedUnitMovementBlocker(
     unit,
     target,
     state.map,
-    { visibilityState, completedTechs },
+    { visibilityState, completedTechs, blockingEntity: getBlockingMapEntityAt(state, unit, target) },
   );
   if (!reason) return false;
 

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -2,26 +2,20 @@ import type { GameState, HexCoord } from '@/core/types';
 import { getUnitAttackProfile } from '@/systems/attack-targeting';
 import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { buildUnitOccupancy, getStackRelationship } from '@/systems/unit-occupancy';
-import { getMovementRange } from '@/systems/unit-system';
+import { getMovementRange, getBlockingMapEntityKeys, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getEmbarkedAssaultTarget } from '@/systems/transport-system';
+import { hasAllianceTreaty } from '@/systems/diplomacy-system';
 
 export type SelectedUnitTapIntent =
   | { kind: 'move' }
   | { kind: 'assault-city'; cityId: string; embarkedAssault?: boolean }
   | { kind: 'assault-minor-civ'; cityId: string; minorCivId: string }
   | { kind: 'confirm-war-minor-civ'; cityId: string; minorCivId: string }
-  | { kind: 'confirm-war-city'; cityId: string; defenderId: string };
-
-function hasTreaty(state: GameState, civA: string, civB: string, type: string): boolean {
-  const treaties = state.civilizations[civA]?.diplomacy?.treaties ?? [];
-  return treaties.some(treaty =>
-    treaty.type === type
-    && ((treaty.civA === civA && treaty.civB === civB) || (treaty.civA === civB && treaty.civB === civA)),
-  );
-}
+  | { kind: 'confirm-war-city'; cityId: string; defenderId: string }
+  | { kind: 'assault-camp'; campId: string };
 
 function canEnterForeignCityPeacefully(state: GameState, owner: string, targetOwner: string): boolean {
-  return hasTreaty(state, owner, targetOwner, 'alliance');
+  return hasAllianceTreaty(state, owner, targetOwner);
 }
 
 function canReachCityAssault(state: GameState, unitId: string, targetCoord: HexCoord): boolean {
@@ -33,6 +27,22 @@ function canReachCityAssault(state: GameState, unitId: string, targetCoord: HexC
     ? wrappedHexDistance(unit.position, targetCoord, state.map.width)
     : hexDistance(unit.position, targetCoord);
   return distance > 0 && distance <= profile.range;
+}
+
+// #845: camps aren't part of attack-targeting.ts's target/profile system (they have no
+// defender to fight when undefended -- see beginPlayerCampAssault), so this doesn't reuse
+// canReachCityAssault's profile.targets gate. Any strength-capable land unit that is
+// literally adjacent can assault a camp, mirroring how any land combat unit can already
+// destroy one by killing its garrison.
+function canReachCampAssault(state: GameState, unitId: string, targetCoord: HexCoord): boolean {
+  const unit = state.units[unitId];
+  if (!unit) return false;
+  const definition = UNIT_DEFINITIONS[unit.type];
+  if (definition.strength <= 0 || (definition.domain ?? 'land') !== 'land') return false;
+  const distance = state.map.wrapsHorizontally
+    ? wrappedHexDistance(unit.position, targetCoord, state.map.width)
+    : hexDistance(unit.position, targetCoord);
+  return distance === 1;
 }
 
 export function resolveSelectedUnitTapIntent(
@@ -60,6 +70,7 @@ export function resolveSelectedUnitTapIntent(
       occupancy.ownersByUnitId,
       hostileOwners,
       { completedTechs: civ?.techState.completed ?? [] },
+      getBlockingMapEntityKeys(state, unit),
     );
   })();
 
@@ -76,6 +87,13 @@ export function resolveSelectedUnitTapIntent(
   const relationship = getStackRelationship(occupancy, unit, targetCoord);
   if (!isEmbarkedCityAssault && relationship.hasHostileBlocker) {
     return { kind: 'move' };
+  }
+
+  const campAtTarget = Object.values(state.barbarianCamps ?? {}).find(camp => hexKey(camp.position) === targetKey);
+  if (campAtTarget && unit.owner !== 'barbarian') {
+    return canReachCampAssault(state, unitId, targetCoord)
+      ? { kind: 'assault-camp', campId: campAtTarget.id }
+      : { kind: 'move' };
   }
 
   const cityAtTarget = Object.values(state.cities).find(city =>

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -34,8 +34,14 @@ export interface AttackTarget {
   result: Extract<AttackTargetResult, { ok: true }>;
 }
 
+// Deliberately no `targetDomains` here (#845): it must stay `undefined` so
+// `canAttackUnitDomain`'s per-attacker-domain fallback runs for every unit that falls back to
+// this shared default -- a hardcoded `['land']` here previously made ANY unit lacking its own
+// `attackProfile` (not just land melee units) silently land-only, including naval units like
+// Galley/Trireme, which could then never attack another ship. Units that need a narrower,
+// explicit restriction (e.g. land melee) declare their own `attackProfile.targetDomains`.
 const DEFAULT_ATTACK_PROFILE: UnitAttackProfile = {
-  kind: 'melee', range: 1, targets: ['unit', 'city'], targetDomains: ['land'],
+  kind: 'melee', range: 1, targets: ['unit', 'city'],
 };
 
 export function getUnitAttackProfile(type: UnitType): UnitAttackProfile {

--- a/src/systems/auto-explore-system.ts
+++ b/src/systems/auto-explore-system.ts
@@ -4,7 +4,7 @@ import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey, hexNeighbors, getWrappedHexNeighbors } from '@/systems/hex-utils';
 import { isThreatenedByVisibleHostiles } from '@/systems/movement-safety';
 import { buildUnitOccupancy, getStackRelationship } from '@/systems/unit-occupancy';
-import { getMovementCost, getMovementRange } from '@/systems/unit-system';
+import { getMovementCost, getMovementRange, getBlockingMapEntityKeys } from '@/systems/unit-system';
 import { executeUnitMove, type ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
 
 export interface AutoExploreOrder {
@@ -74,7 +74,13 @@ export function chooseAutoExploreMove(state: GameState, unitId: string): AutoExp
 
   const occupancy = buildUnitOccupancy(state.units);
   const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
-  const best = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, undefined, { completedTechs })
+  const blockingKeys = getBlockingMapEntityKeys(state, unit);
+  const best = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, undefined, { completedTechs }, blockingKeys)
+    // A blocking entity's own tile (e.g. an undefended foreign city) stays in the reachable
+    // set for consistency with the rest of the movement system (see getBlockingMapEntityAt),
+    // but auto-explore must never nominate it as an ordinary move destination -- entering it
+    // requires the explicit assault action, which auto-explore does not perform (#843).
+    .filter(coord => !blockingKeys.has(hexKey(coord)))
     .map(coord => ({ coord, rank: rankCandidate(state, unitId, coord) }))
     .filter((entry): entry is { coord: HexCoord; rank: { score: number; reason: string } } => entry.rank !== null)
     .sort((a, b) => b.rank.score - a.rank.score)[0];

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -107,6 +107,17 @@ export function isAtWar(state: DiplomacyState, civId: string): boolean {
   return state.atWarWith.includes(civId);
 }
 
+function hasAllianceTreatyFromSide(state: GameState, viewerId: string, otherId: string): boolean {
+  const treaties = state.civilizations[viewerId]?.diplomacy?.treaties ?? [];
+  return treaties.some(treaty =>
+    treaty.type === 'alliance'
+    && ((treaty.civA === viewerId && treaty.civB === otherId) || (treaty.civA === otherId && treaty.civB === viewerId)));
+}
+
+export function hasAllianceTreaty(state: GameState, civA: string, civB: string): boolean {
+  return hasAllianceTreatyFromSide(state, civA, civB) || hasAllianceTreatyFromSide(state, civB, civA);
+}
+
 export function declareWar(
   state: DiplomacyState,
   targetCivId: string,

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -14,7 +14,10 @@ import {
   findPathToCity,
   UNIT_DEFINITIONS,
   canHullEnterOcean,
+  getBlockingMapEntityAt,
+  BLOCKING_MAP_ENTITY_MESSAGES,
   type UnitMovementBlockerCode,
+  type BlockingMapEntity,
 } from '@/systems/unit-system';
 import { visitVillage } from '@/systems/village-system';
 import { processWonderDiscovery } from '@/systems/wonder-system';
@@ -280,19 +283,6 @@ function getOwnerCompletedTechs(state: GameState, owner: string): string[] {
   return state.civilizations[owner]?.techState.completed ?? [];
 }
 
-function hasAlliance(
-  state: GameState,
-  civId: string,
-  otherCivId: string,
-): boolean {
-  return state.civilizations[civId]?.diplomacy.treaties.some(treaty =>
-    treaty.type === 'alliance'
-    && (
-      treaty.civA === civId && treaty.civB === otherCivId
-      || treaty.civA === otherCivId && treaty.civB === civId
-    )) ?? false;
-}
-
 function getImpassableReason(
   unitType: UnitType,
   terrain: string,
@@ -333,20 +323,17 @@ export function validateUnitMove(
   const tile = state.map.tiles[hexKey(target)];
   if (!tile) return movementFailure(from, target, [from], 'unknown-tile', 'Too far away to spot.');
 
-  const foreignCity = Object.values(state.cities).find(city =>
-    city.owner !== unit.owner
-    && hexKey(city.position) === hexKey(target));
+  const blockingEntity = getBlockingMapEntityAt(state, unit, target);
   if (
-    foreignCity
-    && (options.actor === 'world' || options.foreignCityEntryId !== foreignCity.id)
-    && !hasAlliance(state, unit.owner, foreignCity.owner)
+    blockingEntity
+    && (options.actor === 'world' || options.foreignCityEntryId !== blockingEntity.entityId)
   ) {
     return movementFailure(
       from,
       target,
       [from, target],
-      'foreign-city',
-      'Move adjacent, then use the city assault action.',
+      blockingEntity.reason,
+      BLOCKING_MAP_ENTITY_MESSAGES[blockingEntity.reason],
     );
   }
 
@@ -379,23 +366,25 @@ export function validateUnitMove(
       'An enemy unit is blocking the way.',
     );
   }
-  const pathCrossesBlockedForeignCity = path.slice(1).some(coord =>
-    Object.values(state.cities).some(city =>
-      city.owner !== unit.owner
-      && hexKey(city.position) === hexKey(coord)
-      && !hasAlliance(state, unit.owner, city.owner)
-      && (
-        options.actor === 'world'
-        || options.foreignCityEntryId !== city.id
-        || hexKey(coord) !== hexKey(target)
-      )));
-  if (pathCrossesBlockedForeignCity) {
+  let blockedPathEntity: BlockingMapEntity | undefined;
+  for (const coord of path.slice(1)) {
+    const entity = getBlockingMapEntityAt(state, unit, coord);
+    if (!entity) continue;
+    const isExplicitEntryToThisEntity = options.actor !== 'world'
+      && options.foreignCityEntryId === entity.entityId
+      && hexKey(coord) === hexKey(target);
+    if (!isExplicitEntryToThisEntity) {
+      blockedPathEntity = entity;
+      break;
+    }
+  }
+  if (blockedPathEntity) {
     return movementFailure(
       from,
       target,
       path,
-      'foreign-city',
-      'Move adjacent, then use the city assault action.',
+      blockedPathEntity.reason,
+      BLOCKING_MAP_ENTITY_MESSAGES[blockedPathEntity.reason],
     );
   }
 

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -1,6 +1,7 @@
-import type { UnitDefinition, UnitType, Unit, HexCoord, GameMap, GameState, CivBonusEffect, VisibilityState, IdCounters } from '@/core/types';
+import type { UnitDefinition, UnitType, Unit, City, HexCoord, GameMap, GameState, CivBonusEffect, VisibilityState, IdCounters } from '@/core/types';
 import { getZoneOfControlAt } from './zone-of-control-system';
 import { isHostileOwnerTo } from './owner-hostility';
+import { hasAllianceTreaty } from './diplomacy-system';
 import {
   hexKey,
   hexNeighbors,
@@ -428,6 +429,16 @@ const UNIT_DEFINITION_BASES: Record<UnitType, UnitDefinitionBase> = {
     movementPoints: 1, visionRange: 4, strength: 6,
     canFoundCity: false, canBuildImprovements: false, productionCost: 144,
     domain: 'air',
+    // #845 review: this unit has no explicit attackProfile, so before the DEFAULT_ATTACK_PROFILE
+    // fix it accidentally inherited a land-only restriction; after the fix, an air-domain
+    // attacker with no profile of its own falls back to the fully permissive
+    // ['land','naval','air'] set (see canAttackUnitDomain). strength: 6 is nonzero (used
+    // defensively when the balloon itself is attacked), so without this explicit empty-targets
+    // profile it would newly become able to declare attacks -- directly contradicting its own
+    // "Cannot attack" description (UNIT_DESCRIPTIONS.observation_balloon). targets: [] makes
+    // canAttackByProfileOnMap/canUnitAttackTarget structurally always reject it as an attacker,
+    // regardless of domain, matching the description without touching its defensive strength.
+    attackProfile: { kind: 'melee', range: 1, targets: [] },
   },
   biplane: {
     type: 'biplane', name: 'Biplane',
@@ -941,6 +952,7 @@ export type UnitMovementBlockerCode =
   | 'requires-ocean-hull'
   | 'occupied'
   | 'foreign-city'
+  | 'barbarian-camp'
   | 'unreachable'
   | 'insufficient-movement';
 
@@ -1033,6 +1045,8 @@ export interface MovementBlockerReason {
     | 'impassable-terrain'
     | 'requires-ocean-hull'
     | 'occupied'
+    | 'foreign-city'
+    | 'barbarian-camp'
     | 'unreachable'
     | 'insufficient-movement';
   message: string;
@@ -1042,7 +1056,7 @@ export function getMovementBlockerReason(
   unit: Unit,
   to: HexCoord,
   map: GameMap,
-  options: { visibilityState?: VisibilityState; completedTechs?: string[] } = {},
+  options: { visibilityState?: VisibilityState; completedTechs?: string[]; blockingEntity?: BlockingMapEntity | null } = {},
 ): MovementBlockerReason | null {
   if (options.visibilityState === 'unexplored') {
     return { code: 'unexplored', message: 'Too far away to spot.' };
@@ -1052,6 +1066,16 @@ export function getMovementBlockerReason(
   const tile = map.tiles[hexKey(target)];
   if (!tile) {
     return { code: 'unknown-tile', message: 'Too far away to spot.' };
+  }
+
+  // A blocking map entity (e.g. a foreign, unallied city) takes priority over terrain --
+  // the caller supplies it (via getBlockingMapEntityAt) rather than this function taking a
+  // full GameState, matching its existing decoupled-from-state signature (#843).
+  if (options.blockingEntity) {
+    return {
+      code: options.blockingEntity.reason,
+      message: BLOCKING_MAP_ENTITY_MESSAGES[options.blockingEntity.reason],
+    };
   }
 
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
@@ -1105,6 +1129,74 @@ function normalizeOccupants(value: string | string[] | undefined): string[] {
   return Array.isArray(value) ? value : [value];
 }
 
+export interface BlockingMapEntity {
+  reason: 'foreign-city' | 'barbarian-camp';
+  entityId: string;
+}
+
+function isBlockingCityFor(state: GameState, unit: Unit, city: City): boolean {
+  return city.owner !== unit.owner && !hasAllianceTreaty(state, unit.owner, city.owner);
+}
+
+// Camps have no owner field -- they're always barbarian-hostile to every civ (#845), the same
+// way `isAlwaysHostilePair` treats the 'barbarian' owner class elsewhere. The one exception is
+// a barbarian-owned mover itself (e.g. a raider that spawned on/near its own camp), which must
+// not be blocked from its own camp the same way a city never blocks its own owner.
+function isBlockingCampFor(unit: Unit): boolean {
+  return unit.owner !== 'barbarian';
+}
+
+/**
+ * A foreign, unallied city -- or a barbarian camp -- blocks ordinary movement onto its tile
+ * exactly like `validateUnitMove`'s rejection checks: this is the single source of truth both
+ * that executor and the movement-range preview BFS (`getMovementRange`/
+ * `getMovementRangeDetails`) consult, so the two layers can never drift out of sync the way
+ * they did before this predicate existed (#843). Returns `null` when `coord` has no blocking
+ * entity.
+ */
+export function getBlockingMapEntityAt(
+  state: GameState,
+  unit: Unit,
+  coord: HexCoord,
+): BlockingMapEntity | null {
+  const key = hexKey(coord);
+  const city = Object.values(state.cities).find(c => hexKey(c.position) === key);
+  if (city && isBlockingCityFor(state, unit, city)) {
+    return { reason: 'foreign-city', entityId: city.id };
+  }
+  const camp = Object.values(state.barbarianCamps ?? {}).find(c => hexKey(c.position) === key);
+  if (camp && isBlockingCampFor(unit)) {
+    return { reason: 'barbarian-camp', entityId: camp.id };
+  }
+  return null;
+}
+
+export const BLOCKING_MAP_ENTITY_MESSAGES: Record<BlockingMapEntity['reason'], string> = {
+  'foreign-city': 'Move adjacent, then use the city assault action.',
+  'barbarian-camp': 'Move adjacent, then attack to destroy the camp.',
+};
+
+/**
+ * Every hex `unit` cannot enter via ordinary movement due to a blocking map entity
+ * (see `getBlockingMapEntityAt`). Callers that only have decomposed occupancy data
+ * (not a full `GameState`) -- `getMovementRange`'s two live callers -- compute this set
+ * once up front and pass it in, rather than threading `GameState` through the BFS.
+ */
+export function getBlockingMapEntityKeys(state: GameState, unit: Unit): Set<string> {
+  const keys = new Set<string>();
+  for (const city of Object.values(state.cities)) {
+    if (isBlockingCityFor(state, unit, city)) {
+      keys.add(hexKey(city.position));
+    }
+  }
+  if (isBlockingCampFor(unit)) {
+    for (const camp of Object.values(state.barbarianCamps ?? {})) {
+      keys.add(hexKey(camp.position));
+    }
+  }
+  return keys;
+}
+
 export function getMovementRange(
   unit: Unit,
   map: GameMap,
@@ -1112,6 +1204,7 @@ export function getMovementRange(
   unitOwners?: Record<string, string>,
   hostileOwners?: Set<string>,
   options: UnitMovementContext = {},
+  blockingKeys?: ReadonlySet<string>,
 ): HexCoord[] {
   const reachable: HexCoord[] = [];
   const visited = new Map<string, number>();
@@ -1167,6 +1260,23 @@ export function getMovementRange(
           }
           continue;
         }
+      }
+
+      // A blocking map entity (e.g. a foreign, unallied city -- see
+      // `getBlockingMapEntityAt`/`getBlockingMapEntityKeys`) is only ever reachable (for
+      // adjacent tap-to-assault highlighting) when the unit is ALREADY directly adjacent to
+      // it before this action, exactly like how Zone of Control already restricts a hostile
+      // unit's own tile to direct-adjacency-only. Without the `isFromStartPosition` gate this
+      // would be "reachable" from arbitrarily far away, which is the #843 bug.
+      if (blockingKeys?.has(key)) {
+        if (isFromStartPosition) {
+          const prevRemaining = visited.get(key) ?? -1;
+          if (effectiveRemaining > prevRemaining) {
+            visited.set(key, effectiveRemaining);
+            reachable.push(neighbor);
+          }
+        }
+        continue;
       }
 
       const prevRemaining = visited.get(key) ?? -1;
@@ -1242,8 +1352,19 @@ export function getMovementRangeDetails(
         const owner = unitOwners[id];
         return Boolean(owner) && owner !== unit.owner && hostileOwners.has(owner);
       });
-      const zoc = !hostileOccupant && getZoneOfControlAt(state, unit, neighbor).limited;
-      const terminal = hostileOccupant || zoc;
+      const blockingEntity = getBlockingMapEntityAt(state, unit, neighbor);
+      // A blocking map entity's own tile is only ever "reachable" (for tap-to-assault) when
+      // the unit is ALREADY directly adjacent to it before this action -- never via a
+      // multi-hop approach. This matches how Zone of Control already prevents a hostile
+      // unit's own tile from being added except from direct adjacency (any multi-hop
+      // approach must first cross a ZOC-limited tile one hex short, which is terminal and
+      // never enqueued). Cities/camps radiate no ZOC of their own, so without this explicit
+      // fromStart gate they would be "reachable" from arbitrarily far away whenever movement
+      // points allowed -- exactly the #843 bug (a distant city looked tap-able, but tapping
+      // it while not yet adjacent produced a confusing rejection instead of a move).
+      if (blockingEntity && !fromStart) continue;
+      const zoc = !hostileOccupant && !blockingEntity && getZoneOfControlAt(state, unit, neighbor).limited;
+      const terminal = hostileOccupant || Boolean(blockingEntity) || zoc;
       const previous = visited.get(key) ?? -1;
       if (effectiveRemaining <= previous) continue;
       visited.set(key, effectiveRemaining);

--- a/tests/ai/ai-major-turn.test.ts
+++ b/tests/ai/ai-major-turn.test.ts
@@ -442,6 +442,46 @@ describe('processMajorCivStrategicTurn', () => {
       .not.toBe('abandoned');
   });
 
+  // #845: before rankCampAssault/executeAction's 'assault-camp' case existed, the AI had
+  // no way to destroy an undefended camp at all -- only the post-combat follow-up above
+  // (which only fires when the AI kills a garrisoning unit first) existed. An AI adjacent to
+  // an undefended camp would move toward it (now correctly stopping at adjacency, not walking
+  // onto it, per #843's isBlockedMoveDestination) and then have no action, stalling
+  // indefinitely. This proves the AI now destroys an undefended camp exactly like it already
+  // destroys a defended one above -- same events, same reward mechanism, no combat step needed.
+  it('destroys an undefended camp directly, mirroring the defended-camp destruction path', () => {
+    const state = makeState();
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 0, r: 0 });
+    state.barbarianCamps.camp = {
+      id: 'camp',
+      position: { q: 1, r: 0 },
+      strength: 1,
+      spawnCooldown: 2,
+    };
+    const plan = makePlan(
+      { kind: 'camp', id: 'camp', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      { objective: 'repel', requiredRoles: { frontline: 1 } },
+    );
+    const bus = new EventBus();
+    const destroyed = vi.fn();
+    bus.on('barbarian:camp-destroyed', destroyed);
+    const goldBefore = state.civilizations[AI].gold;
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(result.state.barbarianCamps.camp).toBeUndefined();
+    expect(result.state.civilizations[AI].gold).toBe(goldBefore + (15 + 1 * 2));
+    expect(result.state.legendaryWonderHistory?.destroyedStrongholds)
+      .toContainEqual(expect.objectContaining({ civId: AI, campId: 'camp' }));
+    expect(destroyed).toHaveBeenCalledOnce();
+    expect(result.state.units.attacker).toMatchObject({ hasActed: true, position: { q: 0, r: 0 } });
+  });
+
   it('founds a city through the shared whole-state helper', () => {
     const state = makeState();
     addUnit(state, 'settler', 'settler', AI, { q: 2, r: 2 });

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -272,6 +272,50 @@ describe('AI tactical action ranking', () => {
     }));
   });
 
+  // #845 regression: before the DEFAULT_ATTACK_PROFILE fix, this exact scenario silently
+  // produced zero attack candidates for the Galley -- not because of tribute protection or any
+  // other AI-specific gate, but because canAttackUnitDomain rejected ANY naval-vs-naval attack
+  // for a unit lacking its own attackProfile. This is civ-vs-civ (not pirate-hunting, which
+  // routes through a separate bespoke path and never hit the bug), so it proves the fix applies
+  // to ordinary AI-vs-player and AI-vs-AI naval combat, not just the pirate special case.
+  it('offers a Galley an attack against an adjacent hostile naval unit (civ-vs-civ, not pirates)', () => {
+    const state = makeState('veteran');
+    state.map.tiles['0,0'].terrain = 'ocean';
+    state.map.tiles['1,0'].terrain = 'ocean';
+    const warship = addUnit(state, 'warship', 'galley', AI, { q: 0, r: 0 });
+    const enemyShip = addUnit(state, 'enemy-ship', 'trireme', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'unit', id: enemyShip.id, lastKnownPosition: enemyShip.position },
+      [warship.id],
+      { objective: 'repel' },
+    );
+
+    const actions = rankUnitTacticalActions(context(state, plan), warship.id);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      action: { kind: 'attack', unitId: 'warship', targetUnitId: 'enemy-ship' },
+    }));
+  });
+
+  it('offers the same attack at a lower opponent-challenge (difficulty) setting too', () => {
+    const state = makeState('standard');
+    state.map.tiles['0,0'].terrain = 'ocean';
+    state.map.tiles['1,0'].terrain = 'ocean';
+    const warship = addUnit(state, 'warship', 'trireme', AI, { q: 0, r: 0 });
+    const enemyShip = addUnit(state, 'enemy-ship', 'galley', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'unit', id: enemyShip.id, lastKnownPosition: enemyShip.position },
+      [warship.id],
+      { objective: 'repel' },
+    );
+
+    const actions = rankUnitTacticalActions(context(state, plan), warship.id);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      action: { kind: 'attack', unitId: 'warship', targetUnitId: 'enemy-ship' },
+    }));
+  });
+
   it('does not attack a pirate faction while tribute protection is active', () => {
     const state = makeState('veteran');
     state.map.tiles['0,0'].terrain = 'ocean';
@@ -545,6 +589,58 @@ describe('AI tactical action ranking', () => {
       .some(candidate =>
         candidate.action.kind === 'move'
         && hexKey(candidate.action.destination) === hexKey(city.position))).toBe(false);
+  });
+
+  // #843: getMovementRangeDetails no longer treats an undefended enemy city as a
+  // walk-through tile -- this proves the AI's own move candidates never include a
+  // destination on the far side of one, matching the fix in unit-system.ts. Before the
+  // fix, an undefended city radiated no Zone of Control (unlike a hostile unit), so the
+  // BFS walked straight through it; isForeignCityDestination only ever filtered the
+  // city's own coordinate, never tiles beyond it, so this scenario was unprotected.
+  it('does not path an AI unit through an undefended enemy city toward a target beyond it (#843)', () => {
+    const state = makeState('veteran');
+    // 3 movement points is exactly the cost of the straight line (0,0)->(1,0)->(2,0)->(3,0)
+    // on uniform-cost grassland -- the ONLY length-3 path between those two hexes given this
+    // codebase's 6 hex directions (any detour costs 4+), so this isolates "walked through the
+    // city" from "took a legal detour around it" (the latter is fine and not what's under test).
+    const mover = addUnit(state, 'mover', 'warrior', AI, { q: 0, r: 0 }, { movementPointsLeft: 3 });
+    const city = addCity(state, 'undefended-city', HUMAN, { q: 2, r: 0 });
+    const beyondCity = { q: 3, r: 0 };
+    const plan = makePlan(
+      { kind: 'region', id: 'far-front', anchor: beyondCity },
+      [mover.id],
+    );
+
+    const moveDestinations = rankUnitTacticalActions(context(state, plan), mover.id)
+      .filter(candidate => candidate.action.kind === 'move')
+      .map(candidate => (candidate.action as { destination: HexCoord }).destination);
+
+    expect(moveDestinations.some(destination => hexKey(destination) === hexKey(city.position))).toBe(false);
+    expect(moveDestinations.some(destination => hexKey(destination) === hexKey(beyondCity))).toBe(false);
+    // Sanity check the fixture is actually exercising movement at all.
+    expect(moveDestinations.length).toBeGreaterThan(0);
+  });
+
+  // #845: before rankCampAssault existed, an AI unit adjacent to an undefended camp with a
+  // camp-targeting plan had no action for it at all -- movementRange() (post-#843) correctly
+  // stopped offering the camp's own tile as an ordinary move destination, but nothing offered
+  // the dedicated assault instead, so the plan stalled indefinitely with the unit sitting idle
+  // next to a camp it could never destroy without accidental combat against a garrison.
+  it('offers an AI unit an assault-camp action against an adjacent undefended camp', () => {
+    const state = makeState('veteran');
+    const mover = addUnit(state, 'mover', 'warrior', AI, { q: 0, r: 0 }, { movementPointsLeft: 2 });
+    state.barbarianCamps.camp = { id: 'camp', position: { q: 1, r: 0 }, strength: 4, spawnCooldown: 3 };
+    const plan = makePlan(
+      { kind: 'camp', id: 'camp', lastKnownPosition: { q: 1, r: 0 } },
+      [mover.id],
+      { objective: 'repel' },
+    );
+
+    const actions = rankUnitTacticalActions(context(state, plan), mover.id);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      action: { kind: 'assault-camp', unitId: 'mover', campId: 'camp' },
+    }));
   });
 
   it('pursues a visible ranged attacker before advancing toward an unrelated strategic target', () => {

--- a/tests/app/controllers/map-interaction-controller.test.ts
+++ b/tests/app/controllers/map-interaction-controller.test.ts
@@ -169,6 +169,7 @@ function baseDeps(state: GameState, overrides: Partial<MapInteractionControllerD
     executeAttack: vi.fn(),
     executeMinorCivConquest: vi.fn(),
     beginPlayerCityAssault: vi.fn(() => 'resolved' as const),
+    beginPlayerCampAssault: vi.fn(),
     finalizePendingCityCaptureChoice: vi.fn(),
     ...overrides,
   };

--- a/tests/app/controllers/player-action-controller.test.ts
+++ b/tests/app/controllers/player-action-controller.test.ts
@@ -668,4 +668,66 @@ describe('PlayerActionController', () => {
       expect(deps.turnFlow.finalizePendingCityCaptureChoice).toHaveBeenCalledWith('raze', undefined);
     });
   });
+
+  // #845: an undefended barbarian camp previously could not be assaulted at all -- a unit
+  // could only destroy one by first killing a garrisoning unit. This is the new one-step
+  // destroy action for the undefended case.
+  describe('beginPlayerCampAssault', () => {
+    it('destroys an adjacent undefended camp, awards gold, and consumes the unit action', () => {
+      const { state } = makeFixture('camp-assault-basic');
+      placeUnit(state, 'warrior', 'attacker-1', { q: 0, r: 0 }, { movementPointsLeft: 2 });
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+      const goldBefore = state.civilizations.player.gold;
+      const { deps, controller } = build(state);
+
+      controller.beginPlayerCampAssault('attacker-1', 'camp-1');
+
+      const after = deps.session.getState();
+      expect(after.barbarianCamps['camp-1']).toBeUndefined();
+      expect(after.civilizations.player.gold).toBe(goldBefore + (15 + 10 * 2));
+      expect(after.units['attacker-1']).toMatchObject({ hasActed: true, hasMoved: true, movementPointsLeft: 0 });
+      expect(deps.showNotification).toHaveBeenCalledWith('Barbarian camp destroyed! +35 gold', 'success');
+      expect(deps.hud.update).toHaveBeenCalled();
+    });
+
+    it('includes the bandit lord name in the notification when present', () => {
+      const { state } = makeFixture('camp-assault-named');
+      placeUnit(state, 'warrior', 'attacker-1', { q: 0, r: 0 }, { movementPointsLeft: 2 });
+      state.barbarianCamps['camp-1'] = {
+        id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3,
+        resurgent: true, banditLordName: 'Kestrix the Cruel',
+      };
+      const { deps, controller } = build(state);
+
+      controller.beginPlayerCampAssault('attacker-1', 'camp-1');
+
+      expect(deps.showNotification).toHaveBeenCalledWith("Kestrix the Cruel's camp destroyed! +35 gold", 'success');
+    });
+
+    it('refuses to assault a camp the attacker is not adjacent to', () => {
+      const { state } = makeFixture('camp-assault-too-far');
+      placeUnit(state, 'warrior', 'attacker-1', { q: 0, r: 0 }, { movementPointsLeft: 3 });
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 2, r: 0 }, strength: 10, spawnCooldown: 3 };
+      const { deps, controller } = build(state);
+
+      controller.beginPlayerCampAssault('attacker-1', 'camp-1');
+
+      expect(deps.session.getState().barbarianCamps['camp-1']).toBeDefined();
+      expect(deps.showNotification).toHaveBeenCalledWith('That camp is no longer within reach.', 'warning');
+    });
+
+    it('refuses to assault a camp that already has a defender (ordinary combat handles that case)', () => {
+      const { state } = makeFixture('camp-assault-defended');
+      placeUnit(state, 'warrior', 'attacker-1', { q: 0, r: 0 }, { movementPointsLeft: 2 });
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+      const raider = createUnit('warrior', 'barbarian', { q: 1, r: 0 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+      state.units[raider.id] = raider;
+      const { deps, controller } = build(state);
+
+      controller.beginPlayerCampAssault('attacker-1', 'camp-1');
+
+      expect(deps.session.getState().barbarianCamps['camp-1']).toBeDefined();
+      expect(deps.showNotification).toHaveBeenCalledWith('That camp is no longer within reach.', 'warning');
+    });
+  });
 });

--- a/tests/input/map-tap-intent.test.ts
+++ b/tests/input/map-tap-intent.test.ts
@@ -326,6 +326,76 @@ describe('resolveMapTapIntent', () => {
       expect(intent).toEqual({ kind: 'assault-preview', attackerId: 'unit-1', cityId: 'enemyCity', embarkedAssault: false });
     });
 
+    // #845: an undefended barbarian camp previously had no dedicated intent at all -- a tap
+    // resolved as an ordinary 'move' and the unit walked onto it. This proves the tap now
+    // routes to a dedicated preview, and that a non-adjacent camp correctly stays a plain
+    // 'blocked-movement' rather than a silent move/deselect.
+    it('previews a camp assault when resolveSelectedUnitTapIntent returns assault-camp', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        { q: 1, r: 0 },
+        false,
+      );
+
+      expect(intent).toEqual({ kind: 'assault-camp-preview', attackerId: 'unit-1', campId: 'camp-1' });
+    });
+
+    it('reports a clear barbarian-camp blocker when tapping a non-adjacent undefended camp', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      const campCoord = { q: 2, r: 0 };
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: campCoord, strength: 10, spawnCooldown: 3 };
+
+      const intent = resolveMapTapIntent(
+        state,
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        campCoord,
+        false,
+      );
+
+      expect(intent).toEqual({
+        kind: 'blocked-movement',
+        unitId: 'unit-1',
+        reason: { code: 'barbarian-camp', message: 'Move adjacent, then attack to destroy the camp.' },
+      });
+    });
+
+    // #843: a non-adjacent undefended enemy city is correctly excluded from movementRange by
+    // buildSelectedUnitHighlights post-fix (see selected-unit-highlights.test.ts), so tapping
+    // it falls into this !canMove && !canAttack branch. It must resolve to a clear
+    // 'blocked-movement' with the 'foreign-city' reason -- not a silent 'deselect', and not a
+    // 'move' that would then fail downstream at execution.
+    it('reports a clear foreign-city blocker when tapping a non-adjacent undefended enemy city', () => {
+      const state = makeFixture();
+      placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });
+      const cityCoord = { q: 2, r: 0 };
+      state.cities.enemyCity = { ...foundCity('ai-1', cityCoord, state.map, mkC()), id: 'enemyCity', owner: 'ai-1', position: cityCoord };
+      state.civilizations['ai-1'].cities.push('enemyCity');
+      state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+      state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+      makeVisible(state, cityCoord);
+
+      const intent = resolveMapTapIntent(
+        state,
+        // Deliberately does NOT include the city coordinate -- matching the corrected,
+        // adjacency-gated output of buildSelectedUnitHighlights for a non-adjacent city.
+        snapshot({ selectedUnitId: 'unit-1', movementRange: [{ q: 1, r: 0 }] }),
+        cityCoord,
+        false,
+      );
+
+      expect(intent).toEqual({
+        kind: 'blocked-movement',
+        unitId: 'unit-1',
+        reason: { code: 'foreign-city', message: 'Move adjacent, then use the city assault action.' },
+      });
+    });
+
     it('asks for war confirmation when resolveSelectedUnitTapIntent returns confirm-war-city', () => {
       const state = makeFixture();
       placePlayerUnit(state, 'unit-1', { position: { q: 0, r: 0 } });

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -51,6 +51,60 @@ describe('selected-unit-highlights', () => {
     expect(buildSelectedUnitHighlights(state, 'soldier').highlights).not.toContainEqual({ coord: { q: 2, r: 1 }, type: 'attack' });
   });
 
+  // #843: an undefended enemy city radiates no Zone of Control (unlike a hostile unit), so
+  // it was previously treated as ordinary walkable terrain -- highlighted "reachable" from
+  // arbitrarily far away, with the BFS walking straight through it to tiles beyond. Tapping
+  // that false highlight while not yet adjacent produced a confusing "Move adjacent, then
+  // use the city assault action" rejection despite the tile appearing reachable.
+  it('excludes a non-adjacent undefended enemy city (and tiles beyond it) from movementRange/highlights', () => {
+    const state = createNewGame(undefined, 'undefended-city-highlight', 'small');
+    state.currentPlayer = 'player';
+    for (const key of ['0,0', '1,0', '2,0', '3,0']) {
+      state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'plains' };
+    }
+    state.units = {
+      scout: { ...createUnit('scout', 'player', { q: 0, r: 0 }, mkC()), id: 'scout', movementPointsLeft: 3 },
+    };
+    state.civilizations.player.units = ['scout'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'visible', '2,0': 'visible', '3,0': 'visible' };
+    const city = foundCity('ai-1', { q: 2, r: 0 }, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+
+    const result = buildSelectedUnitHighlights(state, 'scout');
+    const movementKeys = result.movementRange.map(hexKey);
+    const highlightKeys = result.highlights.map(h => hexKey(h.coord));
+
+    expect(movementKeys).not.toContain('2,0');
+    expect(movementKeys).not.toContain('3,0');
+    expect(highlightKeys).not.toContain('2,0');
+    expect(highlightKeys).not.toContain('3,0');
+  });
+
+  it('still highlights an undefended enemy city as reachable once the unit is actually adjacent', () => {
+    const state = createNewGame(undefined, 'undefended-city-adjacent-highlight', 'small');
+    state.currentPlayer = 'player';
+    for (const key of ['0,0', '1,0']) {
+      state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'plains' };
+    }
+    state.units = {
+      scout: { ...createUnit('scout', 'player', { q: 0, r: 0 }, mkC()), id: 'scout', movementPointsLeft: 3 },
+    };
+    state.civilizations.player.units = ['scout'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'visible' };
+    const city = foundCity('ai-1', { q: 1, r: 0 }, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+
+    const result = buildSelectedUnitHighlights(state, 'scout');
+
+    expect(result.movementRange.map(hexKey)).toContain('1,0');
+  });
+
   it('marks visible ZOC terminal destinations with a non-attack movement highlight', () => {
     const state = createNewGame(undefined, 'zoc-highlight', 'small');
     state.currentPlayer = 'player';

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -283,4 +283,59 @@ describe('selected-unit-tap-intent', () => {
     );
     expect(intent).toEqual({ kind: 'move' });
   });
+
+  // #845: an undefended barbarian camp previously had no tap-intent case at all -- a tap
+  // resolved as an ordinary 'move', letting the unit silently walk onto/into it instead of
+  // assaulting it.
+  describe('undefended barbarian camps', () => {
+    it('returns assault-camp for an adjacent undefended camp', () => {
+      const state = makeTapAssaultFixture();
+      delete state.cities.enemyCity;
+      state.civilizations['ai-1'].cities = [];
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+
+      const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+      expect(intent).toEqual({ kind: 'assault-camp', campId: 'camp-1' });
+    });
+
+    it('returns move for a non-adjacent camp even when it is in the supplied movementRange', () => {
+      const state = makeTapAssaultFixture();
+      delete state.cities.enemyCity;
+      state.civilizations['ai-1'].cities = [];
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 2, r: 0 }, strength: 10, spawnCooldown: 3 };
+
+      const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 2, r: 0 }, [{ q: 1, r: 0 }, { q: 2, r: 0 }]);
+
+      expect(intent).toEqual({ kind: 'move' });
+    });
+
+    it('returns move (not assault-camp) when a hostile unit garrisons the camp -- ordinary combat handles that case', () => {
+      const state = makeTapAssaultFixture();
+      delete state.cities.enemyCity;
+      state.civilizations['ai-1'].cities = [];
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+      const raider = createUnit('warrior', 'barbarian', { q: 1, r: 0 }, mkC());
+      raider.id = 'raider';
+      state.units[raider.id] = raider;
+
+      const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+      expect(intent).toEqual({ kind: 'move' });
+    });
+
+    it('does not block a barbarian-owned mover from its own camp', () => {
+      const state = makeTapAssaultFixture();
+      delete state.cities.enemyCity;
+      state.civilizations['ai-1'].cities = [];
+      state.units['unit-1'] = { ...state.units['unit-1'], owner: 'barbarian' };
+      state.civilizations.player.units = [];
+      state.civilizations.barbarian = { ...state.civilizations['ai-1'], id: 'barbarian', units: ['unit-1'] };
+      state.barbarianCamps['camp-1'] = { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 };
+
+      const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+      expect(intent).toEqual({ kind: 'move' });
+    });
+  });
 });

--- a/tests/systems/attack-targeting.test.ts
+++ b/tests/systems/attack-targeting.test.ts
@@ -24,7 +24,12 @@ function stateWithUnits(units: Record<string, Unit>, visibility: Record<string, 
 
 describe('attack-targeting', () => {
   it('gives warriors the default melee profile and archers an explicit ranged profile', () => {
-    expect(getUnitAttackProfile('warrior')).toEqual({ kind: 'melee', range: 1, targets: ['unit', 'city'], targetDomains: ['land'] });
+    // #845: DEFAULT_ATTACK_PROFILE no longer carries `targetDomains` itself -- a land unit
+    // like Warrior is still behaviorally restricted to land targets, but that restriction now
+    // comes from canAttackUnitDomain's per-attacker-domain fallback at call time, not from a
+    // static value baked into the profile object. See the naval-attack tests below for the
+    // behavioral (not just shape) coverage this split enables.
+    expect(getUnitAttackProfile('warrior')).toEqual({ kind: 'melee', range: 1, targets: ['unit', 'city'] });
     expect(getUnitAttackProfile('archer')).toEqual({ kind: 'ranged', range: 2, targets: ['unit'] });
   });
 
@@ -66,6 +71,68 @@ describe('attack-targeting', () => {
     });
     expect(canAttackByProfileOnMap(archer, pirate, state.map)).toBe(true);
     expect(canAttackByProfileOnMap(frigate, pirate, state.map)).toBe(true);
+  });
+
+  // #845 regression: commit 1f8ac7fee2 (fixing #826, "land melee cannot attack naval") added
+  // `targetDomains: ['land']` directly onto the shared DEFAULT_ATTACK_PROFILE object. Any unit
+  // with no attackProfile of its own -- including naval units like Galley/Trireme -- resolves
+  // to that same shared object via getUnitAttackProfile, so canAttackUnitDomain's
+  // per-attacker-domain fallback (`profile.targetDomains ?? (attackerDomain === 'land' ...)`)
+  // never ran for them: they silently inherited the land-only restriction regardless of their
+  // own domain, making them unable to attack ANY naval unit -- pirates included. Confirmed
+  // directly: pre-fix, getUnitAttackProfile('galley').targetDomains was ['land'].
+  it('lets a Galley (naval, no explicit attackProfile) attack an adjacent naval unit', () => {
+    const galley = unit('galley', 'galley', 'player', { q: 0, r: 0 });
+    const pirateGalley = unit('pirate-galley', 'pirate_galley', 'pirate-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ galley, 'pirate-galley': pirateGalley }, { '1,0': 'visible' });
+
+    expect(canAttackByProfileOnMap(galley, pirateGalley, state.map)).toBe(true);
+    expect(canUnitAttackTarget(state, galley, pirateGalley.position, { viewerId: 'player' })).toMatchObject({
+      ok: true, targetType: 'unit', targetUnitId: 'pirate-galley',
+    });
+  });
+
+  it('lets a Trireme (naval, no explicit attackProfile) attack an adjacent naval unit', () => {
+    const trireme = unit('trireme', 'trireme', 'player', { q: 0, r: 0 });
+    const enemyTrireme = unit('enemy-trireme', 'trireme', 'ai-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ trireme, 'enemy-trireme': enemyTrireme }, { '1,0': 'visible' });
+
+    expect(canAttackByProfileOnMap(trireme, enemyTrireme, state.map)).toBe(true);
+    expect(canUnitAttackTarget(state, trireme, enemyTrireme.position, { viewerId: 'player' })).toMatchObject({
+      ok: true, targetType: 'unit', targetUnitId: 'enemy-trireme',
+    });
+  });
+
+  it('still blocks a land melee unit with the default profile from attacking naval (control, unchanged by the naval fix)', () => {
+    // Same shared DEFAULT_ATTACK_PROFILE object, but attackerDomain is 'land' here, so
+    // canAttackUnitDomain's fallback must still compute ['land'] and block this -- proving the
+    // #826 fix for land-vs-naval survives removing the hardcoded default.
+    const warrior = unit('warrior', 'warrior', 'player', { q: 0, r: 0 });
+    const pirateGalley = unit('pirate-galley', 'pirate_galley', 'pirate-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ warrior, 'pirate-galley': pirateGalley }, { '1,0': 'visible' });
+
+    expect(canAttackByProfileOnMap(warrior, pirateGalley, state.map)).toBe(false);
+    expect(canUnitAttackTarget(state, warrior, pirateGalley.position, { viewerId: 'player' })).toEqual({
+      ok: false, reason: 'unsupported-target',
+    });
+  });
+
+  // #845 review finding: observation_balloon has no explicit attackProfile and nonzero
+  // strength (used defensively). Before the naval fix it was accidentally land-only-restricted
+  // by the same DEFAULT_ATTACK_PROFILE bug that broke Galley/Trireme; after removing the
+  // hardcoded default, an air-domain attacker with no profile of its own falls back to the
+  // fully permissive domain set, which would have newly let it attack anything -- directly
+  // contradicting its own "Cannot attack" description. Fixed with an explicit
+  // `targets: []` profile; this is the regression test proving that holds.
+  it('keeps the Observation Balloon unable to attack anything, matching its "Cannot attack" description', () => {
+    const balloon = unit('balloon', 'observation_balloon', 'player', { q: 0, r: 0 });
+    const groundTarget = unit('ground-target', 'warrior', 'ai-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ balloon, 'ground-target': groundTarget }, { '1,0': 'visible' });
+
+    expect(canAttackByProfileOnMap(balloon, groundTarget, state.map)).toBe(false);
+    expect(canUnitAttackTarget(state, balloon, groundTarget.position, { viewerId: 'player' })).toEqual({
+      ok: false, reason: 'unsupported-target',
+    });
   });
 
   it('does not expose an aircraft that is based at an airfield as a map target', () => {

--- a/tests/systems/auto-explore-system.test.ts
+++ b/tests/systems/auto-explore-system.test.ts
@@ -1,5 +1,7 @@
 import { chooseAutoExploreMove, applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { makeAutoExploreFixture } from './helpers/auto-explore-fixture';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
 
 describe('auto-explore-system', () => {
   it('prefers unexplored safe tiles and avoids visible hostile attack range when alternatives exist', () => {
@@ -8,6 +10,40 @@ describe('auto-explore-system', () => {
     const order = chooseAutoExploreMove(state, unitId);
 
     expect(order?.to).toEqual({ q: 1, r: 0 });
+  });
+
+  // #843: the tile that would otherwise be the clear best pick (see the test above) is an
+  // undefended, unallied foreign city. Auto-explore must never nominate a blocking map
+  // entity's own tile as an ordinary move destination -- entering it requires the explicit
+  // assault action, which auto-explore does not perform, so the naive best-scoring tile
+  // would previously get chosen and then silently fail at execution (validateUnitMove's
+  // 'foreign-city' rejection), stalling the unit's auto-explore indefinitely.
+  it('does not nominate an undefended enemy city as its own auto-explore destination', () => {
+    const { state, unitId } = makeAutoExploreFixture({ visibleHostileNearEast: true, safeFogNorth: true });
+    const cityCoord = { q: 1, r: 0 };
+    const city = foundCity('raiders', cityCoord, state.map, state.idCounters);
+    city.id = 'undefended-raider-city';
+    state.cities[city.id] = city;
+    state.civilizations.raiders.cities.push(city.id);
+
+    const order = chooseAutoExploreMove(state, unitId);
+
+    expect(order === null || hexKey(order.to) !== hexKey(cityCoord)).toBe(true);
+  });
+
+  // #845: the same fix, but for an undefended barbarian camp -- arguably the more common
+  // real-world case for a wandering scout, since camps sit on open land far more often than
+  // undefended enemy cities are encountered mid-explore. Uses the same shared
+  // getBlockingMapEntityKeys() the city case above exercises, so this mainly proves the fix
+  // generalizes rather than needing a second, camp-specific filter.
+  it('does not nominate an undefended barbarian camp as its own auto-explore destination', () => {
+    const { state, unitId } = makeAutoExploreFixture({ visibleHostileNearEast: true, safeFogNorth: true });
+    const campCoord = { q: 1, r: 0 };
+    state.barbarianCamps['camp-1'] = { id: 'camp-1', position: campCoord, strength: 5, spawnCooldown: 3 };
+
+    const order = chooseAutoExploreMove(state, unitId);
+
+    expect(order === null || hexKey(order.to) !== hexKey(campCoord)).toBe(true);
   });
 
   it('supports wrapped maps without oscillating between seam columns', () => {

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -16,6 +16,7 @@ import {
   decayEvents,
   getAvailableActions,
   isAtWar,
+  hasAllianceTreaty,
   rejectDiplomaticRequest,
   enqueueTreatyProposal,
   pruneExpiredDiplomaticRequests,
@@ -169,6 +170,37 @@ describe('diplomacy-system', () => {
       state = breakTreaty(state, 'ai-egypt', 'non_aggression_pact', 20);
       expect(state.treaties).toHaveLength(0);
       expect(getRelationship(state, 'ai-egypt')).toBe(-25); // +5 from propose, -30 from break
+    });
+  });
+
+  describe('hasAllianceTreaty', () => {
+    it('returns true when civA has an alliance treaty with civB', () => {
+      const state = makeWarState();
+      state.civilizations.player.diplomacy.treaties.push({
+        type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: 5,
+      });
+      expect(hasAllianceTreaty(state, 'player', 'ai-1')).toBe(true);
+    });
+
+    it('is symmetric regardless of which civ is passed first', () => {
+      const state = makeWarState();
+      state.civilizations.player.diplomacy.treaties.push({
+        type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: 5,
+      });
+      expect(hasAllianceTreaty(state, 'ai-1', 'player')).toBe(true);
+    });
+
+    it('returns false when no alliance treaty exists', () => {
+      const state = makeWarState();
+      expect(hasAllianceTreaty(state, 'player', 'ai-1')).toBe(false);
+    });
+
+    it('returns false for a non-alliance treaty type', () => {
+      const state = makeWarState();
+      state.civilizations.player.diplomacy.treaties.push({
+        type: 'non_aggression_pact', civA: 'player', civB: 'ai-1', turnsRemaining: 5,
+      });
+      expect(hasAllianceTreaty(state, 'player', 'ai-1')).toBe(false);
     });
   });
 

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -357,6 +357,65 @@ describe('unit-movement-system', () => {
     expect(state.units.mover.position).toEqual(city.position);
   });
 
+  // #845: an undefended barbarian camp had ZERO representation anywhere in the movement
+  // system before this -- not even a rejection, unlike a foreign city. A unit could walk
+  // straight onto (and through) one as if it were empty terrain. These tests prove
+  // validateUnitMove now rejects it via the same getBlockingMapEntityAt predicate #843 built
+  // for cities, extended with a `state.barbarianCamps` case.
+  it('rejects ordinary movement onto an undefended barbarian camp', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+    ]);
+    state.barbarianCamps['camp-1'] = {
+      id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3,
+    };
+
+    const result = executeUnitMove(state, 'mover', { q: 1, r: 0 }, { actor: 'player', civId: 'player' });
+
+    expect(result).toMatchObject({ ok: false, reason: 'barbarian-camp' });
+    expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
+  });
+
+  it('does not path through an undefended barbarian camp toward a tile beyond it', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    mover.movementPointsLeft = 3;
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }), tile({ q: 1, r: 0 }), tile({ q: 2, r: 0 }),
+    ]);
+    state.barbarianCamps['camp-1'] = {
+      id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3,
+    };
+
+    const result = executeUnitMove(state, 'mover', { q: 2, r: 0 }, { actor: 'player', civId: 'player' });
+
+    expect(result).toMatchObject({ ok: false, reason: 'barbarian-camp' });
+    expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
+  });
+
+  it('does not block a barbarian unit from its own camp', () => {
+    const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    mover.id = 'raider';
+    // movementState derives its civilizations map from the units passed in, so a
+    // barbarian-owned mover already gets a valid `state.civilizations.barbarian` entry --
+    // no manual civ construction needed here.
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+    ]);
+    state.barbarianCamps['camp-1'] = {
+      id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3,
+    };
+
+    const result = executeUnitMove(state, 'raider', { q: 1, r: 0 }, { actor: 'automation', civId: 'barbarian' });
+
+    expect(result.ok).toBe(true);
+    expect(state.units.raider.position).toEqual({ q: 1, r: 0 });
+  });
+
   it('refuses to execute movement onto an occupied foreign unit tile', () => {
     const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
     mover.id = 'mover';

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -2,6 +2,8 @@ import {
   createUnit,
   getMovementRange,
   getMovementRangeDetails,
+  getBlockingMapEntityAt,
+  getBlockingMapEntityKeys,
   moveUnit,
   findPath,
   findPathToCity,
@@ -15,7 +17,7 @@ import {
 import type { GameMap, GameState } from '@/core/types';
 import { generateMap } from '@/systems/map-generator';
 import { hexKey } from '@/systems/hex-utils';
-import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { TRAINABLE_UNITS, foundCity } from '@/systems/city-system';
 import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
 import { createNewGame } from '@/core/game-state';
 
@@ -88,6 +90,301 @@ describe('getMovementRangeDetails zone of control', () => {
     expect(range.reachable.map(hexKey)).toContain('1,0');
     expect(range.zocLimited.map(hexKey)).toContain('1,0');
     expect(range.reachable.map(hexKey)).not.toContain('2,0');
+  });
+});
+
+// #843: an undefended (no garrison unit) foreign city radiates no Zone of Control,
+// unlike a hostile unit -- these tests prove the BFS treats it as a blocking obstacle
+// anyway, via getBlockingMapEntityAt/getBlockingMapEntityKeys, instead of ordinary
+// walkable terrain. The city always sits at (2,0); `moverPosition` controls whether the
+// mover starts already adjacent to it (1,0) or 2+ hexes away (0,0).
+//
+// IMPORTANT (found during implementation, see #843 plan Task 6 correction): a blocking
+// entity's own tile must behave EXACTLY like a hostile unit's tile under Zone of Control --
+// reachable ONLY when the mover is already directly adjacent to it *before* this action,
+// never via "I have enough movement points to get within striking distance." An earlier
+// version of this fix added the city to `reachable` whenever the BFS visited it regardless
+// of hop count (matching only "don't walk past it", not "don't treat it as reachable from
+// far away"), which left the original bug half-fixed: a mover 2 hexes away with 3 movement
+// points still saw the city highlighted as reachable, and tapping it still produced the
+// "Move adjacent, then use the city assault action" rejection instead of a plain move --
+// the exact symptom from the original report. The regression tests below assert the
+// corrected, adjacency-gated behavior; a prior version of this file asserted the opposite
+// (that the city stays reachable from 2+ hexes away) and that assertion was itself the bug.
+function undefendedCityRangeState(
+  moverPosition: { q: number; r: number } = { q: 0, r: 0 },
+  movementPointsLeft = 3,
+): GameState {
+  const state = createNewGame(undefined, 'undefended-city-range', 'small');
+  const mover = { ...createUnit('scout', 'player', moverPosition, mkC()), id: 'mover', movementPointsLeft };
+  state.units = { mover };
+  state.civilizations.player.units = ['mover'];
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  for (const key of ['0,0', '1,0', '2,0', '3,0']) {
+    state.map.tiles[key] = { ...state.map.tiles[key]!, terrain: 'plains' };
+  }
+  const city = foundCity('ai-1', { q: 2, r: 0 }, state.map, state.idCounters);
+  city.id = 'undefended-city';
+  state.cities = { [city.id]: city };
+  state.civilizations['ai-1'].cities = [city.id];
+  return state;
+}
+
+describe('#843 getMovementRangeDetails vs undefended foreign city', () => {
+  it('marks an already-adjacent undefended enemy city reachable but does not walk past it', () => {
+    // Exactly 1 movement point -- just enough to step onto the city, with no budget left
+    // over to reach (3,0) by some unrelated route that never touches the city. This isolates
+    // "walked through the city" from "took a legal detour with leftover movement."
+    const state = undefendedCityRangeState({ q: 1, r: 0 }, 1); // adjacent to the city at (2,0)
+    const range = getMovementRangeDetails(state, 'mover');
+    const keys = range.reachable.map(hexKey);
+
+    expect(keys).toContain('2,0'); // the city itself, reachable for assault
+    expect(keys).not.toContain('3,0'); // BFS must not walk through the city
+  });
+
+  it('does NOT mark a 2+-hexes-away undefended city reachable, even with enough movement to approach it', () => {
+    // This is the exact reported scenario: 2 hexes from the city with 3 movement points --
+    // enough to reach adjacency this turn, but the city must not be shown/treated as
+    // reachable until the mover is actually standing next to it.
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    const range = getMovementRangeDetails(state, 'mover');
+    const keys = range.reachable.map(hexKey);
+
+    expect(keys).toContain('1,0'); // the ordinary approach tile remains a normal move
+    expect(keys).not.toContain('2,0'); // the city itself must not be "reachable" yet
+    expect(keys).not.toContain('3,0'); // and definitely not anything beyond it
+  });
+
+  it('does not mark the city zoc-limited (it is blocked by the city, not ZOC)', () => {
+    const state = undefendedCityRangeState({ q: 1, r: 0 });
+    const range = getMovementRangeDetails(state, 'mover');
+    expect(range.zocLimited.map(hexKey)).not.toContain('2,0');
+  });
+
+  it('leaves an allied foreign city fully passable, matching validateUnitMove', () => {
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    state.civilizations.player.diplomacy.treaties.push({
+      type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: 5,
+    });
+    const range = getMovementRangeDetails(state, 'mover');
+    const keys = range.reachable.map(hexKey);
+
+    expect(keys).toContain('2,0');
+    expect(keys).toContain('3,0'); // BFS walks straight through an allied city
+  });
+});
+
+describe('#843 getMovementRange vs undefended foreign city (blockingKeys param)', () => {
+  it('remains unfixed for callers that omit blockingKeys entirely (back-compat)', () => {
+    // Existing callers that never pass blockingKeys keep their old (buggy) behavior --
+    // this documents that omitting the param is a structural no-op, not a silent fix, so a
+    // future caller of getMovementRange must opt in via blockingKeys to get the #843 fix.
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    const unit = state.units.mover;
+    const occupancy = { unitIdsByHex: {}, ownersByUnitId: {} };
+    const range = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, undefined, {});
+    expect(range.map(hexKey)).toContain('3,0');
+  });
+
+  it('includes the city only when the mover starts directly adjacent to it', () => {
+    const state = undefendedCityRangeState({ q: 1, r: 0 }, 1);
+    const unit = state.units.mover;
+    const occupancy = { unitIdsByHex: {}, ownersByUnitId: {} };
+    const blockingKeys = getBlockingMapEntityKeys(state, unit);
+    expect(blockingKeys.has('2,0')).toBe(true);
+
+    const range = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, undefined, {}, blockingKeys);
+    const keys = range.map(hexKey);
+    expect(keys).toContain('2,0');
+    expect(keys).not.toContain('3,0');
+  });
+
+  it('excludes the city entirely when the mover is 2+ hexes away, even with blockingKeys supplied', () => {
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    const unit = state.units.mover;
+    const occupancy = { unitIdsByHex: {}, ownersByUnitId: {} };
+    const blockingKeys = getBlockingMapEntityKeys(state, unit);
+
+    const range = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, undefined, {}, blockingKeys);
+    const keys = range.map(hexKey);
+    expect(keys).not.toContain('2,0');
+    expect(keys).not.toContain('3,0');
+  });
+});
+
+describe('#843 getBlockingMapEntityAt', () => {
+  it('reports the foreign city at its own coordinate regardless of the mover\'s distance from it', () => {
+    // getBlockingMapEntityAt itself is a pure "is this coordinate blocking" lookup with no
+    // adjacency concept -- the distance gate lives in the BFS callers (getMovementRange/
+    // getMovementRangeDetails), not here, so this must return the same result regardless of
+    // where the mover currently stands.
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 2, r: 0 })).toEqual({
+      reason: 'foreign-city', entityId: 'undefended-city',
+    });
+  });
+
+  it('returns null for a coordinate with no city', () => {
+    const state = undefendedCityRangeState();
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 1, r: 0 })).toBeNull();
+  });
+
+  it('returns null for an allied foreign city', () => {
+    const state = undefendedCityRangeState();
+    state.civilizations.player.diplomacy.treaties.push({
+      type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: 5,
+    });
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 2, r: 0 })).toBeNull();
+  });
+
+  it('returns null for the unit\'s own city', () => {
+    const state = undefendedCityRangeState();
+    state.cities['undefended-city']!.owner = 'player';
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 2, r: 0 })).toBeNull();
+  });
+
+  // #843 root-cause review: the bug applies identically to minor-civ (city-state) cities, not
+  // just major-civ ones -- resolveSelectedUnitTapIntent's cityAtTarget lookup is generic across
+  // state.cities regardless of owner kind, and so is getBlockingMapEntityAt. This was asserted
+  // in the root-cause writeup but never had its own automated proof; this closes that gap.
+  it('blocks an undefended minor-civ (city-state) city the same as a major-civ one', () => {
+    const state = undefendedCityRangeState({ q: 0, r: 0 });
+    state.cities['undefended-city']!.owner = 'mc-warriors';
+    const unit = state.units.mover;
+
+    expect(getBlockingMapEntityAt(state, unit, { q: 2, r: 0 })).toEqual({
+      reason: 'foreign-city', entityId: 'undefended-city',
+    });
+    expect(getMovementRangeDetails(state, 'mover').reachable.map(hexKey)).not.toContain('2,0');
+  });
+});
+
+// #843 hot-seat regression: blocking must key off the ACTING unit's owner, never
+// state.currentPlayer (CLAUDE.md's Hot Seat rule -- "NEVER hardcode ownership checks,
+// always use the acting unit's owner"). Two human-controlled civs share the device and
+// take turns; state.currentPlayer flips between their turns. Civ B's undefended city must
+// block civ A's unit identically regardless of which civ's seat happens to be active when
+// the check runs.
+function hotSeatCityBlockState(activePlayer: 'civ-a' | 'civ-b'): GameState {
+  const state = createNewGame(undefined, 'hot-seat-city-block', 'small');
+  state.hotSeat = {
+    playerCount: 2,
+    mapSize: 'small',
+    players: [
+      { name: 'Player One', slotId: 'civ-a', civType: 'rome', isHuman: true },
+      { name: 'Player Two', slotId: 'civ-b', civType: 'egypt', isHuman: true },
+    ],
+  };
+  state.currentPlayer = activePlayer;
+  for (const key of ['0,0', '1,0', '2,0']) {
+    state.map.tiles[key] = { ...state.map.tiles[key]!, terrain: 'plains' };
+  }
+  const mover = { ...createUnit('scout', 'civ-a', { q: 0, r: 0 }, mkC()), id: 'mover', movementPointsLeft: 1 };
+  state.units = { mover };
+  state.civilizations['civ-a'] = {
+    ...state.civilizations.player, id: 'civ-a', name: 'Civ A', isHuman: true, units: ['mover'], cities: [],
+  };
+  state.civilizations['civ-b'] = {
+    ...state.civilizations['ai-1'], id: 'civ-b', name: 'Civ B', isHuman: true, units: [], cities: [],
+  };
+  delete state.civilizations.player;
+  delete state.civilizations['ai-1'];
+  state.civilizations['civ-a'].diplomacy.atWarWith = ['civ-b'];
+  state.civilizations['civ-b'].diplomacy.atWarWith = ['civ-a'];
+  const city = foundCity('civ-b', { q: 1, r: 0 }, state.map, state.idCounters);
+  city.id = 'civ-b-city';
+  state.cities = { [city.id]: city };
+  state.civilizations['civ-b'].cities = [city.id];
+  return state;
+}
+
+describe('#843 hot-seat: blocking follows the acting unit\'s owner, not state.currentPlayer', () => {
+  it('blocks civ A\'s unit from civ B\'s undefended city while civ A\'s seat is active', () => {
+    const state = hotSeatCityBlockState('civ-a');
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 1, r: 0 })).toEqual({
+      reason: 'foreign-city', entityId: 'civ-b-city',
+    });
+    expect(getMovementRangeDetails(state, 'mover').reachable.map(hexKey)).toContain('1,0');
+  });
+
+  it('gives the identical result once civ B\'s seat becomes active, for the same civ-A unit', () => {
+    // Only state.currentPlayer changes between these two states -- the acting unit (civ A's
+    // scout) and its owner are identical. A currentPlayer-keyed implementation would (wrongly)
+    // change its answer here; an owner-keyed one must not.
+    const stillCivAsTurn = hotSeatCityBlockState('civ-a');
+    const nowCivBsTurn = hotSeatCityBlockState('civ-b');
+    const unitDuringA = stillCivAsTurn.units.mover;
+    const unitDuringB = nowCivBsTurn.units.mover;
+
+    expect(getBlockingMapEntityAt(nowCivBsTurn, unitDuringB, { q: 1, r: 0 }))
+      .toEqual(getBlockingMapEntityAt(stillCivAsTurn, unitDuringA, { q: 1, r: 0 }));
+    expect(getMovementRangeDetails(nowCivBsTurn, 'mover').reachable.map(hexKey))
+      .toEqual(getMovementRangeDetails(stillCivAsTurn, 'mover').reachable.map(hexKey));
+  });
+});
+
+// #845: the same hot-seat requirement, but for barbarian camps -- both hot-seat civs
+// (neither of which is 'barbarian') must be blocked identically by the same undefended camp
+// regardless of which civ's seat is currently active.
+function hotSeatCampBlockState(activePlayer: 'civ-a' | 'civ-b'): GameState {
+  const state = createNewGame(undefined, 'hot-seat-camp-block', 'small');
+  state.hotSeat = {
+    playerCount: 2,
+    mapSize: 'small',
+    players: [
+      { name: 'Player One', slotId: 'civ-a', civType: 'rome', isHuman: true },
+      { name: 'Player Two', slotId: 'civ-b', civType: 'egypt', isHuman: true },
+    ],
+  };
+  state.currentPlayer = activePlayer;
+  for (const key of ['0,0', '1,0', '2,0']) {
+    state.map.tiles[key] = { ...state.map.tiles[key]!, terrain: 'plains' };
+  }
+  const mover = { ...createUnit('scout', 'civ-a', { q: 0, r: 0 }, mkC()), id: 'mover', movementPointsLeft: 1 };
+  state.units = { mover };
+  state.civilizations['civ-a'] = {
+    ...state.civilizations.player, id: 'civ-a', name: 'Civ A', isHuman: true, units: ['mover'], cities: [],
+  };
+  state.civilizations['civ-b'] = {
+    ...state.civilizations['ai-1'], id: 'civ-b', name: 'Civ B', isHuman: true, units: [], cities: [],
+  };
+  delete state.civilizations.player;
+  delete state.civilizations['ai-1'];
+  // Clear the procedurally-generated cities from createNewGame's default 'player'/'ai-1'
+  // civs -- otherwise one may sit at/near (1,0) and shadow the camp this test cares about.
+  state.cities = {};
+  state.barbarianCamps = {
+    'camp-1': { id: 'camp-1', position: { q: 1, r: 0 }, strength: 10, spawnCooldown: 3 },
+  };
+  return state;
+}
+
+describe('#845 hot-seat: camp blocking follows the acting unit\'s owner, not state.currentPlayer', () => {
+  it('blocks civ A\'s unit from an undefended camp while civ A\'s seat is active', () => {
+    const state = hotSeatCampBlockState('civ-a');
+    const unit = state.units.mover;
+    expect(getBlockingMapEntityAt(state, unit, { q: 1, r: 0 })).toEqual({
+      reason: 'barbarian-camp', entityId: 'camp-1',
+    });
+  });
+
+  it('gives the identical result once civ B\'s seat becomes active, for the same civ-A unit', () => {
+    const stillCivAsTurn = hotSeatCampBlockState('civ-a');
+    const nowCivBsTurn = hotSeatCampBlockState('civ-b');
+    const unitDuringA = stillCivAsTurn.units.mover;
+    const unitDuringB = nowCivBsTurn.units.mover;
+
+    expect(getBlockingMapEntityAt(nowCivBsTurn, unitDuringB, { q: 1, r: 0 }))
+      .toEqual(getBlockingMapEntityAt(stillCivAsTurn, unitDuringA, { q: 1, r: 0 }));
+    expect(getMovementRangeDetails(nowCivBsTurn, 'mover').reachable.map(hexKey))
+      .toEqual(getMovementRangeDetails(stillCivAsTurn, 'mover').reachable.map(hexKey));
   });
 });
 
@@ -478,6 +775,39 @@ describe('getMovementBlockerReason', () => {
     expect(
       getMovementBlockerReason(transport, { q: 2, r: 0 }, map, { completedTechs: ['galleys', 'celestial-navigation'] })?.code,
     ).toBe('requires-ocean-hull');
+  });
+
+  // #843: before this, getMovementBlockerReason had no 'foreign-city' code at all, even
+  // though UnitMoveValidationResult's reason type did -- masked because canMove was
+  // wrongly true for these tiles pre-fix, so this branch was never reached. Now that Task 1
+  // correctly excludes far-away city tiles from movementRange, a tap on one falls into the
+  // blocked-movement path and must get the same message validateUnitMove would give.
+  it('reports the foreign-city reason when the caller supplies a blocking entity', () => {
+    const map = createWrappedGrasslandMap(5, 5);
+    const scout = createUnit('scout', 'player', { q: 0, r: 0 }, mkC());
+
+    expect(getMovementBlockerReason(scout, { q: 2, r: 0 }, map, {
+      blockingEntity: { reason: 'foreign-city', entityId: 'some-city' },
+    })).toEqual({
+      code: 'foreign-city',
+      message: 'Move adjacent, then use the city assault action.',
+    });
+  });
+
+  it('takes the blocking-entity reason over an otherwise-passable tile', () => {
+    const map = createWrappedGrasslandMap(5, 5);
+    const scout = createUnit('scout', 'player', { q: 0, r: 0 }, mkC());
+    // Adjacent + passable would otherwise return null (forced march) -- the blocking entity
+    // must still win.
+    expect(getMovementBlockerReason(scout, { q: 1, r: 0 }, map, {
+      blockingEntity: { reason: 'foreign-city', entityId: 'some-city' },
+    })?.code).toBe('foreign-city');
+  });
+
+  it('falls through to normal terrain logic when no blocking entity is supplied', () => {
+    const map = createWrappedGrasslandMap(5, 5);
+    const scout = createUnit('scout', 'player', { q: 0, r: 0 }, mkC());
+    expect(getMovementBlockerReason(scout, { q: 1, r: 0 }, map, { blockingEntity: null })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Root-cause investigation into #843 ("Cannot attack or enter the enemy city even though I have the movement left") and #845 ("Archer went into pirate alcove" / naval attack regression) surfaced three related defects, all now fixed:

### 1. Undefended enemy cities were never a movement obstacle (#843)
The shared movement-range BFS (`getMovementRange`/`getMovementRangeDetails`) only considered terrain and unit occupancy — never `state.cities`. A **defended** city "worked" only by accident, via its garrison unit's hostile-occupant/ZOC logic. An **undefended** city was silently walkable-through from arbitrarily far away, producing a false "reachable" highlight and the exact reported "Move adjacent, then use the city assault action" rejection on tap.

Fixed by extracting one shared `getBlockingMapEntityAt` predicate, consumed by both `validateUnitMove` and the BFS, gated to direct adjacency only (matching how Zone of Control already restricts a hostile unit's own tile) — the rule now lives in exactly one place instead of being able to drift out of sync the way it did before.

### 2. Barbarian camps had zero movement representation at all (#845)
Worse than cities — not even a rejection existed. A unit could walk straight onto/through an undefended camp. Extended the same shared predicate with a `state.barbarianCamps` case, and added a full player (`beginPlayerCampAssault` + preview panel) and AI (`rankCampAssault` + execution case) path to destroy an undefended camp in one step, mirroring the existing defended-camp destruction sequence (notifications, quest transitions, gold reward, bandit-lord-name flavor when present).

### 3. Galley/Trireme lost the ability to attack any naval unit (#845)
A regression from the `#826` fix two days ago: `DEFAULT_ATTACK_PROFILE` gained a hardcoded `targetDomains: ['land']`, which every unit lacking its own `attackProfile` inherits — not just land units. This silently broke Galley/Trireme (and any other bare naval/air unit) against **any** naval target, not just pirates. Removed the hardcoded default so the intended per-attacker-domain fallback runs again.

While verifying this fix, found and closed a direct side effect: `observation_balloon` (air, no `attackProfile`) would have newly gained the ability to declare attacks, contradicting its own "Cannot attack" description — given an explicit empty-`targets` profile instead.

## Review

Full root-cause writeups and task-by-task plans, including an inline review across gameplay balance, ages 7–43, hot-seat, AI/difficulty, architecture, and a documented final review pass with the findings above:
- `docs/superpowers/plans/2026-08-16-issue-843-undefended-city-movement.md`
- `docs/superpowers/plans/2026-08-16-issue-845-camp-entry-and-naval-domain.md`

## Test plan
- [x] Every new/changed assertion confirmed to **fail** without its corresponding source change (`git stash` revert-and-rerun on the specific file, not just reasoning), then confirmed to pass with the fix restored
- [x] Solo play and hot-seat coverage (both the city and camp cases, keyed off the acting unit's `owner`, not `state.currentPlayer`)
- [x] AI coverage across difficulty/opponent-challenge tiers for both the naval fix and the camp-assault action
- [x] `bash scripts/run-with-mise.sh yarn test` — 487/487 files, 8051/8054 passing (3 pre-existing skips), zero regressions
- [x] `bash scripts/run-with-mise.sh yarn build` — clean
- [x] `scripts/check-src-rule-violations.sh` — clean across every changed `src/` file
- [ ] Manual browser verification — attempted but not completed; the app has no debug hook or save-injection path to hand-engineer the exact scenario without unbounded manual play (documented honestly in both plan docs rather than claimed)

Closes #843
Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)