### PR TITLE
ci: gate GitHub Pages deploy on same-commit test/smoke/security checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -176,7 +176,7 @@ jobs:
 
   web-smoke:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -284,7 +284,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: web-build
+    needs: [web-build, test, web-smoke, security-analysis]
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## The hole

`deploy` needed only `web-build`. `test` (`yarn verify:push` = full suite + build) and `web-smoke` (Playwright) were both hard-gated to `pull_request` events and never ran on the push-to-main that actually triggers `deploy`. A commit could reach `main`, compile, and publish to GitHub Pages without the exact deployed revision ever passing the test suite or the browser smoke test.

## Changed job graph

```
before:  deploy  <-- needs -- web-build

after:   deploy  <-- needs -- web-build
                  <-- needs -- test              (now also runs on push-to-main)
                  <-- needs -- web-smoke         (now also runs on push-to-main)
                  <-- needs -- security-analysis (already ran unconditionally)
```

Three-line diff:
- `test`'s `if:` widened from `github.event_name == 'pull_request'` to `... || github.ref == 'refs/heads/main'` — the exact pattern `tauri-frontend-build` already used in this same file.
- `web-smoke`'s `if:` widened identically.
- `deploy`'s `needs: web-build` → `needs: [web-build, test, web-smoke, security-analysis]`.

## Jobs that now gate deployment, and why

- **`web-build`** — already did. Produces the artifact being published; also runs the app's TS/Vite build.
- **`test`** — the actual behavioral gate (full vitest suite) plus its own `yarn build`. This is the primary fix: previously never ran on `main` at all.
- **`web-smoke`** — real-browser Playwright smoke test. Second half of the primary fix.
- **`security-analysis`** (zizmor) — already ran unconditionally on every push and PR with no `if:` gate; adding it to `deploy`'s needs is including an already-mandatory static check in the gate, per the task's own guidance. Cheap (~15s), directly relevant to a job holding `pages: write`/`id-token: write`.

## Deliberately NOT added to the gate

- **`tauri-frontend-build`** — a different deployment target (desktop/Tauri), doesn't exercise app *behavior* beyond an alternate compile that's largely redundant with `web-build`'s own `tsc && vite build`.
- **`tauri-macos-build`** — native macOS packaging, expensive, platform-specific, explicitly named in the task as something not to make a web-deploy blocker.
- **`pirate-audio-reproducibility`** — narrow, feature-scoped (only runs its real check when audio-generator files changed), PR-only by design.
- **`desktop-change-check`** — not a verification job; just a diff-detector feeding `tauri-macos-build`'s `if:`.

## Things checked that are NOT part of this diff

- **`web-build`'s early artifact upload**: `actions/upload-pages-artifact` runs unconditionally on `main` inside `web-build`, before `test`/`web-smoke` are known to pass. This is harmless — the action only *stages* the artifact; nothing is published until `deploy` runs `actions/deploy-pages`, and `deploy` now genuinely waits on all four jobs. No change needed.
- **Permissions**: untouched. Top-level stays `contents: read`; `security-analysis` and `deploy` keep their own scoped elevated permissions. Least-privilege model preserved.
- **Concurrency**: untouched (`cancel-in-progress: true` per-ref group already prevents overlapping runs).
- **Duplicate deployments**: none introduced — one workflow run per push event, same as before.

## Residual risks / follow-ups (not fixed here, flagging for a decision)

1. **Branch protection has a phantom required check.** `gh api repos/a1flecke/conquestoria/branches/main/protection` shows required status-check contexts `["build", "test"]`. `git log -p` shows the `build` job was renamed to `web-build` at commit `03f87d6c` — branch protection was never updated, so `build` can never be satisfied by the current workflow. Additionally, since `test` was PR-only until this PR, a rebase-merged commit's new SHA never got a fresh `test` run either — both required contexts have effectively been unsatisfiable via the normal merge button, only bypassable via admin override. This PR fixes the `test`-on-push half of that as a side effect; the `build` → `web-build` branch-protection rename is a separate, non-code, admin-settings fix I did not make as part of this PR.
2. **`web-smoke` verifies dev-mode, not the production build.** `playwright.config.ts`'s `webServer` runs `yarn dev --mode e2e`, not the built `dist/` artifact `web-build` produces and `deploy` publishes. A bug that only manifests in the minified production build (vs. Vite dev server) wouldn't be caught by this gate. Out of scope for a focused CI-hardening change; worth a follow-up if it becomes a real incident vector.

## Validation

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"`).
- `bash scripts/run-with-mise.sh yarn build` — exit 0.
- `bash scripts/run-with-mise.sh yarn test` — exit 0 (487 files, 8052 tests).
- Pre-push hook (full suite + build) passed.
- `git diff` reviewed for scope creep: exactly 3 lines changed in exactly 1 file.
- The workflow's own `security-analysis` (zizmor) job will lint this exact diff for security issues as part of this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)