### PR TITLE
feat(espionage): era 8-9 mission ladder — expose_scandal + signals_intercept (#442 Phase 2)

### DIFF
--- a/docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md
@@ -265,8 +265,40 @@ text). Full test coverage added across `tests/systems/espionage-system.test.ts`,
 `tests/presentation/register-espionage-presentation.test.ts`, and `tests/ui/notification-routing.test.ts`.
 `yarn build` and `yarn test` both green (491 files / 8110 tests passing) at the time this phase closed.
 
-`expose_scandal` (era 8) and `signals_intercept` (era 9) are **designed above but not yet implemented** —
-planned as Phase 2, a separate PR, per the incremental-delivery preference confirmed with the user.
+`expose_scandal` (era 8) and `signals_intercept` (era 9) are **implemented on branch
+`claude/era-8-9-espionage-missions`** (Phase 2, off updated `main` after Phase 1 merged as `4ada9123`).
+
+## Phase 2 status (2026-08-17)
+
+Implemented in `src/systems/espionage-system.ts`, `src/ai/basic-ai.ts`, `src/ui/espionage-panel.ts`,
+`src/ui/notification-routing.ts` + `register-espionage-presentation.ts`, and
+`tech-definitions-eras8.ts`/`tech-definitions-eras9.ts` (unlock text — also fixed a pre-existing dishonest
+claim on `disinformation-bureau`, "state disinformation weakens foreign loyalty," which named a mechanic that
+never existed; replaced with the real `expose_scandal` effect it now gates).
+
+**One deviation worth flagging**: implementing `signals_intercept` surfaced a real, pre-existing "dead computed
+data" bug (`end-to-end-wiring.md`: "if you compute data ... it MUST be rendered") — `resolveMissionResult`'s
+per-mission result payload (`nearbyUnits`, `resources`, tech progress, etc.) for every purely-informational
+mission (`monitor_troops`, `gather_intel`, `identify_resources`, `monitor_diplomacy`) is returned in the
+`espionage:mission-succeeded` bus event, but that event has **no notification-registrar handler anywhere** —
+so none of those missions' results were ever actually shown to the player before this MR. `signals_intercept`
+would have shipped straight into the same dead end. Fixed for this new mission only (not retrofitted onto the
+four pre-existing ones, which is a separate, larger follow-up): added `EspionageCivState.signalsIntelligence`
+(a small persisted per-target snapshot, additive optional field, no schema bump) and a new "Signals
+Intelligence" panel section that actually renders it. Flagged the four pre-existing dead-end missions as a
+follow-up (see spawned task).
+
+`expose_scandal` is the first multilateral (non-bilateral) relationship-affecting mission — implemented as
+designed above (−10 per partner, capped at 4 partners, target's relationship with the *acting* civ untouched).
+`signals_intercept` is remote-capable as designed, with the non-digital-remote-mission justification recorded
+inline in `missionRequiresPlacedSpy`.
+
+Full test coverage mirrors Phase 1's structure: gating, `resolveMissionResult` unit tests (including the
+partner-cap and minor-civ-exclusion edge cases for `expose_scandal`), `processEspionageTurn` end-to-end
+resolution tests, AI preference tests, notification-routing tests (the first 4-recipient routing test in the
+file), hot-seat privacy (another civ's `signalsIntelligence` snapshot never leaks into the current player's
+panel data), and UI catalog coverage. `yarn build` and `yarn test` both green (491 files / 8135 tests) at the
+time this phase closed.
 
 **Post-implementation review (2026-08-16) found and fixed one real gap**: the mission catalog UI showed only a
 label, stage tag, and access tag for every mission — no plain-language effect description or duration anywhere,

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1629,19 +1629,19 @@ export function chooseAiMission(
   if (hasStage5 && (civ.civType === 'annuvin' || traits.has('aggressive'))) {
     preferredOrder = [
       'flip_loyalty', 'cyber_attack', 'misinformation_campaign', 'satellite_surveillance',
-      'election_interference', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production',
-      'arms_smuggling', 'incite_unrest', 'gather_intel', 'monitor_troops',
+      'election_interference', 'expose_scandal', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production',
+      'arms_smuggling', 'incite_unrest', 'signals_intercept', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('aggressive')) {
     preferredOrder = [
-      'flip_loyalty', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production', 'arms_smuggling',
+      'flip_loyalty', 'signals_intercept', 'intercept_courier', 'bribe_official', 'steal_tech', 'sabotage_production', 'arms_smuggling',
       'incite_unrest', 'gather_intel', 'monitor_troops',
       'monitor_diplomacy', 'identify_resources', 'scout_area',
     ];
   } else if (traits.has('diplomatic') || traits.has('trader')) {
     preferredOrder = [
-      'forge_documents', 'flip_loyalty', 'bribe_official', 'intercept_courier', 'incite_unrest', 'fund_rebels',
+      'forge_documents', 'expose_scandal', 'flip_loyalty', 'bribe_official', 'intercept_courier', 'incite_unrest', 'fund_rebels',
       'gather_intel', 'monitor_diplomacy', 'identify_resources',
       'monitor_troops', 'scout_area', 'steal_tech',
     ];
@@ -1649,7 +1649,7 @@ export function chooseAiMission(
     preferredOrder = [
       'gather_intel', 'monitor_diplomacy', 'identify_resources',
       'monitor_troops', 'scout_area', 'steal_tech',
-      'sabotage_production', 'incite_unrest', 'intercept_courier', 'bribe_official',
+      'sabotage_production', 'incite_unrest', 'intercept_courier', 'bribe_official', 'expose_scandal', 'signals_intercept',
     ];
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -892,7 +892,12 @@ export type SpyMissionType =
   // #442 MR1: black-chambers tech (era 5) — its own bucket, not folded into Stage 4
   | 'intercept_courier'   // severs one active trade route touching the target city
   // #442 MR1: diplomatic-networks tech (era 5) — its own bucket, not folded into Stage 4
-  | 'bribe_official';     // steals a capped share of the target civ's treasury
+  | 'bribe_official'      // steals a capped share of the target civ's treasury
+  // #442 MR2: disinformation-bureau tech (era 8) — its own bucket, not folded into Stage 4
+  | 'expose_scandal'      // bounded relationship penalty between the target and each of its treaty partners
+  // #442 MR2: counterintelligence tech (era 9) — its own bucket. Remote-capable (see
+  // missionRequiresPlacedSpy) — the first non-digital remote mission, justified inline there.
+  | 'signals_intercept';  // one-time empire-wide snapshot of the target civ's unit positions/health
 
 export interface SpyMission {
   type: SpyMissionType;
@@ -962,6 +967,11 @@ export interface EspionageCivState {
   detectedThreats?: Record<string, DetectedSpyThreat>;
   activeInterrogations?: Record<string, InterrogationRecord>;
   recentDetections?: Array<{ position: HexCoord; turn: number; wasDisguised: boolean }>;
+  // #442 MR2 signals_intercept: latest empire-wide troop snapshot per target civ. A
+  // one-shot intel reveal, not an ongoing grant (unlike satellite_surveillance) — each
+  // new signals_intercept overwrites the previous snapshot for that target, since a
+  // stale disposition list has no value once the target's units have moved.
+  signalsIntelligence?: Record<string, { turn: number; units: Array<{ type: UnitType; position: HexCoord; health: number }> }>;
 }
 
 export type EspionageState = Record<string, EspionageCivState>;
@@ -2126,6 +2136,10 @@ export interface GameEvents {
   // caller subscribes to this event and performs the actual route removal.
   'espionage:courier-intercepted': { civId: string; targetCivId: string; routeId: string; fromCityId: string; toCityId: string };
   'espionage:official-bribed': { civId: string; targetCivId: string; amount: number };
+  // #442 MR2 expose_scandal: bounded multilateral reputation broadcast — fires once per
+  // successful mission, naming every partner civ whose relationship with the target
+  // soured (already capped/deduped by resolveMissionResult before this fires).
+  'espionage:scandal-exposed': { civId: string; targetCivId: string; partnerCivIds: string[] };
 }
 
 // --- Crisis Events & Revolutionary Movements ---

--- a/src/presentation/register-espionage-presentation.ts
+++ b/src/presentation/register-espionage-presentation.ts
@@ -4,7 +4,7 @@
  * itself (`showEspionageCaptureChoice`) stays a `main.ts`-local function --
  * see `PresentationContext`'s doc comment for why.
  */
-import { routeCityFlipped, routeSabotageReliefDiscovered, routeCourierIntercepted, routeOfficialBribed } from '@/ui/notification-routing';
+import { routeCityFlipped, routeSabotageReliefDiscovered, routeCourierIntercepted, routeOfficialBribed, routeScandalExposed } from '@/ui/notification-routing';
 import type { PresentationRegistrar } from '@/presentation/register-all';
 
 export const registerEspionagePresentation: PresentationRegistrar = (bus, ctx) => {
@@ -69,6 +69,9 @@ export const registerEspionagePresentation: PresentationRegistrar = (bus, ctx) =
     }),
     bus.on('espionage:official-bribed', event => {
       routeOfficialBribed(ctx.session.getState(), event, ctx.notifier.deliver);
+    }),
+    bus.on('espionage:scandal-exposed', event => {
+      routeScandalExposed(ctx.session.getState(), event, ctx.notifier.deliver);
     }),
   ];
 

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -58,6 +58,8 @@ const MISSION_BASE_SUCCESS = {
   flip_loyalty: 0.40, // #524 MR2a: lowest tier alongside election_interference — outright city transfer, not a temporary effect
   intercept_courier: 0.55, // #442 MR1: mid-stakes, comparable to forge_documents
   bribe_official: 0.45, // #442 MR1: harder than intercept_courier — direct treasury theft, comparable to assassinate_advisor
+  expose_scandal: 0.50, // #442 MR2: comparable to steal_tech — mid-tier social/intel operation
+  signals_intercept: 0.60, // #442 MR2: comparable to satellite_surveillance — passive intel, no disruption
 } as Record<SpyMissionType, number>;
 
 const MISSION_DURATIONS = {
@@ -81,6 +83,8 @@ const MISSION_DURATIONS = {
   flip_loyalty: 8, // #524 MR2a: longest duration in the game, above fund_rebels/assassinate_advisor (6) — matches the stakes
   intercept_courier: 4, // #442 MR1: matches sabotage_relief's setup window
   bribe_official: 5, // #442 MR1: matches forge_documents — a slow social build, not a snap action
+  expose_scandal: 6, // #442 MR2: between forge_documents (5) and flip_loyalty (8) — more research/setup than a simple frame job
+  signals_intercept: 2, // #442 MR2: matches cyber_attack's tier — quick remote intel snapshot
 } as Record<SpyMissionType, number>;
 
 // --- State creation ---
@@ -93,6 +97,7 @@ export function createEspionageCivState(): EspionageCivState {
     detectedThreats: {},
     activeInterrogations: {},
     recentDetections: [],
+    signalsIntelligence: {},
   };
 }
 
@@ -371,6 +376,10 @@ const PROPAGANDA_TECHS = ['propaganda']; // era 6 — gates flip_loyalty specifi
 // one mission.
 const INTERCEPT_COURIER_TECHS = ['black-chambers'];
 const BRIBE_OFFICIAL_TECHS = ['diplomatic-networks'];
+// #442 MR2: disinformation-bureau/counterintelligence (era 8/9) get their own single-mission
+// buckets, same pattern as the era-5 pair above.
+const EXPOSE_SCANDAL_TECHS = ['disinformation-bureau'];
+const SIGNALS_INTERCEPT_TECHS = ['counterintelligence'];
 
 const STAGE_1_MISSIONS: SpyMissionType[] = ['scout_area', 'monitor_troops'];
 const STAGE_2_MISSIONS: SpyMissionType[] = ['gather_intel', 'identify_resources', 'monitor_diplomacy'];
@@ -383,6 +392,8 @@ const SABOTAGE_RELIEF_MISSIONS: SpyMissionType[] = ['sabotage_relief'];
 const PROPAGANDA_MISSIONS: SpyMissionType[] = ['flip_loyalty'];
 const INTERCEPT_COURIER_MISSIONS: SpyMissionType[] = ['intercept_courier'];
 const BRIBE_OFFICIAL_MISSIONS: SpyMissionType[] = ['bribe_official'];
+const EXPOSE_SCANDAL_MISSIONS: SpyMissionType[] = ['expose_scandal'];
+const SIGNALS_INTERCEPT_MISSIONS: SpyMissionType[] = ['signals_intercept'];
 
 export function getAvailableMissions(completedTechs: string[]): SpyMissionType[] {
   const missions: SpyMissionType[] = [];
@@ -397,11 +408,18 @@ export function getAvailableMissions(completedTechs: string[]): SpyMissionType[]
   if (PROPAGANDA_TECHS.some(t => completedTechs.includes(t))) missions.push(...PROPAGANDA_MISSIONS);
   if (INTERCEPT_COURIER_TECHS.some(t => completedTechs.includes(t))) missions.push(...INTERCEPT_COURIER_MISSIONS);
   if (BRIBE_OFFICIAL_TECHS.some(t => completedTechs.includes(t))) missions.push(...BRIBE_OFFICIAL_MISSIONS);
+  if (EXPOSE_SCANDAL_TECHS.some(t => completedTechs.includes(t))) missions.push(...EXPOSE_SCANDAL_MISSIONS);
+  if (SIGNALS_INTERCEPT_TECHS.some(t => completedTechs.includes(t))) missions.push(...SIGNALS_INTERCEPT_MISSIONS);
   return missions;
 }
 
+// #442 MR2: signals_intercept is the first remote-capable mission that isn't a
+// digital-era (cyber-warfare/digital-surveillance-family) effect — it's codebreaking, not
+// hacking, so it doesn't need a spy physically inside the target's territory the way
+// intercept_courier/bribe_official/expose_scandal do. Placed alongside the era-10+ remote
+// missions on that basis, not by proximity to their tech era.
 export function missionRequiresPlacedSpy(missionType: SpyMissionType): boolean {
-  return !['cyber_attack', 'misinformation_campaign', 'satellite_surveillance'].includes(missionType);
+  return !['cyber_attack', 'misinformation_campaign', 'satellite_surveillance', 'signals_intercept'].includes(missionType);
 }
 
 // --- Mission lifecycle ---
@@ -474,7 +492,10 @@ const INFILTRATOR_MISSIONS = new Set<SpyMissionType>([
 const HANDLER_MISSIONS = new Set<SpyMissionType>([
   'incite_unrest', 'forge_documents', 'fund_rebels', 'monitor_diplomacy', 'flip_loyalty',
   'bribe_official', // #442 MR1: social/manipulation-flavored, matches this bucket's other entries
+  'expose_scandal', // #442 MR2: social/manipulation-flavored, matches this bucket's other entries
 ]);
+// signals_intercept (#442 MR2) is intel-flavored, like monitor_troops/gather_intel — falls
+// through to Sentinel, the same as those, rather than joining either bucket above.
 // Sentinel: everything else (intel, scouting, defensive)
 
 const XP_PER_MISSION = {
@@ -498,6 +519,8 @@ const XP_PER_MISSION = {
   flip_loyalty: 20, // #524 MR2a: highest xp in the game, above assassinate_advisor (18)
   intercept_courier: 14, // #442 MR1: matches misinformation_campaign's tier
   bribe_official: 16, // #442 MR1: matches election_interference's tier — high-value theft
+  expose_scandal: 16, // #442 MR2: matches bribe_official's tier — high-value multilateral effect
+  signals_intercept: 10, // #442 MR2: matches gather_intel's tier — informational, not disruptive
 } as Record<SpyMissionType, number>;
 
 const EXPULSION_COOLDOWN = 5;
@@ -671,6 +694,11 @@ export interface MissionResult {
   interceptedToCityId?: string;
   // bribe_official (#442 MR1): capped gold transfer from the target's treasury.
   bribedGoldAmount?: number;
+  // expose_scandal (#442 MR2): every other civ whose relationship with the target sours,
+  // already capped/deduped.
+  exposedPartnerCivIds?: string[];
+  // signals_intercept (#442 MR2) reuses the nearbyUnits shape from monitor_troops above
+  // (same field, generalized from one city's radius to the whole target civ).
 }
 
 const SCOUT_VISION_RADIUS = 3;
@@ -680,6 +708,11 @@ const TROOP_MONITOR_RADIUS = 4;
 // cripple a city/civ from one successful spy action").
 const BRIBE_GOLD_FRACTION = 0.15;
 const BRIBE_GOLD_CAP = 200;
+// #442 MR2 expose_scandal: bounded per-partner penalty and a cap on affected partners so
+// a maximally-connected civ can't be devastated in one mission (game-balance.md "never
+// permanently cripple a city/civ from one successful spy action").
+const EXPOSE_SCANDAL_PENALTY = -10;
+const EXPOSE_SCANDAL_MAX_PARTNERS = 4;
 
 export function resolveMissionResult(
   missionType: SpyMissionType,
@@ -857,6 +890,42 @@ export function resolveMissionResult(
       const amount = Math.min(Math.round(targetCiv.gold * BRIBE_GOLD_FRACTION), BRIBE_GOLD_CAP);
       if (amount <= 0) return {};
       return { bribedGoldAmount: amount };
+    }
+
+    // expose_scandal (#442 MR2): the first multilateral (non-bilateral) relationship
+    // mission — every existing one touches exactly two civs. A target with no treaties
+    // (with civs other than the spying civ itself) is not a valid/valuable target, same
+    // "not always optimal" shape as fund_rebels' unrestLevel guard. Deterministic partner
+    // selection (sorted, capped) keeps the advertised "up to 4 partners" bound honest.
+    case 'expose_scandal': {
+      const targetCiv = gameState.civilizations[targetCivId];
+      if (!targetCiv) return {};
+      const partners = new Set<string>();
+      for (const treaty of targetCiv.diplomacy.treaties) {
+        const partner = treaty.civA === targetCivId ? treaty.civB : treaty.civA;
+        if (partner === targetCivId || partner === spyingCivId) continue;
+        if (!gameState.civilizations[partner]) continue; // major civs only
+        partners.add(partner);
+      }
+      if (partners.size === 0) return {};
+      const exposedPartnerCivIds = [...partners].sort().slice(0, EXPOSE_SCANDAL_MAX_PARTNERS);
+      return { exposedPartnerCivIds };
+    }
+
+    // signals_intercept (#442 MR2): generalizes monitor_troops from a single city's
+    // radius to the whole target civ — reuses its nearbyUnits shape. Remote-capable (see
+    // missionRequiresPlacedSpy), so targetCityId is unused here (same as
+    // satellite_surveillance ignoring it).
+    case 'signals_intercept': {
+      const targetCiv = gameState.civilizations[targetCivId];
+      if (!targetCiv) return {};
+      const nearbyUnits: Array<{ type: UnitType; position: HexCoord; health: number }> = [];
+      for (const unit of Object.values(gameState.units)) {
+        if (unit.owner === targetCivId) {
+          nearbyUnits.push({ type: unit.type, position: { ...unit.position }, health: unit.health });
+        }
+      }
+      return { nearbyUnits };
     }
 
     case 'assassinate_advisor': {
@@ -1617,6 +1686,56 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
                 },
               };
               bus.emit('espionage:official-bribed', { civId, targetCivId, amount });
+            }
+          }
+
+          // expose_scandal (#442 MR2): applies the bounded per-partner penalty
+          // bilaterally (target <-> each partner), then emits one event naming every
+          // affected partner — no import-cycle concern, everything here is plain
+          // civilizations/diplomacy state already on GameState.
+          if (evt.missionType === 'expose_scandal' && result.exposedPartnerCivIds) {
+            const originalSpy = civEspBefore.spies[evt.spyId];
+            const targetCivId = originalSpy?.targetCivId;
+            const partners = result.exposedPartnerCivIds as string[];
+            if (targetCivId && state.civilizations[targetCivId] && partners.length > 0) {
+              for (const partnerId of partners) {
+                if (!state.civilizations[partnerId]) continue;
+                state = {
+                  ...state,
+                  civilizations: {
+                    ...state.civilizations,
+                    [targetCivId]: {
+                      ...state.civilizations[targetCivId],
+                      diplomacy: modifyRelationship(state.civilizations[targetCivId].diplomacy, partnerId, EXPOSE_SCANDAL_PENALTY),
+                    },
+                    [partnerId]: {
+                      ...state.civilizations[partnerId],
+                      diplomacy: modifyRelationship(state.civilizations[partnerId].diplomacy, targetCivId, EXPOSE_SCANDAL_PENALTY),
+                    },
+                  },
+                };
+              }
+              bus.emit('espionage:scandal-exposed', { civId, targetCivId, partnerCivIds: partners });
+            }
+          }
+
+          // signals_intercept (#442 MR2): persist the snapshot on the acting civ's own
+          // EspionageCivState so it can actually be rendered (end-to-end-wiring.md
+          // "computed data ... MUST be rendered — dead computed data is a bug"). Latest
+          // snapshot per target civ only — a stale disposition list has no value once the
+          // target's units have moved, so this overwrites rather than appends.
+          if (evt.missionType === 'signals_intercept' && result.nearbyUnits) {
+            const originalSpy = civEspBefore.spies[evt.spyId];
+            const targetCivId = originalSpy?.targetCivId;
+            if (targetCivId) {
+              updatedEsp = {
+                ...updatedEsp,
+                signalsIntelligence: {
+                  ...(updatedEsp.signalsIntelligence ?? {}),
+                  [targetCivId]: { turn: state.turn, units: result.nearbyUnits },
+                },
+              };
+              state.espionage![civId] = updatedEsp;
             }
           }
 

--- a/src/systems/tech-definitions-eras8.ts
+++ b/src/systems/tech-definitions-eras8.ts
@@ -129,7 +129,10 @@ const ERA_8_TECHS: Tech[] = [
     unlocks: ['+3 spy slots empire-wide; political intelligence networks improve spy mission success rates by 10%'], unlocksBuildings: ['intelligence-agency'], era: 8 },
   { id: 'disinformation-bureau', name: 'Disinformation Bureau', track: 'espionage', cost: 145,
     prerequisites: ['secret-police'],
-    unlocks: ['Enemy spy missions in your cities have -25% success rate; state disinformation weakens foreign loyalty'], era: 8 },
+    // #442 MR2: dropped "state disinformation weakens foreign loyalty" — no such
+    // mechanic exists (content-description-honesty.md); replaced with the actual new
+    // effect this tech now gates.
+    unlocks: ['Enemy spy missions in your cities have -25% success rate', 'Spy mission: expose a rival\'s secret treaties to their partners, damaging those relationships'], era: 8 },
 
   // SPIRITUALITY (2)
   { id: 'modernist-theology', name: 'Modernist Theology', track: 'spirituality', cost: 165,

--- a/src/systems/tech-definitions-eras9.ts
+++ b/src/systems/tech-definitions-eras9.ts
@@ -133,7 +133,7 @@ const ERA_9_TECHS: Tech[] = [
   // ESPIONAGE (2)
   { id: 'counterintelligence', name: 'Counterintelligence', track: 'espionage', cost: 190,
     prerequisites: ['political-intelligence', 'disinformation-bureau'],
-    unlocks: ['Enemy spy missions in your cities suffer -30% success rate; double-agent networks protect secrets'], era: 9 },
+    unlocks: ['Enemy spy missions in your cities suffer -30% success rate; double-agent networks protect secrets', 'Spy mission: intercept a rival empire\'s troop dispositions, empire-wide'], era: 9 },
   { id: 'propaganda-campaigns', name: 'Propaganda Campaigns', track: 'espionage', cost: 270,
     prerequisites: ['disinformation-bureau', 'radio-broadcast'],
     unlocks: ['+2 gold per city with a film studio or radio station; state media shapes public opinion'],

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -43,6 +43,10 @@ export interface EspionagePanelData {
   missionSuccessChances?: Partial<Record<SpyMissionType, number>>;
   missionSuccessBreakdown?: Partial<Record<SpyMissionType, string>>;
   currentTurn: number;
+  // #442 MR2 signals_intercept: the latest empire-wide troop snapshot per target civ this
+  // player has intercepted. Without this, the computed data would never be rendered
+  // (end-to-end-wiring.md "dead computed data is a bug").
+  signalsIntelligence: Array<{ targetCivId: string; targetCivName: string; turn: number; unitCount: number }>;
 }
 
 export interface MissionStageGroup {
@@ -92,6 +96,8 @@ const MISSION_LABELS: Record<SpyMissionType, string> = {
   sabotage_relief: 'Sabotage Relief',
   intercept_courier: 'Intercept Courier',
   bribe_official: 'Bribe Official',
+  expose_scandal: 'Expose Scandal',
+  signals_intercept: 'Signals Intercept',
 };
 
 // #442 MR1 review: the mission catalog previously showed only a label, stage tag, and
@@ -123,6 +129,8 @@ const MISSION_DESCRIPTIONS: Record<SpyMissionType, string> = {
   sabotage_relief: "Delays a rival's crisis relief; witnessed civilizations notice if discovered.",
   intercept_courier: "Severs the target city's most valuable active trade route.",
   bribe_official: "Steals a capped share of the target empire's treasury.",
+  expose_scandal: 'Exposes the target\'s secret dealings, damaging their relationship with up to 4 of their treaty partners.',
+  signals_intercept: "One-time snapshot of the target empire's unit positions and strength, empire-wide.",
 };
 
 const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
@@ -147,6 +155,8 @@ const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
   sabotage_relief: 5, // covert-operations is era 7, same UI bucket as the other era 5-7 missions
   intercept_courier: 4, // #442 MR1: black-chambers is era 5, same "Shadow Operations" UI bucket as flip_loyalty/other era 5-6 Stage 4 missions
   bribe_official: 4, // #442 MR1: diplomatic-networks is era 5, same UI bucket as above
+  expose_scandal: 5, // #442 MR2: disinformation-bureau is era 8, same "higher stakes" bucket as sabotage_relief (era 7)
+  signals_intercept: 5, // #442 MR2: counterintelligence is era 9, same bucket as above
 };
 
 function toMissionCatalog(missions: SpyMissionType[]): MissionCatalogEntry[] {
@@ -457,6 +467,40 @@ function appendRecentDetections(
   parent.appendChild(block);
 }
 
+// #442 MR2 signals_intercept: renders the persisted snapshot from
+// EspionagePanelData.signalsIntelligence — see that field's doc comment for why this
+// exists (dead-computed-data avoidance).
+function appendSignalsIntelligence(
+  parent: HTMLElement,
+  snapshots: Array<{ targetCivId: string; targetCivName: string; turn: number; unitCount: number }>,
+  currentTurn: number,
+): void {
+  const block = createEl('section');
+  block.dataset.section = 'signals-intelligence';
+  appendSectionHeader(block, 'Signals Intelligence', 'Latest intercepted troop snapshots. Ages fast — positions may have changed.');
+
+  if (snapshots.length === 0) {
+    const empty = createEl('div', 'No signals intelligence gathered yet.');
+    empty.style.cssText = 'font-size:11px;opacity:0.55;';
+    block.appendChild(empty);
+    parent.appendChild(block);
+    return;
+  }
+
+  for (const snapshot of [...snapshots].sort((a, b) => b.turn - a.turn)) {
+    const age = currentTurn - snapshot.turn;
+    const row = createEl(
+      'div',
+      `${snapshot.targetCivName}: ${snapshot.unitCount} unit${snapshot.unitCount === 1 ? '' : 's'} spotted (turn ${snapshot.turn}, ${age === 0 ? 'this turn' : `${age} turn${age === 1 ? '' : 's'} ago`})`,
+    );
+    row.dataset.signalsTarget = snapshot.targetCivId;
+    row.style.cssText = 'font-size:11px;opacity:0.8;padding:4px 0;';
+    block.appendChild(row);
+  }
+
+  parent.appendChild(block);
+}
+
 function formatIntelItem(item: InterrogationIntel): string {
   switch (item.type) {
     case 'spy_identity': return `Enemy spy ${item.data.spyName as string} is currently ${item.data.status as string}${item.data.location ? ` in ${item.data.location as string}` : ''}`;
@@ -594,6 +638,7 @@ export function createEspionagePanel(
 
   appendThreatBoard(panel, data.threatBoard);
   appendRecentDetections(panel, data.recentDetections);
+  appendSignalsIntelligence(panel, data.signalsIntelligence, data.currentTurn);
   appendInterrogationProgress(panel, state);
 
   return panel;
@@ -614,6 +659,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
       threatBoard: [],
       recentDetections: [],
       currentTurn: state.turn,
+      signalsIntelligence: [],
     };
   }
 
@@ -695,6 +741,15 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
     if (Object.keys(breakdowns).length > 0) missionSuccessBreakdown = breakdowns;
   }
 
+  const signalsIntelligence = Object.entries(civEsp.signalsIntelligence ?? {}).map(
+    ([targetCivId, snapshot]) => ({
+      targetCivId,
+      targetCivName: state.civilizations[targetCivId]?.name ?? targetCivId,
+      turn: snapshot.turn,
+      unitCount: snapshot.units.length,
+    }),
+  );
+
   return {
     spies,
     spySummaries,
@@ -707,6 +762,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
     threatBoard,
     recentDetections: civEsp.recentDetections ?? [],
     currentTurn: state.turn,
+    signalsIntelligence,
     ...(missionSuccessChances !== undefined ? { missionSuccessChances } : {}),
     ...(missionSuccessBreakdown !== undefined ? { missionSuccessBreakdown } : {}),
   };

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -786,6 +786,30 @@ export function routeOfficialBribed(
   sink(event.civId, `Your spy bribed an official in ${targetName}'s court, siphoning ${event.amount} gold into your treasury.`, 'success');
 }
 
+// expose_scandal (#442 MR2): the first multilateral espionage notification — unlike every
+// prior router (at most 2 parties), this tells the target AND every exposed partner
+// individually, plus the acting civ. Each recipient gets a message scoped to what
+// actually changed for them, not a shared broadcast string.
+export function routeScandalExposed(
+  state: GameState,
+  event: GameEvents['espionage:scandal-exposed'],
+  sink: NotificationSink,
+): void {
+  const actorName = state.civilizations[event.civId]?.name ?? 'A rival';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a rival';
+  const partnerNames = event.partnerCivIds.map(id => state.civilizations[id]?.name ?? id);
+
+  sink(
+    event.targetCivId,
+    `${actorName}'s spies exposed your secret dealings — ${partnerNames.join(', ')} now trust${partnerNames.length === 1 ? 's' : ''} you less.`,
+    'warning',
+  );
+  for (const partnerId of event.partnerCivIds) {
+    sink(partnerId, `${actorName}'s spies revealed ${targetName}'s secret dealings with you — your relationship has soured.`, 'warning');
+  }
+  sink(event.civId, `Your spy exposed ${targetName}'s secret dealings with ${partnerNames.length} other ${partnerNames.length === 1 ? 'civilization' : 'civilizations'}.`, 'success');
+}
+
 export function routeCityFlipped(
   state: GameState,
   event: GameEvents['espionage:city-flipped'],

--- a/tests/ai/ai-espionage.test.ts
+++ b/tests/ai/ai-espionage.test.ts
@@ -243,6 +243,31 @@ describe('AI espionage decisions', () => {
       const mission = chooseAiMission(state, 'ai-egypt');
       expect(mission).toBe('bribe_official');
     });
+
+    // #442 MR2
+    it('diplomatic civs choose expose_scandal once disinformation-bureau is researched (no higher-priority mission available)', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'greece';
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting', 'disinformation-bureau'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('expose_scandal');
+    });
+
+    it('aggressive civs choose signals_intercept once counterintelligence is researched (no higher-priority mission available)', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].civType = 'annuvin';
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting', 'counterintelligence'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBe('signals_intercept');
+    });
+
+    it('expose_scandal/signals_intercept are unavailable without their gating techs', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].techState.completed = ['espionage-scouting'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).not.toBe('expose_scandal');
+      expect(mission).not.toBe('signals_intercept');
+    });
   });
 
   // #526 MR7 review fix: infiltrated (embedded) spies pick their next mission via a

