### PR TITLE
fix(787): GameSession state-mutation audit — Phase 6 (regression guard)

### DIFF
--- a/.claude/hooks/check-src-edit.sh
+++ b/.claude/hooks/check-src-edit.sh
@@ -47,6 +47,25 @@ if grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" >/de
 $lines"
 fi
 
+# --- direct mutation through session.getState() outside game-session.ts/ports.ts ---
+case "$file_path" in
+  */src/app/game-session.ts|*/src/app/ports.ts)
+    : # allowed: game-session.ts is the one sanctioned mutation path; ports.ts is types-only
+    ;;
+  *)
+    if grep -nE 'getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]' "$file_path" | grep -v '//' >/dev/null; then
+      lines="$(grep -nE 'getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]' "$file_path" | grep -v '//' | head -5)"
+      append "Direct mutation through session.getState() detected -- use session.commit()/session.update() instead (see docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md):
+$lines"
+    fi
+    if grep -nE 'delete [A-Za-z0-9_.]*getState\(\)' "$file_path" >/dev/null; then
+      lines="$(grep -nE 'delete [A-Za-z0-9_.]*getState\(\)' "$file_path" | head -5)"
+      append "delete through session.getState() detected -- build a new object and use session.commit()/session.update() instead:
+$lines"
+    fi
+    ;;
+esac
+
 # --- Math.random in src ---
 if grep -nE 'Math\.random\(' "$file_path" | grep -v '//' >/dev/null; then
   lines="$(grep -nE 'Math\.random\(' "$file_path" | grep -v '//' | head -5)"

--- a/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
+++ b/docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md
@@ -2398,7 +2398,7 @@ Both the grep-based boundary test and the real-time edit hook, added only once P
 - Consumes: `readdirSync`, `readFileSync` (already imported in this file, per its existing `controllers depend on ports...` test).
 - Produces: no new exports — this is a test-only addition.
 
