### PR TITLE
feat(espionage): era-5 mission ladder — intercept_courier + bribe_official (#442 Phase 1)

### DIFF
--- a/docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md
@@ -1,0 +1,279 @@
+# Issue #442 — Espionage missions for eras 5–9: design analysis
+
+Status: **design analysis, pre-spec**. Written fresh against `main` @ `601f5a1f` (2026-08-16), per the
+issue's own instruction to re-verify rather than trust the original body or older comments.
+
+## 0. Issue re-audit — what's stale, what's current
+
+The issue body is **stale** on two points, corrected by its own comment thread:
+
+- `digital-surveillance` is **era 10**, not era 5 (moved in MR10, #469). It gates `misinformation_campaign`
+  and `satellite_surveillance`... actually no — verified against current code: `digital-surveillance` gates
+  **zero missions**. It only affects spy-capture/detection mechanics (`ESPIONAGE_TECH_MAX_SPIES` is not it;
+  it's referenced in `canTurnCapturedSpy` and `applyBuildingCI`'s building-fade check, and the threat-board
+  `canDetectThreats` gate in `espionage-panel.ts`). The comment claiming it gates those two missions is
+  itself wrong — `cold-war-networks` (also era 10) is what gates them, per `STAGE_5_TECHS`.
+- **The mission-count plateau is narrower than the issue thread's most recent comment describes.** Two
+  missions already shipped into this exact gap in MRs that landed *after* the last issue comment:
+  - `flip_loyalty` — gated by `propaganda` (era 6), shipped in commit `c9260673` ("#604 MR2a").
+  - `sabotage_relief` — gated by `covert-operations` (era 7), shipped in commit `9c268aa7` ("#526 MR7").
+
+  So the **real remaining gap is eras 5, 8, and 9 — zero new missions each** — not "eras 5–9 uniformly."
+  Era 6 and 7 already got one well-built, well-tested new mission apiece from unrelated recent arcs. This
+  document does not touch era 6/7's mission set; re-adding there would be redundant work the issue's own
+  closing instruction ("re-audit and implement only the remaining gap") tells us to skip.
+
+## 1–5. Current state, verified against code
+
+**Mission ladder by era** (`getAvailableMissions`, `src/systems/espionage-system.ts:375`):
+
+| Era | Gating tech(s) | Missions unlocked | New missions here |
+|---|---|---|---|
+| 1 | `espionage-scouting` | `scout_area`, `monitor_troops` | — |
+| 2 | `espionage-informants` | `gather_intel`, `identify_resources`, `monitor_diplomacy` | — |
+| 3 | `spy-networks` or `sabotage` | `steal_tech`, `sabotage_production`, `incite_unrest` | — |
+| 4 | `cryptography` or `counter-intelligence` | `assassinate_advisor`, `forge_documents`, `fund_rebels`, `arms_smuggling` | 4 |
+| 5 | `black-chambers`, `diplomatic-networks` | *(none)* | **0 — the gap** |
+| 6 | `propaganda` | `flip_loyalty` | 1 |
+| 6 | `counter-espionage` | *(modifier only — no mission)* | — |
+| 7 | `covert-operations` | `sabotage_relief` | 1 |
+| 7 | `secret-police` | *(modifier only)* | — |
+| 8 | `political-intelligence`, `disinformation-bureau` | *(none)* | **0 — the gap** |
+| 9 | `counterintelligence`, `propaganda-campaigns` | *(none)* | **0 — the gap** |
+| 10 | `cold-war-networks` | `misinformation_campaign`, `election_interference` | 2 |
+| 11 | `satellite-surveillance` | `satellite_surveillance` | 1 |
+| 12 | `cyber-intelligence` | `cyber_attack` | 1 |
+
+**Era 5–9 tech effects already wired** (`espionage-modifier-definitions.ts`, all real, all tested):
+
+| Tech | Era | Effect |
+|---|---|---|
+| `black-chambers` | 5 | +1 spy slot (`ESPIONAGE_TECH_MAX_SPIES`) |
+| `diplomatic-networks` | 5 | +20% mission success vs. foreign capitals only |
+| `propaganda` | 6 | gates `flip_loyalty` (already a full mission, not just a modifier) |
+| `counter-espionage` | 6 | -25% enemy mission success (defense) |
+| `covert-operations` | 7 | +2 spy slots, +15% mission success (offense); gates `sabotage_relief` |
+| `secret-police` | 7 | -30% enemy success, +10% detection (defense) |
+| `political-intelligence` | 8 | +3 spy slots, +10% mission success (offense) |
+| `disinformation-bureau` | 8 | -25% enemy success (defense) |
+| `counterintelligence` | 9 | -30% enemy success (defense) |
+| `propaganda-campaigns` | 9 | *(no `ESPIONAGE_MODIFIERS` row — verified, it currently does nothing beyond being a prerequisite. This is itself a minor content-honesty gap, not part of #442's scope, flagged below as a candidate follow-up.)* |
+
+**Spy units** (`TRAINABLE_UNITS`, `city-system.ts:1209-1213`):
+
+`spy_scout` (era 1, `espionage-scouting`) → `spy_informant` (era 2) → `spy_agent` (era 3, `spy-networks`) →
+`spy_operative` (era 4, `cryptography`) → **[8-era plateau, eras 4–11]** → `spy_hacker` (era 12, `cyber-warfare`).
+Confirmed: no intermediate unit or `upgradesTo` link exists between era 4 and era 12. This matches the issue.
+
+**AI**: `chooseAiMission` (`basic-ai.ts:1611`) is a personality-ordered preference list over `getAvailableMissions`,
+generic and data-driven — no per-mission-ID branch beyond the list itself and one explicit `sabotage_relief`
+exclusion (documented as "human-initiated only, future extension"). A second, simpler random-pick path exists
+for spies newly stationed inside an infiltrated city (`basic-ai.ts:1306`), with its own exclusion list. AI
+target selection (`chooseAiSpyTarget`) uses only relationship/war-state and `MajorCivPerception` (legitimately
+known cities) — no hidden-information reads found.
+
+**UI**: `espionage-panel.ts` renders missions grouped into 5 "stages" (a display concept distinct from the
+code's tech-gating "stages" — `MISSION_STAGE` is a separate hardcoded map that already absorbed `flip_loyalty`
+and `sabotage_relief` into stage 4/5 with a comment explaining the era mismatch is intentional). New missions
+need one entry each in `MISSION_LABELS`, `MISSION_STAGE`, and (if they use a duration/base-success) the two
+`Record<SpyMissionType, ...>` tables in `espionage-system.ts`.
+
+**Notifications / hot-seat**: `register-espionage-presentation.ts` routes 8 of the ~16 espionage events emitted;
+`mission-succeeded`/`mission-failed`/`spy-arrived`/`advisor-assassinated`/`documents-forged`/`spy-expelled`/
+`spy-detected`/`spy-promoted` currently have **no notification handler anywhere** (verified — not in `main.ts`,
+not in any registrar; this predates the #787 registrar extraction, which moved code verbatim). This is a
+pre-existing gap across *all* current missions, not something #442 introduced. The two most recently added
+missions (`flip_loyalty`, `sabotage_relief`) both got dedicated `route*` functions in `notification-routing.ts`
+that fan out to victim + witnesses — **that's the current best-practice pattern**, and this document's new
+missions will follow it rather than the older silent pattern. (The older gap is worth its own follow-up issue;
+flagged at the end, out of scope here.)
+
+## 6. What's actually missing vs. merely underpowered
+
+Every era 5–9 tech's *modifier* effect is real and tested (MR12 closed that gap already). What's missing is
+strictly **new verbs** — era 5, 8, and 9 have no player-facing action a spy can take that didn't already exist
+at era 3–4. The "plateau" a player feels is: research 3 espionage techs across 3 eras, gain only percentage
+tweaks to missions they already had. That is exactly the "flat percentage bonuses masquerading as new gameplay"
+failure mode the task brief warns against — except it's not a new mistake to avoid, it's the **existing state**
+this issue exists to fix.
+
+## 7–8. Reusable mechanics vs. genuinely new state
+
+Systems inventory relevant to candidate mechanics, verified to exist:
+
+| System | File | Reusable for |
+|---|---|---|
+| Trade routes (`TradeRoute[]`, per-city-pair, `foreignCivId` marks foreign) | `trade-system.ts`, `types.ts:1547` | A **new** target type — no mission currently touches trade routes. Embargo already has a "remove/suppress a route" precedent (`scrubEmbargoedRoutes`). |
+| Pending treaty proposals (`state.pendingDiplomacyRequests`) | `diplomacy-system.ts:522` | **Not usable** for AI-vs-AI interception — this queue only holds proposals *to a human* (AI-AI treaties resolve same-turn, no pending state to intercept). Ruled out as a mechanic base. |
+| Bilateral relationship penalty | `modifyRelationship` | Already used 3×: `forge_documents` (2 arbitrary civs), `flip_loyalty` (spy's civ + victim, side effect), `sabotage_relief` (witnessed reputation via `crisis-interaction-definitions.ts`). A 4th bilateral-only mission would be a duplicate; a **multilateral** broadcast (one target civ's relationship with *every* civ that has a treaty with them) has no precedent and is a genuine new shape. |
+| Unrest injection (`spyUnrestBonus`) | `incite_unrest`, `fund_rebels`, `election_interference` | Already used 3×. A 4th unrest mission for era 8/9 would be the "five differently named reduce-X" trap called out explicitly — **avoid**. |
+| Temporary yield/production debuff | `productionDisabledTurns` (cyber_attack), `researchPenaltyTurns/Multiplier` (misinformation_campaign) | Gold-income has no debuff yet, but combining it with a new gold-theft mechanic (below) in the same design would double up on "economy" as the era 8/9 theme — avoid stacking two money mechanics. |
+| `feedsFalseIntel` / turned-spy false-intel flag | capture/interrogation system | Already fully used for captured-and-turned spies; not obviously extensible to a new mission without inventing a second false-intel channel. |
+| Empire-wide territory vision grant | `satellite_surveillance` → `applySatelliteSurveillance` | A narrower, remote-capable, one-time version (troop positions only, not full territory) is a legitimate era-9 precursor — same shape as `monitor_troops` (single-city radius) generalized to empire-wide, no new persisted state needed (it's a snapshot event, not an ongoing grant). |
+| War weariness / war-exhaustion | *(does not exist as a system)* | Ruled out — would require inventing a whole new mechanic outside this issue's scope. |
+
+**Conclusion: 3 new `SpyMissionType` values are justified by real, non-duplicate mechanics reusing existing
+state shapes; forcing a 4th or a uniform "2 per era" would mean either duplicating an existing verb (unrest,
+bilateral relationship, or economy-debuff) or inventing a disconnected new subsystem.** This directly follows
+the brief's "do not assume two missions every era" instruction — the honest count here is per-era zero, two,
+zero, zero, one, driven by what's real rather than a template.
+
+## 9. Proposed mission ladder (era 5 gets 2 — it has two clean, distinct anchors already; era 8 and 9 get 1 each)
+
+### Era 5 — `intercept_courier` (courier interception → trade route disruption)
+
+- **Gate**: `black-chambers` (era 5). Reusing an existing gate bucket pattern (own `SABOTAGE_RELIEF_TECHS`-style
+  singleton array), not folded into an existing stage.
+- **Target**: a foreign city with an active trade route touching it (either endpoint). Requires placed spy
+  (thematically it's a physical interception, matches the existing placed-spy missions of similar tier).
+- **Effect (as implemented, refined from the original plan below)**: picks the highest-`goldPerTrip` active
+  route touching the target city and **removes it outright**, reusing `trade-system.ts`'s existing
+  `removeRouteById` — the exact function embargo/war-declaration already call to sever a route, extended with
+  one new `reason: 'espionage'`. This turned out cleaner than the `disabledUntilTurn`-field plan below: **zero
+  new persisted state**, 100% mechanic reuse, and a real analog to a courier physically not arriving (the
+  route is gone, not paused) rather than a novel "disabled" status nothing else in the codebase has. Losing
+  one route (of up to 6 a city can support) is bounded and recoverable — the caravan unit itself survives and
+  can re-commit to a new route, same as it does today after an embargo severs its route.
+  *(Original plan, superseded once the embargo precedent was found during implementation: a new optional
+  `TradeRoute.disabledUntilTurn?: number` field that trade-income processing would skip over for N turns.
+  Kept here per spec-fidelity's "note the deviation" guidance rather than silently editing history.)*
+- **Why new**: no existing mission touches `MarketplaceState.tradeRoutes`. Distinct target type from every
+  other mission (a route, not a city/civ/advisor).
+- **Counterplay**: target sees an immediate, visible gold-per-turn drop and a routed notification naming the
+  severed route (`espionage:courier-intercepted`, both sides notified); can send a new caravan to re-establish
+  trade at any point — no cooldown beyond the normal cost of building/routing a fresh caravan;
+  `counter-espionage`/`secret-police`/`disinformation-bureau` all still apply as normal defense modifiers to
+  the mission's success roll itself. No eligible route (city has no active trade) means no effect — natural
+  counterplay for civs that don't trade through that city.
+- **AI story**: aggressive/mercantile-leaning personalities value routes with higher `goldPerTrip`; slot into
+  `chooseAiMission`'s existing preferred-order arrays (no ID-branch, just another array entry). AI never reads
+  route data the player couldn't also see (routes are public state, not fog-gated).
+
+### Era 5 — `bribe_official` (bribery → direct treasury theft)
+
+- **Gate**: `diplomatic-networks` (era 5) — its own existing "+20% success in capitals" modifier makes capitals
+  the natural high-value target for a bribery mission; thematically coherent pairing, not a forced anchor.
+- **Target**: any foreign civ (city required for spy placement, per the placed-spy convention).
+- **Effect**: transfers a bounded amount of the target's current gold treasury to the acting civ (e.g.
+  `min(targetGold * 0.15, cap)`). This is the **first** mission that moves a resource between civs rather
+  than only revealing or disrupting — genuinely new verb.
+- **Why new**: `gather_intel` reveals treasury; nothing currently *moves* gold between civs via espionage.
+- **Counterplay**: capped both as a fraction and an absolute amount so it can't cripple a civ in one hit
+  (mirrors the "never permanently cripple a city/civ from one action" balance rule); visible to victim via
+  a routed notification with the exact amount lost; diplomatic relationship penalty on discovery-equivalent
+  (treat capture/expulsion exactly like existing missions — no special-cased leniency).
+- **AI story**: personality-weighted toward `aggressive`/`trader` traits (gold-seeking); AI only targets
+  civs whose treasury it can legitimately observe having spied on before, or uses the same `chooseAiSpyTarget`
+  relationship-based targeting already in place (no new hidden-info read — the mission doesn't require
+  pre-knowledge of the exact amount, only eligibility).
+
+### Era 9 — `signals_intercept` (signals interception → empire-wide troop snapshot)
+
+- **Gate**: `counterintelligence` (era 9) — codebreaking fits its "defensive intelligence" theme applied
+  offensively; a legitimate stretch but no worse a fit than `covert-operations` gating `sabotage_relief`.
+- **Target**: a foreign civ (not a specific city) — **remote-capable**, added to the existing
+  `missionRequiresPlacedSpy` exclusion list alongside `cyber_attack`/`misinformation_campaign`/
+  `satellite_surveillance` (all "digital/remote" era 10+ missions; era 9 becomes the first non-digital
+  remote mission, which needs an explicit one-line justification in-code, not just precedent-by-proximity).
+- **Effect**: one-time snapshot of all the target civ's unit types/positions/health empire-wide (reuses
+  `monitor_troops`'s existing `nearbyUnits` result shape, generalized from a single city's radius to the
+  whole civ) — no new persisted state, it's an immediate intel event like `gather_intel`.
+- **Why new**: `monitor_troops` is capped to a 4-hex radius around one city; nothing currently gives a
+  point-in-time empire-wide military snapshot. Distinct from `satellite_surveillance` (era 11), which grants
+  an *ongoing* territory-vision window, not a one-shot unit list.
+- **Counterplay**: one-shot (not an ongoing leak, unlike satellite surveillance) — the target's dispositions
+  change the next turn, so its value decays fast. Same detection/capture risk as any mission of its tier.
+- **AI story**: primarily useful pre-war — aggressive personalities prioritize it against civs they're
+  already hostile toward or at war with, reusing `chooseAiSpyTarget`'s existing relationship scoring.
+
+### Era 8 — `expose_scandal` (political intelligence → multilateral reputation broadcast)
+
+- **Gate**: `disinformation-bureau` (era 8) — thematically the mirror image of that tech's existing
+  "-25% enemy success" defense: this mission is the offensive act it's presumably meant to defend against
+  (a genuine two-sided fit, one tech gating both the sword and the shield is a defensible pattern already
+  used implicitly elsewhere in the file, e.g. `secret-police` defends what `covert-operations`/`propaganda`
+  enable offensively).
+- **Target**: a foreign civ. Placed-spy (this is "uncovered secret documents," not remote signal-breaking).
+- **Effect**: for every *other* major civ that currently has an active treaty with the target, apply a
+  bounded relationship penalty (proposed −10, below `forge_documents`'s −25 since it's spread thinner and
+  the "victim" here didn't do anything wrong, they were just exposed) between the target and each of those
+  treaty partners. The acting civ's own relationship with the target is *not* directly touched by this
+  mission (no free diplomatic upside beyond the strategic value of weakening their alliances) — keeps it
+  from being strictly-better than `forge_documents` in every situation, preserving "not always optimal."
+- **Why new**: every existing relationship-affecting mission is bilateral (exactly 2 parties). This is the
+  first N-ary one. Reuses `modifyRelationship` in a loop — no new primitive, just a new *shape* of use.
+- **Counterplay**: bounded per-partner penalty, capped total partner count (propose capping at 4 affected
+  pairs so a maximally-connected civ doesn't get devastated in one mission — matches the "avoid indefinite
+  stacking" and "no crippling from one action" rules); visible via a routed notification naming which
+  relationships soured; a civ with no treaties is simply not a valid/valuable target (natural counterplay:
+  isolationist civs are immune).
+- **AI story**: diplomatic/trader-trait AI values this against well-connected rivals (many treaties = juicier
+  target); needs a cheap "does target have ≥1 treaty" eligibility check before offering it as a `chooseAiMission`
+  candidate, otherwise AI wastes turns targeting isolated civs (same shape as `fund_rebels`'s existing
+  `unrestLevel === 0` eligibility guard in `resolveMissionResult`).
+
+## 10. Spy-unit plateau — recommend **deferring to a follow-up**, not bundling
+
+Reasoning:
+- The mission-ladder work above already touches `espionage-system.ts`, `espionage-panel.ts`,
+  `basic-ai.ts`, `notification-routing.ts`, `tech-definitions-eras5-7/8/9.ts`, plus full test coverage
+  per mission (unlock gating, positive/negative success, AI, hot-seat, save/load where stateful). That's
+  a full, reviewable, independently-mergeable slice on its own.
+- A new spy unit requires the *full* end-to-end wiring checklist from `end-to-end-wiring.md` (definition,
+  description, renderer icon, `TRAINABLE_UNITS` + tech `unlocksUnits`, `PRODUCTION_ICONS`, AI candidate
+  classification in `ai-production.ts`/`ai-unit-roles.ts`, sprite via the v2 SVG pipeline, SFX, upgrade-chain
+  `obsoletedByTech`/`upgradesTo` correctness) — a comparable amount of work to the entire mission ladder,
+  for a mechanically separate problem (unit stats/promotion economy, not mission variety).
+- Bundling both turns this into exactly the "oversized release" the brief warns against, and this session's
+  established preference is incremental, reviewable slices over batched delivery.
+- The plateau is real but *secondary* to the issue's primary ask (missions) — the issue title is "Add
+  era-appropriate espionage missions," and the unit plateau is presented as an "also" in the issue body.
+
+**Recommendation: ship the mission ladder as this arc; open a follow-up issue for 1–2 intermediate spy units
+(era 7–9, per the original issue's own suggestion) once this lands**, so it gets the same full design-analysis
+treatment rather than being rushed as a bolt-on.
+
+## Non-goals / explicitly out of scope for this arc
+
+- Era 6/7's existing `flip_loyalty`/`sabotage_relief` missions are not touched or expanded.
+- `propaganda-campaigns` (era 9) having no modifier row is a pre-existing content-honesty gap, not
+  introduced or worsened here — flagged as a candidate follow-up, not fixed inline (fixing it is unrelated
+  to adding new missions and would blur this PR's scope).
+- The pre-existing silent-notification gap for `mission_succeeded`/`mission_failed`/etc. on *all* current
+  missions (not just new ones) is not fixed here — new missions get routed notifications (current best
+  practice); retrofitting old missions is a separate, larger follow-up.
+- No changes to barbarian/beast/crisis/combat/fortification/world-pressure systems (per the #547 overlap
+  constraint) — none of the three proposed missions touch those systems.
+
+## Save/schema impact
+
+All three new missions need **zero new persisted state**. `intercept_courier` (as implemented) reuses
+`removeRouteById` — no new field, no schema-relevant change at all. `expose_scandal` and `signals_intercept`
+are broadcast/snapshot effects, not ongoing. `bribe_official` mutates plain existing `Civilization.gold`.
+**No `CURRENT_SAVE_SCHEMA_VERSION` bump.** Mid-mission save/load already works generically through
+`SpyMission`/`Spy` — no new fields needed there since none of these missions need custom in-flight mission
+state beyond `targetCivId`/`targetCityId`.
+
+## Phase 1 status (2026-08-16)
+
+`intercept_courier` and `bribe_official` (era 5) are **implemented on this branch** — see
+`src/systems/espionage-system.ts`, `src/core/turn-manager.ts` (route-removal glue), `src/ai/basic-ai.ts`,
+`src/ui/espionage-panel.ts`, `src/ui/notification-routing.ts` +
+`src/presentation/register-espionage-presentation.ts`, and `src/systems/tech-definitions-eras5-7.ts` (unlock
+text). Full test coverage added across `tests/systems/espionage-system.test.ts`, `tests/ai/ai-espionage.test.ts`,
+`tests/core/turn-manager.test.ts` (genuine `processTurn` end-to-end wiring proof), `tests/ui/espionage-panel.test.ts`,
+`tests/presentation/register-espionage-presentation.test.ts`, and `tests/ui/notification-routing.test.ts`.
+`yarn build` and `yarn test` both green (491 files / 8110 tests passing) at the time this phase closed.
+
+`expose_scandal` (era 8) and `signals_intercept` (era 9) are **designed above but not yet implemented** —
+planned as Phase 2, a separate PR, per the incremental-delivery preference confirmed with the user.
+
+**Post-implementation review (2026-08-16) found and fixed one real gap**: the mission catalog UI showed only a
+label, stage tag, and access tag for every mission — no plain-language effect description or duration anywhere,
+for any of the 21 mission types, not just the two added here. This violated CLAUDE.md's "all UI elements must
+be self-explanatory" rule and the established world-pressure-interaction precedent ("cost, effect, and risk
+inline at the point of choice... a 7-year-old should understand the trade from the button alone" —
+`docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md`). Fixed by adding a
+`MISSION_DESCRIPTIONS: Record<SpyMissionType, string>` table and a duration tag, covering the full existing
+catalog (not just the two new missions) so descriptions don't appear inconsistently between old and new
+entries — one data table, no architecture change. Covered by new tests in `tests/ui/espionage-panel.test.ts`.

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1629,19 +1629,19 @@ export function chooseAiMission(
   if (hasStage5 && (civ.civType === 'annuvin' || traits.has('aggressive'))) {
     preferredOrder = [
       'flip_loyalty', 'cyber_attack', 'misinformation_campaign', 'satellite_surveillance',
-      'election_interference', 'steal_tech', 'sabotage_production',
+      'election_interference', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production',
       'arms_smuggling', 'incite_unrest', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('aggressive')) {
     preferredOrder = [
-      'flip_loyalty', 'steal_tech', 'sabotage_production', 'arms_smuggling',
+      'flip_loyalty', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production', 'arms_smuggling',
       'incite_unrest', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('diplomatic') || traits.has('trader')) {
     preferredOrder = [
-      'forge_documents', 'flip_loyalty', 'incite_unrest', 'fund_rebels',
+      'forge_documents', 'flip_loyalty', 'bribe_official', 'intercept_courier', 'incite_unrest', 'fund_rebels',
       'gather_intel', 'monitor_diplomacy', 'identify_resources',
       'monitor_troops', 'scout_area', 'steal_tech',
     ];
@@ -1649,7 +1649,7 @@ export function chooseAiMission(
     preferredOrder = [
       'gather_intel', 'monitor_diplomacy', 'identify_resources',
       'monitor_troops', 'scout_area', 'steal_tech',
-      'sabotage_production', 'incite_unrest',
+      'sabotage_production', 'incite_unrest', 'intercept_courier', 'bribe_official',
     ];
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -74,7 +74,7 @@ import {
   getLeagueForCiv,
   pruneExpiredDiplomaticRequests,
 } from '@/systems/diplomacy-system';
-import { processTradeRouteIncome, processFashionCycle, updatePrices, removeRouteForUnit, scrubStaleForeignRoutes, scrubEmbargoedRoutes } from '@/systems/trade-system';
+import { processTradeRouteIncome, processFashionCycle, updatePrices, removeRouteForUnit, scrubStaleForeignRoutes, scrubEmbargoedRoutes, removeRouteById } from '@/systems/trade-system';
 import { advanceRouteRunners } from '@/systems/unit-movement-system';
 import { processWonderEffects } from '@/systems/wonder-system';
 import { createRng } from '@/systems/map-generator';
@@ -1213,11 +1213,22 @@ export function processTurn(
   // using the events that turn just emitted.
   const pendingCityFlips: GameEvents['espionage:city-flipped'][] = [];
   const unsubscribeCityFlip = bus.on('espionage:city-flipped', (evt) => pendingCityFlips.push(evt));
+  // intercept_courier (#442 MR1): same import-cycle reason as the city-flip collection
+  // above — trade-system.ts's removeRouteById can't be called from inside
+  // espionage-system.ts, so it's applied here from the event it emits.
+  const pendingCourierIntercepts: GameEvents['espionage:courier-intercepted'][] = [];
+  const unsubscribeCourierIntercept = bus.on('espionage:courier-intercepted', (evt) => pendingCourierIntercepts.push(evt));
   newState = processEspionageTurn(newState, bus);
   unsubscribeCityFlip();
+  unsubscribeCourierIntercept();
   for (const flip of pendingCityFlips) {
     if (newState.cities[flip.cityId]?.owner === flip.victimCivId) {
       newState = transferCapturedCityOwnership(newState, flip.cityId, flip.civId, newState.turn);
+    }
+  }
+  for (const intercept of pendingCourierIntercepts) {
+    if (newState.marketplace?.tradeRoutes.some(r => r.id === intercept.routeId)) {
+      newState = removeRouteById(newState, intercept.routeId, bus, 'espionage');
     }
   }
   newState = processDetection(newState, bus);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -888,7 +888,11 @@ export type SpyMissionType =
   | 'election_interference'
   | 'satellite_surveillance'
   // covert-operations tech (#526 MR7): human-initiated only, see chooseAiMission
-  | 'sabotage_relief';     // pause a rival's outbreak remedy for 4 turns; witnessed on discovery
+  | 'sabotage_relief'     // pause a rival's outbreak remedy for 4 turns; witnessed on discovery
+  // #442 MR1: black-chambers tech (era 5) — its own bucket, not folded into Stage 4
+  | 'intercept_courier'   // severs one active trade route touching the target city
+  // #442 MR1: diplomatic-networks tech (era 5) — its own bucket, not folded into Stage 4
+  | 'bribe_official';     // steals a capped share of the target civ's treasury
 
 export interface SpyMission {
   type: SpyMissionType;
@@ -2010,7 +2014,7 @@ export interface GameEvents {
   'diplomacy:treaty-broken': { breakerId: string; otherCiv: string; treaty: TreatyType };
   'advisor:message': { advisor: AdvisorType; message: string; icon: string; tone?: CouncilCallbackTone; memoryKey?: string };
   'trade:route-created': { route: TradeRoute };
-  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' | 'trips-exhausted' | 'unit-captured' };
+  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' | 'trips-exhausted' | 'unit-captured' | 'espionage' };
   'trade:route-delivered': { unitId: string; routeId: string; toCityId: string };
   'trade:price-changed': { resource: ResourceType; oldPrice: number; newPrice: number };
   'wonder:discovered': { civId: string; wonderId: string; position: HexCoord; isFirstDiscoverer: boolean };
@@ -2116,6 +2120,12 @@ export interface GameEvents {
   // detection roll at mission-success time) -- an undiscovered sabotage fires nothing,
   // per spec §Interactions "Undiscovered: no penalty."
   'espionage:sabotage-relief-discovered': { crisisId: string; actorCivId: string; targetCivId: string };
+  // #442 MR1 intercept_courier: espionage-system.ts cannot import trade-system.ts's
+  // removeRouteById directly (import cycle through city-system.ts, same reason
+  // 'espionage:city-flipped' is applied in turn-manager.ts rather than inline) — the
+  // caller subscribes to this event and performs the actual route removal.
+  'espionage:courier-intercepted': { civId: string; targetCivId: string; routeId: string; fromCityId: string; toCityId: string };
+  'espionage:official-bribed': { civId: string; targetCivId: string; amount: number };
 }
 
 // --- Crisis Events & Revolutionary Movements ---

--- a/src/presentation/register-espionage-presentation.ts
+++ b/src/presentation/register-espionage-presentation.ts
@@ -4,7 +4,7 @@
  * itself (`showEspionageCaptureChoice`) stays a `main.ts`-local function --
  * see `PresentationContext`'s doc comment for why.
  */
-import { routeCityFlipped, routeSabotageReliefDiscovered } from '@/ui/notification-routing';
+import { routeCityFlipped, routeSabotageReliefDiscovered, routeCourierIntercepted, routeOfficialBribed } from '@/ui/notification-routing';
 import type { PresentationRegistrar } from '@/presentation/register-all';
 
 export const registerEspionagePresentation: PresentationRegistrar = (bus, ctx) => {
@@ -63,6 +63,12 @@ export const registerEspionagePresentation: PresentationRegistrar = (bus, ctx) =
     }),
     bus.on('espionage:city-flipped', event => {
       routeCityFlipped(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('espionage:courier-intercepted', event => {
+      routeCourierIntercepted(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('espionage:official-bribed', event => {
+      routeOfficialBribed(ctx.session.getState(), event, ctx.notifier.deliver);
     }),
   ];
 

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -56,6 +56,8 @@ const MISSION_BASE_SUCCESS = {
   satellite_surveillance: 0.70,
   sabotage_relief: 0.60, // #526 MR7: reuses sabotage_production's detection parameters
   flip_loyalty: 0.40, // #524 MR2a: lowest tier alongside election_interference — outright city transfer, not a temporary effect
+  intercept_courier: 0.55, // #442 MR1: mid-stakes, comparable to forge_documents
+  bribe_official: 0.45, // #442 MR1: harder than intercept_courier — direct treasury theft, comparable to assassinate_advisor
 } as Record<SpyMissionType, number>;
 
 const MISSION_DURATIONS = {
@@ -77,6 +79,8 @@ const MISSION_DURATIONS = {
   satellite_surveillance: 1,
   sabotage_relief: 4, // #526 MR7: reuses sabotage_production's duration
   flip_loyalty: 8, // #524 MR2a: longest duration in the game, above fund_rebels/assassinate_advisor (6) — matches the stakes
+  intercept_courier: 4, // #442 MR1: matches sabotage_relief's setup window
+  bribe_official: 5, // #442 MR1: matches forge_documents — a slow social build, not a snap action
 } as Record<SpyMissionType, number>;
 
 // --- State creation ---
@@ -361,6 +365,12 @@ const STAGE_7_TECHS = ['cyber-intelligence'];        // era 12 — cyber operati
 // gating techs (cryptography/counter-intelligence) and gates only this one mission.
 const SABOTAGE_RELIEF_TECHS = ['covert-operations'];
 const PROPAGANDA_TECHS = ['propaganda']; // era 6 — gates flip_loyalty specifically, not the shared Stage 4 set
+// #442 MR1: black-chambers/diplomatic-networks (era 5) each get their own single-mission
+// bucket, same pattern as SABOTAGE_RELIEF_TECHS/PROPAGANDA_TECHS above — neither tech is
+// one of Stage 4's gating techs (cryptography/counter-intelligence), and each gates only
+// one mission.
+const INTERCEPT_COURIER_TECHS = ['black-chambers'];
+const BRIBE_OFFICIAL_TECHS = ['diplomatic-networks'];
 
 const STAGE_1_MISSIONS: SpyMissionType[] = ['scout_area', 'monitor_troops'];
 const STAGE_2_MISSIONS: SpyMissionType[] = ['gather_intel', 'identify_resources', 'monitor_diplomacy'];
@@ -371,6 +381,8 @@ const STAGE_6_MISSIONS: SpyMissionType[] = ['satellite_surveillance'];
 const STAGE_7_MISSIONS: SpyMissionType[] = ['cyber_attack'];
 const SABOTAGE_RELIEF_MISSIONS: SpyMissionType[] = ['sabotage_relief'];
 const PROPAGANDA_MISSIONS: SpyMissionType[] = ['flip_loyalty'];
+const INTERCEPT_COURIER_MISSIONS: SpyMissionType[] = ['intercept_courier'];
+const BRIBE_OFFICIAL_MISSIONS: SpyMissionType[] = ['bribe_official'];
 
 export function getAvailableMissions(completedTechs: string[]): SpyMissionType[] {
   const missions: SpyMissionType[] = [];
@@ -383,6 +395,8 @@ export function getAvailableMissions(completedTechs: string[]): SpyMissionType[]
   if (STAGE_7_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_7_MISSIONS);
   if (SABOTAGE_RELIEF_TECHS.some(t => completedTechs.includes(t))) missions.push(...SABOTAGE_RELIEF_MISSIONS);
   if (PROPAGANDA_TECHS.some(t => completedTechs.includes(t))) missions.push(...PROPAGANDA_MISSIONS);
+  if (INTERCEPT_COURIER_TECHS.some(t => completedTechs.includes(t))) missions.push(...INTERCEPT_COURIER_MISSIONS);
+  if (BRIBE_OFFICIAL_TECHS.some(t => completedTechs.includes(t))) missions.push(...BRIBE_OFFICIAL_MISSIONS);
   return missions;
 }
 
@@ -455,9 +469,11 @@ const PROMOTION_XP_THRESHOLD = 60;
 // Mission categories for auto-promotion
 const INFILTRATOR_MISSIONS = new Set<SpyMissionType>([
   'steal_tech', 'sabotage_production', 'assassinate_advisor', 'arms_smuggling', 'sabotage_relief',
+  'intercept_courier', // #442 MR1: physical/sabotage-flavored, matches this bucket's other entries
 ]);
 const HANDLER_MISSIONS = new Set<SpyMissionType>([
   'incite_unrest', 'forge_documents', 'fund_rebels', 'monitor_diplomacy', 'flip_loyalty',
+  'bribe_official', // #442 MR1: social/manipulation-flavored, matches this bucket's other entries
 ]);
 // Sentinel: everything else (intel, scouting, defensive)
 
@@ -480,6 +496,8 @@ const XP_PER_MISSION = {
   satellite_surveillance: 8,
   sabotage_relief: 12, // #526 MR7: matches sabotage_production's xp
   flip_loyalty: 20, // #524 MR2a: highest xp in the game, above assassinate_advisor (18)
+  intercept_courier: 14, // #442 MR1: matches misinformation_campaign's tier
+  bribe_official: 16, // #442 MR1: matches election_interference's tier — high-value theft
 } as Record<SpyMissionType, number>;
 
 const EXPULSION_COOLDOWN = 5;
@@ -646,10 +664,22 @@ export interface MissionResult {
   // (non-capital, still owned by targetCivId).
   flippedCityId?: string;
   flippedFromCivId?: string;
+  // intercept_courier (#442 MR1): the trade route to sever, if the target city has one.
+  // Actual removal happens in turn-manager.ts — see 'espionage:courier-intercepted'.
+  interceptedRouteId?: string;
+  interceptedFromCityId?: string;
+  interceptedToCityId?: string;
+  // bribe_official (#442 MR1): capped gold transfer from the target's treasury.
+  bribedGoldAmount?: number;
 }
 
 const SCOUT_VISION_RADIUS = 3;
 const TROOP_MONITOR_RADIUS = 4;
+// #442 MR1 bribe_official: capped both as a fraction and an absolute amount so a single
+// mission can't cripple a civ's treasury in one hit (game-balance.md "never permanently
+// cripple a city/civ from one successful spy action").
+const BRIBE_GOLD_FRACTION = 0.15;
+const BRIBE_GOLD_CAP = 200;
 
 export function resolveMissionResult(
   missionType: SpyMissionType,
@@ -795,6 +825,38 @@ export function resolveMissionResult(
 
     case 'counter_espionage': {
       return {}; // passive — handled by assignSpyDefensive
+    }
+
+    // intercept_courier (#442 MR1): pick the highest-value route touching the target
+    // city (either endpoint) — deterministic so the UI's advertised effect ("severs a
+    // trade route") is predictable rather than random among several. No eligible route
+    // (city has no active trade) means no effect, same "not always optimal" shape as
+    // fund_rebels' unrestLevel guard above.
+    case 'intercept_courier': {
+      const targetCity = gameState.cities[targetCityId];
+      if (!targetCity || targetCity.owner !== targetCivId) return {};
+      const routes = (gameState.marketplace?.tradeRoutes ?? []).filter(
+        r => r.fromCityId === targetCityId || r.toCityId === targetCityId,
+      );
+      if (routes.length === 0) return {};
+      const route = [...routes].sort(
+        (a, b) => b.goldPerTrip - a.goldPerTrip || a.id.localeCompare(b.id),
+      )[0];
+      return {
+        interceptedRouteId: route.id,
+        interceptedFromCityId: route.fromCityId,
+        interceptedToCityId: route.toCityId,
+      };
+    }
+
+    // bribe_official (#442 MR1): a target with no gold has nothing to steal — no effect,
+    // matching fund_rebels' eligibility-guard shape.
+    case 'bribe_official': {
+      const targetCiv = gameState.civilizations[targetCivId];
+      if (!targetCiv || targetCiv.gold <= 0) return {};
+      const amount = Math.min(Math.round(targetCiv.gold * BRIBE_GOLD_FRACTION), BRIBE_GOLD_CAP);
+      if (amount <= 0) return {};
+      return { bribedGoldAmount: amount };
     }
 
     case 'assassinate_advisor': {
@@ -1509,6 +1571,52 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
               const hostileUnit = createUnit('warrior', 'rebels', pos, state.idCounters);
               state = { ...state, units: { ...state.units, [hostileUnit.id]: hostileUnit } };
               bus.emit('unit:created', { unit: hostileUnit });
+            }
+          }
+
+          // intercept_courier (#442 MR1): the actual route removal happens in
+          // turn-manager.ts (subscribed to 'espionage:courier-intercepted'), via
+          // trade-system.ts's existing removeRouteById -- espionage-system.ts cannot
+          // import trade-system.ts directly (trade-system -> city-system ->
+          // espionage-system is a real cycle, same reason flip_loyalty's transfer above
+          // is applied by the caller instead of here).
+          if (evt.missionType === 'intercept_courier' && result.interceptedRouteId) {
+            const originalSpy = civEspBefore.spies[evt.spyId];
+            const targetCivId = originalSpy?.targetCivId;
+            if (targetCivId) {
+              bus.emit('espionage:courier-intercepted', {
+                civId,
+                targetCivId,
+                routeId: result.interceptedRouteId,
+                fromCityId: result.interceptedFromCityId!,
+                toCityId: result.interceptedToCityId!,
+              });
+            }
+          }
+
+          // bribe_official (#442 MR1): direct bilateral gold transfer — no import-cycle
+          // concern (both civilizations are plain state already on GameState), so this
+          // applies inline like cyber_attack/misinformation_campaign above.
+          if (evt.missionType === 'bribe_official' && result.bribedGoldAmount) {
+            const originalSpy = civEspBefore.spies[evt.spyId];
+            const targetCivId = originalSpy?.targetCivId;
+            const amount = result.bribedGoldAmount as number;
+            if (targetCivId && state.civilizations[targetCivId] && state.civilizations[civId]) {
+              state = {
+                ...state,
+                civilizations: {
+                  ...state.civilizations,
+                  [targetCivId]: {
+                    ...state.civilizations[targetCivId],
+                    gold: Math.max(0, state.civilizations[targetCivId].gold - amount),
+                  },
+                  [civId]: {
+                    ...state.civilizations[civId],
+                    gold: state.civilizations[civId].gold + amount,
+                  },
+                },
+              };
+              bus.emit('espionage:official-bribed', { civId, targetCivId, amount });
             }
           }
 

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -126,10 +126,10 @@ const ERA_5_TECHS: Tech[] = [
   // ESPIONAGE (2)
   { id: 'black-chambers', name: 'Black Chambers', track: 'espionage', cost: 155,
     prerequisites: ['cryptography', 'counter-intelligence'],
-    unlocks: ['+1 spy slot empire-wide'], era: 5 },
+    unlocks: ['+1 spy slot empire-wide', 'Spy mission: intercept a courier and sever one of a rival city\'s trade routes'], era: 5 },
   { id: 'diplomatic-networks', name: 'Diplomatic Networks', track: 'espionage', cost: 100,
     prerequisites: ['counter-intelligence'],
-    unlocks: ['Spy missions in foreign capitals have +20% success rate', 'Reveal detailed crisis intelligence on civilizations you have met'], era: 5 },
+    unlocks: ['Spy missions in foreign capitals have +20% success rate', 'Reveal detailed crisis intelligence on civilizations you have met', 'Spy mission: bribe a foreign official to steal gold from their treasury'], era: 5 },
 
   // SPIRITUALITY (2)
   { id: 'reformation', name: 'Reformation', track: 'spirituality', cost: 100,

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -377,7 +377,7 @@ export function removeRouteById(
   state: GameState,
   routeId: string,
   bus: EventBus | undefined,
-  reason: 'war-declared' | 'hostile-relations' | 'embargo',
+  reason: 'war-declared' | 'hostile-relations' | 'embargo' | 'espionage',
 ): GameState {
   const route = state.marketplace?.tradeRoutes.find(r => r.id === routeId);
   if (!route) return state;

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -1,6 +1,6 @@
 // src/ui/espionage-panel.ts
 import type { AdvisorType, GameState, Spy, SpyMissionType, SpyPromotion, InterrogationIntel } from '../core/types';
-import { getAvailableMissions, getEspionageModifierBreakdown, getSpySuccessChance, missionRequiresPlacedSpy } from '../systems/espionage-system';
+import { getAvailableMissions, getEspionageModifierBreakdown, getMissionDuration, getSpySuccessChance, missionRequiresPlacedSpy } from '../systems/espionage-system';
 import { getProductionLabel } from '../systems/economy-system';
 
 export interface MissionCatalogEntry {
@@ -8,6 +8,8 @@ export interface MissionCatalogEntry {
   label: string;
   stage: 1 | 2 | 3 | 4 | 5;
   accessLabel: string;
+  description: string;
+  durationTurns: number;
 }
 
 export interface SpySummary {
@@ -88,6 +90,39 @@ const MISSION_LABELS: Record<SpyMissionType, string> = {
   election_interference: 'Election Interference',
   satellite_surveillance: 'Satellite Surveillance',
   sabotage_relief: 'Sabotage Relief',
+  intercept_courier: 'Intercept Courier',
+  bribe_official: 'Bribe Official',
+};
+
+// #442 MR1 review: the mission catalog previously showed only a label, stage tag, and
+// access tag — no plain-language effect text anywhere, for any mission (not just the two
+// added here). That fails CLAUDE.md's "all UI elements must be self-explanatory" rule and
+// the precedent set by world-pressure interactions ("cost, effect, and risk inline at the
+// point of choice" — docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md).
+// Fixed for the whole catalog rather than just the two new missions, so descriptions don't
+// appear inconsistently between old and new entries.
+const MISSION_DESCRIPTIONS: Record<SpyMissionType, string> = {
+  scout_area: 'Reveals the fog of war around the target city.',
+  monitor_troops: 'Reveals enemy unit positions and strength near the target city.',
+  gather_intel: "Reveals the target's tech progress, treasury, and treaties.",
+  identify_resources: "Reveals strategic resources in the target city's territory.",
+  monitor_diplomacy: "Reveals the target's relationships and trade partners.",
+  steal_tech: "Copies one technology the target has that you don't.",
+  sabotage_production: "Destroys several turns of the target city's production progress.",
+  incite_unrest: 'Increases unrest in the target city.',
+  counter_espionage: 'Passively strengthens counter-intelligence in the defending city.',
+  assassinate_advisor: 'Disables one of the target empire\'s advisors for 10 turns.',
+  forge_documents: 'Frames the target, damaging their relationship with another civilization.',
+  fund_rebels: 'Escalates unrest further in an already-unstable city.',
+  arms_smuggling: 'Spawns a hostile armed group near the target city.',
+  flip_loyalty: 'Peacefully defects a non-capital foreign city to your empire.',
+  cyber_attack: "Disables the target city's production for several turns.",
+  misinformation_campaign: "Slows the target empire's research for several turns.",
+  election_interference: 'Injects unrest and political instability into the target city.',
+  satellite_surveillance: "Grants ongoing vision of the target empire's territory.",
+  sabotage_relief: "Delays a rival's crisis relief; witnessed civilizations notice if discovered.",
+  intercept_courier: "Severs the target city's most valuable active trade route.",
+  bribe_official: "Steals a capped share of the target empire's treasury.",
 };
 
 const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
@@ -110,6 +145,8 @@ const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
   election_interference: 5,
   satellite_surveillance: 5,
   sabotage_relief: 5, // covert-operations is era 7, same UI bucket as the other era 5-7 missions
+  intercept_courier: 4, // #442 MR1: black-chambers is era 5, same "Shadow Operations" UI bucket as flip_loyalty/other era 5-6 Stage 4 missions
+  bribe_official: 4, // #442 MR1: diplomatic-networks is era 5, same UI bucket as above
 };
 
 function toMissionCatalog(missions: SpyMissionType[]): MissionCatalogEntry[] {
@@ -118,6 +155,8 @@ function toMissionCatalog(missions: SpyMissionType[]): MissionCatalogEntry[] {
     label: MISSION_LABELS[mission],
     stage: MISSION_STAGE[mission],
     accessLabel: missionRequiresPlacedSpy(mission) ? 'Requires placed spy' : 'Remote-capable',
+    description: MISSION_DESCRIPTIONS[mission],
+    durationTurns: getMissionDuration(mission),
   }));
 }
 
@@ -212,26 +251,39 @@ function appendMissionStage(
     section.appendChild(empty);
   } else {
     const list = createEl('div');
-    list.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;';
+    list.style.cssText = 'display:flex;flex-direction:column;gap:6px;';
     for (const mission of group.missions) {
       const item = createEl('div');
       item.dataset.missionId = mission.id;
-      item.style.cssText = 'display:flex;align-items:center;gap:6px;padding:6px 10px;border-radius:8px;background:rgba(255,255,255,0.06);font-size:11px;';
-      item.appendChild(createEl('span', mission.label));
+      item.style.cssText = 'display:flex;flex-direction:column;gap:3px;padding:6px 10px;border-radius:8px;background:rgba(255,255,255,0.06);font-size:11px;';
+
+      const topRow = createEl('div');
+      topRow.style.cssText = 'display:flex;align-items:center;flex-wrap:wrap;gap:6px;';
+      topRow.appendChild(createEl('span', mission.label));
       const stageTag = createEl('span', `S${mission.stage}`);
       stageTag.style.cssText = 'color:#e8c170;font-size:10px;font-weight:700;';
-      item.appendChild(stageTag);
+      topRow.appendChild(stageTag);
       const accessTag = createEl('span', mission.accessLabel);
       accessTag.style.cssText = 'color:#9dd1ff;font-size:10px;';
-      item.appendChild(accessTag);
+      topRow.appendChild(accessTag);
+      const durationTag = createEl('span', `${mission.durationTurns} turn${mission.durationTurns === 1 ? '' : 's'}`);
+      durationTag.style.cssText = 'color:#b8bfd0;font-size:10px;';
+      topRow.appendChild(durationTag);
       if (successChances && successChances[mission.id] !== undefined) {
         const pct = Math.round((successChances[mission.id] as number) * 100);
         const pctTag = createEl('span', `${pct}%`);
         pctTag.style.cssText = 'color:#7cff8a;font-size:10px;font-weight:700;';
         const breakdown = successBreakdown?.[mission.id];
         if (breakdown) pctTag.title = `Modifiers: ${breakdown}`;
-        item.appendChild(pctTag);
+        topRow.appendChild(pctTag);
       }
+      item.appendChild(topRow);
+
+      const descriptionEl = createEl('div', mission.description);
+      descriptionEl.dataset.missionDescription = 'true';
+      descriptionEl.style.cssText = 'font-size:10px;opacity:0.75;line-height:1.3;';
+      item.appendChild(descriptionEl);
+
       list.appendChild(item);
     }
     section.appendChild(list);

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -752,6 +752,40 @@ export function routeSabotageReliefDiscovered(
 // processEspionageTurn returns, before any listener runs. Both sides must be told: the
 // victim especially, since losing a city with zero in-game feedback (the original gap
 // this router closes) is far worse than any other espionage consequence.
+// intercept_courier (#442 MR1): mirrors routeSabotageReliefDiscovered's shape — the
+// route is already gone by the time this fires (turn-manager.ts applies removeRouteById
+// right after processEspionageTurn returns, before any listener runs), so both sides
+// need telling: the victim especially, since a silently vanished trade route with zero
+// feedback is exactly the "invisible consequence" pattern the brief warns against.
+export function routeCourierIntercepted(
+  state: GameState,
+  event: GameEvents['espionage:courier-intercepted'],
+  sink: NotificationSink,
+): void {
+  const fromCity = state.cities[event.fromCityId];
+  const toCity = state.cities[event.toCityId];
+  const routeLabel = fromCity && toCity ? `${fromCity.name} – ${toCity.name}` : 'a trade route';
+  const actorName = state.civilizations[event.civId]?.name ?? 'A rival';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a rival';
+
+  sink(event.targetCivId, `${actorName}'s spies intercepted a courier, severing the ${routeLabel} trade route!`, 'warning');
+  sink(event.civId, `Your spy intercepted a courier, severing ${targetName}'s ${routeLabel} trade route.`, 'success');
+}
+
+// bribe_official (#442 MR1): same both-sides pattern — the victim needs to know their
+// treasury dropped, and the exact amount, so a sudden gold loss doesn't read as a bug.
+export function routeOfficialBribed(
+  state: GameState,
+  event: GameEvents['espionage:official-bribed'],
+  sink: NotificationSink,
+): void {
+  const actorName = state.civilizations[event.civId]?.name ?? 'A rival';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a rival';
+
+  sink(event.targetCivId, `${actorName}'s spies bribed an official and siphoned ${event.amount} gold from your treasury!`, 'warning');
+  sink(event.civId, `Your spy bribed an official in ${targetName}'s court, siphoning ${event.amount} gold into your treasury.`, 'success');
+}
+
 export function routeCityFlipped(
   state: GameState,
   event: GameEvents['espionage:city-flipped'],

--- a/tests/ai/ai-espionage.test.ts
+++ b/tests/ai/ai-espionage.test.ts
@@ -210,6 +210,39 @@ describe('AI espionage decisions', () => {
       const mission = chooseAiMission(state, 'ai-egypt');
       expect(mission).not.toBe('flip_loyalty');
     });
+
+    // #442 MR1
+    it('aggressive civs choose intercept_courier once black-chambers is researched (no higher-priority mission available)', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'annuvin';
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting', 'black-chambers'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('intercept_courier');
+    });
+
+    it('aggressive civs choose bribe_official once diplomatic-networks is researched (no higher-priority mission available)', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'annuvin';
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting', 'diplomatic-networks'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('bribe_official');
+    });
+
+    it('intercept_courier/bribe_official are unavailable without their gating techs', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).not.toBe('intercept_courier');
+      expect(mission).not.toBe('bribe_official');
+    });
+
+    it('diplomatic civs prefer bribe_official over intercept_courier when both are available', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'greece';
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting', 'black-chambers', 'diplomatic-networks'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('bribe_official');
+    });
   });
 
   // #526 MR7 review fix: infiltrated (embedded) spies pick their next mission via a

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1516,6 +1516,62 @@ describe('espionage post-loop snapshot', () => {
   });
 });
 
+describe('intercept_courier turn-manager wiring (#442 MR1)', () => {
+  it('actually removes the intercepted trade route via processTurn, end to end', async () => {
+    const { startMission, createEspionageCivState } = await import('@/systems/espionage-system');
+
+    let succeeded = false;
+    for (let attempt = 1; attempt <= 200 && !succeeded; attempt++) {
+      let state = createNewGame(undefined, `intercept-courier-turnmgr-${attempt}`, 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const startPos = state.units[state.civilizations[targetCivId].units[0]].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      const otherCity = foundCity(targetCivId, { q: startPos.q + 6, r: startPos.r }, state.map, state.idCounters);
+
+      state = {
+        ...state,
+        turn: attempt,
+        cities: { ...state.cities, [city.id]: city, [otherCity.id]: otherCity },
+        civilizations: {
+          ...state.civilizations,
+          [targetCivId]: { ...state.civilizations[targetCivId], cities: [city.id, otherCity.id] },
+        },
+        marketplace: {
+          ...state.marketplace!,
+          tradeRoutes: [
+            { id: 'route-only', fromCityId: city.id, toCityId: otherCity.id, goldPerTrip: 40, turnsPerTrip: 4 },
+          ],
+        },
+        espionage: {
+          player: {
+            ...createEspionageCivState(),
+            spies: {
+              'spy-1': {
+                id: 'spy-1', owner: 'player', name: 'Agent Shadow', unitType: 'spy_scout' as UnitType,
+                targetCivId, targetCityId: city.id, position: city.position,
+                status: 'stationed', experience: 0, currentMission: null, cooldownTurns: 0,
+                promotionAvailable: false, feedsFalseIntel: false, stolenTechFrom: {},
+              },
+            },
+          },
+          [targetCivId]: createEspionageCivState(),
+        },
+      };
+      state.espionage!.player.spies['spy-1'] = startMission(state.espionage!.player, 'spy-1', 'intercept_courier').spies['spy-1'];
+      state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+      const bus = new EventBus();
+      const result = processTurn(state, bus);
+
+      if (result.marketplace!.tradeRoutes.find(r => r.id === 'route-only') === undefined
+          && result.marketplace!.tradeRoutes.length === 0) {
+        succeeded = true;
+      }
+    }
+    expect(succeeded).toBe(true);
+  });
+});
+
 describe('journey automation', () => {
   function makeJourneyFixture(start: HexCoord, destination: HexCoord): { state: GameState; unitId: string } {
     const map = createWrappedGrasslandMap(6, 3);

--- a/tests/presentation/register-espionage-presentation.test.ts
+++ b/tests/presentation/register-espionage-presentation.test.ts
@@ -108,6 +108,32 @@ describe('espionage presentation', () => {
     expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning');
   });
 
+  it('notifies both civs when a courier is intercepted (#442 MR1)', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext({
+      state: { cities: { 'city-a': { name: 'Utica' }, 'city-b': { name: 'Carthago Nova' } } as never },
+    });
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:courier-intercepted', {
+      civId: 'rome', targetCivId: 'carthage', routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-b',
+    });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning');
+  });
+
+  it('notifies both civs of the exact amount when an official is bribed (#442 MR1)', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:official-bribed', { civId: 'rome', targetCivId: 'carthage', amount: 42 });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.stringContaining('42'), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('42'), 'warning');
+  });
+
   it('disposing removes every subscription this registrar added', () => {
     const bus = new EventBus();
     const ctx = makePresentationContext({
@@ -124,6 +150,8 @@ describe('espionage presentation', () => {
     bus.emit('espionage:spy-expired', { civId: 'rome', spyId: 'spy-1', spyName: 'Agent X', unitType: 'spy' as never });
     bus.emit('espionage:spy-auto-exfiltrated', { civId: 'rome', spyId: 'spy-1', cityId: 'city-a' });
     bus.emit('espionage:city-flipped', { civId: 'rome', victimCivId: 'carthage', cityId: 'city-a' });
+    bus.emit('espionage:courier-intercepted', { civId: 'rome', targetCivId: 'carthage', routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-a' });
+    bus.emit('espionage:official-bribed', { civId: 'rome', targetCivId: 'carthage', amount: 42 });
 
     expect(ctx.deliver).not.toHaveBeenCalled();
     expect(ctx.showEspionageCaptureChoice).not.toHaveBeenCalled();

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -895,6 +895,242 @@ describe('flip_loyalty gating and end-to-end resolution (#524 MR2a)', () => {
   });
 });
 
+describe('era 5 missions — intercept_courier and bribe_official (#442 MR1)', () => {
+  it('black-chambers gates intercept_courier (unavailable without the tech, available with it)', () => {
+    expect(getAvailableMissions([])).not.toContain('intercept_courier');
+    expect(getAvailableMissions(['black-chambers'])).toContain('intercept_courier');
+  });
+
+  it('diplomatic-networks gates bribe_official (unavailable without the tech, available with it)', () => {
+    expect(getAvailableMissions([])).not.toContain('bribe_official');
+    expect(getAvailableMissions(['diplomatic-networks'])).toContain('bribe_official');
+  });
+
+  it('intercept_courier and bribe_official each require a placed (stationed) spy', () => {
+    expect(missionRequiresPlacedSpy('intercept_courier')).toBe(true);
+    expect(missionRequiresPlacedSpy('bribe_official')).toBe(true);
+  });
+
+  describe('resolveMissionResult — intercept_courier', () => {
+    function makeRouteState(): GameState {
+      let state = createNewGame(undefined, 'intercept-courier-fixture', 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const startPos = state.units[state.civilizations[targetCivId].units[0]].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      const otherCity = foundCity(targetCivId, { q: startPos.q + 6, r: startPos.r }, state.map, state.idCounters);
+      state = {
+        ...state,
+        cities: { ...state.cities, [city.id]: city, [otherCity.id]: otherCity },
+        civilizations: {
+          ...state.civilizations,
+          [targetCivId]: { ...state.civilizations[targetCivId], cities: [city.id, otherCity.id] },
+        },
+        marketplace: {
+          ...state.marketplace!,
+          tradeRoutes: [
+            { id: 'route-low', fromCityId: city.id, toCityId: otherCity.id, goldPerTrip: 20, turnsPerTrip: 4 },
+            { id: 'route-high', fromCityId: otherCity.id, toCityId: city.id, goldPerTrip: 80, turnsPerTrip: 4 },
+            { id: 'route-unrelated', fromCityId: otherCity.id, toCityId: otherCity.id, goldPerTrip: 999, turnsPerTrip: 4 },
+          ],
+        },
+      };
+      return { state, targetCivId, cityId: city.id, otherCityId: otherCity.id } as unknown as GameState & {
+        targetCivId: string; cityId: string; otherCityId: string;
+      };
+    }
+
+    it('picks the highest-value route touching the target city, ignoring unrelated routes', () => {
+      const fixture = makeRouteState() as any;
+      const result = resolveMissionResult(
+        'intercept_courier', fixture.targetCivId, fixture.cityId, fixture.state, 'player', 'spy-1',
+      );
+      expect(result.interceptedRouteId).toBe('route-high');
+      expect(result.interceptedFromCityId).toBe(fixture.otherCityId);
+      expect(result.interceptedToCityId).toBe(fixture.cityId);
+    });
+
+    it('has no effect when the target city has no active trade route', () => {
+      const fixture = makeRouteState() as any;
+      fixture.state.marketplace.tradeRoutes = [];
+      const result = resolveMissionResult(
+        'intercept_courier', fixture.targetCivId, fixture.cityId, fixture.state, 'player', 'spy-1',
+      );
+      expect(result.interceptedRouteId).toBeUndefined();
+    });
+
+    it('has no effect when the target city no longer belongs to the named target civ', () => {
+      const fixture = makeRouteState() as any;
+      const result = resolveMissionResult(
+        'intercept_courier', 'someone-else', fixture.cityId, fixture.state, 'player', 'spy-1',
+      );
+      expect(result.interceptedRouteId).toBeUndefined();
+    });
+  });
+
+  describe('resolveMissionResult — bribe_official', () => {
+    it('steals 15% of the target treasury, uncapped case', () => {
+      const state = { civilizations: { rival: { gold: 100 } }, cities: {} } as unknown as GameState;
+      const result = resolveMissionResult('bribe_official', 'rival', 'city-x', state, 'player', 'spy-1');
+      expect(result.bribedGoldAmount).toBe(15);
+    });
+
+    it('caps the theft at 200 gold regardless of a larger treasury', () => {
+      const state = { civilizations: { rival: { gold: 100000 } }, cities: {} } as unknown as GameState;
+      const result = resolveMissionResult('bribe_official', 'rival', 'city-x', state, 'player', 'spy-1');
+      expect(result.bribedGoldAmount).toBe(200);
+    });
+
+    it('has no effect against a civ with no gold', () => {
+      const state = { civilizations: { rival: { gold: 0 } }, cities: {} } as unknown as GameState;
+      const result = resolveMissionResult('bribe_official', 'rival', 'city-x', state, 'player', 'spy-1');
+      expect(result.bribedGoldAmount).toBeUndefined();
+    });
+  });
+
+  describe('intercept_courier end-to-end resolution', () => {
+    function makeCourierFixture() {
+      let state = createNewGame(undefined, 'intercept-courier-e2e', 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const startPos = state.units[state.civilizations[targetCivId].units[0]].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      const otherCity = foundCity(targetCivId, { q: startPos.q + 6, r: startPos.r }, state.map, state.idCounters);
+      state = {
+        ...state,
+        cities: { ...state.cities, [city.id]: city, [otherCity.id]: otherCity },
+        civilizations: {
+          ...state.civilizations,
+          [targetCivId]: { ...state.civilizations[targetCivId], cities: [city.id, otherCity.id] },
+        },
+        marketplace: {
+          ...state.marketplace!,
+          tradeRoutes: [
+            { id: 'route-only', fromCityId: city.id, toCityId: otherCity.id, goldPerTrip: 40, turnsPerTrip: 4 },
+          ],
+        },
+        espionage: {
+          player: {
+            ...createEspionageCivState(),
+            spies: {
+              'spy-1': makeTestSpy('spy-1', 'player', {
+                status: 'stationed', targetCivId, targetCityId: city.id, position: city.position,
+              }),
+            },
+          },
+          [targetCivId]: createEspionageCivState(),
+        },
+      };
+      return { state, targetCivId, cityId: city.id };
+    }
+
+    it('emits espionage:courier-intercepted with the severed route on success, mirroring the turn-manager removal glue', () => {
+      const { state: baseState, targetCivId } = makeCourierFixture();
+      let succeeded = false;
+      for (let turn = 1; turn <= 200 && !succeeded; turn++) {
+        const state: GameState = {
+          ...baseState,
+          turn,
+          espionage: {
+            ...baseState.espionage!,
+            player: {
+              ...baseState.espionage!.player,
+              spies: {
+                'spy-1': startMission(baseState.espionage!.player, 'spy-1', 'intercept_courier').spies['spy-1'],
+              },
+            },
+          },
+        };
+        state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+        const bus = new EventBus();
+        const pendingIntercepts: Array<{ civId: string; targetCivId: string; routeId: string }> = [];
+        bus.on('espionage:courier-intercepted', evt => pendingIntercepts.push(evt));
+        let result = processEspionageTurn(state, bus);
+        // Mirrors turn-manager.ts's removeRouteById glue (same import-cycle reason as
+        // flip_loyalty's transferCapturedCityOwnership above).
+        for (const intercept of pendingIntercepts) {
+          result = {
+            ...result,
+            marketplace: {
+              ...result.marketplace!,
+              tradeRoutes: result.marketplace!.tradeRoutes.filter(r => r.id !== intercept.routeId),
+            },
+          };
+        }
+
+        if (pendingIntercepts.length > 0) {
+          succeeded = true;
+          expect(pendingIntercepts).toHaveLength(1);
+          expect(pendingIntercepts[0].targetCivId).toBe(targetCivId);
+          expect(pendingIntercepts[0].civId).toBe('player');
+          expect(result.marketplace!.tradeRoutes.find(r => r.id === 'route-only')).toBeUndefined();
+        }
+      }
+      expect(succeeded).toBe(true);
+    });
+  });
+
+  describe('bribe_official end-to-end resolution', () => {
+    function makeBribeFixture() {
+      let state = createNewGame(undefined, 'bribe-official-e2e', 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const startPos = state.units[state.civilizations[targetCivId].units[0]].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      state = {
+        ...state,
+        cities: { ...state.cities, [city.id]: city },
+        civilizations: {
+          ...state.civilizations,
+          player: { ...state.civilizations.player, gold: 0 },
+          [targetCivId]: { ...state.civilizations[targetCivId], cities: [city.id], gold: 100 },
+        },
+        espionage: {
+          player: {
+            ...createEspionageCivState(),
+            spies: {
+              'spy-1': makeTestSpy('spy-1', 'player', {
+                status: 'stationed', targetCivId, targetCityId: city.id, position: city.position,
+              }),
+            },
+          },
+          [targetCivId]: createEspionageCivState(),
+        },
+      };
+      return { state, targetCivId };
+    }
+
+    it('transfers 15% of the target treasury to the acting civ on success', () => {
+      const { state: baseState, targetCivId } = makeBribeFixture();
+      let succeeded = false;
+      for (let turn = 1; turn <= 200 && !succeeded; turn++) {
+        const state: GameState = {
+          ...baseState,
+          turn,
+          espionage: {
+            ...baseState.espionage!,
+            player: {
+              ...baseState.espionage!.player,
+              spies: {
+                'spy-1': startMission(baseState.espionage!.player, 'spy-1', 'bribe_official').spies['spy-1'],
+              },
+            },
+          },
+        };
+        state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+        const bus = new EventBus();
+        const result = processEspionageTurn(state, bus);
+
+        if (result.civilizations.player.gold > 0) {
+          succeeded = true;
+          expect(result.civilizations.player.gold).toBe(15);
+          expect(result.civilizations[targetCivId].gold).toBe(85);
+        }
+      }
+      expect(succeeded).toBe(true);
+    });
+  });
+});
+
 describe('espionage diplomatic consequences', () => {
   describe('handleSpyExpelled', () => {
     it('reduces relationship between spy owner and detecting civ', () => {

--- a/tests/ui/espionage-panel.test.ts
+++ b/tests/ui/espionage-panel.test.ts
@@ -260,6 +260,80 @@ describe('espionage-panel', () => {
       expect(allMissionIds).not.toContain('flip_loyalty');
     });
 
+    // #442 MR1
+    it('shows intercept_courier in the Stage 4 group once black-chambers is researched', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['black-chambers'];
+      const view = getEspionagePanelViewModel(state);
+      const stage4 = view.missionStages.find(s => s.stage === 4)!;
+      expect(stage4.missions.some(m => m.id === 'intercept_courier')).toBe(true);
+      expect(stage4.missions.find(m => m.id === 'intercept_courier')!.label).toBe('Intercept Courier');
+    });
+
+    it('shows bribe_official in the Stage 4 group once diplomatic-networks is researched', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['diplomatic-networks'];
+      const view = getEspionagePanelViewModel(state);
+      const stage4 = view.missionStages.find(s => s.stage === 4)!;
+      expect(stage4.missions.some(m => m.id === 'bribe_official')).toBe(true);
+      expect(stage4.missions.find(m => m.id === 'bribe_official')!.label).toBe('Bribe Official');
+    });
+
+    // #442 MR1 review: the mission catalog must be self-explanatory (CLAUDE.md "all UI
+    // elements must be self-explanatory") — every entry needs a plain-language effect
+    // description and its duration, not just a label.
+    it('every mission in the catalog has a non-empty description and a positive duration', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = [
+        'espionage-scouting', 'espionage-informants', 'spy-networks', 'cryptography',
+        'black-chambers', 'diplomatic-networks', 'propaganda', 'covert-operations',
+      ];
+      const view = getEspionagePanelViewModel(state);
+      const allMissions = view.missionStages.flatMap(s => s.missions);
+      expect(allMissions.length).toBeGreaterThan(0);
+      for (const mission of allMissions) {
+        expect(mission.description.length).toBeGreaterThan(0);
+        expect(mission.durationTurns).toBeGreaterThan(0);
+      }
+    });
+
+    it('intercept_courier and bribe_official describe their actual effect', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['black-chambers', 'diplomatic-networks'];
+      const view = getEspionagePanelViewModel(state);
+      const allMissions = view.missionStages.flatMap(s => s.missions);
+      const courier = allMissions.find(m => m.id === 'intercept_courier')!;
+      const bribe = allMissions.find(m => m.id === 'bribe_official')!;
+      expect(courier.description.toLowerCase()).toContain('trade route');
+      expect(courier.durationTurns).toBe(4);
+      expect(bribe.description.toLowerCase()).toContain('treasury');
+      expect(bribe.durationTurns).toBe(5);
+    });
+
+    it('does not show intercept_courier or bribe_official before their gating techs', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = [];
+      const view = getEspionagePanelViewModel(state);
+      const allMissionIds = view.missionStages.flatMap(s => s.missions.map(m => m.id));
+      expect(allMissionIds).not.toContain('intercept_courier');
+      expect(allMissionIds).not.toContain('bribe_official');
+    });
+
+    // #442 MR1: a same-shape hot-seat check for the two new missions — an in-progress
+    // intercept_courier/bribe_official mission belonging to another civ (e.g. an AI, or
+    // another human in the same hot-seat game) must not surface in this civ's panel data.
+    it('does not expose another civ\'s in-progress intercept_courier or bribe_official mission', () => {
+      const state = makeEspUiState();
+      const aiSpy = makeTestSpy('spy-ai-2', 'ai-egypt', {
+        status: 'on_mission',
+        currentMission: { type: 'bribe_official', turnsRemaining: 2, turnsTotal: 5, targetCivId: 'player', targetCityId: 'city-player-1' },
+      });
+      state.espionage!['ai-egypt'] = addSpy(state.espionage!['ai-egypt'], aiSpy);
+      const data = getEspionagePanelData(state);
+      expect(data.spySummaries.some(s => s.id === 'spy-ai-2')).toBe(false);
+      expect(data.spies.every(s => s.id !== 'spy-ai-2')).toBe(true);
+    });
+
     it('never exposes other players spy data', () => {
       const state = makeEspUiState();
       const aiSpy = makeTestSpy('spy-ai-1', 'ai-egypt');

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -28,6 +28,8 @@ import {
   routeOpportunisticWar,
   routeSabotageReliefDiscovered,
   routeCityFlipped,
+  routeCourierIntercepted,
+  routeOfficialBribed,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -1072,6 +1074,74 @@ describe('espionage:city-flipped routing (#524 MR2a review fix)', () => {
     const { sink, calls } = makeSink();
     routeCityFlipped(flipState(), { civId: 'rome', victimCivId: 'unknown-civ', cityId: 'city-1' }, sink);
     expect(calls.every(c => typeof c.message === 'string' && c.message.length > 0)).toBe(true);
+  });
+});
+
+describe('espionage:courier-intercepted routing (#442 MR1)', () => {
+  function courierState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+      } as any,
+      cities: {
+        'city-1': { id: 'city-1', name: 'Utica', owner: 'carthage', position: { q: 0, r: 0 } },
+        'city-2': { id: 'city-2', name: 'Carthago Nova', owner: 'carthage', position: { q: 1, r: 0 } },
+      } as any,
+    });
+  }
+
+  it('notifies both the intercepting civ and the victim civ, with distinct messages naming the route', () => {
+    const { sink, calls } = makeSink();
+    routeCourierIntercepted(
+      courierState(),
+      { civId: 'rome', targetCivId: 'carthage', routeId: 'route-1', fromCityId: 'city-1', toCityId: 'city-2' },
+      sink,
+    );
+    expect(calls).toHaveLength(2);
+    const romeCall = calls.find(c => c.civId === 'rome')!;
+    const carthageCall = calls.find(c => c.civId === 'carthage')!;
+    expect(romeCall.message).toContain('Utica');
+    expect(romeCall.message).toContain('Carthage');
+    expect(romeCall.type).toBe('success');
+    expect(carthageCall.message).toContain('Utica');
+    expect(carthageCall.message).toContain('Rome');
+    expect(carthageCall.type).toBe('warning');
+  });
+
+  it('falls back to generic names when a civ or city record is missing', () => {
+    const { sink, calls } = makeSink();
+    routeCourierIntercepted(
+      courierState(),
+      { civId: 'rome', targetCivId: 'unknown-civ', routeId: 'route-1', fromCityId: 'missing-city', toCityId: 'city-2' },
+      sink,
+    );
+    expect(calls.every(c => typeof c.message === 'string' && c.message.length > 0)).toBe(true);
+  });
+});
+
+describe('espionage:official-bribed routing (#442 MR1)', () => {
+  function bribeState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+      } as any,
+      cities: {} as any,
+    });
+  }
+
+  it('notifies both civs and names the exact amount stolen', () => {
+    const { sink, calls } = makeSink();
+    routeOfficialBribed(bribeState(), { civId: 'rome', targetCivId: 'carthage', amount: 42 }, sink);
+    expect(calls).toHaveLength(2);
+    const romeCall = calls.find(c => c.civId === 'rome')!;
+    const carthageCall = calls.find(c => c.civId === 'carthage')!;
+    expect(romeCall.message).toContain('42');
+    expect(romeCall.type).toBe('success');
+    expect(carthageCall.message).toContain('42');
+    expect(carthageCall.message).toContain('Rome');
+    expect(carthageCall.type).toBe('warning');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the era-5 espionage mission gap from #442. Re-audited the issue's comment thread against current `main` before implementing — the thread corrected the original issue body twice (`digital-surveillance` was moved to era 10 and gates nothing; `flip_loyalty`/`sabotage_relief` already shipped into era 6/7 in unrelated recent MRs). The real remaining gap is eras 5, 8, and 9 with zero new missions each. This PR closes era 5; era 8/9 are designed but deferred to a follow-up PR (Phase 2).

- **`intercept_courier`** (`black-chambers`, era 5): severs the target city's highest-value active trade route, reusing `trade-system.ts`'s existing `removeRouteById` — the same mechanic embargo/war-declaration already use. Zero new persisted state.
- **`bribe_official`** (`diplomatic-networks`, era 5): steals a capped share (15%, max 200) of the target civ's treasury — the first espionage mission that transfers a resource between civs instead of only revealing or disrupting.

Both are wired end-to-end: AI mission preference (no hidden-info reads, no difficulty branching), bilateral notification routing (hot-seat safe — explicit recipient civ IDs, never `currentPlayer` at emit time), content-honesty tech unlock text, and mission-catalog UI entries.

**Review-pass fix (not scoped to just these two missions):** the mission catalog UI showed only a label/stage/access tag for every one of the 21 mission types — no plain-language effect description or duration anywhere. That violated the repo's "self-explanatory UI" rule. Fixed with a `MISSION_DESCRIPTIONS` table + duration display covering the whole catalog, so old and new entries look consistent.

Full design analysis, era-by-era ladder audit, and the Phase 2 plan (era 8 `expose_scandal`, era 9 `signals_intercept`) are recorded in `docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md`.

## Out of scope (deferred, by design)

- Era 8 (`expose_scandal`) and era 9 (`signals_intercept`) — designed, not implemented. Separate PR.
- Spy-unit plateau (`spy_operative` unchanged eras 4–11) — separate follow-up issue, per its own design-analysis pass.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` — 491 files / 8112 tests passing, 3 unrelated pre-existing skips
- [x] Mission gating (unlock/lock by tech), positive/negative success resolution
- [x] AI mission preference + no-hidden-info coverage
- [x] `processTurn` end-to-end integration test proving the real trade-route removal wiring (not just mocked glue)
- [x] Bilateral notification routing tests (both new events, both sides)
- [x] Hot-seat privacy test (another civ's in-progress mission never leaks into the current player's panel)
- [x] UI catalog description/duration coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)