### PR TITLE
Scenario infrastructure for deterministic debug reproduction (#846)

### DIFF
--- a/docs/scenario-infrastructure.md
+++ b/docs/scenario-infrastructure.md
@@ -1,0 +1,109 @@
+# Scenario Infrastructure
+
+Deterministically reproduce a specific game state for debugging or regression testing,
+without playing dozens of turns. See the design rationale in
+`docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md`.
+
+## How it works
+
+A `ScenarioDefinition` (`src/testing/scenario-types.ts`) names a `base` config
+(everything `createNewGame`/`createHotSeatGame` needs: civ, map size, seed) plus a list
+of typed `steps` (`terrain`, `unit`, `city`, `camp`, `tech`, `diplomacy`, `gold`).
+`buildScenario()` (`src/testing/scenario-builder.ts`) folds a definition into a real
+`GameState` by calling the same canonical system helpers gameplay itself uses
+(`createUnit`, `foundCity`, `declareWar`, ...) -- never a hand-built partial state.
+
+## Creating a scenario
+
+Add an entry to `SCENARIOS` in `src/testing/scenarios.ts`:
+
+```ts
+'my-new-scenario': {
+  name: 'my-new-scenario',
+  description: 'One sentence: what condition this reproduces and why.',
+  seed: 'scenario-my-new-scenario',
+  base: { kind: 'solo', config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'My New Scenario' } },
+  steps: [
+    { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+    { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+  ],
+},
+```
+
+Available step kinds: `terrain` (guarantee a tile's terrain, e.g. so a hand-picked
+coordinate is land regardless of what the seed's procedural generation produced there),
+`unit` (via `createUnit` + optional `overrides`), `city` (via `foundCity` + territory
+recalculation), `camp` (a barbarian camp at an exact position), `tech` (mark techs
+completed for a civ), `diplomacy` (war/peace/alliance, applied bilaterally), and `gold`.
+
+## Running one manually
+
+```bash
+bash scripts/run-with-mise.sh yarn dev
+```
+
+Then open `http://localhost:5173/conquestoria/?scenario=my-new-scenario`. This only
+works in dev mode (`import.meta.env.DEV`) -- see "Production isolation" below. An
+unknown scenario name throws a clear error naming the known scenarios, instead of
+silently doing nothing.
+
+## Using one in a test
+
+```ts
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+
+const state = buildScenario(SCENARIOS['undefended-enemy-city']);
+// state is a real GameState -- pass it directly to whatever system you're testing.
+```
+
+This is the same function and the same named definition the dev-mode browser loader
+uses -- there is no separate test-only construction path.
+
+## What NOT to represent directly
+
+Do not add a step `kind` that lets a caller push a raw partial `Unit`/`City`/other
+entity -- every step must map to a canonical constructor (`createUnit`, `foundCity`,
+...) plus narrow `overrides`. If you find yourself hand-writing gameplay fields
+(strength, movement, yields) in a step, that is a sign the step should call a real
+system helper instead.
+
+By default, a step rejects placing something on an already-occupied tile. Pass
+`unsafe: true` on a `unit`/`city`/`camp` step only when you are deliberately
+reproducing a corrupt or edge-case state -- it is an explicit, visible marker, never a
+silent default.
+
+## How canonical state is derived
+
+Everything not named in `base`/`steps` -- map, starting units for every civ, initial
+visibility, minor civs, espionage state, idCounters -- comes from
+`createNewGame`/`createHotSeatGame`, called once at the start of `buildScenario`. Steps
+only add the specific delta a scenario needs. After all steps run, `buildScenario`
+recomputes visibility/contacts for every civ via the same system calls `createNewGame`
+itself uses -- never hand-set. IDs come from the built state's own `idCounters`, so
+they stay collision-free the same way real gameplay's do.
+
+## Production/debug isolation guarantees
+
+- The browser loader is gated on `import.meta.env.DEV`, a Vite compile-time constant --
+  `false` for `vite build` (production), so the branch and its dynamic imports are
+  eliminated from the production bundle, not merely hidden behind a runtime check.
+- The loader only accepts a name that must match a key in the closed `SCENARIOS`
+  registry -- an unknown name throws, it never falls through to arbitrary behavior.
+- Building a scenario never mutates a live `GameSession` -- `buildScenario` is a pure
+  function; the only thing that touches `GameSession` is the same
+  `campaignEntry.enterCampaign(...)` call every other game-entry path already uses.
+
+## Example
+
+The two scenarios shipped in `src/testing/scenarios.ts` reproduce the exact starting
+conditions two real, previously-hard-to-reproduce bugs needed:
+
+- `undefended-enemy-city` (#843): a player scout 2 hexes from an undefended, at-war AI
+  city, proving the city blocks movement/assault only from direct adjacency.
+- `undefended-barbarian-camp` (#845): a player unit directly adjacent to an undefended
+  barbarian camp, for the one-step assault path.
+
+Both are asserted against in `tests/testing/scenarios.test.ts`, and both can be opened
+directly with `?scenario=undefended-enemy-city` / `?scenario=undefended-barbarian-camp`
+under `yarn dev` -- no manual play required to reach either state.

--- a/docs/superpowers/plans/2026-08-16-issue-846-scenario-infrastructure.md
+++ b/docs/superpowers/plans/2026-08-16-issue-846-scenario-infrastructure.md
@@ -1,0 +1,1243 @@
+# Scenario Infrastructure (Issue #846) Implementation Plan
+
+> **For agentic workers:** Per this repository's CLAUDE.md ("NEVER use subagents or parallel agents"), execute this plan **inline in the current session** using `superpowers:executing-plans`, not `superpowers:subagent-driven-development`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give developers and tests a typed, deterministic way to construct a specific `GameState` (era/turn, map, civs, units, cities, tech, diplomacy) without playing dozens of turns, built entirely from canonical system helpers so it can never drift into a duplicate fixture format.
+
+**Architecture:** A `ScenarioDefinition` (a `base` config for `createNewGame`/`createHotSeatGame` plus a list of typed `ScenarioStep`s) is folded by `buildScenario()` into a `GameState`, applying each step through the same canonical system functions gameplay itself uses (`createUnit`, `foundCity`, `declareWar`, etc.). The same `buildScenario` + a small named `SCENARIOS` registry are consumed by (a) Vitest tests directly, and (b) a `DEV`-only `?scenario=<name>` branch in the composition root that publishes the built state through the existing `campaignEntry.enterCampaign` path — no new state-management or mutation surface.
+
+**Tech Stack:** TypeScript, Vitest, Vite (`import.meta.env.DEV`), existing `@/core/game-state.ts` and `@/systems/*` helpers.
+
+## Global Constraints
+
+- Full design/rationale: `docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md` — read it if a task below is ambiguous.
+- Never hand-construct `Unit`/`City` objects with literal gameplay fields (strength, movement, etc.) — always start from the real `createUnit`/`foundCity` and layer only scenario-specific `overrides` on top.
+- Diplomacy changes must update both civs' `diplomacy` state (matches `declareWar`/`makePeace`/`signTreaty` call-site convention everywhere else in this codebase).
+- All commands run via `bash scripts/run-with-mise.sh yarn <cmd>` — never bare `yarn` or `eval "$(mise activate bash)"`.
+- Before `git push`/`gh pr create`, run `yarn build` and `yarn test` and confirm both exit 0.
+- Do not modify `src/systems/barbarian-system.ts`, `src/systems/beast-system.ts`, `src/ai/*` or any other file under active work by the parallel #547 agent — this plan only adds new files under `src/testing/` and `tests/testing/`, plus one small additive branch in `src/app/controllers/game-session-controller.ts`.
+
+---
+
+## Task 1: Scenario types
+
+**Files:**
+- Create: `src/testing/scenario-types.ts`
+- Test: `tests/testing/scenario-types.test.ts`
+
+**Interfaces:**
+- Produces: `ScenarioDefinition`, `ScenarioStep` (discriminated union: `terrain` | `unit` | `city` | `camp` | `tech` | `diplomacy` | `gold`), `ScenarioError` class. Every later task imports these from `@/testing/scenario-types`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/testing/scenario-types.test.ts
+import { describe, expect, it } from 'vitest';
+import { ScenarioError } from '@/testing/scenario-types';
+
+describe('ScenarioError', () => {
+  it('is a real Error with a readable name', () => {
+    const error = new ScenarioError('bad step');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('ScenarioError');
+    expect(error.message).toBe('bad step');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-types.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-types'`
+
+- [ ] **Step 3: Write the types file**
+
+```ts
+// src/testing/scenario-types.ts
+/**
+ * Canonical scenario representation (#846). A ScenarioDefinition never carries
+ * raw partial GameState — every step maps 1:1 to a canonical system call in
+ * scenario-builder.ts, so a scenario can never bypass the same construction
+ * rules real gameplay uses. See docs/superpowers/specs/
+ * 2026-08-16-issue-846-scenario-infrastructure-design.md for the full design.
+ */
+import type {
+  City,
+  HexCoord,
+  HexTile,
+  HotSeatConfig,
+  SoloSetupConfig,
+  TreatyType,
+  Unit,
+  UnitType,
+} from '@/core/types';
+
+export class ScenarioError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScenarioError';
+  }
+}
+
+export interface TerrainStep {
+  readonly kind: 'terrain';
+  readonly position: HexCoord;
+  readonly terrain: HexTile['terrain'];
+}
+
+export interface UnitStep {
+  readonly kind: 'unit';
+  readonly civId: string;
+  readonly type: UnitType;
+  readonly position: HexCoord;
+  readonly overrides?: Partial<Unit>;
+  /** Skip the "tile already occupied" guard — for intentionally corrupt/edge-case scenarios. */
+  readonly unsafe?: boolean;
+}
+
+export interface CityStep {
+  readonly kind: 'city';
+  readonly civId: string;
+  readonly position: HexCoord;
+  readonly overrides?: Partial<City>;
+  readonly unsafe?: boolean;
+}
+
+export interface CampStep {
+  readonly kind: 'camp';
+  readonly position: HexCoord;
+  readonly overrides?: Partial<{ strength: number; spawnCooldown: number; resurgent: boolean; banditLordName: string }>;
+  readonly unsafe?: boolean;
+}
+
+export interface TechStep {
+  readonly kind: 'tech';
+  readonly civId: string;
+  readonly techIds: readonly string[];
+}
+
+export interface DiplomacyStep {
+  readonly kind: 'diplomacy';
+  readonly civA: string;
+  readonly civB: string;
+  readonly status: 'war' | 'peace' | 'alliance';
+}
+
+export interface GoldStep {
+  readonly kind: 'gold';
+  readonly civId: string;
+  readonly amount: number;
+}
+
+export type ScenarioStep =
+  | TerrainStep
+  | UnitStep
+  | CityStep
+  | CampStep
+  | TechStep
+  | DiplomacyStep
+  | GoldStep;
+
+export type ScenarioBase =
+  | { readonly kind: 'solo'; readonly config: SoloSetupConfig }
+  | { readonly kind: 'hotSeat'; readonly config: HotSeatConfig };
+
+export interface ScenarioDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly seed: string;
+  readonly base: ScenarioBase;
+  readonly steps: readonly ScenarioStep[];
+}
+
+/** TreatyType re-exported for callers building diplomacy assertions in tests. */
+export type { TreatyType };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-types.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/testing/scenario-types.ts tests/testing/scenario-types.test.ts
+git commit -m "feat(testing): add typed ScenarioDefinition/ScenarioStep for #846"
+```
+
+---
+
+## Task 2: Scenario builder
+
+**Files:**
+- Create: `src/testing/scenario-builder.ts`
+- Test: `tests/testing/scenario-builder.test.ts`
+
+**Interfaces:**
+- Consumes: `ScenarioDefinition`, `ScenarioStep`, `ScenarioError` from `@/testing/scenario-types` (Task 1).
+- Produces: `buildScenario(definition: ScenarioDefinition): GameState`. Task 3 (named scenarios + their tests) and Task 4 (dev loader) both call this exact function.
+
+- [ ] **Step 1: Write the failing determinism + base-construction test**
+
+```ts
+// tests/testing/scenario-builder.test.ts
+import { describe, expect, it } from 'vitest';
+import { buildScenario } from '@/testing/scenario-builder';
+import { ScenarioError, type ScenarioDefinition, type ScenarioStep } from '@/testing/scenario-types';
+import { hexKey } from '@/systems/hex-utils';
+import { getBlockingMapEntityAt } from '@/systems/unit-system';
+
+function withoutGameId(state: ReturnType<typeof buildScenario>) {
+  const { gameId, ...rest } = state;
+  return rest;
+}
+
+const soloBase: ScenarioDefinition['base'] = {
+  kind: 'solo',
+  config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Determinism Check' },
+};
+
+describe('buildScenario', () => {
+  it('is deterministic for a given seed (excluding gameId)', () => {
+    const definition: ScenarioDefinition = {
+      name: 'determinism-check',
+      description: 'test only',
+      seed: 'scenario-determinism-check',
+      base: soloBase,
+      steps: [],
+    };
+    const first = buildScenario(definition);
+    const second = buildScenario(definition);
+    expect(withoutGameId(first)).toEqual(withoutGameId(second));
+  });
+
+  it('derives everything not named in base/steps from createNewGame', () => {
+    const definition: ScenarioDefinition = {
+      name: 'base-only',
+      description: 'test only',
+      seed: 'scenario-base-only',
+      base: soloBase,
+      steps: [],
+    };
+    const state = buildScenario(definition);
+    expect(Object.keys(state.civilizations)).toEqual(['player', 'ai-1']);
+    expect(state.civilizations.player.units.length).toBeGreaterThan(0);
+    expect(state.map.tiles).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-builder'`
+
+- [ ] **Step 3: Write the builder's base construction + step dispatch skeleton**
+
+```ts
+// src/testing/scenario-builder.ts
+/**
+ * Folds a ScenarioDefinition into a GameState by starting from the canonical
+ * createNewGame/createHotSeatGame constructor, then applying each step
+ * through the same system helpers gameplay uses. See
+ * docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md.
+ */
+import type { GameState, Unit } from '@/core/types';
+import { createHotSeatGame, createNewGame } from '@/core/game-state';
+import { hexKey } from '@/systems/hex-utils';
+import { updateVisibility } from '@/systems/fog-of-war';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
+import { ScenarioError, type ScenarioDefinition, type ScenarioStep } from '@/testing/scenario-types';
+import { applyUnitStep } from '@/testing/scenario-steps/unit-step';
+import { applyCityStep } from '@/testing/scenario-steps/city-step';
+import { applyCampStep } from '@/testing/scenario-steps/camp-step';
+import { applyTechStep } from '@/testing/scenario-steps/tech-step';
+import { applyDiplomacyStep } from '@/testing/scenario-steps/diplomacy-step';
+import { applyGoldStep } from '@/testing/scenario-steps/gold-step';
+
+function applyTerrainStep(state: GameState, step: Extract<ScenarioStep, { kind: 'terrain' }>): GameState {
+  const key = hexKey(step.position);
+  const tile = state.map.tiles[key];
+  if (!tile) throw new ScenarioError(`Invalid coordinate ${key} in terrain step`);
+  return { ...state, map: { ...state.map, tiles: { ...state.map.tiles, [key]: { ...tile, terrain: step.terrain } } } };
+}
+
+function applyStep(state: GameState, step: ScenarioStep): GameState {
+  switch (step.kind) {
+    case 'terrain': return applyTerrainStep(state, step);
+    case 'unit': return applyUnitStep(state, step);
+    case 'city': return applyCityStep(state, step);
+    case 'camp': return applyCampStep(state, step);
+    case 'tech': return applyTechStep(state, step);
+    case 'diplomacy': return applyDiplomacyStep(state, step);
+    case 'gold': return applyGoldStep(state, step);
+  }
+}
+
+function refreshVisibilityAndContacts(state: GameState): GameState {
+  for (const civId of Object.keys(state.civilizations)) {
+    const civ = state.civilizations[civId];
+    const civUnits = civ.units
+      .map(unitId => state.units[unitId])
+      .filter((unit): unit is Unit => unit != null);
+    const cityPositions = Object.values(state.cities)
+      .filter(city => city.owner === civId)
+      .map(city => city.position);
+    updateVisibility(civ.visibility, civUnits, state.map, cityPositions);
+  }
+  for (const civId of Object.keys(state.civilizations)) {
+    refreshLastSeenPresentationsForCiv(state, civId);
+    syncCivilizationContactsFromVisibility(state, civId);
+  }
+  return state;
+}
+
+export function buildScenario(definition: ScenarioDefinition): GameState {
+  let state: GameState = definition.base.kind === 'solo'
+    ? createNewGame({ ...definition.base.config, seed: definition.seed })
+    : createHotSeatGame(definition.base.config, definition.seed);
+
+  definition.steps.forEach((step, index) => {
+    try {
+      state = applyStep(state, step);
+    } catch (error) {
+      if (error instanceof ScenarioError) throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new ScenarioError(`Scenario "${definition.name}" step ${index} (${step.kind}) failed: ${reason}`);
+    }
+  });
+
+  return refreshVisibilityAndContacts(state);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes (step appliers still missing — expected next failure)**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/unit-step'` (the six step-applier modules don't exist yet; this is the expected next failure, not a regression)
+
+- [ ] **Step 5: Write the failing unit-step test**
+
+Append to `tests/testing/scenario-builder.test.ts`:
+
+```ts
+describe('unit step', () => {
+  it('places a canonical unit via createUnit, then layers overrides on top', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-check',
+      description: 'test only',
+      seed: 'scenario-unit-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 }, overrides: { health: 40 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player');
+    expect(scout).toBeDefined();
+    expect(scout!.movementPointsLeft).toBe(3); // UNIT_DEFINITIONS.scout.movementPoints — proves createUnit ran
+    expect(scout!.health).toBe(40); // proves the override layered on top
+    expect(state.civilizations.player.units).toContain(scout!.id);
+  });
+
+  it('works identically for an AI-owned civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-ai-check',
+      description: 'test only',
+      seed: 'scenario-unit-step-ai-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'ai-1', type: 'warrior', position: { q: 0, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const warrior = Object.values(state.units).find(u => u.type === 'warrior' && u.owner === 'ai-1');
+    expect(warrior).toBeDefined();
+    expect(state.civilizations['ai-1'].units).toContain(warrior!.id);
+  });
+
+  it('throws ScenarioError on an invalid coordinate', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-bad-coord',
+      description: 'test only',
+      seed: 'scenario-unit-step-bad-coord',
+      base: soloBase,
+      steps: [{ kind: 'unit', civId: 'player', type: 'scout', position: { q: 99999, r: 99999 } }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('throws ScenarioError on an unknown civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-bad-civ',
+      description: 'test only',
+      seed: 'scenario-unit-step-bad-civ',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'nonexistent', type: 'scout', position: { q: 0, r: 0 } },
+      ],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('rejects placing a unit on an already-occupied tile unless unsafe: true', () => {
+    const stepsBase: ScenarioStep[] = [
+      { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+      { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+      { kind: 'unit', civId: 'ai-1', type: 'warrior', position: { q: 0, r: 0 } },
+    ];
+    const blocked: ScenarioDefinition = {
+      name: 'unit-step-occupied', description: 'test only', seed: 'scenario-unit-step-occupied',
+      base: soloBase, steps: stepsBase,
+    };
+    expect(() => buildScenario(blocked)).toThrow(ScenarioError);
+
+    const allowed: ScenarioDefinition = {
+      ...blocked,
+      name: 'unit-step-occupied-unsafe',
+      steps: [...stepsBase.slice(0, 2), { ...stepsBase[2], unsafe: true } as ScenarioStep],
+    };
+    expect(() => buildScenario(allowed)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/unit-step'`
+
+- [ ] **Step 7: Implement the unit step**
+
+```ts
+// src/testing/scenario-steps/unit-step.ts
+import type { GameState, Unit } from '@/core/types';
+import { createUnit } from '@/systems/unit-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type UnitStep } from '@/testing/scenario-types';
+
+export function applyUnitStep(state: GameState, step: UnitStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in unit step`);
+
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in unit step`);
+
+  if (!step.unsafe) {
+    const occupant = Object.values(state.units).find(unit => hexKey(unit.position) === key);
+    if (occupant) {
+      throw new ScenarioError(`Tile ${key} already occupied by unit "${occupant.id}" (pass unsafe: true to override)`);
+    }
+  }
+
+  const civDef = resolveCivDefinition(state, civ.civType);
+  const unit: Unit = { ...createUnit(step.type, step.civId, step.position, state.idCounters, civDef?.bonusEffect), ...step.overrides };
+
+  return {
+    ...state,
+    units: { ...state.units, [unit.id]: unit },
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: { ...civ, units: [...civ.units, unit.id] },
+    },
+  };
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/city-step'` (next missing module; unit-step tests themselves now pass, remaining failures are import errors from the skeleton's other imports)
+
+- [ ] **Step 9: Write the failing city-step test**
+
+Append to `tests/testing/scenario-builder.test.ts`:
+
+```ts
+describe('city step', () => {
+  it('founds a canonical city via foundCity and claims nearby territory', () => {
+    const definition: ScenarioDefinition = {
+      name: 'city-step-check',
+      description: 'test only',
+      seed: 'scenario-city-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+        { kind: 'terrain', position: { q: 1, r: 0 }, terrain: 'plains' },
+        { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const city = Object.values(state.cities).find(c => hexKey(c.position) === hexKey({ q: 2, r: 0 }));
+    expect(city).toBeDefined();
+    expect(city!.owner).toBe('ai-1');
+    expect(city!.name.length).toBeGreaterThan(0); // proves foundCity's naming ran, not a hand literal
+    expect(state.civilizations['ai-1'].cities).toContain(city!.id);
+    expect(state.map.tiles[hexKey({ q: 1, r: 0 })].owner).toBe('ai-1'); // territory recalculated
+  });
+
+  it('rejects founding on an already-occupied tile unless unsafe: true', () => {
+    const steps: ScenarioStep[] = [
+      { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+      { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+      { kind: 'city', civId: 'player', position: { q: 2, r: 0 } },
+    ];
+    const blocked: ScenarioDefinition = {
+      name: 'city-step-occupied', description: 'test only', seed: 'scenario-city-step-occupied',
+      base: soloBase, steps,
+    };
+    expect(() => buildScenario(blocked)).toThrow(ScenarioError);
+  });
+});
+```
+
+- [ ] **Step 10: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/city-step'`
+
+- [ ] **Step 11: Implement the city step**
+
+```ts
+// src/testing/scenario-steps/city-step.ts
+import type { City, GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { collectUsedCityNames } from '@/systems/city-name-system';
+import { recalculateTerritory } from '@/systems/city-territory-system';
+import { initializeLegendaryWonderProjectsForCity } from '@/systems/legendary-wonder-system';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type CityStep } from '@/testing/scenario-types';
+
+export function applyCityStep(state: GameState, step: CityStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in city step`);
+
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in city step`);
+
+  if (!step.unsafe) {
+    const existingCity = Object.values(state.cities).find(c => hexKey(c.position) === key);
+    if (existingCity) {
+      throw new ScenarioError(`Tile ${key} already has city "${existingCity.id}" (pass unsafe: true to override)`);
+    }
+  }
+
+  const civDef = resolveCivDefinition(state, civ.civType);
+  const city: City = {
+    ...foundCity(step.civId, step.position, state.map, state.idCounters, {
+      civType: civ.civType,
+      namingPool: civDef?.cityNames,
+      civName: civDef?.name ?? civ.name,
+      usedNames: collectUsedCityNames(state),
+      completedTechs: civ.techState.completed,
+    }),
+    ...step.overrides,
+  };
+
+  let nextState: GameState = {
+    ...state,
+    cities: { ...state.cities, [city.id]: city },
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: { ...civ, cities: [...civ.cities, city.id] },
+    },
+  };
+  nextState = initializeLegendaryWonderProjectsForCity(nextState, step.civId, city.id);
+  nextState = recalculateTerritory(nextState, { reason: 'founding', preserveForeignHolders: true }).state;
+  return nextState;
+}
+```
+
+- [ ] **Step 12: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/camp-step'` (next missing module)
+
+- [ ] **Step 13: Write the failing camp-step test**
+
+Append to `tests/testing/scenario-builder.test.ts`:
+
+```ts
+describe('camp step', () => {
+  it('places a barbarian camp that getBlockingMapEntityAt recognizes', () => {
+    const definition: ScenarioDefinition = {
+      name: 'camp-step-check',
+      description: 'test only',
+      seed: 'scenario-camp-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 5, r: 5 }, terrain: 'plains' },
+        { kind: 'terrain', position: { q: 6, r: 5 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player', type: 'warrior', position: { q: 5, r: 5 } },
+        { kind: 'camp', position: { q: 6, r: 5 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const camp = Object.values(state.barbarianCamps).find(c => hexKey(c.position) === hexKey({ q: 6, r: 5 }));
+    expect(camp).toBeDefined();
+    const mover = Object.values(state.units).find(u => u.owner === 'player');
+    const blocking = getBlockingMapEntityAt(state, mover!, { q: 6, r: 5 });
+    expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
+  });
+});
+```
+
+- [ ] **Step 14: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/camp-step'`
+
+- [ ] **Step 15: Implement the camp step**
+
+```ts
+// src/testing/scenario-steps/camp-step.ts
+import type { BarbarianCamp, GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type CampStep } from '@/testing/scenario-types';
+
+export function applyCampStep(state: GameState, step: CampStep): GameState {
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in camp step`);
+
+  if (!step.unsafe) {
+    const occupantUnit = Object.values(state.units).find(unit => hexKey(unit.position) === key);
+    const occupantCamp = Object.values(state.barbarianCamps ?? {}).find(camp => hexKey(camp.position) === key);
+    if (occupantUnit || occupantCamp) {
+      throw new ScenarioError(`Tile ${key} already occupied (pass unsafe: true to override)`);
+    }
+  }
+
+  const id = `scenario-camp-${state.idCounters.nextCampId++}`;
+  // No canonical constructor exists for an exact-position camp — spawnBarbarianCamp
+  // only picks a random distance-constrained tile. BarbarianCamp is a flat data
+  // record with no derived fields, so a direct literal is the correct level here
+  // (same justification as the terrain step).
+  const camp: BarbarianCamp = {
+    id,
+    position: { ...step.position },
+    strength: 1,
+    spawnCooldown: 99, // inert for the scenario's lifetime; scenarios don't advance turns
+    ...step.overrides,
+  };
+
+  return { ...state, barbarianCamps: { ...(state.barbarianCamps ?? {}), [id]: camp } };
+}
+```
+
+- [ ] **Step 16: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/tech-step'` (next missing module)
+
+- [ ] **Step 17: Write the failing tech-step and diplomacy-step and gold-step tests**
+
+Append to `tests/testing/scenario-builder.test.ts`:
+
+```ts
+describe('tech step', () => {
+  it('marks the named techs completed for the civ', () => {
+    const definition: ScenarioDefinition = {
+      name: 'tech-step-check',
+      description: 'test only',
+      seed: 'scenario-tech-step-check',
+      base: soloBase,
+      steps: [{ kind: 'tech', civId: 'player', techIds: ['pottery', 'bronze-working'] }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.techState.completed).toEqual(
+      expect.arrayContaining(['pottery', 'bronze-working']),
+    );
+  });
+
+  it('throws ScenarioError on an unknown tech id', () => {
+    const definition: ScenarioDefinition = {
+      name: 'tech-step-bad-id',
+      description: 'test only',
+      seed: 'scenario-tech-step-bad-id',
+      base: soloBase,
+      steps: [{ kind: 'tech', civId: 'player', techIds: ['not-a-real-tech'] }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+});
+
+describe('diplomacy step', () => {
+  it('declares war bilaterally', () => {
+    const definition: ScenarioDefinition = {
+      name: 'diplomacy-step-check',
+      description: 'test only',
+      seed: 'scenario-diplomacy-step-check',
+      base: soloBase,
+      steps: [{ kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'war' }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+    expect(state.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
+  });
+});
+
+describe('gold step', () => {
+  it('adds gold to the civ', () => {
+    const definition: ScenarioDefinition = {
+      name: 'gold-step-check',
+      description: 'test only',
+      seed: 'scenario-gold-step-check',
+      base: soloBase,
+      steps: [{ kind: 'gold', civId: 'player', amount: 250 }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.gold).toBe(250);
+  });
+});
+```
+
+- [ ] **Step 18: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenario-steps/tech-step'`
+
+- [ ] **Step 19: Implement the tech, diplomacy, and gold steps**
+
+```ts
+// src/testing/scenario-steps/tech-step.ts
+import type { GameState } from '@/core/types';
+import { getTechById } from '@/systems/tech-system';
+import { ScenarioError, type TechStep } from '@/testing/scenario-types';
+
+export function applyTechStep(state: GameState, step: TechStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in tech step`);
+
+  for (const techId of step.techIds) {
+    if (!getTechById(techId)) throw new ScenarioError(`Unknown tech id "${techId}" in tech step`);
+  }
+
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: {
+        ...civ,
+        techState: {
+          ...civ.techState,
+          completed: [...new Set([...civ.techState.completed, ...step.techIds])],
+        },
+      },
+    },
+  };
+}
+```
+
+```ts
+// src/testing/scenario-steps/diplomacy-step.ts
+import type { GameState } from '@/core/types';
+import { declareWar, makePeace, signTreaty } from '@/systems/diplomacy-system';
+import { ScenarioError, type DiplomacyStep } from '@/testing/scenario-types';
+
+const ALLIANCE_TURNS_REMAINING = 999; // scenarios don't tick turns; effectively permanent
+
+export function applyDiplomacyStep(state: GameState, step: DiplomacyStep): GameState {
+  const civA = state.civilizations[step.civA];
+  const civB = state.civilizations[step.civB];
+  if (!civA) throw new ScenarioError(`Unknown civId "${step.civA}" in diplomacy step`);
+  if (!civB) throw new ScenarioError(`Unknown civId "${step.civB}" in diplomacy step`);
+
+  if (step.status === 'war') {
+    return {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [step.civA]: { ...civA, diplomacy: declareWar(civA.diplomacy, step.civB, state.turn) },
+        [step.civB]: { ...civB, diplomacy: declareWar(civB.diplomacy, step.civA, state.turn) },
+      },
+    };
+  }
+
+  if (step.status === 'peace') {
+    return {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [step.civA]: { ...civA, diplomacy: makePeace(civA.diplomacy, step.civB, state.turn) },
+        [step.civB]: { ...civB, diplomacy: makePeace(civB.diplomacy, step.civA, state.turn) },
+      },
+    };
+  }
+
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [step.civA]: {
+        ...civA,
+        diplomacy: signTreaty(civA.diplomacy, step.civA, step.civB, 'alliance', ALLIANCE_TURNS_REMAINING, state.turn),
+      },
+      [step.civB]: {
+        ...civB,
+        diplomacy: signTreaty(civB.diplomacy, step.civB, step.civA, 'alliance', ALLIANCE_TURNS_REMAINING, state.turn),
+      },
+    },
+  };
+}
+```
+
+```ts
+// src/testing/scenario-steps/gold-step.ts
+import type { GameState } from '@/core/types';
+import { ScenarioError, type GoldStep } from '@/testing/scenario-types';
+
+export function applyGoldStep(state: GameState, step: GoldStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in gold step`);
+  return {
+    ...state,
+    civilizations: { ...state.civilizations, [step.civId]: { ...civ, gold: civ.gold + step.amount } },
+  };
+}
+```
+
+- [ ] **Step 20: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: PASS (all suites)
+
+- [ ] **Step 21: Write and run the hot-seat variant test**
+
+Append to `tests/testing/scenario-builder.test.ts`:
+
+```ts
+describe('hot-seat base', () => {
+  it('builds a hot-seat state with correct per-slot visibility', () => {
+    const definition: ScenarioDefinition = {
+      name: 'hot-seat-check',
+      description: 'test only',
+      seed: 'scenario-hot-seat-check',
+      base: {
+        kind: 'hotSeat',
+        config: {
+          playerCount: 2,
+          mapSize: 'small',
+          players: [
+            { name: 'Alice', slotId: 'player-1', civType: 'generic', isHuman: true },
+            { name: 'Bob', slotId: 'player-2', civType: 'generic', isHuman: true },
+          ],
+        },
+      },
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player-1', type: 'scout', position: { q: 0, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    expect(state.hotSeat).toBeDefined();
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player-1');
+    expect(scout).toBeDefined();
+    expect(state.civilizations['player-1'].visibility.tiles[hexKey({ q: 0, r: 0 })]).toBe('visible');
+  });
+});
+```
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenario-builder.test.ts`
+Expected: PASS
+
+- [ ] **Step 22: Commit**
+
+```bash
+git add src/testing/scenario-builder.ts src/testing/scenario-steps/ tests/testing/scenario-builder.test.ts
+git commit -m "feat(testing): add buildScenario with terrain/unit/city/camp/tech/diplomacy/gold steps"
+```
+
+---
+
+## Task 3: Named scenario registry with the two representative bug scenarios
+
+**Files:**
+- Create: `src/testing/scenarios.ts`
+- Test: `tests/testing/scenarios.test.ts`
+
+**Interfaces:**
+- Consumes: `buildScenario` (Task 2), `ScenarioDefinition` (Task 1).
+- Produces: `SCENARIOS: Record<string, ScenarioDefinition>`. Task 4 (dev loader) imports this exact export.
+
+- [ ] **Step 1: Write the failing test proving the #843 undefended-city condition**
+
+```ts
+// tests/testing/scenarios.test.ts
+import { describe, expect, it } from 'vitest';
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+import { hexKey } from '@/systems/hex-utils';
+import { getBlockingMapEntityAt, getMovementRangeDetails } from '@/systems/unit-system';
+
+describe('undefended-enemy-city scenario (#843)', () => {
+  it('reproduces a player scout 2 hexes from an undefended, at-war AI city', () => {
+    const state = buildScenario(SCENARIOS['undefended-enemy-city']);
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player');
+    const city = Object.values(state.cities).find(c => c.owner === 'ai-1');
+    expect(scout).toBeDefined();
+    expect(city).toBeDefined();
+    // city has no garrison unit
+    expect(Object.values(state.units).some(u => hexKey(u.position) === hexKey(city!.position))).toBe(false);
+    expect(state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+
+    // Exactly what #843's fix guards: reachable adjacency-only, not walk-through.
+    const range = getMovementRangeDetails(state, scout!.id);
+    const keys = range.reachable.map(hexKey);
+    expect(keys).not.toContain(hexKey(city!.position));
+    const blocking = getBlockingMapEntityAt(state, scout!, city!.position);
+    expect(blocking).toEqual({ reason: 'foreign-city', entityId: city!.id });
+  });
+});
+
+describe('undefended-barbarian-camp scenario (#845)', () => {
+  it('reproduces a player unit directly adjacent to an undefended camp', () => {
+    const state = buildScenario(SCENARIOS['undefended-barbarian-camp']);
+    const mover = Object.values(state.units).find(u => u.owner === 'player');
+    const camp = Object.values(state.barbarianCamps)[0];
+    expect(mover).toBeDefined();
+    expect(camp).toBeDefined();
+    const blocking = getBlockingMapEntityAt(state, mover!, camp!.position);
+    expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenarios.test.ts`
+Expected: FAIL — `Cannot find module '@/testing/scenarios'`
+
+- [ ] **Step 3: Write the scenario registry**
+
+```ts
+// src/testing/scenarios.ts
+/**
+ * Named, reusable scenarios (#846). Both Vitest tests and the DEV-only
+ * `?scenario=` browser loader (game-session-controller.ts) build from this
+ * exact registry via buildScenario — no duplicate construction path.
+ */
+import type { ScenarioDefinition } from '@/testing/scenario-types';
+
+export const SCENARIOS: Record<string, ScenarioDefinition> = {
+  'undefended-enemy-city': {
+    name: 'undefended-enemy-city',
+    description:
+      'Player scout 2 hexes from an undefended AI city while at war — validates #843 '
+      + '(the city blocks movement/is assault-reachable only from direct adjacency, '
+      + 'never walked through or treated as reachable from further away).',
+    seed: 'scenario-undefended-enemy-city',
+    base: {
+      kind: 'solo',
+      config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Undefended Enemy City' },
+    },
+    steps: [
+      { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 1, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 3, r: 0 }, terrain: 'plains' },
+      { kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'war' },
+      { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+      { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+    ],
+  },
+  'undefended-barbarian-camp': {
+    name: 'undefended-barbarian-camp',
+    description:
+      'Player unit directly adjacent to an undefended barbarian camp — validates #845 '
+      + '(one-step camp assault; barbarians need no war check per game-systems.md).',
+    seed: 'scenario-undefended-barbarian-camp',
+    base: {
+      kind: 'solo',
+      config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Undefended Barbarian Camp' },
+    },
+    steps: [
+      { kind: 'terrain', position: { q: 5, r: 5 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 6, r: 5 }, terrain: 'plains' },
+      { kind: 'unit', civId: 'player', type: 'warrior', position: { q: 5, r: 5 } },
+      { kind: 'camp', position: { q: 6, r: 5 } },
+    ],
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/testing/scenarios.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/testing/scenarios.ts tests/testing/scenarios.test.ts
+git commit -m "feat(testing): add undefended-enemy-city and undefended-barbarian-camp scenarios (#843/#845)"
+```
+
+---
+
+## Task 4: DEV-only `?scenario=` browser loader
+
+**Files:**
+- Modify: `src/app/controllers/game-session-controller.ts:105` (widen the `campaignEntry` Pick), `game-session-controller.ts:349` (insert the new branch before the existing `MODE === 'e2e'` branch)
+- Test: `tests/app/game-session-controller-scenario-loader.test.ts`
+
+**Interfaces:**
+- Consumes: `SCENARIOS` (Task 3), `buildScenario` (Task 2), `CampaignEntryController.enterCampaign` (existing).
+
+- [ ] **Step 1: Read current state of the two edit sites**
+
+Run: `sed -n '100,110p;345,385p' src/app/controllers/game-session-controller.ts`
+
+Confirm line 105 currently reads:
+```ts
+  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E'>;
+```
+and line 350 opens `if (import.meta.env.MODE === 'e2e') {`. If either has drifted (another PR touched this file), re-locate the equivalent lines before editing — do not blind-patch by line number.
+
+- [ ] **Step 2: Widen the campaignEntry Pick to include `enterCampaign`**
+
+Modify `src/app/controllers/game-session-controller.ts:105`:
+
+```ts
+// Before:
+  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E'>;
+
+// After:
+  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E' | 'enterCampaign'>;
+```
+
+- [ ] **Step 3: Insert the DEV-only scenario branch**
+
+Modify `src/app/controllers/game-session-controller.ts`, immediately before the existing `if (import.meta.env.MODE === 'e2e') {` line (currently line 350):
+
+```ts
+    // #846: developer scenario loader. import.meta.env.DEV is a Vite
+    // compile-time constant (true for `vite`/`vite dev`, false for
+    // `vite build`) — this whole branch, and the dynamic imports inside it,
+    // are dead code eliminated from the production bundle. Distinct from the
+    // MODE === 'e2e' branch below: this is reachable under plain `yarn dev`,
+    // not only the Playwright test build.
+    if (import.meta.env.DEV) {
+      const scenarioName = new URLSearchParams(window.location.search).get('scenario');
+      if (scenarioName) {
+        const { SCENARIOS } = await import('@/testing/scenarios');
+        const definition = SCENARIOS[scenarioName];
+        if (!definition) {
+          throw new Error(`Unknown scenario "${scenarioName}". Known scenarios: ${Object.keys(SCENARIOS).join(', ')}`);
+        }
+        const { buildScenario } = await import('@/testing/scenario-builder');
+        await deps.campaignEntry.enterCampaign(buildScenario(definition), `Scenario: ${definition.name}`);
+        return;
+      }
+    }
+
+```
+
+This goes directly above the existing:
+```ts
+    if (import.meta.env.MODE === 'e2e') {
+```
+
+- [ ] **Step 4: Write the test**
+
+```ts
+// tests/app/game-session-controller-scenario-loader.test.ts
+import { describe, expect, it } from 'vitest';
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+
+// This test does not spin up the full GameSessionController (that needs a
+// DOM, canvas, audio system, etc. — out of scope here). It instead proves
+// the two invariants Task 4's manual code change depends on: (1) every name
+// a developer might type resolves through the same SCENARIOS registry the
+// Vitest suite uses, and (2) an unknown name is a clear, catchable error
+// rather than a silent no-op — matching the `throw new Error(...)` in the
+// controller branch itself.
+describe('scenario loader contract', () => {
+  it('SCENARIOS has at least the two representative bug scenarios', () => {
+    expect(Object.keys(SCENARIOS)).toEqual(
+      expect.arrayContaining(['undefended-enemy-city', 'undefended-barbarian-camp']),
+    );
+  });
+
+  it('every registered scenario builds without throwing', () => {
+    for (const name of Object.keys(SCENARIOS)) {
+      expect(() => buildScenario(SCENARIOS[name]), `scenario "${name}"`).not.toThrow();
+    }
+  });
+
+  it('mirrors the controller branch\'s unknown-name error message shape', () => {
+    const scenarioName = 'not-a-real-scenario';
+    const definition = SCENARIOS[scenarioName as keyof typeof SCENARIOS];
+    expect(definition).toBeUndefined();
+    const buildErrorMessage = () =>
+      `Unknown scenario "${scenarioName}". Known scenarios: ${Object.keys(SCENARIOS).join(', ')}`;
+    expect(buildErrorMessage()).toContain('undefended-enemy-city');
+  });
+});
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/game-session-controller-scenario-loader.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Run the full architecture-boundary test to confirm the widened Pick doesn't violate composition-root rules**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/app/architecture-boundaries.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Manually verify under `yarn dev`**
+
+Run: `bash scripts/run-with-mise.sh yarn dev` (or use the project's `run`/preview tooling), then open
+`http://localhost:5173/?scenario=undefended-enemy-city` in a browser and confirm the game loads directly
+into the scenario (no start-menu, an AI city visible near the player's scout). Then try
+`http://localhost:5173/?scenario=not-a-real-name` and confirm the console shows the
+"Unknown scenario" error rather than a silent blank screen.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/app/controllers/game-session-controller.ts tests/app/game-session-controller-scenario-loader.test.ts
+git commit -m "feat(app): add DEV-only ?scenario= developer loader (#846)"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Create: `docs/scenario-infrastructure.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Scenario Infrastructure
+
+Deterministically reproduce a specific game state for debugging or regression testing,
+without playing dozens of turns. See the design rationale in
+`docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md`.
+
+## How it works
+
+A `ScenarioDefinition` (`src/testing/scenario-types.ts`) names a `base` config
+(everything `createNewGame`/`createHotSeatGame` needs: civ, map size, seed) plus a list
+of typed `steps` (`terrain`, `unit`, `city`, `camp`, `tech`, `diplomacy`, `gold`).
+`buildScenario()` (`src/testing/scenario-builder.ts`) folds a definition into a real
+`GameState` by calling the same canonical system helpers gameplay itself uses
+(`createUnit`, `foundCity`, `declareWar`, ...) — never a hand-built partial state.
+
+## Creating a scenario
+
+Add an entry to `SCENARIOS` in `src/testing/scenarios.ts`:
+
+```ts
+'my-new-scenario': {
+  name: 'my-new-scenario',
+  description: 'One sentence: what condition this reproduces and why.',
+  seed: 'scenario-my-new-scenario',
+  base: { kind: 'solo', config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'My New Scenario' } },
+  steps: [
+    { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+    { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+  ],
+},
+```
+
+## Running one manually
+
+```bash
+bash scripts/run-with-mise.sh yarn dev
+```
+
+Then open `http://localhost:5173/?scenario=my-new-scenario`. This only works in dev mode
+(`import.meta.env.DEV`) — see "Production isolation" below.
+
+## Using one in a test
+
+```ts
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+
+const state = buildScenario(SCENARIOS['undefended-enemy-city']);
+// state is a real GameState — pass it directly to whatever system you're testing.
+```
+
+## What NOT to represent directly
+
+Do not add a step `kind` that lets a caller push a raw partial `Unit`/`City`/other
+entity — every step must map to a canonical constructor (`createUnit`, `foundCity`,
+...) plus narrow `overrides`. If you find yourself hand-writing gameplay fields
+(strength, movement, yields) in a step, that is a sign the step should call a real
+system helper instead.
+
+## How canonical state is derived
+
+Everything not named in `base`/`steps` — map, starting units for every civ, initial
+visibility, minor civs, espionage state, idCounters — comes from
+`createNewGame`/`createHotSeatGame`, called once at the start of `buildScenario`. Steps
+only add the specific delta a scenario needs. After all steps run, `buildScenario`
+recomputes visibility/contacts for every civ via the same system calls
+`createNewGame` itself uses — never hand-set.
+
+## Production/debug isolation guarantees
+
+- The browser loader is gated on `import.meta.env.DEV`, a Vite compile-time constant —
+  `false` for `vite build` (production), so the branch and its dynamic imports are
+  eliminated from the production bundle, not merely hidden behind a runtime check.
+- The loader only accepts a name that must match a key in the closed `SCENARIOS`
+  registry — an unknown name throws, it never falls through to arbitrary behavior.
+- Building a scenario never mutates a live `GameSession` — `buildScenario` is a pure
+  function; the only thing that touches `GameSession` is the same
+  `campaignEntry.enterCampaign(...)` call every other game-entry path already uses.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/scenario-infrastructure.md
+git commit -m "docs: document scenario infrastructure usage (#846)"
+```
+
+---
+
+## Task 6: Full validation pass
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: all suites pass, 0 failures.
+
+- [ ] **Step 2: Run the production build**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: exits 0.
+
+- [ ] **Step 3: Confirm the scenario module graph is absent from the production bundle**
+
+Run:
+```bash
+grep -rl "undefended-enemy-city" dist/assets/*.js
+```
+Expected: no matches (empty output, `grep` exits 1). If it matches, the DEV gate in Task 4 Step 3 did not tree-shake correctly — check that `import.meta.env.DEV` (not a runtime variable) guards both the branch and the dynamic imports.
+
+- [ ] **Step 4: Run the hook smoke tests**
+
+Run: `bash scripts/run-with-mise.sh yarn test:hooks`
+Expected: exits 0 — confirms `check-src-edit.sh` has no complaints about the new/modified files (direct `session.getState()` mutation, etc.).
+
+- [ ] **Step 5: Check for whitespace/newline issues**
+
+Run: `git diff --check`
+Expected: no output.
+
+- [ ] **Step 6: Final full-suite confirmation before considering this plan done**
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: exits 0. This is the same command the `require-green-before-push` hook runs before any `git push`/`gh pr create` — confirming it here avoids a surprise at push time.

--- a/docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md
@@ -1,0 +1,276 @@
+# Issue #846 — Scenario Infrastructure Design
+
+## Problem
+
+Recent gameplay debugging (`e0ecc7dc`, fixing #843/#845) hit a wall its own plan docs
+name explicitly: *"the app exposes no debug hook or save-injection path... manual
+verification isn't feasible without unbounded manual play."* Automated tests could
+construct the precise starting condition; a developer in the running app could not.
+
+Separately, every Vitest fixture that needs a non-trivial `GameState`
+(`tests/systems/helpers/crisis-fixture.ts`, the `undefendedCityRangeState` helper added
+by `e0ecc7dc` itself) hand-builds the state object field-by-field, per test file. There
+is no shared, typed, reusable way to say "give me a game state where X" — for a test, or
+for a developer.
+
+## Goal
+
+A small, durable scenario infrastructure: a developer or test describes a game
+situation and reliably gets that `GameState`, without playing dozens of turns and
+without a second hand-rolled fixture per consumer.
+
+## Non-goals
+
+- No cheat console, no arbitrary JS eval, no runtime mutation API.
+- No new mutable state store — scenarios only ever produce a `GameState` that enters
+  the game through the existing `GameSession`/`campaignEntry.enterCampaign` publication
+  path, exactly like a loaded save.
+- No Playwright integration in this PR (see Phase 3 below — deferred, not needed by any
+  current spec).
+- No changes to combat/barbarian/crisis system *logic* — those systems are scenario
+  *consumers* only, per the parallel-work constraint with the #547 agent.
+
+## Existing infrastructure this reuses
+
+| Piece | File | Role |
+|---|---|---|
+| Canonical state constructors | `src/core/game-state.ts` (`createNewGame`, `createHotSeatGame`) | The only legitimate way to derive a fully-formed base state (map, civs, visibility, minor civs, espionage, idCounters). |
+| Legitimate publication path | `src/app/controllers/campaign-entry-controller.ts` (`enterCampaign`) | The only correct way to hand a constructed `GameState` to `GameSession`. |
+| Existing dev-mode-shaped entry gate | `src/app/controllers/game-session-controller.ts:349-379` | Already reads `import.meta.env.MODE`/`window.location.search` and dynamic-imports a narrow runtime (`e2e-mode.ts`/`e2e-runtime.ts`) that calls `enterCampaignForE2E`. The scenario loader is an extension of this exact pattern, not a new one. |
+| Save-injection precedent | `tests/e2e/helpers/save-fixture.ts` (`installAutosave`) | Already used by one Playwright-adjacent Vitest test; the pattern Phase 3 would extend, not invent. |
+| Save normalization | `src/storage/save-manager.ts` (`normalizeLoadedState`) | Anything entering through the save path still goes through this — scenarios don't bypass it. |
+| Bilateral diplomacy helper | `src/systems/diplomacy-system.ts` (`declareWar`) | Every real call site (`player-action-controller.ts`, `basic-ai.ts`, `minor-civ-actions.ts`) calls it once per side. The scenario builder's war step does the same — no new diplomacy logic. |
+
+## Design
+
+### 1. Canonical scenario representation
+
+```ts
+// src/testing/scenario-types.ts
+export interface ScenarioDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly seed: string;
+  readonly base:
+    | { readonly kind: 'solo'; readonly config: SoloSetupConfig }
+    | { readonly kind: 'hotSeat'; readonly config: HotSeatConfig };
+  readonly steps: readonly ScenarioStep[];
+}
+
+export type ScenarioStep =
+  | { readonly kind: 'unit'; readonly civId: string; readonly type: UnitType;
+      readonly position: HexCoord; readonly overrides?: Partial<Unit>; readonly unsafe?: boolean }
+  | { readonly kind: 'city'; readonly civId: string; readonly position: HexCoord;
+      readonly overrides?: Partial<City>; readonly unsafe?: boolean }
+  | { readonly kind: 'tech'; readonly civId: string; readonly techIds: readonly string[] }
+  | { readonly kind: 'diplomacy'; readonly civA: string; readonly civB: string;
+      readonly status: 'war' | 'peace' | 'alliance' }
+  | { readonly kind: 'gold'; readonly civId: string; readonly amount: number };
+```
+
+A step is never a raw partial `GameState`. It is a small, closed union whose `kind`s
+map 1:1 to a canonical system call. This directly satisfies the "canonical
+construction" requirement: `scenario.units.push({ type: 'tank', strength: 80, ... })` is
+structurally impossible — a `unit` step can only carry a `UnitType` plus narrow
+`overrides`, and the builder is what calls `createUnit(type, civId, position,
+idCounters, bonusEffect)` and *then* applies `overrides` on top of the canonically
+constructed unit, not instead of it.
+
+### 2. How much of `GameState` callers specify vs. derive
+
+Everything not named in `base`/`steps` is derived, never specified:
+
+- Map, terrain, wonders, villages, beast lairs, minor civs, starting units for every
+  civ, initial visibility, espionage state, idCounters — all come from
+  `createNewGame`/`createHotSeatGame`, called once at the start of `buildScenario`.
+- Each step only adds/overrides the specific delta a scenario cares about (one enemy
+  city with no garrison; one unit at war with the player), through the same helper
+  gameplay uses to create that entity.
+- After any `unit`/`city` step, the builder re-runs `updateVisibility` +
+  `refreshLastSeenPresentationsForCiv` + `syncCivilizationContactsFromVisibility` for
+  every affected civ — the same three calls `createNewGame` already makes — so
+  fog-of-war/hot-seat privacy is never hand-set and never stale.
+
+### 3. Stable IDs
+
+No new ID scheme. `buildScenario` threads the base state's own `idCounters` object
+through every step exactly as `createUnit`/`foundCity` already expect (they mutate it in
+place). IDs stay monotonic and collision-free by construction — the same mechanism
+`createNewGame` itself relies on.
+
+### 4. RNG / seed determinism
+
+One `seed: string` on the definition, passed straight into `createNewGame`/
+`createHotSeatGame` (which already thread it into `createRng`, map generation, and
+barbarian placement). No step introduces a second RNG surface. Two calls to
+`buildScenario` with the same definition must produce structurally identical output
+(mod `gameId`, which embeds `Date.now()` — the determinism test compares state with
+`gameId` excluded, not the seed's actual entropy).
+
+### 5. Map coordinate validation
+
+Any step naming a `HexCoord` is checked against `state.map.tiles[hexKey(coord)]`
+before use. A missing tile throws `ScenarioError` naming the scenario, step index, and
+coordinate — never a silent no-op, never a deep renderer/system crash with no context.
+
+### 6. Opting into unusual/inconsistent states
+
+Default behavior validates and throws. A step-level `unsafe: true` flag (see the
+`unit`/`city` step shapes above) skips the specific check that would otherwise reject
+it — e.g., placing a unit on a tile that already has an occupant, for a scenario that
+deliberately reproduces a corrupt save. This mirrors `save-manager.ts`'s own honest
+posture (it warns and drops invalid data rather than crashing) but is opt-in per step so
+"unsafe" is always a visible, deliberate marker in the scenario definition, never an
+accident.
+
+### 7. Schema migrations / save normalization
+
+`buildScenario` output is already current-shape — built from the current
+`createNewGame`, it needs no migration. The dev-mode loader (below) publishes it
+directly via `enterCampaign`, bypassing the save path entirely (same as
+`enterCampaignForE2E` does today for autosaves). If a *future* consumer routes a
+scenario through the save system (Phase 3's Playwright `installAutosave`), it goes
+through `normalizeLoadedState` like any other save — never a shortcut around it.
+
+### 8. Hot seat
+
+`base.kind: 'hotSeat'` uses `createHotSeatGame(config)`; every step's `civId` accepts a
+hot-seat slot id exactly as it accepts a solo civ id (`'player'`/`'ai-1'`) — there is no
+separate hot-seat scenario type, matching the codebase's existing pattern of treating
+solo as "hot seat with one human slot" everywhere else.
+
+### 9. Current-viewer visibility
+
+Covered under (2): visibility is always recomputed by the real system helpers after any
+entity-creating step, never hand-set. `currentPlayer` on the built state follows
+whatever `base.config` specifies (defaults to the first slot), same as
+`createNewGame`/`createHotSeatGame` today.
+
+### 10. Developer launch mechanism
+
+Extend the existing gate in `game-session-controller.ts`'s `init()` (currently
+`if (import.meta.env.MODE === 'e2e') { ... }`) with a sibling `DEV`-gated branch:
+
+```ts
+if (import.meta.env.DEV) {
+  const scenarioName = new URLSearchParams(window.location.search).get('scenario');
+  if (scenarioName) {
+    const { SCENARIOS } = await import('@/testing/scenarios');
+    const { buildScenario } = await import('@/testing/scenario-builder');
+    const definition = SCENARIOS[scenarioName];
+    if (!definition) throw new Error(`Unknown scenario "${scenarioName}". Known: ${Object.keys(SCENARIOS).join(', ')}`);
+    await deps.campaignEntry.enterCampaign(buildScenario(definition), `Scenario: ${definition.name}`);
+    return;
+  }
+}
+```
+
+`import.meta.env.DEV` is Vite's own dev/prod flag (`true` under `vite`/`yarn dev`,
+`false` under `vite build`) — distinct from the existing `MODE === 'e2e'` check, so
+`?scenario=` works under plain `yarn dev`, not only the Playwright test build. The
+dynamic `import()` keeps the scenario registry and builder out of the production
+bundle's static import graph, the same tree-shaking precedent `e2e-mode.ts`/
+`e2e-runtime.ts` already establish for the e2e branch right above it — verified in
+Testing/Validation below by inspecting the built `dist/` output.
+
+Usage: `bash scripts/run-with-mise.sh yarn dev`, then open
+`http://localhost:5173/?scenario=undefended-enemy-city`.
+
+### 11. Same infrastructure for regression tests
+
+Vitest tests call `buildScenario(SCENARIOS['undefended-enemy-city'])` directly — the
+identical function and identical named definition the dev loader uses. No parallel
+construction path.
+
+### 12. Preventing a parallel gameplay API
+
+`buildScenario` is a pure function (`ScenarioDefinition → GameState`) invoked once,
+before a game session starts. It has no live handle into a running `GameSession`, no
+subscribe/mutate surface, and is never called after `enterCampaign` publishes the
+result. The only thing touching `GameSession` is the existing, already-reviewed
+`enterCampaign` call — identical to how a loaded save or a fresh `createNewGame` reaches
+the player today. There is no new way to mutate a game in progress.
+
+## Scenarios shipped in this PR
+
+Two scenarios reproducing the starting conditions `e0ecc7dc` needed and could not get
+outside of Vitest, demonstrating this infrastructure would have closed that exact gap:
+
+- **`undefended-enemy-city`** — mirrors `tests/systems/unit-system.test.ts`'s
+  `undefendedCityRangeState`: player scout near an AI city with no garrison unit, at
+  war, on flat terrain. Validates #843's fix (city blocks movement/is reachable only
+  from direct adjacency).
+- **`undefended-barbarian-camp`** — mirrors `tests/systems/attack-targeting.test.ts`'s
+  camp-adjacency setup from #845 finding 2: player unit adjacent to an undefended
+  barbarian camp, for the one-step assault path.
+
+A third, `naval-domain-attack` (galley vs. galley, at war, adjacent, #845 finding 3 /
+#826), is included if it fits the PR's test budget; otherwise it is the first item in
+the deferred scenario-library backlog, not a blocker for this PR.
+
+## Alternatives considered
+
+1. **Raw partial-`GameState` scenario objects** (caller writes `{ units: {...} }`
+   directly). Rejected: this is exactly the "BAD" pattern from the issue — no
+   canonical-construction guarantee, and every field becomes a place fixture drift can
+   hide.
+2. **A full debug console / command palette** (type commands into a dev overlay to
+   mutate a running game). Rejected: explicitly out of scope per the issue ("Do not
+   build a giant cheat console"); also the highest-risk option for accidentally shipping
+   a second mutation surface into `GameSession`.
+3. **Save-file-only injection** (developer pastes/imports a JSON save). Considered for
+   Phase 3 (Playwright `installAutosave` already does this for one test). Rejected as
+   the *primary* mechanism because it doesn't help someone who doesn't already have a
+   captured save for the exact bug — the typed builder is strictly more useful and
+   composable, and this is still available as a secondary path since scenarios stay
+   installable as autosaves.
+
+## Production-security implications
+
+- No arbitrary JS evaluation surface — the loader only accepts a `scenario` name that
+  must match a key in the closed `SCENARIOS` registry; unknown names throw rather than
+  doing anything.
+- Gated on `import.meta.env.DEV`, a compile-time constant Vite replaces at build time —
+  the `if` branch and its dynamic imports are dead code in a production build, not a
+  runtime check that could be bypassed by URL manipulation in prod.
+- No new persistent/standing state — nothing is written to IndexedDB/localStorage by
+  the loader itself (it calls `enterCampaign` directly, same as e2e mode; `enterCampaign`'s
+  own autosave-on-start behavior is unchanged, existing behavior).
+- Verified by inspecting `dist/` after `yarn build` (see Testing/Validation) to confirm
+  `SCENARIOS`/`buildScenario` do not appear in the shipped bundle.
+
+## Implementation phases
+
+- **Phase 1 (this PR):** `src/testing/scenario-types.ts`, `scenario-builder.ts`,
+  `scenarios/index.ts` (2-3 definitions) + Vitest coverage + the `?scenario=` DEV-gated
+  branch in `game-session-controller.ts` + docs (`docs/scenario-infrastructure.md` or a
+  section in an existing doc). New files only, plus one small additive branch in a file
+  not touched by the #547 agent's barbarian/beast work.
+- **Phase 2 (deferred, separate issue):** Playwright helper
+  (`tests/e2e/helpers/scenario.ts`) wrapping `installAutosave(page,
+  buildScenario(SCENARIOS[name]))`, added only once a Playwright spec actually needs a
+  named scenario — avoids pre-building fixtures nothing consumes yet.
+- **Phase 3 (deferred, separate issue):** grow the scenario library as new
+  hard-to-reproduce bugs are found; each addition is a new `ScenarioDefinition` entry,
+  no builder changes required unless a genuinely new step `kind` is needed.
+
+## Testing expectations for Phase 1
+
+- Deterministic construction: same definition twice → structurally equal (excluding
+  `gameId`).
+- Canonical definition use: a scenario's unit/city matches `UNIT_DEFINITIONS`/
+  `BUILDINGS`-derived shape, not a hand literal (spot-check via the same definitions the
+  builder itself imports).
+- Invalid coordinate → `ScenarioError` with a clear message.
+- Invalid/missing civ id reference → `ScenarioError`.
+- Human vs. AI ownership: scenario steps work identically for `'player'` and an AI civ
+  id.
+- Hot-seat variant: a scenario built with `base.kind: 'hotSeat'` produces a state with
+  `state.hotSeat` populated and per-slot visibility correct.
+- `unsafe: true` escape hatch: proves the default path rejects an invalid placement and
+  the `unsafe` path accepts it.
+- Production/debug isolation: `dist/` inspection after `yarn build` confirms the
+  scenario module graph is absent.
+- The two representative bug scenarios reproduce the exact conditions the #843/#845
+  Vitest tests independently hand-built, proven by asserting the same predicates those
+  tests assert (city blocks BFS at the same hex, etc.) against the scenario-built state.

--- a/src/app/controllers/game-session-controller.ts
+++ b/src/app/controllers/game-session-controller.ts
@@ -102,7 +102,7 @@ export interface GameSessionControllerDeps {
   readonly mapInteraction: Pick<MapInteractionController, 'handleHexTap' | 'handleHexLongPress'>;
   readonly selectionController: Pick<SelectionController, 'selectNextUnit' | 'selectUnit'>;
   readonly hud: HudController;
-  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E'>;
+  readonly campaignEntry: Pick<CampaignEntryController, 'showStartSavePanel' | 'showGameModeSelection' | 'enterCampaignForE2E' | 'enterCampaign'>;
   readonly getElementById: (id: string) => HTMLElement | null;
   readonly showNotification: (message: string, type?: 'info' | 'success' | 'warning') => void;
   /** Phase 13's future home -- passed as a dep until `PlayerActionController` exists. */
@@ -346,6 +346,26 @@ export function createGameSessionController(deps: GameSessionControllerDeps): Ga
     // installed eagerly at module scope (#787 phase 5).
     installGlobalShortcuts({ target: window, selection: deps.selection, router: deps.router, notifier });
     await deps.userSettingsStore.refresh();
+
+    // #846: developer scenario loader. import.meta.env.DEV is a Vite
+    // compile-time constant (true for `vite`/`vite dev`, false for
+    // `vite build`) -- this whole branch, and the dynamic imports inside it,
+    // are dead code eliminated from the production bundle. Distinct from the
+    // MODE === 'e2e' branch below: this is reachable under plain `yarn dev`,
+    // not only the Playwright test build.
+    if (import.meta.env.DEV) {
+      const scenarioName = new URLSearchParams(window.location.search).get('scenario');
+      if (scenarioName) {
+        const { SCENARIOS } = await import('@/testing/scenarios');
+        const definition = SCENARIOS[scenarioName];
+        if (!definition) {
+          throw new Error(`Unknown scenario "${scenarioName}". Known scenarios: ${Object.keys(SCENARIOS).join(', ')}`);
+        }
+        const { buildScenario } = await import('@/testing/scenario-builder');
+        await deps.campaignEntry.enterCampaign(buildScenario(definition), `Scenario: ${definition.name}`);
+        return;
+      }
+    }
 
     if (import.meta.env.MODE === 'e2e') {
       // Browser tests must target the same live camera transform as player input;

--- a/src/testing/scenario-builder.ts
+++ b/src/testing/scenario-builder.ts
@@ -1,0 +1,74 @@
+/**
+ * Folds a ScenarioDefinition into a GameState by starting from the canonical
+ * createNewGame/createHotSeatGame constructor, then applying each step
+ * through the same system helpers gameplay uses. See
+ * docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md.
+ */
+import type { GameState, Unit } from '@/core/types';
+import { createHotSeatGame, createNewGame } from '@/core/game-state';
+import { hexKey } from '@/systems/hex-utils';
+import { updateVisibility } from '@/systems/fog-of-war';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
+import { ScenarioError, type ScenarioDefinition, type ScenarioStep } from '@/testing/scenario-types';
+import { applyUnitStep } from '@/testing/scenario-steps/unit-step';
+import { applyCityStep } from '@/testing/scenario-steps/city-step';
+import { applyCampStep } from '@/testing/scenario-steps/camp-step';
+import { applyTechStep } from '@/testing/scenario-steps/tech-step';
+import { applyDiplomacyStep } from '@/testing/scenario-steps/diplomacy-step';
+import { applyGoldStep } from '@/testing/scenario-steps/gold-step';
+
+function applyTerrainStep(state: GameState, step: Extract<ScenarioStep, { kind: 'terrain' }>): GameState {
+  const key = hexKey(step.position);
+  const tile = state.map.tiles[key];
+  if (!tile) throw new ScenarioError(`Invalid coordinate ${key} in terrain step`);
+  return { ...state, map: { ...state.map, tiles: { ...state.map.tiles, [key]: { ...tile, terrain: step.terrain } } } };
+}
+
+function applyStep(state: GameState, step: ScenarioStep): GameState {
+  switch (step.kind) {
+    case 'terrain': return applyTerrainStep(state, step);
+    case 'unit': return applyUnitStep(state, step);
+    case 'city': return applyCityStep(state, step);
+    case 'camp': return applyCampStep(state, step);
+    case 'tech': return applyTechStep(state, step);
+    case 'diplomacy': return applyDiplomacyStep(state, step);
+    case 'gold': return applyGoldStep(state, step);
+  }
+}
+
+function refreshVisibilityAndContacts(state: GameState): GameState {
+  for (const civId of Object.keys(state.civilizations)) {
+    const civ = state.civilizations[civId];
+    const civUnits = civ.units
+      .map(unitId => state.units[unitId])
+      .filter((unit): unit is Unit => unit != null);
+    const cityPositions = Object.values(state.cities)
+      .filter(city => city.owner === civId)
+      .map(city => city.position);
+    updateVisibility(civ.visibility, civUnits, state.map, cityPositions);
+  }
+  for (const civId of Object.keys(state.civilizations)) {
+    refreshLastSeenPresentationsForCiv(state, civId);
+    syncCivilizationContactsFromVisibility(state, civId);
+  }
+  return state;
+}
+
+export function buildScenario(definition: ScenarioDefinition): GameState {
+  let state: GameState = definition.base.kind === 'solo'
+    ? createNewGame({ ...definition.base.config, seed: definition.seed })
+    : createHotSeatGame(definition.base.config, definition.seed);
+
+  definition.steps.forEach((step, index) => {
+    try {
+      state = applyStep(state, step);
+    } catch (error) {
+      if (error instanceof ScenarioError) throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new ScenarioError(`Scenario "${definition.name}" step ${index} (${step.kind}) failed: ${reason}`);
+    }
+  });
+
+  return refreshVisibilityAndContacts(state);
+}

--- a/src/testing/scenario-steps/camp-step.ts
+++ b/src/testing/scenario-steps/camp-step.ts
@@ -1,0 +1,31 @@
+import type { BarbarianCamp, GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type CampStep } from '@/testing/scenario-types';
+
+export function applyCampStep(state: GameState, step: CampStep): GameState {
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in camp step`);
+
+  if (!step.unsafe) {
+    const occupantUnit = Object.values(state.units).find(unit => hexKey(unit.position) === key);
+    const occupantCamp = Object.values(state.barbarianCamps ?? {}).find(camp => hexKey(camp.position) === key);
+    if (occupantUnit || occupantCamp) {
+      throw new ScenarioError(`Tile ${key} already occupied (pass unsafe: true to override)`);
+    }
+  }
+
+  const id = `scenario-camp-${state.idCounters.nextCampId++}`;
+  // No canonical constructor exists for an exact-position camp -- spawnBarbarianCamp
+  // only picks a random distance-constrained tile. BarbarianCamp is a flat data
+  // record with no derived fields, so a direct literal is the correct level here
+  // (same justification as the terrain step).
+  const camp: BarbarianCamp = {
+    id,
+    position: { ...step.position },
+    strength: 1,
+    spawnCooldown: 99, // inert for the scenario's lifetime; scenarios don't advance turns
+    ...step.overrides,
+  };
+
+  return { ...state, barbarianCamps: { ...(state.barbarianCamps ?? {}), [id]: camp } };
+}

--- a/src/testing/scenario-steps/city-step.ts
+++ b/src/testing/scenario-steps/city-step.ts
@@ -1,0 +1,47 @@
+import type { City, GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { collectUsedCityNames } from '@/systems/city-name-system';
+import { recalculateTerritory } from '@/systems/city-territory-system';
+import { initializeLegendaryWonderProjectsForCity } from '@/systems/legendary-wonder-system';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type CityStep } from '@/testing/scenario-types';
+
+export function applyCityStep(state: GameState, step: CityStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in city step`);
+
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in city step`);
+
+  if (!step.unsafe) {
+    const existingCity = Object.values(state.cities).find(c => hexKey(c.position) === key);
+    if (existingCity) {
+      throw new ScenarioError(`Tile ${key} already has city "${existingCity.id}" (pass unsafe: true to override)`);
+    }
+  }
+
+  const civDef = resolveCivDefinition(state, civ.civType);
+  const city: City = {
+    ...foundCity(step.civId, step.position, state.map, state.idCounters, {
+      civType: civ.civType,
+      namingPool: civDef?.cityNames,
+      civName: civDef?.name ?? civ.name,
+      usedNames: collectUsedCityNames(state),
+      completedTechs: civ.techState.completed,
+    }),
+    ...step.overrides,
+  };
+
+  let nextState: GameState = {
+    ...state,
+    cities: { ...state.cities, [city.id]: city },
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: { ...civ, cities: [...civ.cities, city.id] },
+    },
+  };
+  nextState = initializeLegendaryWonderProjectsForCity(nextState, step.civId, city.id);
+  nextState = recalculateTerritory(nextState, { reason: 'founding', preserveForeignHolders: true }).state;
+  return nextState;
+}

--- a/src/testing/scenario-steps/diplomacy-step.ts
+++ b/src/testing/scenario-steps/diplomacy-step.ts
@@ -1,0 +1,49 @@
+import type { GameState } from '@/core/types';
+import { declareWar, makePeace, signTreaty } from '@/systems/diplomacy-system';
+import { ScenarioError, type DiplomacyStep } from '@/testing/scenario-types';
+
+const ALLIANCE_TURNS_REMAINING = 999; // scenarios don't tick turns; effectively permanent
+
+export function applyDiplomacyStep(state: GameState, step: DiplomacyStep): GameState {
+  const civA = state.civilizations[step.civA];
+  const civB = state.civilizations[step.civB];
+  if (!civA) throw new ScenarioError(`Unknown civId "${step.civA}" in diplomacy step`);
+  if (!civB) throw new ScenarioError(`Unknown civId "${step.civB}" in diplomacy step`);
+
+  if (step.status === 'war') {
+    return {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [step.civA]: { ...civA, diplomacy: declareWar(civA.diplomacy, step.civB, state.turn) },
+        [step.civB]: { ...civB, diplomacy: declareWar(civB.diplomacy, step.civA, state.turn) },
+      },
+    };
+  }
+
+  if (step.status === 'peace') {
+    return {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [step.civA]: { ...civA, diplomacy: makePeace(civA.diplomacy, step.civB, state.turn) },
+        [step.civB]: { ...civB, diplomacy: makePeace(civB.diplomacy, step.civA, state.turn) },
+      },
+    };
+  }
+
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [step.civA]: {
+        ...civA,
+        diplomacy: signTreaty(civA.diplomacy, step.civA, step.civB, 'alliance', ALLIANCE_TURNS_REMAINING, state.turn),
+      },
+      [step.civB]: {
+        ...civB,
+        diplomacy: signTreaty(civB.diplomacy, step.civB, step.civA, 'alliance', ALLIANCE_TURNS_REMAINING, state.turn),
+      },
+    },
+  };
+}

--- a/src/testing/scenario-steps/gold-step.ts
+++ b/src/testing/scenario-steps/gold-step.ts
@@ -1,0 +1,11 @@
+import type { GameState } from '@/core/types';
+import { ScenarioError, type GoldStep } from '@/testing/scenario-types';
+
+export function applyGoldStep(state: GameState, step: GoldStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in gold step`);
+  return {
+    ...state,
+    civilizations: { ...state.civilizations, [step.civId]: { ...civ, gold: civ.gold + step.amount } },
+  };
+}

--- a/src/testing/scenario-steps/tech-step.ts
+++ b/src/testing/scenario-steps/tech-step.ts
@@ -1,0 +1,26 @@
+import type { GameState } from '@/core/types';
+import { getTechById } from '@/systems/tech-system';
+import { ScenarioError, type TechStep } from '@/testing/scenario-types';
+
+export function applyTechStep(state: GameState, step: TechStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in tech step`);
+
+  for (const techId of step.techIds) {
+    if (!getTechById(techId)) throw new ScenarioError(`Unknown tech id "${techId}" in tech step`);
+  }
+
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: {
+        ...civ,
+        techState: {
+          ...civ.techState,
+          completed: [...new Set([...civ.techState.completed, ...step.techIds])],
+        },
+      },
+    },
+  };
+}

--- a/src/testing/scenario-steps/unit-step.ts
+++ b/src/testing/scenario-steps/unit-step.ts
@@ -1,0 +1,32 @@
+import type { GameState, Unit } from '@/core/types';
+import { createUnit } from '@/systems/unit-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { hexKey } from '@/systems/hex-utils';
+import { ScenarioError, type UnitStep } from '@/testing/scenario-types';
+
+export function applyUnitStep(state: GameState, step: UnitStep): GameState {
+  const civ = state.civilizations[step.civId];
+  if (!civ) throw new ScenarioError(`Unknown civId "${step.civId}" in unit step`);
+
+  const key = hexKey(step.position);
+  if (!state.map.tiles[key]) throw new ScenarioError(`Invalid coordinate ${key} in unit step`);
+
+  if (!step.unsafe) {
+    const occupant = Object.values(state.units).find(unit => hexKey(unit.position) === key);
+    if (occupant) {
+      throw new ScenarioError(`Tile ${key} already occupied by unit "${occupant.id}" (pass unsafe: true to override)`);
+    }
+  }
+
+  const civDef = resolveCivDefinition(state, civ.civType);
+  const unit: Unit = { ...createUnit(step.type, step.civId, step.position, state.idCounters, civDef?.bonusEffect), ...step.overrides };
+
+  return {
+    ...state,
+    units: { ...state.units, [unit.id]: unit },
+    civilizations: {
+      ...state.civilizations,
+      [step.civId]: { ...civ, units: [...civ.units, unit.id] },
+    },
+  };
+}

--- a/src/testing/scenario-types.ts
+++ b/src/testing/scenario-types.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical scenario representation (#846). A ScenarioDefinition never carries
+ * raw partial GameState -- every step maps 1:1 to a canonical system call in
+ * scenario-builder.ts, so a scenario can never bypass the same construction
+ * rules real gameplay uses. See docs/superpowers/specs/
+ * 2026-08-16-issue-846-scenario-infrastructure-design.md for the full design.
+ */
+import type {
+  City,
+  HexCoord,
+  HexTile,
+  HotSeatConfig,
+  SoloSetupConfig,
+  TreatyType,
+  Unit,
+  UnitType,
+} from '@/core/types';
+
+export class ScenarioError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScenarioError';
+  }
+}
+
+export interface TerrainStep {
+  readonly kind: 'terrain';
+  readonly position: HexCoord;
+  readonly terrain: HexTile['terrain'];
+}
+
+export interface UnitStep {
+  readonly kind: 'unit';
+  readonly civId: string;
+  readonly type: UnitType;
+  readonly position: HexCoord;
+  readonly overrides?: Partial<Unit>;
+  /** Skip the "tile already occupied" guard -- for intentionally corrupt/edge-case scenarios. */
+  readonly unsafe?: boolean;
+}
+
+export interface CityStep {
+  readonly kind: 'city';
+  readonly civId: string;
+  readonly position: HexCoord;
+  readonly overrides?: Partial<City>;
+  readonly unsafe?: boolean;
+}
+
+export interface CampStep {
+  readonly kind: 'camp';
+  readonly position: HexCoord;
+  readonly overrides?: Partial<{ strength: number; spawnCooldown: number; resurgent: boolean; banditLordName: string }>;
+  readonly unsafe?: boolean;
+}
+
+export interface TechStep {
+  readonly kind: 'tech';
+  readonly civId: string;
+  readonly techIds: readonly string[];
+}
+
+export interface DiplomacyStep {
+  readonly kind: 'diplomacy';
+  readonly civA: string;
+  readonly civB: string;
+  readonly status: 'war' | 'peace' | 'alliance';
+}
+
+export interface GoldStep {
+  readonly kind: 'gold';
+  readonly civId: string;
+  readonly amount: number;
+}
+
+export type ScenarioStep =
+  | TerrainStep
+  | UnitStep
+  | CityStep
+  | CampStep
+  | TechStep
+  | DiplomacyStep
+  | GoldStep;
+
+export type ScenarioBase =
+  | { readonly kind: 'solo'; readonly config: SoloSetupConfig }
+  | { readonly kind: 'hotSeat'; readonly config: HotSeatConfig };
+
+export interface ScenarioDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly seed: string;
+  readonly base: ScenarioBase;
+  readonly steps: readonly ScenarioStep[];
+}
+
+/** TreatyType re-exported for callers building diplomacy assertions in tests. */
+export type { TreatyType };

--- a/src/testing/scenarios.ts
+++ b/src/testing/scenarios.ts
@@ -1,0 +1,47 @@
+/**
+ * Named, reusable scenarios (#846). Both Vitest tests and the DEV-only
+ * `?scenario=` browser loader (game-session-controller.ts) build from this
+ * exact registry via buildScenario -- no duplicate construction path.
+ */
+import type { ScenarioDefinition } from '@/testing/scenario-types';
+
+export const SCENARIOS: Record<string, ScenarioDefinition> = {
+  'undefended-enemy-city': {
+    name: 'undefended-enemy-city',
+    description:
+      'Player scout 2 hexes from an undefended AI city while at war -- validates #843 '
+      + '(the city blocks movement/is assault-reachable only from direct adjacency, '
+      + 'never walked through or treated as reachable from further away).',
+    seed: 'scenario-undefended-enemy-city',
+    base: {
+      kind: 'solo',
+      config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Undefended Enemy City' },
+    },
+    steps: [
+      { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 1, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 3, r: 0 }, terrain: 'plains' },
+      { kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'war' },
+      { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+      { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+    ],
+  },
+  'undefended-barbarian-camp': {
+    name: 'undefended-barbarian-camp',
+    description:
+      'Player unit directly adjacent to an undefended barbarian camp -- validates #845 '
+      + '(one-step camp assault; barbarians need no war check per game-systems.md).',
+    seed: 'scenario-undefended-barbarian-camp',
+    base: {
+      kind: 'solo',
+      config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Undefended Barbarian Camp' },
+    },
+    steps: [
+      { kind: 'terrain', position: { q: 5, r: 5 }, terrain: 'plains' },
+      { kind: 'terrain', position: { q: 6, r: 5 }, terrain: 'plains' },
+      { kind: 'unit', civId: 'player', type: 'warrior', position: { q: 5, r: 5 } },
+      { kind: 'camp', position: { q: 6, r: 5 } },
+    ],
+  },
+};

--- a/tests/app/controllers/game-session-controller.test.ts
+++ b/tests/app/controllers/game-session-controller.test.ts
@@ -100,6 +100,7 @@ function baseDeps(state: GameState, overrides: Partial<GameSessionControllerDeps
       showStartSavePanel: vi.fn().mockResolvedValue(undefined),
       showGameModeSelection: vi.fn(),
       enterCampaignForE2E: vi.fn().mockResolvedValue(undefined),
+      enterCampaign: vi.fn().mockResolvedValue(undefined),
     },
     getElementById: id => elements.get(id) ?? document.getElementById(id),
     showNotification: vi.fn(),

--- a/tests/app/game-session-controller-scenario-loader.test.ts
+++ b/tests/app/game-session-controller-scenario-loader.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+
+// This test does not spin up the full GameSessionController (that needs a
+// DOM, canvas, audio system, etc. -- out of scope here). It instead proves
+// the two invariants Task 4's manual code change depends on: (1) every name
+// a developer might type resolves through the same SCENARIOS registry the
+// Vitest suite uses, and (2) an unknown name is a clear, catchable error
+// rather than a silent no-op -- matching the `throw new Error(...)` in the
+// controller branch itself.
+describe('scenario loader contract', () => {
+  it('SCENARIOS has at least the two representative bug scenarios', () => {
+    expect(Object.keys(SCENARIOS)).toEqual(
+      expect.arrayContaining(['undefended-enemy-city', 'undefended-barbarian-camp']),
+    );
+  });
+
+  it('every registered scenario builds without throwing', () => {
+    for (const name of Object.keys(SCENARIOS)) {
+      expect(() => buildScenario(SCENARIOS[name]), `scenario "${name}"`).not.toThrow();
+    }
+  });
+
+  it("mirrors the controller branch's unknown-name error message shape", () => {
+    const scenarioName = 'not-a-real-scenario';
+    const definition = SCENARIOS[scenarioName as keyof typeof SCENARIOS];
+    expect(definition).toBeUndefined();
+    const buildErrorMessage = () =>
+      `Unknown scenario "${scenarioName}". Known scenarios: ${Object.keys(SCENARIOS).join(', ')}`;
+    expect(buildErrorMessage()).toContain('undefended-enemy-city');
+  });
+});

--- a/tests/testing/scenario-builder.test.ts
+++ b/tests/testing/scenario-builder.test.ts
@@ -162,6 +162,31 @@ describe('city step', () => {
     };
     expect(() => buildScenario(blocked)).toThrow(ScenarioError);
   });
+
+  it('throws ScenarioError on an invalid coordinate', () => {
+    const definition: ScenarioDefinition = {
+      name: 'city-step-bad-coord',
+      description: 'test only',
+      seed: 'scenario-city-step-bad-coord',
+      base: soloBase,
+      steps: [{ kind: 'city', civId: 'ai-1', position: { q: 99999, r: 99999 } }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('throws ScenarioError on an unknown civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'city-step-bad-civ',
+      description: 'test only',
+      seed: 'scenario-city-step-bad-civ',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+        { kind: 'city', civId: 'nonexistent', position: { q: 2, r: 0 } },
+      ],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
 });
 
 describe('camp step', () => {
@@ -184,6 +209,42 @@ describe('camp step', () => {
     const mover = Object.values(state.units).find(u => u.owner === 'player');
     const blocking = getBlockingMapEntityAt(state, mover!, { q: 6, r: 5 });
     expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
+  });
+
+  it('throws ScenarioError on an invalid coordinate', () => {
+    const definition: ScenarioDefinition = {
+      name: 'camp-step-bad-coord',
+      description: 'test only',
+      seed: 'scenario-camp-step-bad-coord',
+      base: soloBase,
+      steps: [{ kind: 'camp', position: { q: 99999, r: 99999 } }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('rejects placing a camp on an already-occupied tile unless unsafe: true', () => {
+    const stepsBase: ScenarioStep[] = [
+      { kind: 'terrain', position: { q: 6, r: 5 }, terrain: 'plains' },
+      { kind: 'camp', position: { q: 6, r: 5 } },
+      { kind: 'camp', position: { q: 6, r: 5 } },
+    ];
+    const blocked: ScenarioDefinition = {
+      name: 'camp-step-occupied', description: 'test only', seed: 'scenario-camp-step-occupied',
+      base: soloBase, steps: stepsBase,
+    };
+    expect(() => buildScenario(blocked)).toThrow(ScenarioError);
+
+    const allowed: ScenarioDefinition = {
+      ...blocked,
+      name: 'camp-step-occupied-unsafe',
+      steps: [...stepsBase.slice(0, 2), { ...stepsBase[2], unsafe: true } as ScenarioStep],
+    };
+    expect(() => buildScenario(allowed)).not.toThrow();
+    const camps = buildScenario(allowed).barbarianCamps;
+    // createNewGame also seeds its own base camps elsewhere on the map, so
+    // this counts only camps at the contested tile, not the total.
+    const campsAtTile = Object.values(camps).filter(c => hexKey(c.position) === hexKey({ q: 6, r: 5 }));
+    expect(campsAtTile.length).toBe(2); // both camps coexist on the same tile
   });
 });
 
@@ -227,6 +288,52 @@ describe('diplomacy step', () => {
     expect(state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
     expect(state.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
   });
+
+  it('makes peace bilaterally after a war step', () => {
+    const definition: ScenarioDefinition = {
+      name: 'diplomacy-step-peace-check',
+      description: 'test only',
+      seed: 'scenario-diplomacy-step-peace-check',
+      base: soloBase,
+      steps: [
+        { kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'war' },
+        { kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'peace' },
+      ],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.diplomacy.atWarWith).not.toContain('ai-1');
+    expect(state.civilizations['ai-1'].diplomacy.atWarWith).not.toContain('player');
+  });
+
+  it('signs an alliance treaty bilaterally', () => {
+    const definition: ScenarioDefinition = {
+      name: 'diplomacy-step-alliance-check',
+      description: 'test only',
+      seed: 'scenario-diplomacy-step-alliance-check',
+      base: soloBase,
+      steps: [{ kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'alliance' }],
+    };
+    const state = buildScenario(definition);
+    const playerTreaty = state.civilizations.player.diplomacy.treaties.find(
+      t => t.type === 'alliance' && t.civA === 'player' && t.civB === 'ai-1',
+    );
+    const aiTreaty = state.civilizations['ai-1'].diplomacy.treaties.find(
+      t => t.type === 'alliance' && t.civA === 'ai-1' && t.civB === 'player',
+    );
+    expect(playerTreaty).toBeDefined();
+    expect(aiTreaty).toBeDefined();
+  });
+
+  it('throws ScenarioError on an unknown civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'diplomacy-step-bad-civ',
+      description: 'test only',
+      seed: 'scenario-diplomacy-step-bad-civ',
+      base: soloBase,
+      steps: [{ kind: 'diplomacy', civA: 'player', civB: 'nonexistent', status: 'war' }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
 });
 
 describe('gold step', () => {
@@ -240,6 +347,17 @@ describe('gold step', () => {
     };
     const state = buildScenario(definition);
     expect(state.civilizations.player.gold).toBe(250);
+  });
+
+  it('throws ScenarioError on an unknown civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'gold-step-bad-civ',
+      description: 'test only',
+      seed: 'scenario-gold-step-bad-civ',
+      base: soloBase,
+      steps: [{ kind: 'gold', civId: 'nonexistent', amount: 100 }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
   });
 });
 

--- a/tests/testing/scenario-builder.test.ts
+++ b/tests/testing/scenario-builder.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest';
+import { buildScenario } from '@/testing/scenario-builder';
+import { ScenarioError, type ScenarioDefinition, type ScenarioStep } from '@/testing/scenario-types';
+import { hexKey } from '@/systems/hex-utils';
+import { getBlockingMapEntityAt, getMovementRangeDetails } from '@/systems/unit-system';
+
+function withoutGameId(state: ReturnType<typeof buildScenario>) {
+  const { gameId, ...rest } = state;
+  return rest;
+}
+
+const soloBase: ScenarioDefinition['base'] = {
+  kind: 'solo',
+  config: { civType: 'generic', mapSize: 'small', opponentCount: 1, gameTitle: 'Determinism Check' },
+};
+
+describe('buildScenario', () => {
+  it('is deterministic for a given seed (excluding gameId)', () => {
+    const definition: ScenarioDefinition = {
+      name: 'determinism-check',
+      description: 'test only',
+      seed: 'scenario-determinism-check',
+      base: soloBase,
+      steps: [],
+    };
+    const first = buildScenario(definition);
+    const second = buildScenario(definition);
+    expect(withoutGameId(first)).toEqual(withoutGameId(second));
+  });
+
+  it('derives everything not named in base/steps from createNewGame', () => {
+    const definition: ScenarioDefinition = {
+      name: 'base-only',
+      description: 'test only',
+      seed: 'scenario-base-only',
+      base: soloBase,
+      steps: [],
+    };
+    const state = buildScenario(definition);
+    expect(Object.keys(state.civilizations)).toEqual(['player', 'ai-1']);
+    expect(state.civilizations.player.units.length).toBeGreaterThan(0);
+    expect(state.map.tiles).toBeDefined();
+  });
+});
+
+describe('unit step', () => {
+  it('places a canonical unit via createUnit, then layers overrides on top', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-check',
+      description: 'test only',
+      seed: 'scenario-unit-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 }, overrides: { health: 40 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player');
+    expect(scout).toBeDefined();
+    expect(scout!.movementPointsLeft).toBe(3); // UNIT_DEFINITIONS.scout.movementPoints -- proves createUnit ran
+    expect(scout!.health).toBe(40); // proves the override layered on top
+    expect(state.civilizations.player.units).toContain(scout!.id);
+  });
+
+  it('works identically for an AI-owned civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-ai-check',
+      description: 'test only',
+      seed: 'scenario-unit-step-ai-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'ai-1', type: 'warrior', position: { q: 0, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const warrior = Object.values(state.units).find(u => u.type === 'warrior' && u.owner === 'ai-1');
+    expect(warrior).toBeDefined();
+    expect(state.civilizations['ai-1'].units).toContain(warrior!.id);
+  });
+
+  it('throws ScenarioError on an invalid coordinate', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-bad-coord',
+      description: 'test only',
+      seed: 'scenario-unit-step-bad-coord',
+      base: soloBase,
+      steps: [{ kind: 'unit', civId: 'player', type: 'scout', position: { q: 99999, r: 99999 } }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('throws ScenarioError on an unknown civId', () => {
+    const definition: ScenarioDefinition = {
+      name: 'unit-step-bad-civ',
+      description: 'test only',
+      seed: 'scenario-unit-step-bad-civ',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'nonexistent', type: 'scout', position: { q: 0, r: 0 } },
+      ],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+
+  it('rejects placing a unit on an already-occupied tile unless unsafe: true', () => {
+    const stepsBase: ScenarioStep[] = [
+      { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+      { kind: 'unit', civId: 'player', type: 'scout', position: { q: 0, r: 0 } },
+      { kind: 'unit', civId: 'ai-1', type: 'warrior', position: { q: 0, r: 0 } },
+    ];
+    const blocked: ScenarioDefinition = {
+      name: 'unit-step-occupied', description: 'test only', seed: 'scenario-unit-step-occupied',
+      base: soloBase, steps: stepsBase,
+    };
+    expect(() => buildScenario(blocked)).toThrow(ScenarioError);
+
+    const allowed: ScenarioDefinition = {
+      ...blocked,
+      name: 'unit-step-occupied-unsafe',
+      steps: [...stepsBase.slice(0, 2), { ...stepsBase[2], unsafe: true } as ScenarioStep],
+    };
+    expect(() => buildScenario(allowed)).not.toThrow();
+  });
+});
+
+describe('city step', () => {
+  it('founds a canonical city via foundCity and claims nearby territory', () => {
+    const definition: ScenarioDefinition = {
+      name: 'city-step-check',
+      description: 'test only',
+      seed: 'scenario-city-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+        { kind: 'terrain', position: { q: 1, r: 0 }, terrain: 'plains' },
+        { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const city = Object.values(state.cities).find(c => hexKey(c.position) === hexKey({ q: 2, r: 0 }));
+    expect(city).toBeDefined();
+    expect(city!.owner).toBe('ai-1');
+    expect(city!.name.length).toBeGreaterThan(0); // proves foundCity's naming ran, not a hand literal
+    expect(state.civilizations['ai-1'].cities).toContain(city!.id);
+    // city has no garrison unit
+    expect(Object.values(state.units).some(u => hexKey(u.position) === hexKey(city!.position))).toBe(false);
+    expect(state.map.tiles[hexKey({ q: 1, r: 0 })].owner).toBe('ai-1'); // territory recalculated
+  });
+
+  it('rejects founding on an already-occupied tile unless unsafe: true', () => {
+    const steps: ScenarioStep[] = [
+      { kind: 'terrain', position: { q: 2, r: 0 }, terrain: 'plains' },
+      { kind: 'city', civId: 'ai-1', position: { q: 2, r: 0 } },
+      { kind: 'city', civId: 'player', position: { q: 2, r: 0 } },
+    ];
+    const blocked: ScenarioDefinition = {
+      name: 'city-step-occupied', description: 'test only', seed: 'scenario-city-step-occupied',
+      base: soloBase, steps,
+    };
+    expect(() => buildScenario(blocked)).toThrow(ScenarioError);
+  });
+});
+
+describe('camp step', () => {
+  it('places a barbarian camp that getBlockingMapEntityAt recognizes', () => {
+    const definition: ScenarioDefinition = {
+      name: 'camp-step-check',
+      description: 'test only',
+      seed: 'scenario-camp-step-check',
+      base: soloBase,
+      steps: [
+        { kind: 'terrain', position: { q: 5, r: 5 }, terrain: 'plains' },
+        { kind: 'terrain', position: { q: 6, r: 5 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player', type: 'warrior', position: { q: 5, r: 5 } },
+        { kind: 'camp', position: { q: 6, r: 5 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    const camp = Object.values(state.barbarianCamps).find(c => hexKey(c.position) === hexKey({ q: 6, r: 5 }));
+    expect(camp).toBeDefined();
+    const mover = Object.values(state.units).find(u => u.owner === 'player');
+    const blocking = getBlockingMapEntityAt(state, mover!, { q: 6, r: 5 });
+    expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
+  });
+});
+
+describe('tech step', () => {
+  it('marks the named techs completed for the civ', () => {
+    const definition: ScenarioDefinition = {
+      name: 'tech-step-check',
+      description: 'test only',
+      seed: 'scenario-tech-step-check',
+      base: soloBase,
+      steps: [{ kind: 'tech', civId: 'player', techIds: ['pottery', 'bronze-working'] }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.techState.completed).toEqual(
+      expect.arrayContaining(['pottery', 'bronze-working']),
+    );
+  });
+
+  it('throws ScenarioError on an unknown tech id', () => {
+    const definition: ScenarioDefinition = {
+      name: 'tech-step-bad-id',
+      description: 'test only',
+      seed: 'scenario-tech-step-bad-id',
+      base: soloBase,
+      steps: [{ kind: 'tech', civId: 'player', techIds: ['not-a-real-tech'] }],
+    };
+    expect(() => buildScenario(definition)).toThrow(ScenarioError);
+  });
+});
+
+describe('diplomacy step', () => {
+  it('declares war bilaterally', () => {
+    const definition: ScenarioDefinition = {
+      name: 'diplomacy-step-check',
+      description: 'test only',
+      seed: 'scenario-diplomacy-step-check',
+      base: soloBase,
+      steps: [{ kind: 'diplomacy', civA: 'player', civB: 'ai-1', status: 'war' }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+    expect(state.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
+  });
+});
+
+describe('gold step', () => {
+  it('adds gold to the civ', () => {
+    const definition: ScenarioDefinition = {
+      name: 'gold-step-check',
+      description: 'test only',
+      seed: 'scenario-gold-step-check',
+      base: soloBase,
+      steps: [{ kind: 'gold', civId: 'player', amount: 250 }],
+    };
+    const state = buildScenario(definition);
+    expect(state.civilizations.player.gold).toBe(250);
+  });
+});
+
+describe('hot-seat base', () => {
+  it('builds a hot-seat state with correct per-slot visibility', () => {
+    const definition: ScenarioDefinition = {
+      name: 'hot-seat-check',
+      description: 'test only',
+      seed: 'scenario-hot-seat-check',
+      base: {
+        kind: 'hotSeat',
+        config: {
+          playerCount: 2,
+          mapSize: 'small',
+          players: [
+            { name: 'Alice', slotId: 'player-1', civType: 'generic', isHuman: true },
+            { name: 'Bob', slotId: 'player-2', civType: 'generic', isHuman: true },
+          ],
+        },
+      },
+      steps: [
+        { kind: 'terrain', position: { q: 0, r: 0 }, terrain: 'plains' },
+        { kind: 'unit', civId: 'player-1', type: 'scout', position: { q: 0, r: 0 } },
+      ],
+    };
+    const state = buildScenario(definition);
+    expect(state.hotSeat).toBeDefined();
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player-1');
+    expect(scout).toBeDefined();
+    expect(state.civilizations['player-1'].visibility.tiles[hexKey({ q: 0, r: 0 })]).toBe('visible');
+  });
+});

--- a/tests/testing/scenario-types.test.ts
+++ b/tests/testing/scenario-types.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { ScenarioError } from '@/testing/scenario-types';
+
+describe('ScenarioError', () => {
+  it('is a real Error with a readable name', () => {
+    const error = new ScenarioError('bad step');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('ScenarioError');
+    expect(error.message).toBe('bad step');
+  });
+});

--- a/tests/testing/scenarios.test.ts
+++ b/tests/testing/scenarios.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { SCENARIOS } from '@/testing/scenarios';
+import { buildScenario } from '@/testing/scenario-builder';
+import { hexKey } from '@/systems/hex-utils';
+import { getBlockingMapEntityAt, getMovementRangeDetails } from '@/systems/unit-system';
+
+describe('undefended-enemy-city scenario (#843)', () => {
+  it('reproduces a player scout 2 hexes from an undefended, at-war AI city', () => {
+    const state = buildScenario(SCENARIOS['undefended-enemy-city']);
+    const scout = Object.values(state.units).find(u => u.type === 'scout' && u.owner === 'player');
+    const city = Object.values(state.cities).find(c => c.owner === 'ai-1');
+    expect(scout).toBeDefined();
+    expect(city).toBeDefined();
+    // city has no garrison unit
+    expect(Object.values(state.units).some(u => hexKey(u.position) === hexKey(city!.position))).toBe(false);
+    expect(state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+
+    // Exactly what #843's fix guards: reachable adjacency-only, not walk-through.
+    const range = getMovementRangeDetails(state, scout!.id);
+    const keys = range.reachable.map(hexKey);
+    expect(keys).not.toContain(hexKey(city!.position));
+    const blocking = getBlockingMapEntityAt(state, scout!, city!.position);
+    expect(blocking).toEqual({ reason: 'foreign-city', entityId: city!.id });
+  });
+});
+
+describe('undefended-barbarian-camp scenario (#845)', () => {
+  it('reproduces a player unit directly adjacent to an undefended camp', () => {
+    const state = buildScenario(SCENARIOS['undefended-barbarian-camp']);
+    const mover = Object.values(state.units).find(u => u.owner === 'player');
+    const camp = Object.values(state.barbarianCamps)[0];
+    expect(mover).toBeDefined();
+    expect(camp).toBeDefined();
+    const blocking = getBlockingMapEntityAt(state, mover!, camp!.position);
+    expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
+  });
+});

--- a/tests/testing/scenarios.test.ts
+++ b/tests/testing/scenarios.test.ts
@@ -3,6 +3,9 @@ import { SCENARIOS } from '@/testing/scenarios';
 import { buildScenario } from '@/testing/scenario-builder';
 import { hexKey } from '@/systems/hex-utils';
 import { getBlockingMapEntityAt, getMovementRangeDetails } from '@/systems/unit-system';
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
+import { normalizeLoadedState } from '@/storage/save-manager';
 
 describe('undefended-enemy-city scenario (#843)', () => {
   it('reproduces a player scout 2 hexes from an undefended, at-war AI city', () => {
@@ -34,4 +37,32 @@ describe('undefended-barbarian-camp scenario (#845)', () => {
     const blocking = getBlockingMapEntityAt(state, mover!, camp!.position);
     expect(blocking).toEqual({ reason: 'barbarian-camp', entityId: camp!.id });
   });
+});
+
+describe('every registered scenario is a legitimately reachable state', () => {
+  for (const name of Object.keys(SCENARIOS)) {
+    it(`${name}: survives real turn processing (AI civs, crisis/religion/loyalty ticks)`, () => {
+      const state = buildScenario(SCENARIOS[name]);
+      expect(() => processTurn(state, new EventBus())).not.toThrow();
+    });
+
+    it(`${name}: round-trips through save normalization without losing data`, () => {
+      const state = buildScenario(SCENARIOS[name]);
+      // normalizeLoadedState is allowed to backfill newer default fields (e.g.
+      // lastCombatTurnByLandmass) the way it would for ANY freshly-created
+      // game, scenario or not -- so this checks for no data LOSS, not byte
+      // equality. Same civ/unit/city ids, and every gameplay-relevant field a
+      // scenario step could have set survives the round trip untouched.
+      const normalized = normalizeLoadedState(structuredClone(state));
+      expect(() => normalizeLoadedState(structuredClone(state))).not.toThrow();
+      expect(Object.keys(normalized.civilizations)).toEqual(Object.keys(state.civilizations));
+      expect(Object.keys(normalized.units)).toEqual(Object.keys(state.units));
+      expect(Object.keys(normalized.cities)).toEqual(Object.keys(state.cities));
+      for (const civId of Object.keys(state.civilizations)) {
+        expect(normalized.civilizations[civId].gold).toBe(state.civilizations[civId].gold);
+        expect(normalized.civilizations[civId].techState.completed).toEqual(state.civilizations[civId].techState.completed);
+        expect(normalized.civilizations[civId].diplomacy.atWarWith).toEqual(state.civilizations[civId].diplomacy.atWarWith);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- Adds a typed `ScenarioDefinition`/`ScenarioStep` DSL and `buildScenario()` (`src/testing/`) that folds a scenario into a real `GameState` entirely through canonical system helpers (`createUnit`, `foundCity`, `declareWar`, etc.) — never a hand-built partial state.
- Ships two representative scenarios (`undefended-enemy-city`, `undefended-barbarian-camp`) reproducing the exact starting conditions `e0ecc7dc` (fixing #843/#845) needed but could not get outside of Vitest — its own plan docs note "the app exposes no debug hook or save-injection path... manual verification isn't feasible without unbounded manual play."
- Adds a `DEV`-only `?scenario=<name>` browser loader in `game-session-controller.ts`, dynamic-imported and dead-code-eliminated from production builds (verified against the `dist/` bundle).
- The same `buildScenario` + `SCENARIOS` registry is used by Vitest tests and the dev-mode loader — no duplicate construction path.

## Design

Full written analysis and design: `docs/superpowers/specs/2026-08-16-issue-846-scenario-infrastructure-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-16-issue-846-scenario-infrastructure.md`
Usage docs: `docs/scenario-infrastructure.md`

## Test plan

- [x] `yarn test` — 491 files, 8085 tests passing, 0 failures
- [x] `yarn build` — passes; `dist/assets/*.js` confirmed to contain no scenario-related symbols (`undefended-enemy-city`, `buildScenario`, `ScenarioError`)
- [x] `yarn test:hooks` — all hook smoke tests pass
- [x] `git diff --check` — clean
- [x] Manual browser verification: `?scenario=undefended-enemy-city` loads directly into the scenario (start menu skipped); `?scenario=not-a-real-name` throws a clear "Unknown scenario ... Known scenarios: ..." error
- [x] Coverage: determinism, invalid coordinate/civId errors per step kind, the `unsafe: true` escape hatch, human vs AI ownership, hot-seat, diplomacy war/peace/alliance, `processTurn()` safety (AI/crisis/religion/loyalty), and save-normalization round-trip without data loss — all per registered scenario

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)