-- [ ] **Step 1: Re-run the full inventory** from the spec's grep commands against the current `src/` tree, restricted to `src/app/**`, `src/presentation/**`, `src/ui/**`, excluding `src/app/game-session.ts` and `src/app/ports.ts`:
+- [x] **Step 1: Re-run the full inventory** from the spec's grep commands against the current `src/` tree, restricted to `src/app/**`, `src/presentation/**`, `src/ui/**`, excluding `src/app/game-session.ts` and `src/app/ports.ts`:
 
 ```bash
 grep -rnE "getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^]]+\])+\s*=[^=]" src/app src/presentation src/ui --include="*.ts" | grep -v "src/app/game-session.ts\|src/app/ports.ts"
@@ -2408,7 +2408,7 @@ grep -rnE "getState\(\)(\.[A-Za-z0-9_]+|\[[^]]+\])+\.(push|splice|pop|shift|unsh
 
 Expected: zero output from all three, confirming Phases 1-5 closed the count. If anything remains, stop here and add a Task 6.0 to convert it before proceeding — do not add a passing test with a documented allowlist for a real leftover site; the spec's whole point is zero, not "zero except these."
 
-- [ ] **Step 2: Write the test.** Add to `tests/app/architecture-boundaries.test.ts`, after the existing `'controllers depend on ports...'` test:
+- [x] **Step 2: Write the test.** Add to `tests/app/architecture-boundaries.test.ts`, after the existing `'controllers depend on ports...'` test:
 
 ```ts
 it('no app/presentation/ui file mutates the object returned by session.getState() directly', () => {
@@ -2450,14 +2450,14 @@ it('no app/presentation/ui file mutates the object returned by session.getState(
 });
 ```
 
-- [ ] **Step 2: Run test to verify it passes** (Phases 1-5 already emptied the inventory, so this should pass immediately — it's a regression guard, not a TDD-from-red test).
+- [x] **Step 2: Run test to verify it passes** (Phases 1-5 already emptied the inventory, so this should pass immediately — it's a regression guard, not a TDD-from-red test).
 
 Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/architecture-boundaries.test.ts`
 Expected: PASS.
 
-- [ ] **Step 3: Prove the guard actually catches a violation** (temporary, do not commit): add a throwaway line like `deps.session.getState().turn = 1;` to any file under `src/app/`, re-run the test, confirm it fails with a message naming the file and line, then revert the throwaway line.
+- [x] **Step 3: Prove the guard actually catches a violation** (temporary, do not commit): add a throwaway line like `deps.session.getState().turn = 1;` to any file under `src/app/`, re-run the test, confirm it fails with a message naming the file and line, then revert the throwaway line.
 
-- [ ] **Step 4: Commit.**
+- [x] **Step 4: Commit.**
 
 ```bash
 git add tests/app/architecture-boundaries.test.ts
@@ -2473,7 +2473,7 @@ git commit -m "test(architecture-boundaries): ban direct mutation through sessio
 **Interfaces:**
 - Consumes: the hook's existing `append()` helper function (already defined in the file, used by every other check block).
 
-- [ ] **Step 1: Add block-case and allow-case fixtures to the smoke test.** In `tests/hooks/check-src-edit.test.sh`, after the existing `# --- block: cities[0] in a UI file ---` block (or any existing block near the top), add:
+- [x] **Step 1: Add block-case and allow-case fixtures to the smoke test.** In `tests/hooks/check-src-edit.test.sh`, after the existing `# --- block: cities[0] in a UI file ---` block (or any existing block near the top), add:
 
 ```bash
 # --- block: direct mutation through session.getState() in src/app ---
@@ -2489,12 +2489,12 @@ EOF
 expect_allow "$tmp/src/ui/reader.ts" "getState() read-only in src/ui"
 ```
 
-- [ ] **Step 2: Run the smoke test to verify it fails.**
+- [x] **Step 2: Run the smoke test to verify it fails.**
 
 Run: `bash tests/hooks/check-src-edit.test.sh`
 Expected: FAIL on the new `expect_block` case (`check-src-edit.sh` doesn't check this pattern yet, so it exits 0 instead of the expected 2).
 
-- [ ] **Step 3: Write minimal implementation.** Add a new check block to `.claude/hooks/check-src-edit.sh`, placed near the existing "direct state mutation in turn processing" block (mirroring its structure), before the final `if [ -n "$violations" ]; then`:
+- [x] **Step 3: Write minimal implementation.** Add a new check block to `.claude/hooks/check-src-edit.sh`, placed near the existing "direct state mutation in turn processing" block (mirroring its structure), before the final `if [ -n "$violations" ]; then`:
 
 ```bash
 # --- direct mutation through session.getState() outside game-session.ts/ports.ts ---
@@ -2517,17 +2517,17 @@ $lines"
 esac
 ```
 
-- [ ] **Step 4: Run the smoke test to verify it passes.**
+- [x] **Step 4: Run the smoke test to verify it passes.**
 
 Run: `bash tests/hooks/check-src-edit.test.sh`
 Expected: PASS, all cases (existing ones plus the 2 new ones).
 
-- [ ] **Step 5: Run the full test suite once more** to confirm this hook change doesn't break anything else (it's a hook script, not directly exercised by `yarn test`, but `tests/hooks/run.sh` — if that's how hook smoke tests are wired into `yarn test`, per `.claude/rules/hooks-and-tooling.md` — must still pass):
+- [x] **Step 5: Run the full test suite once more** to confirm this hook change doesn't break anything else (it's a hook script, not directly exercised by `yarn test`, but `tests/hooks/run.sh` — if that's how hook smoke tests are wired into `yarn test`, per `.claude/rules/hooks-and-tooling.md` — must still pass):
 
 Run: `bash scripts/run-with-mise.sh yarn test`
 Expected: PASS.
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
 ```bash
 git add .claude/hooks/check-src-edit.sh tests/hooks/check-src-edit.test.sh
@@ -2536,9 +2536,9 @@ git commit -m "feat(check-src-edit): catch direct mutation through session.getSt
 
 ### Phase 6 close-out
 
-- [ ] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
-- [ ] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
-- [ ] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 6 (regression guard)`. Body confirms the inventory is verified at zero as of this PR and links Phases 1-5.
+- [x] Run `bash scripts/run-with-mise.sh yarn build` — expect exit 0.
+- [x] Run `bash scripts/run-with-mise.sh yarn test` — expect exit 0.
+- [x] Open the PR. Title: `fix(787): GameSession state-mutation audit — Phase 6 (regression guard)`. Body confirms the inventory is verified at zero as of this PR and links Phases 1-5.
 
 ---
 

--- a/tests/app/architecture-boundaries.test.ts
+++ b/tests/app/architecture-boundaries.test.ts
@@ -51,3 +51,41 @@ it('controllers depend on ports, not on RenderLoop/AudioSystem/document', () => 
     expect(stripComments(source), file).not.toMatch(/\bdocument\.getElementById\(/);
   }
 });
+
+it('no app/presentation/ui file mutates the object returned by session.getState() directly', () => {
+  // GameSession.commit()/update() are the only sanctioned publish path (see
+  // src/app/ports.ts's GameSession doc comment). Mutating getState()'s return
+  // value in place bypasses both subscribers (renderLoop, hud) that only fire
+  // through commit/update -- see docs/superpowers/specs/2026-08-15-gamesession-state-mutation-audit-design.md.
+  const dirs = [
+    resolve(__dirname, '../../src/app'),
+    resolve(__dirname, '../../src/presentation'),
+    resolve(__dirname, '../../src/ui'),
+  ];
+  const excluded = new Set(['game-session.ts', 'ports.ts']);
+  const mutationPatterns = [
+    /getState\(\)(\.[A-Za-z0-9_]+[!]?|\[[^\]]+\])+\s*=[^=]/,
+    /delete [A-Za-z0-9_.]*getState\(\)/,
+    /getState\(\)(\.[A-Za-z0-9_]+|\[[^\]]+\])+\.(push|splice|pop|shift|unshift|sort|reverse)\(/,
+  ];
+
+  function walk(dir: string): string[] {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    return entries.flatMap(entry => {
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return entry.name.endsWith('.ts') && !excluded.has(entry.name) ? [full] : [];
+    });
+  }
+
+  for (const dir of dirs) {
+    for (const file of walk(dir)) {
+      const source = readFileSync(file, 'utf8');
+      for (const line of source.split('\n')) {
+        for (const pattern of mutationPatterns) {
+          expect(pattern.test(line), `${file}: ${line}`).toBe(false);
+        }
+      }
+    }
+  }
+});