--- a/tests/presentation/register-espionage-presentation.test.ts
+++ b/tests/presentation/register-espionage-presentation.test.ts
@@ -134,6 +134,18 @@ describe('espionage presentation', () => {
     expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.stringContaining('42'), 'warning');
   });
 
+  it('notifies target, partners, and acting civ when a scandal is exposed (#442 MR2)', () => {
+    const bus = new EventBus();
+    const ctx = makePresentationContext();
+
+    registerEspionagePresentation(bus, ctx);
+    bus.emit('espionage:scandal-exposed', { civId: 'rome', targetCivId: 'carthage', partnerCivIds: ['egypt'] });
+
+    expect(ctx.deliver).toHaveBeenCalledWith('rome', expect.any(String), 'success');
+    expect(ctx.deliver).toHaveBeenCalledWith('carthage', expect.any(String), 'warning');
+    expect(ctx.deliver).toHaveBeenCalledWith('egypt', expect.any(String), 'warning');
+  });
+
   it('disposing removes every subscription this registrar added', () => {
     const bus = new EventBus();
     const ctx = makePresentationContext({
@@ -152,6 +164,7 @@ describe('espionage presentation', () => {
     bus.emit('espionage:city-flipped', { civId: 'rome', victimCivId: 'carthage', cityId: 'city-a' });
     bus.emit('espionage:courier-intercepted', { civId: 'rome', targetCivId: 'carthage', routeId: 'route-1', fromCityId: 'city-a', toCityId: 'city-a' });
     bus.emit('espionage:official-bribed', { civId: 'rome', targetCivId: 'carthage', amount: 42 });
+    bus.emit('espionage:scandal-exposed', { civId: 'rome', targetCivId: 'carthage', partnerCivIds: ['egypt'] });
 
     expect(ctx.deliver).not.toHaveBeenCalled();
     expect(ctx.showEspionageCaptureChoice).not.toHaveBeenCalled();

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -1131,6 +1131,265 @@ describe('era 5 missions — intercept_courier and bribe_official (#442 MR1)', (
   });
 });
 
+describe('era 8-9 missions — expose_scandal and signals_intercept (#442 MR2)', () => {
+  it('disinformation-bureau gates expose_scandal (unavailable without the tech, available with it)', () => {
+    expect(getAvailableMissions([])).not.toContain('expose_scandal');
+    expect(getAvailableMissions(['disinformation-bureau'])).toContain('expose_scandal');
+  });
+
+  it('counterintelligence gates signals_intercept (unavailable without the tech, available with it)', () => {
+    expect(getAvailableMissions([])).not.toContain('signals_intercept');
+    expect(getAvailableMissions(['counterintelligence'])).toContain('signals_intercept');
+  });
+
+  it('expose_scandal requires a placed (stationed) spy; signals_intercept is remote-capable', () => {
+    expect(missionRequiresPlacedSpy('expose_scandal')).toBe(true);
+    expect(missionRequiresPlacedSpy('signals_intercept')).toBe(false);
+  });
+
+  describe('resolveMissionResult — expose_scandal', () => {
+    function makeTreatyState(): GameState {
+      return {
+        civilizations: {
+          rome: {
+            gold: 0,
+            diplomacy: {
+              treaties: [
+                { type: 'alliance', civA: 'rome', civB: 'carthage', turnsRemaining: -1 },
+                { type: 'trade_agreement', civA: 'egypt', civB: 'rome', turnsRemaining: -1 },
+                { type: 'non_aggression_pact', civA: 'rome', civB: 'player', turnsRemaining: -1 },
+              ],
+            },
+          },
+          carthage: {},
+          egypt: {},
+          player: {},
+        },
+        cities: {},
+      } as unknown as GameState;
+    }
+
+    it('exposes every other civ with an active treaty against the target', () => {
+      const state = makeTreatyState();
+      const result = resolveMissionResult('expose_scandal', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.exposedPartnerCivIds).toEqual(['carthage', 'egypt']);
+    });
+
+    it('excludes the spying civ itself from the exposed partner list', () => {
+      const state = makeTreatyState();
+      const result = resolveMissionResult('expose_scandal', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.exposedPartnerCivIds).not.toContain('player');
+    });
+
+    it('has no effect against a civ with no treaties (other than with the spying civ)', () => {
+      const state = makeTreatyState();
+      state.civilizations.rome.diplomacy.treaties = [
+        { type: 'non_aggression_pact', civA: 'rome', civB: 'player', turnsRemaining: -1 },
+      ];
+      const result = resolveMissionResult('expose_scandal', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.exposedPartnerCivIds).toBeUndefined();
+    });
+
+    it('caps the exposed partner list at 4', () => {
+      const state = makeTreatyState();
+      state.civilizations.rome.diplomacy.treaties = ['a', 'b', 'c', 'd', 'e', 'f'].map(id => ({
+        type: 'non_aggression_pact' as const, civA: 'rome', civB: id, turnsRemaining: -1,
+      }));
+      for (const id of ['a', 'b', 'c', 'd', 'e', 'f']) {
+        (state.civilizations as any)[id] = {};
+      }
+      const result = resolveMissionResult('expose_scandal', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.exposedPartnerCivIds).toHaveLength(4);
+    });
+
+    it('ignores treaty partners that are not real civilizations (e.g. minor civs)', () => {
+      const state = makeTreatyState();
+      state.civilizations.rome.diplomacy.treaties = [
+        { type: 'non_aggression_pact', civA: 'rome', civB: 'minor-nabatea', turnsRemaining: -1 },
+      ];
+      const result = resolveMissionResult('expose_scandal', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.exposedPartnerCivIds).toBeUndefined();
+    });
+  });
+
+  describe('resolveMissionResult — signals_intercept', () => {
+    it('reports every unit owned by the target civ, empire-wide, ignoring distance', () => {
+      const state = {
+        civilizations: { rome: {} },
+        units: {
+          'u1': { type: 'warrior', owner: 'rome', position: { q: 0, r: 0 }, health: 100 },
+          'u2': { type: 'archer', owner: 'rome', position: { q: 40, r: 40 }, health: 60 },
+          'u3': { type: 'warrior', owner: 'player', position: { q: 1, r: 1 }, health: 100 },
+        },
+        cities: {},
+      } as unknown as GameState;
+      const result = resolveMissionResult('signals_intercept', 'rome', 'city-x', state, 'player', 'spy-1');
+      expect(result.nearbyUnits).toHaveLength(2);
+      expect(result.nearbyUnits!.map(u => u.type).sort()).toEqual(['archer', 'warrior']);
+    });
+
+    it('has no effect against a civ that does not exist', () => {
+      const state = { civilizations: {}, units: {}, cities: {} } as unknown as GameState;
+      const result = resolveMissionResult('signals_intercept', 'nobody', 'city-x', state, 'player', 'spy-1');
+      expect(result.nearbyUnits).toBeUndefined();
+    });
+  });
+
+  describe('expose_scandal end-to-end resolution', () => {
+    function makeScandalFixture() {
+      let state = createNewGame(undefined, 'expose-scandal-e2e', 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const startPos = state.units[state.civilizations[targetCivId].units[0]].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      state = {
+        ...state,
+        cities: { ...state.cities, [city.id]: city },
+        civilizations: {
+          ...state.civilizations,
+          [targetCivId]: {
+            ...state.civilizations[targetCivId],
+            cities: [city.id],
+            diplomacy: {
+              ...state.civilizations[targetCivId].diplomacy,
+              treaties: [
+                { type: 'trade_agreement' as const, civA: targetCivId, civB: 'third-civ', turnsRemaining: -1 },
+              ],
+            },
+          },
+          'third-civ': {
+            ...state.civilizations.player,
+            id: 'third-civ',
+            name: 'Third Civ',
+            diplomacy: { ...createDiplomacyState([targetCivId, 'third-civ', 'player'], 'third-civ') },
+          },
+        },
+        espionage: {
+          player: {
+            ...createEspionageCivState(),
+            spies: {
+              'spy-1': makeTestSpy('spy-1', 'player', {
+                status: 'stationed', targetCivId, targetCityId: city.id, position: city.position,
+              }),
+            },
+          },
+          [targetCivId]: createEspionageCivState(),
+          'third-civ': createEspionageCivState(),
+        },
+      };
+      return { state, targetCivId };
+    }
+
+    it('applies the bilateral relationship penalty between the target and each exposed partner', () => {
+      const { state: baseState, targetCivId } = makeScandalFixture();
+      const beforeRelationship = baseState.civilizations[targetCivId].diplomacy.relationships['third-civ'] ?? 0;
+      let succeeded = false;
+      for (let turn = 1; turn <= 200 && !succeeded; turn++) {
+        const state: GameState = {
+          ...baseState,
+          turn,
+          espionage: {
+            ...baseState.espionage!,
+            player: {
+              ...baseState.espionage!.player,
+              spies: {
+                'spy-1': startMission(baseState.espionage!.player, 'spy-1', 'expose_scandal').spies['spy-1'],
+              },
+            },
+          },
+        };
+        state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+        const bus = new EventBus();
+        const pendingExposures: Array<{ civId: string; targetCivId: string; partnerCivIds: string[] }> = [];
+        bus.on('espionage:scandal-exposed', evt => pendingExposures.push(evt));
+        const result = processEspionageTurn(state, bus);
+
+        if (pendingExposures.length > 0) {
+          succeeded = true;
+          expect(pendingExposures[0].partnerCivIds).toContain('third-civ');
+          expect(result.civilizations[targetCivId].diplomacy.relationships['third-civ']).toBeLessThan(beforeRelationship);
+          expect(result.civilizations['third-civ'].diplomacy.relationships[targetCivId]).toBeLessThan(0);
+        }
+      }
+      expect(succeeded).toBe(true);
+    });
+  });
+
+  describe('signals_intercept end-to-end resolution', () => {
+    function makeSignalsFixture() {
+      let state = createNewGame(undefined, 'signals-intercept-e2e', 'small');
+      const targetCivId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+      const targetUnitId = state.civilizations[targetCivId].units[0];
+      const startPos = state.units[targetUnitId].position;
+      const city = foundCity(targetCivId, startPos, state.map, state.idCounters);
+      state = {
+        ...state,
+        cities: { ...state.cities, [city.id]: city },
+        civilizations: {
+          ...state.civilizations,
+          [targetCivId]: { ...state.civilizations[targetCivId], cities: [city.id] },
+        },
+      };
+      return {
+        state: {
+          ...state,
+          espionage: {
+            player: {
+              ...createEspionageCivState(),
+              spies: {
+                'spy-1': makeTestSpy('spy-1', 'player', {
+                  status: 'idle', targetCivId, targetCityId: null,
+                }),
+              },
+            },
+            [targetCivId]: createEspionageCivState(),
+          },
+        },
+        targetCivId,
+        targetUnitId,
+      };
+    }
+
+    it('persists the latest snapshot on the acting civ\'s own EspionageCivState (so it can be rendered)', () => {
+      const { state: baseState, targetCivId } = makeSignalsFixture();
+      // signals_intercept is remote-capable, so 'stationed' isn't required — but
+      // startMission still needs an explicit target since spy.targetCivId/targetCityId
+      // are both null on this idle spy.
+      const capitalCityId = Object.keys(baseState.cities).find(id => baseState.cities[id].owner === targetCivId)!;
+      let succeeded = false;
+      for (let turn = 1; turn <= 200 && !succeeded; turn++) {
+        const state: GameState = {
+          ...baseState,
+          turn,
+          espionage: {
+            ...baseState.espionage!,
+            player: {
+              ...baseState.espionage!.player,
+              spies: {
+                'spy-1': startMission(
+                  baseState.espionage!.player, 'spy-1', 'signals_intercept', undefined, targetCivId, capitalCityId,
+                ).spies['spy-1'],
+              },
+            },
+          },
+        };
+        state.espionage!.player.spies['spy-1'].currentMission!.turnsRemaining = 1;
+
+        const bus = new EventBus();
+        const result = processEspionageTurn(state, bus);
+        const snapshot = result.espionage!.player.signalsIntelligence?.[targetCivId];
+
+        if (snapshot) {
+          succeeded = true;
+          expect(snapshot.turn).toBe(turn);
+          expect(snapshot.units.length).toBeGreaterThan(0);
+        }
+      }
+      expect(succeeded).toBe(true);
+    });
+  });
+});
+
 describe('espionage diplomatic consequences', () => {
   describe('handleSpyExpelled', () => {
     it('reduces relationship between spy owner and detecting civ', () => {

--- a/tests/ui/espionage-panel.test.ts
+++ b/tests/ui/espionage-panel.test.ts
@@ -310,6 +310,35 @@ describe('espionage-panel', () => {
       expect(bribe.durationTurns).toBe(5);
     });
 
+    // #442 MR2
+    it('shows expose_scandal in the Stage 5 group once disinformation-bureau is researched', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['disinformation-bureau'];
+      const view = getEspionagePanelViewModel(state);
+      const stage5 = view.missionStages.find(s => s.stage === 5)!;
+      expect(stage5.missions.some(m => m.id === 'expose_scandal')).toBe(true);
+      expect(stage5.missions.find(m => m.id === 'expose_scandal')!.label).toBe('Expose Scandal');
+    });
+
+    it('shows signals_intercept in the Stage 5 group once counterintelligence is researched, as remote-capable', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = ['counterintelligence'];
+      const view = getEspionagePanelViewModel(state);
+      const stage5 = view.missionStages.find(s => s.stage === 5)!;
+      const signalsMission = stage5.missions.find(m => m.id === 'signals_intercept')!;
+      expect(signalsMission.label).toBe('Signals Intercept');
+      expect(signalsMission.accessLabel).toBe('Remote-capable');
+    });
+
+    it('does not show expose_scandal or signals_intercept before their gating techs', () => {
+      const state = makeEspUiState();
+      state.civilizations.player.techState.completed = [];
+      const view = getEspionagePanelViewModel(state);
+      const allMissionIds = view.missionStages.flatMap(s => s.missions.map(m => m.id));
+      expect(allMissionIds).not.toContain('expose_scandal');
+      expect(allMissionIds).not.toContain('signals_intercept');
+    });
+
     it('does not show intercept_courier or bribe_official before their gating techs', () => {
       const state = makeEspUiState();
       state.civilizations.player.techState.completed = [];
@@ -332,6 +361,29 @@ describe('espionage-panel', () => {
       const data = getEspionagePanelData(state);
       expect(data.spySummaries.some(s => s.id === 'spy-ai-2')).toBe(false);
       expect(data.spies.every(s => s.id !== 'spy-ai-2')).toBe(true);
+    });
+
+    // #442 MR2 signals_intercept
+    it('surfaces the current player\'s own signals_intercept snapshot with a resolved target civ name', () => {
+      const state = makeEspUiState();
+      state.espionage!.player.signalsIntelligence = {
+        'ai-egypt': { turn: 8, units: [{ type: 'warrior', position: { q: 1, r: 1 }, health: 100 }] },
+      };
+      state.turn = 10;
+      const data = getEspionagePanelData(state);
+      expect(data.signalsIntelligence).toEqual([
+        { targetCivId: 'ai-egypt', targetCivName: 'Egypt', turn: 8, unitCount: 1 },
+      ]);
+    });
+
+    it('does not expose another civ\'s signals_intercept snapshot in the current player\'s panel data', () => {
+      const state = makeEspUiState();
+      state.espionage!['ai-egypt'] = {
+        ...state.espionage!['ai-egypt'],
+        signalsIntelligence: { player: { turn: 5, units: [{ type: 'warrior', position: { q: 0, r: 0 }, health: 100 }] } },
+      };
+      const data = getEspionagePanelData(state);
+      expect(data.signalsIntelligence).toEqual([]);
     });
 
     it('never exposes other players spy data', () => {

--- a/tests/ui/espionage-panel.test.ts
+++ b/tests/ui/espionage-panel.test.ts
@@ -578,6 +578,34 @@ describe('espionage-panel', () => {
       expect(collectText(threat)).toContain('No foreign spy activity detected.');
     });
 
+    // #442 MR2 signals_intercept — DOM-level proof the persisted snapshot actually
+    // renders (end-to-end-wiring.md), mirroring the threat-board test pair above.
+    it('renders a signals intelligence section with the intercepted snapshot', () => {
+      const state = makeEspUiState();
+      state.espionage!.player.signalsIntelligence = {
+        'ai-egypt': { turn: 8, units: [{ type: 'warrior', position: { q: 1, r: 1 }, health: 100 }] },
+      };
+
+      const panel = createEspionagePanel(state) as unknown;
+      const section = findAll(panel, el => el.dataset?.section === 'signals-intelligence')[0];
+      expect(collectText(section)).toContain('Egypt');
+      expect(collectText(section)).toContain('1 unit');
+      expect(collectText(section)).toContain('turn 8');
+    });
+
+    it('shows an empty state and never renders another civ\'s signals intelligence snapshot', () => {
+      const state = makeEspUiState();
+      state.espionage!['ai-egypt'] = {
+        ...state.espionage!['ai-egypt'],
+        signalsIntelligence: { player: { turn: 5, units: [{ type: 'warrior', position: { q: 0, r: 0 }, health: 100 }] } },
+      };
+
+      const panel = createEspionagePanel(state) as unknown;
+      const section = findAll(panel, el => el.dataset?.section === 'signals-intelligence')[0];
+      expect(collectText(section)).toContain('No signals intelligence gathered yet.');
+      expect(collectText(panel)).not.toContain('turn 5');
+    });
+
     it('renders a close button for the panel shell', () => {
       const state = makeEspUiState();
       const panel = createEspionagePanel(state) as unknown;

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -30,6 +30,7 @@ import {
   routeCityFlipped,
   routeCourierIntercepted,
   routeOfficialBribed,
+  routeScandalExposed,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -1142,6 +1143,58 @@ describe('espionage:official-bribed routing (#442 MR1)', () => {
     expect(carthageCall.message).toContain('42');
     expect(carthageCall.message).toContain('Rome');
     expect(carthageCall.type).toBe('warning');
+  });
+});
+
+describe('espionage:scandal-exposed routing (#442 MR2)', () => {
+  function scandalState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        egypt: { id: 'egypt', name: 'Egypt', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+        nubia: { id: 'nubia', name: 'Nubia', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} } },
+      } as any,
+      cities: {} as any,
+    });
+  }
+
+  it('notifies the target, every exposed partner individually, and the acting civ', () => {
+    const { sink, calls } = makeSink();
+    routeScandalExposed(
+      scandalState(),
+      { civId: 'rome', targetCivId: 'carthage', partnerCivIds: ['egypt', 'nubia'] },
+      sink,
+    );
+    const civIds = calls.map(c => c.civId).sort();
+    expect(civIds).toEqual(['carthage', 'egypt', 'nubia', 'rome']);
+
+    const carthageCall = calls.find(c => c.civId === 'carthage')!;
+    expect(carthageCall.message).toContain('Egypt');
+    expect(carthageCall.message).toContain('Nubia');
+    expect(carthageCall.type).toBe('warning');
+
+    const egyptCall = calls.find(c => c.civId === 'egypt')!;
+    expect(egyptCall.message).toContain('Carthage');
+    expect(egyptCall.type).toBe('warning');
+
+    const nubiaCall = calls.find(c => c.civId === 'nubia')!;
+    expect(nubiaCall.message).toContain('Carthage');
+    expect(nubiaCall.type).toBe('warning');
+
+    const romeCall = calls.find(c => c.civId === 'rome')!;
+    expect(romeCall.message).toContain('2');
+    expect(romeCall.type).toBe('success');
+  });
+
+  it('falls back to generic names when a civ record is missing', () => {
+    const { sink, calls } = makeSink();
+    routeScandalExposed(
+      scandalState(),
+      { civId: 'rome', targetCivId: 'unknown-civ', partnerCivIds: ['also-unknown'] },
+      sink,
+    );
+    expect(calls.every(c => typeof c.message === 'string' && c.message.length > 0)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 2 of #442, following #853 (Phase 1, era 5). Closes the remaining mission-ladder gap: era 8 (`disinformation-bureau`) and era 9 (`counterintelligence`) previously gated only percentage modifiers, no new mission verbs.

- **`expose_scandal`** (`disinformation-bureau`, era 8): exposes the target's secret treaties, applying a bounded relationship penalty (−10, capped at 4 partners) between the target and every other civ it has an active treaty with. The first **multilateral** (non-bilateral) espionage mission — every prior relationship-affecting mission touches exactly two civs.
- **`signals_intercept`** (`counterintelligence`, era 9): one-time empire-wide snapshot of the target civ's unit positions/health. Remote-capable — the first non-digital remote mission (justified inline in `missionRequiresPlacedSpy`, not just precedent-by-proximity to the era-10+ digital missions it sits next to).

## Fixes found along the way

- **Content honesty**: `disinformation-bureau`'s unlock text claimed "state disinformation weakens foreign loyalty" — no such mechanic ever existed. Replaced with the real `expose_scandal` effect it now gates.
- **Dead computed data**: implementing `signals_intercept` surfaced a real pre-existing bug — none of the four existing purely-informational missions (`monitor_troops`, `gather_intel`, `identify_resources`, `monitor_diplomacy`) ever actually show their results to the player anywhere (`espionage:mission-succeeded` has no notification handler for its per-mission result payload). Fixed for `signals_intercept` only: added `EspionageCivState.signalsIntelligence` (additive optional field, no schema bump) and a new "Signals Intelligence" panel section that renders it, with DOM-level tests proving it actually appears (and that it's hot-seat private). The four older missions are flagged as a separate follow-up rather than retrofitted here.

Full design record: `docs/superpowers/specs/2026-08-16-issue-442-espionage-eras-5-9-design.md`.

## Out of scope (deferred, by design)

- Retrofitting `monitor_troops`/`gather_intel`/`identify_resources`/`monitor_diplomacy` result display — separate follow-up (spawned as a background task suggestion).
- Spy-unit plateau (`spy_operative` unchanged eras 4–11) — separate follow-up issue.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` — 491 files / 8137 tests passing, 3 unrelated pre-existing skips
- [x] Mission gating, positive/negative `resolveMissionResult` coverage (including `expose_scandal`'s partner-cap and minor-civ-exclusion edge cases)
- [x] `processEspionageTurn` end-to-end resolution for both missions
- [x] AI mission-preference coverage
- [x] Notification routing — first 4-recipient routing test in the file (target + every partner + acting civ)
- [x] Hot-seat privacy — `signalsIntelligence` never leaks cross-civ, at both the data-shape and rendered-DOM level
- [x] UI catalog coverage (label/stage/description/duration/remote-capable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)