--- a/tests/hooks/check-src-edit.test.sh
+++ b/tests/hooks/check-src-edit.test.sh
@@ -46,6 +46,18 @@ const capital = civ.cities[0];
 EOF
 expect_allow "$tmp/src/ai/basic-ai.ts" "cities[0] allowed in src/ai"
 
+# --- block: direct mutation through session.getState() in src/app ---
+cat > "$tmp/src/ui/panel.ts" <<'EOF'
+session.getState().cities[cityId] = enqueueCityProduction(city, itemId);
+EOF
+expect_block "$tmp/src/ui/panel.ts" "getState() mutation in src/ui"
+
+# --- allow: reading getState() without mutating it ---
+cat > "$tmp/src/ui/reader.ts" <<'EOF'
+const city = session.getState().cities[cityId];
+EOF
+expect_allow "$tmp/src/ui/reader.ts" "getState() read-only in src/ui"
+
 # --- block: Math.random in src ---
 cat > "$tmp/src/systems/rng-bug.ts" <<'EOF'
 const x = Math.random();


### PR DESCRIPTION
## Summary

Phase 6 (final phase) of the [GameSession state-mutation audit](docs/superpowers/plans/2026-08-15-gamesession-state-mutation-audit.md) (issue #787). Adds the regression guard that locks in the zero-mutation-sites state Phases 1-5 drove the codebase to, so the count can never silently climb back up.

- **Task 6.1** (`tests/app/architecture-boundaries.test.ts`): a generic test that walks every `.ts` file under `src/app`, `src/presentation`, and `src/ui` (excluding `game-session.ts`/`ports.ts`, the one sanctioned mutation path) and fails if any line directly mutates the object returned by `session.getState()` — an assignment, a `delete`, or a mutating array method. Proven to actually catch a violation: a temporary throwaway `deps.session.getState().turn = 1;` line was added, confirmed the test fails naming the exact file/line, then reverted before committing.
- **Task 6.2** (`.claude/hooks/check-src-edit.sh`): the same check as a real-time PostToolUse hook, so a new violation is flagged the moment it's written rather than at the next test run. Mirrors the existing "direct state mutation in turn processing" block's structure. Smoke-tested with a matching block/allow case pair in `tests/hooks/check-src-edit.test.sh`.

## Verification

- Re-ran the full inventory (all 3 grep patterns from the design spec, restricted to `src/app`/`src/presentation`/`src/ui`, excluding the two sanctioned files) immediately before starting this phase: **zero matches**, confirming Phases 1-5 closed the count.
- `bash scripts/run-with-mise.sh yarn build` — exit 0
- `bash scripts/run-with-mise.sh yarn test` — exit 0 (487 test files, 8052 tests, 3 skipped)
- `bash tests/hooks/check-src-edit.test.sh` — exit 0, all cases including the 2 new ones
- Pre-push hook (full suite + build) passed

## Inline review (mid-development)

Reviewed this change and the preceding Phase 5 gameplay-touching code across balance/UX/architecture/data/testing/hot-seat/AI dimensions before opening this PR. No fixable issues in this phase's own diff (both additions follow existing codebase conventions exactly and are fully tested). One pre-existing, cross-cutting finding from Phases 1-5 (not introduced by this phase): converted handlers call `session.commit()` and then also manually re-trigger `renderLoop.setGameState()`/`hud.update()`, which `bootstrap.ts`'s subscriptions already do — redundant but idempotent (no visible bug, just wasted DOM/compute work). Flagged as a follow-up rather than retrofitted here, since fixing it properly means rewiring ~5 controller test files' fixtures across already-merged PRs.

## Closes out #787's GameSession state-mutation audit

All 6 phases complete: 44 flagged mutation sites converted across `player-action-controller.ts`, `campaign-entry-controller.ts`, `turn-flow-controller.ts`, `selection-controller.ts`, and `panel-actions-controller.ts` (+ its `city-panel.ts` companion change), now backed by a permanent regression guard at both test time and edit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)